### PR TITLE
fix: pass agent imageDetail through to the image encoder

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -1675,6 +1675,7 @@ class AgentClient extends BaseClient {
       {
         provider: this.options.agent.provider,
         endpoint: this.options.endpoint,
+        imageDetail: this.options.agent.model_parameters?.imageDetail,
       },
       VisionModes.agents,
     );

--- a/api/server/services/Files/images/encode.js
+++ b/api/server/services/Files/images/encode.js
@@ -94,11 +94,12 @@ const blobStorageSources = new Set([
  * @param {object} params - Object containing provider/endpoint information
  * @param {Providers | EModelEndpoint | string} [params.provider] - The provider for the image
  * @param {string} [params.endpoint] - Optional: The endpoint for the image
+ * @param {ImageDetail} [params.imageDetail] - Optional: Detail level, for routes that resolve it outside of the request body.
  * @param {string} [mode] - Optional: The endpoint mode for the image.
  * @returns {Promise<{ files: MongoFile[]; image_urls: MessageContentImageUrl[] }>} - A promise that resolves to the result object containing the encoded images and file details.
  */
 async function encodeAndFormat(req, files, params, mode) {
-  const { provider, endpoint } = params;
+  const { provider, endpoint, imageDetail } = params;
   const effectiveEndpoint = endpoint ?? provider;
   const promises = [];
   /** @type {Record<FileSources, Pick<ReturnType<typeof getStrategyFunctions>, 'prepareImagePayload' | 'getDownloadStream'>>} */
@@ -159,7 +160,7 @@ async function encodeAndFormat(req, files, params, mode) {
     promises.push(preparePayload(req, file));
   }
 
-  const detail = req.body.imageDetail ?? ImageDetail.auto;
+  const detail = imageDetail ?? req.body.imageDetail ?? ImageDetail.auto;
 
   /** @type {Array<[MongoFile, string]>} */
   const formattedImages = await Promise.all(promises);

--- a/api/server/services/Files/images/encode.spec.js
+++ b/api/server/services/Files/images/encode.spec.js
@@ -22,10 +22,10 @@ jest.mock('~/server/services/Files/strategies', () => ({
 }));
 
 const axios = require('axios');
-const { FileSources } = require('librechat-data-provider');
+const { FileSources, ImageDetail, VisionModes } = require('librechat-data-provider');
 const { encodeAndFormat } = require('./encode');
 
-const makeReq = () => ({ body: {}, config: {} });
+const makeReq = (body = {}) => ({ body, config: {} });
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -107,5 +107,55 @@ describe('encodeAndFormat - request memory guard', () => {
     expect(mockRunGuardedEncode).not.toHaveBeenCalled();
     expect(result.image_urls).toHaveLength(1);
     expect(result.image_urls[0].image_url.url).toBe(`data:image/png;base64,${localBase64}`);
+  });
+});
+
+describe('encodeAndFormat - image detail resolution', () => {
+  const imageFile = {
+    source: FileSources.local,
+    height: 10,
+    width: 10,
+    type: 'image/png',
+    file_id: 'f-detail',
+    filepath: 'local/detail.png',
+    filename: 'detail.png',
+    bytes: 128,
+  };
+
+  beforeEach(() => {
+    mockPrepareImagePayload.mockResolvedValue([
+      { source: FileSources.local, type: 'image/png' },
+      Buffer.from('detail-image').toString('base64'),
+    ]);
+  });
+
+  const encodeWith = (params, body) =>
+    encodeAndFormat(makeReq(body), [imageFile], params, VisionModes.agents);
+
+  it('uses the detail passed in params when the request body has none', async () => {
+    const result = await encodeWith({ endpoint: 'openai', imageDetail: ImageDetail.high });
+
+    expect(result.image_urls[0].image_url.detail).toBe(ImageDetail.high);
+  });
+
+  it('prefers the detail passed in params over the request body', async () => {
+    const result = await encodeWith(
+      { endpoint: 'openai', imageDetail: ImageDetail.low },
+      { imageDetail: ImageDetail.high },
+    );
+
+    expect(result.image_urls[0].image_url.detail).toBe(ImageDetail.low);
+  });
+
+  it('falls back to the request body when params carry no detail', async () => {
+    const result = await encodeWith({ endpoint: 'openai' }, { imageDetail: ImageDetail.high });
+
+    expect(result.image_urls[0].image_url.detail).toBe(ImageDetail.high);
+  });
+
+  it('defaults to auto when neither source provides a detail', async () => {
+    const result = await encodeWith({ endpoint: 'openai' });
+
+    expect(result.image_urls[0].image_url.detail).toBe(ImageDetail.auto);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #15359.

An agent stores `imageDetail` in `model_parameters` and the Agent Builder model panel saves it correctly, but `encodeAndFormat` only ever read `req.body.imageDetail`, which the agents route never populates. The stored value was written and never read, so the `ImageDetail.auto` fallback always won.

That makes image input unusable on any provider whose OpenAI-compatible API rejects `detail: "auto"`. MiniMax, for example, accepts only `low` and `high` and answers with `400 invalid params, invalid image detail: auto (2013)`.

`AgentClient.addImageURLs` already holds the resolved agent, so it now passes the value down through `params`. This avoids depending on `endpointOption`, which the issue reporter confirmed is empty on this route. The request body still applies for every other route, so no other endpoint changes behaviour.

The resolution order is now `params.imageDetail` → `req.body.imageDetail` → `ImageDetail.auto`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added four cases to `api/server/services/Files/images/encode.spec.js` covering the full precedence chain:

- uses the detail passed in `params` when the request body has none
- prefers `params` over the request body
- falls back to the request body when `params` carries no detail
- defaults to `auto` when neither source provides one

Verified the tests actually pin the fix: with the one-line change to `encode.js` reverted, the first two fail and the last two still pass, confirming existing behaviour is preserved.

```
cd api && npx jest server/services/Files/images
# 2 suites, 21 tests passed

cd api && npx jest server/controllers/agents
# 26 suites, 888 tests passed
```

### **Test Configuration**:

Node.js v24.16.0, Windows. No config changes required.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
