### PR TITLE
🧳 fix: Carry Custom Endpoint Names Through Chat URLs

### DIFF
--- a/packages/data-provider/specs/createPayload.spec.ts
+++ b/packages/data-provider/specs/createPayload.spec.ts
@@ -1,0 +1,55 @@
+import type { TSubmission } from '../src/types';
+import { EModelEndpoint } from '../src/schemas';
+import { EndpointURLs } from '../src/config';
+import createPayload from '../src/createPayload';
+
+const agentsChatRoot = EndpointURLs[EModelEndpoint.agents];
+
+const makeSubmission = (endpoint: string): TSubmission =>
+  ({
+    conversation: { conversationId: 'convo-1', endpoint },
+    userMessage: { text: 'hello' },
+    endpointOption: { endpoint },
+  }) as unknown as TSubmission;
+
+describe('createPayload server URL', () => {
+  it('builds the chat URL from a plain custom endpoint name', () => {
+    const { server } = createPayload(makeSubmission('OpenRouter'));
+
+    expect(server).toBe(`${agentsChatRoot}/OpenRouter`);
+  });
+
+  it('percent-encodes a slash so the name stays a single path segment', () => {
+    /** A raw `/` would split into an extra path segment and miss the server's
+     * `/:endpoint` route, which answers with a generic 404 "Endpoint not found"
+     * (danny-avila/LibreChat#15270). */
+    const { server } = createPayload(makeSubmission('Company/API'));
+
+    expect(server).toBe(`${agentsChatRoot}/Company%2FAPI`);
+    expect(server.slice(agentsChatRoot.length + 1)).not.toContain('/');
+  });
+
+  it('round-trips the encoded name back to the configured value', () => {
+    const { server } = createPayload(makeSubmission('Company/API'));
+
+    expect(decodeURIComponent(server.slice(agentsChatRoot.length + 1))).toBe('Company/API');
+  });
+
+  it('encodes other characters that are unsafe in a path segment', () => {
+    const { server } = createPayload(makeSubmission('Team A?v=1#x'));
+
+    expect(server).toBe(`${agentsChatRoot}/Team%20A%3Fv%3D1%23x`);
+  });
+
+  it('leaves the endpoint name itself untouched in the payload body', () => {
+    const { payload } = createPayload(makeSubmission('Company/API'));
+
+    expect(payload.endpoint).toBe('Company/API');
+  });
+
+  it('does not touch the assistants URL, which carries no endpoint segment', () => {
+    const { server } = createPayload(makeSubmission(EModelEndpoint.assistants));
+
+    expect(server).toBe(EndpointURLs[EModelEndpoint.assistants]);
+  });
+});

--- a/packages/data-provider/src/createPayload.ts
+++ b/packages/data-provider/src/createPayload.ts
@@ -35,7 +35,9 @@ export default function createPayload(submission: t.TSubmission) {
   };
 
   const endpoint = _e as s.EModelEndpoint;
-  let server = `${EndpointURLs[s.EModelEndpoint.agents]}/${endpoint}`;
+  /** Custom endpoint names are user-defined and may contain `/`, which would
+   * otherwise split into extra path segments and miss the `/:endpoint` route. */
+  let server = `${EndpointURLs[s.EModelEndpoint.agents]}/${encodeURIComponent(endpoint)}`;
   if (s.isAssistantsEndpoint(endpoint)) {
     server =
       EndpointURLs[(endpointType ?? endpoint) as 'assistants' | 'azureAssistants'] +


### PR DESCRIPTION
## Summary

Fixes #15270.

`createPayload` interpolated the endpoint name straight into the chat URL:

```ts
let server = `${EndpointURLs[s.EModelEndpoint.agents]}/${endpoint}`;
```

Custom endpoint names are user-defined, so a name like `Company/API` produces `/api/agents/chat/Company/API`. The slash reads as a path separator, the request stops matching the router's `/:endpoint` in `api/server/routes/agents/chat.js`, and it falls through to the catch-all handler in `packages/api/src/middleware/notFound.ts` — which is where the reported `Endpoint not found` actually comes from. It is the generic API 404, not an endpoint-resolution error, which is why the message gives no hint about the real cause.

Encoding the name keeps it a single path segment. Express matches the encoded segment and decodes `req.params.endpoint` back to the original value, and the endpoint the server acts on is read from the request body regardless (`req.params.endpoint` is never read anywhere in the codebase — the segment exists only for routing), so nothing downstream has to change.

This also aligns the call site with the `encodeURIComponent` convention already used throughout `api-endpoints.ts`.

I went with encoding rather than rejecting slashes at config-validation time, since the issue offers both and encoding keeps working configurations working. Happy to switch to validation instead if maintainers prefer that direction.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Confirmed the routing behaviour empirically against this repo's Express version before writing the fix — a raw slash reproduces the exact reported 404, and the percent-encoded form matches `/:endpoint` and decodes back to `Company/API`.

Added `packages/data-provider/specs/createPayload.spec.ts`:

- builds the chat URL from a plain custom endpoint name
- percent-encodes a slash so the name stays a single path segment
- round-trips the encoded name back to the configured value
- encodes other characters unsafe in a path segment (space, `?`, `=`, `#`)
- leaves the endpoint name itself untouched in the payload body
- does not touch the assistants URL, which carries no endpoint segment

The slash and unsafe-character cases fail without the fix; the rest pass either way, confirming existing URLs are unchanged.

```
cd packages/data-provider && npx jest
# 36 suites, 1701 tests passed
```

### **Test Configuration**:

Node.js v24.16.0, Windows. Reproduces with any custom endpoint whose `name` contains `/`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
