### PR TITLE
🎯 ci: Backport Automatic Pull Request Retargeting

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Project maintainers have the right and responsibility to remove, edit, or reject
 
 ## 2. Development Notes
 
-1. Before starting work, make sure your main branch has the latest commits with `npm run update`.
+1. Before starting work, make sure your `dev` branch has the latest commits with `npm run update`.
 2. Run linting command to find errors: `npm run lint`. Alternatively, ensure husky pre-commit checks are functioning.
     - `npm install` sets the hooks up for you; set `HUSKY=0` to opt out.
     - The pre-commit hook runs the Static Checks CI job locally, scoped to the files in the commit. Run it by hand with `npm run static-checks`, against a base ref with `npm run static-checks -- --against origin/dev`, or with the slow gates (TypeScript, config migration tests, unused i18n keys, unused npm packages) via `npm run static-checks:full`.
@@ -60,11 +60,11 @@ Project maintainers have the right and responsibility to remove, edit, or reject
 
 We utilize a GitFlow workflow to manage changes to this project's codebase. Follow these general steps when contributing code:
 
-1. Fork the repository and create a new branch with a descriptive slash-based name (e.g., `new/feature/x`).
+1. Fork the repository and branch off `dev` with a descriptive slash-based name (e.g., `new/feature/x`). All contributions target `dev`; `main` only moves at release time, and pull requests opened against it are retargeted automatically.
 2. Implement your changes and ensure that all tests pass.
 3. Commit your changes using conventional commit messages with GitFlow flags. Begin the commit message with a tag indicating the change type, such as "feat" (new feature), "fix" (bug fix), "docs" (documentation), or "refactor" (code refactoring), followed by a brief summary of the changes (e.g., `feat: Add new feature X to the project`).
-4. Submit a pull request with a clear and concise description of your changes and the reasons behind them.
-5. We will review your pull request, provide feedback as needed, and eventually merge the approved changes into the main branch.
+4. Submit a pull request against `dev` with a clear and concise description of your changes and the reasons behind them.
+5. We will review your pull request, provide feedback as needed, and eventually merge the approved changes into the `dev` branch.
 
 ## 4. Commit Message Format
 

--- a/.github/scripts/retarget-prs.sh
+++ b/.github/scripts/retarget-prs.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Retarget pull requests opened against the release branch onto the development branch.
+# Used by .github/workflows/pr-retarget-dev.yml for both the on-open hook and the manual sweep.
+set -euo pipefail
+
+REPO="${REPO:?REPO is required (owner/name)}"
+RELEASE_BASE="${RELEASE_BASE:-main}"
+TARGET_BASE="${TARGET_BASE:-dev}"
+DRY_RUN="${DRY_RUN:-false}"
+KEEP_LABEL="${KEEP_LABEL:-target: main}"
+THROTTLE_SECONDS="${THROTTLE_SECONDS:-0}"
+MARKER="<!-- librechat:auto-retarget -->"
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: REPO=owner/name $0 <pr-number> [pr-number...]" >&2
+  exit 64
+fi
+
+# Branches on the upstream repository that legitimately merge into the release branch.
+keeps_release_base() {
+  local head_repo="$1" head_ref="$2"
+  [ "$head_repo" = "$REPO" ] || return 1
+  case "$head_ref" in
+    "$TARGET_BASE" | release/* | hotfix/* | backport/* | *-"$RELEASE_BASE") return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Collected before grepping: piping directly into `grep -q` lets SIGPIPE fail the
+# pipeline under `set -o pipefail` and report a false negative.
+already_explained() {
+  local bodies
+  bodies="$(gh api "repos/$REPO/issues/$1/comments" --paginate --jq '.[].body')" || return 1
+  grep -qF "$MARKER" <<<"$bodies"
+}
+
+comment_body() {
+  cat <<BODY
+$MARKER
+👋 Thanks for the contribution! LibreChat merges all changes into \`$TARGET_BASE\` first — \`$RELEASE_BASE\` only moves at release time — so this pull request's base branch was switched from \`$RELEASE_BASE\` to \`$TARGET_BASE\` automatically.
+
+Nothing is needed from you; your commits, reviews and discussion are unchanged. If the diff now shows files you did not touch, rebase onto \`$TARGET_BASE\`:
+
+\`\`\`bash
+git remote add upstream https://github.com/$REPO.git
+git fetch upstream $TARGET_BASE
+git rebase upstream/$TARGET_BASE
+git push --force-with-lease
+\`\`\`
+
+Maintainers: apply the \`$KEEP_LABEL\` label and restore the base branch if this one genuinely belongs on \`$RELEASE_BASE\`.
+BODY
+}
+
+retargeted=0
+skipped=0
+failed=0
+
+for number in "$@"; do
+  if ! pr="$(gh api "repos/$REPO/pulls/$number")"; then
+    echo "#$number: FAILED to read pull request"
+    failed=$((failed + 1))
+    continue
+  fi
+  state="$(jq -r '.state' <<<"$pr")"
+  base_ref="$(jq -r '.base.ref' <<<"$pr")"
+  head_ref="$(jq -r '.head.ref' <<<"$pr")"
+  head_repo="$(jq -r '.head.repo.full_name // ""' <<<"$pr")"
+
+  if [ "$state" != "open" ]; then
+    echo "#$number: skipped — pull request is $state"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  if [ "$base_ref" != "$RELEASE_BASE" ]; then
+    echo "#$number: skipped — already based on $base_ref"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  if jq -e --arg keep "$KEEP_LABEL" 'any(.labels[]; .name == $keep)' <<<"$pr" >/dev/null; then
+    echo "#$number: skipped — labelled '$KEEP_LABEL'"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  if keeps_release_base "$head_repo" "$head_ref"; then
+    echo "#$number: skipped — $head_repo:$head_ref is a release-bound branch"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "#$number: would retarget $RELEASE_BASE -> $TARGET_BASE ($head_repo:$head_ref)"
+    retargeted=$((retargeted + 1))
+    continue
+  fi
+
+  echo "#$number: retargeting $RELEASE_BASE -> $TARGET_BASE ($head_repo:$head_ref)"
+  if ! gh pr edit "$number" --repo "$REPO" --base "$TARGET_BASE"; then
+    echo "#$number: FAILED to change base branch"
+    failed=$((failed + 1))
+    continue
+  fi
+  if already_explained "$number"; then
+    echo "#$number: explanation already posted"
+  else
+    comment_body | gh pr comment "$number" --repo "$REPO" --body-file - || echo "#$number: comment failed"
+  fi
+  retargeted=$((retargeted + 1))
+  [ "$THROTTLE_SECONDS" = "0" ] || sleep "$THROTTLE_SECONDS"
+done
+
+echo "retargeted=$retargeted skipped=$skipped failed=$failed"
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  echo "Retargeted **$retargeted** pull request(s) onto \`$TARGET_BASE\`, skipped **$skipped**, failed **$failed**." >> "$GITHUB_STEP_SUMMARY"
+fi
+
+[ "$failed" -eq 0 ]

--- a/.github/workflows/pr-retarget-dev.yml
+++ b/.github/workflows/pr-retarget-dev.yml
@@ -1,0 +1,76 @@
+name: Retarget PRs to dev
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report what would change without editing any pull request'
+        type: boolean
+        default: true
+      pr_numbers:
+        description: 'Space-separated PR numbers (default: every open pull request based on main)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-retarget-dev-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  on-open:
+    name: Retarget on open
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # pull_request_target runs with a write token: check out the trusted base
+          # commit only, never the pull request head.
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+
+      - name: Retarget onto dev
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: .github/scripts/retarget-prs.sh "$PR_NUMBER"
+
+  sweep:
+    name: Sweep open pull requests
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+
+      - name: Retarget onto dev
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          PR_NUMBERS: ${{ inputs.pr_numbers }}
+          THROTTLE_SECONDS: '2'
+        run: |
+          numbers="$PR_NUMBERS"
+          if [ -z "$numbers" ]; then
+            numbers="$(gh pr list --repo "$REPO" --base main --state open --limit 500 --json number --jq '.[].number')"
+          fi
+          if [ -z "$numbers" ]; then
+            echo "No open pull requests based on main."
+            exit 0
+          fi
+          # shellcheck disable=SC2086
+          .github/scripts/retarget-prs.sh $numbers


### PR DESCRIPTION
## Summary

Backport of #15416, which adds a workflow that retargets pull requests opened
against `main` onto `dev`. Same commit, unmodified.

## Why this needs to be on `main`

`pull_request_target` reads its workflow definition from the **base branch** of
the pull request that triggers it. Every pull request this is meant to catch is
based on `main`, so the workflow has to exist on `main` — merged only to `dev`,
it would never fire.

It lands on both branches so the next release merge does not leave the two
copies drifting.

## Review

The change, the reasoning, and the test evidence are all in #15416 — this
carries no additional changes. Merge order does not matter; the workflow is
inert on `dev` and becomes active the moment this lands on `main`.

Note that this pull request is itself based on `main`, and its head branch
(`danny-avila/pr-auto-retarget-dev-main`) matches the `*-main` backport
exemption the workflow honors — so once this is merged, future backports of
this shape are left alone.
