### PR TITLE
🪣 fix: Decode S3 Object Keys from URLs

### DIFF
--- a/packages/api/src/storage/cloudfront/__tests__/crud.test.ts
+++ b/packages/api/src/storage/cloudfront/__tests__/crud.test.ts
@@ -92,6 +92,28 @@ describe('CloudFront CRUD', () => {
       expect(mockGetSignedUrl).not.toHaveBeenCalled();
     });
 
+    it('percent-encodes non-ASCII characters in the key', async () => {
+      const { getCloudFrontURL } = await import('~/storage/cloudfront/crud');
+      const url = await getCloudFrontURL({ userId: 'user1', fileName: 'Ársreikningur.pdf' });
+      expect(url).toBe('https://d123.cloudfront.net/i/images/user1/%C3%81rsreikningur.pdf');
+    });
+
+    it('percent-encodes a literal % so it cannot be read back as an escape', async () => {
+      const { getCloudFrontURL } = await import('~/storage/cloudfront/crud');
+      const url = await getCloudFrontURL({ userId: 'user1', fileName: 'report%20final.pdf' });
+      expect(url).toBe('https://d123.cloudfront.net/i/images/user1/report%2520final.pdf');
+    });
+
+    it('leaves path separators literal', async () => {
+      const { getCloudFrontURL } = await import('~/storage/cloudfront/crud');
+      const url = await getCloudFrontURL({
+        userId: 'user1',
+        fileName: 'doc.pdf',
+        basePath: 'documents',
+      });
+      expect(url).toBe('https://d123.cloudfront.net/documents/user1/doc.pdf');
+    });
+
     it('uses custom basePath when provided', async () => {
       const { getCloudFrontURL } = await import('~/storage/cloudfront/crud');
       const url = await getCloudFrontURL({

--- a/packages/api/src/storage/cloudfront/__tests__/crud.test.ts
+++ b/packages/api/src/storage/cloudfront/__tests__/crud.test.ts
@@ -534,6 +534,26 @@ describe('CloudFront CRUD', () => {
       );
     });
 
+    it('encodes the invalidation path the same way as the viewer URL', async () => {
+      mockResolveStoredS3Key.mockReturnValue('images/u/report%20final \u0151.webp');
+      mockGetCloudFrontConfig.mockReturnValue(
+        makeConfig({ invalidateOnDelete: true, distributionId: 'E123' }),
+      );
+      mockCloudFrontSend.mockResolvedValue({});
+
+      const { deleteFileFromCloudFront } = await import('~/storage/cloudfront/crud');
+      await deleteFileFromCloudFront(mockReq, mockFile);
+
+      const { CreateInvalidationCommand } = await import('@aws-sdk/client-cloudfront');
+      expect(CreateInvalidationCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          InvalidationBatch: expect.objectContaining({
+            Paths: { Quantity: 1, Items: ['/images/u/report%2520final%20%C5%91.webp'] },
+          }),
+        }),
+      );
+    });
+
     it('prefixes key with / for invalidation path', async () => {
       mockResolveStoredS3Key.mockReturnValue('images/u/file.webp'); // no leading slash
       mockGetCloudFrontConfig.mockReturnValue(

--- a/packages/api/src/storage/cloudfront/crud.ts
+++ b/packages/api/src/storage/cloudfront/crud.ts
@@ -1,10 +1,9 @@
 import crypto from 'crypto';
+import { logger } from '@librechat/data-schemas';
 import { getSignedUrl } from '@aws-sdk/cloudfront-signer';
 import { CloudFrontClient, CreateInvalidationCommand } from '@aws-sdk/client-cloudfront';
-import { logger } from '@librechat/data-schemas';
 import type { TFile } from 'librechat-data-provider';
 import type { Readable } from 'stream';
-import type { ServerRequest } from '~/types';
 import type {
   SaveBufferParams,
   GetURLParams,
@@ -14,10 +13,7 @@ import type {
   SaveURLResult,
   UploadResult,
 } from '~/storage/types';
-import { getCloudFrontConfig } from '~/cdn/cloudfront';
-import { s3Config } from '~/storage/s3/s3Config';
-import { AVATAR_BASE_PATH, DEFAULT_BASE_PATH as defaultBasePath } from '~/storage/constants';
-import { sanitizeContentDispositionFilename } from '~/storage/validation';
+import type { ServerRequest } from '~/types';
 import {
   getS3Key,
   saveBufferToS3,
@@ -27,6 +23,10 @@ import {
   getS3FileStream,
   resolveStoredS3Key,
 } from '~/storage/s3/crud';
+import { AVATAR_BASE_PATH, DEFAULT_BASE_PATH as defaultBasePath } from '~/storage/constants';
+import { sanitizeContentDispositionFilename } from '~/storage/validation';
+import { getCloudFrontConfig } from '~/cdn/cloudfront';
+import { s3Config } from '~/storage/s3/s3Config';
 
 let _cloudFrontClient: CloudFrontClient | null = null;
 

--- a/packages/api/src/storage/cloudfront/crud.ts
+++ b/packages/api/src/storage/cloudfront/crud.ts
@@ -84,7 +84,15 @@ function buildCloudFrontUrl(s3Key: string): string {
   }
   const cleanDomain = config.domain.replace(/\/+$/, '');
   const cleanKey = s3Key.replace(/^\/+/, '');
-  return `${cleanDomain}/${cleanKey}`;
+  /**
+   * Percent-encode each path segment (the separators stay literal). Without this a CloudFront
+   * URL carries the raw key while an SDK-generated S3 URL carries an encoded one, so the two
+   * forms of `file.filepath` disagree about what a `%` means: a key containing the literal text
+   * `%20` would be indistinguishable from a key containing a space. Encoding here keeps both
+   * producers consistent, which is what lets `extractKeyFromS3Url` decode unconditionally.
+   */
+  const encodedKey = cleanKey.split('/').map(encodeURIComponent).join('/');
+  return `${cleanDomain}/${encodedKey}`;
 }
 
 function signUrl(url: string | URL): string {

--- a/packages/api/src/storage/cloudfront/crud.ts
+++ b/packages/api/src/storage/cloudfront/crud.ts
@@ -77,22 +77,25 @@ function isInlineFileUpload({ basePath, file, useInlinePath }: UploadFileParams)
   return (basePath ?? defaultBasePath) === defaultBasePath && file.mimetype?.startsWith('image/');
 }
 
+/**
+ * Percent-encodes each path segment of an S3 key (the separators stay literal). Without this a
+ * CloudFront URL carries the raw key while an SDK-generated S3 URL carries an encoded one, so the
+ * two forms of `file.filepath` disagree about what a `%` means: a key containing the literal text
+ * `%20` would be indistinguishable from a key containing a space. Encoding here keeps both
+ * producers consistent, which is what lets `extractKeyFromS3Url` decode unconditionally. The
+ * invalidation path must use the same encoding, or it no longer matches the cached viewer URL.
+ */
+function encodeKeyPath(s3Key: string): string {
+  return s3Key.replace(/^\/+/, '').split('/').map(encodeURIComponent).join('/');
+}
+
 function buildCloudFrontUrl(s3Key: string): string {
   const config = getCloudFrontConfig();
   if (!config?.domain) {
     throw new Error('[buildCloudFrontUrl] CloudFront not initialized.');
   }
   const cleanDomain = config.domain.replace(/\/+$/, '');
-  const cleanKey = s3Key.replace(/^\/+/, '');
-  /**
-   * Percent-encode each path segment (the separators stay literal). Without this a CloudFront
-   * URL carries the raw key while an SDK-generated S3 URL carries an encoded one, so the two
-   * forms of `file.filepath` disagree about what a `%` means: a key containing the literal text
-   * `%20` would be indistinguishable from a key containing a space. Encoding here keeps both
-   * producers consistent, which is what lets `extractKeyFromS3Url` decode unconditionally.
-   */
-  const encodedKey = cleanKey.split('/').map(encodeURIComponent).join('/');
-  return `${cleanDomain}/${encodedKey}`;
+  return `${cleanDomain}/${encodeKeyPath(s3Key)}`;
 }
 
 function signUrl(url: string | URL): string {
@@ -243,8 +246,7 @@ export async function deleteFileFromCloudFront(req: ServerRequest, file: TFile):
     try {
       const client = getOrCreateCloudFrontClient();
       // CloudFront URL pathname matches S3 key when no origin path prefix is configured
-      const key = resolveStoredS3Key(file);
-      const path = key.startsWith('/') ? key : `/${key}`;
+      const path = `/${encodeKeyPath(resolveStoredS3Key(file))}`;
 
       await client.send(
         new CreateInvalidationCommand({

--- a/packages/api/src/storage/s3/__tests__/crud.test.ts
+++ b/packages/api/src/storage/s3/__tests__/crud.test.ts
@@ -1463,6 +1463,40 @@ describe('S3 CRUD', () => {
       expect(key).toBe('images/user123/file.png');
     });
 
+    it('decodes percent-encoded keys from virtual-hosted-style URLs', async () => {
+      const { extractKeyFromS3Url } = await import('../crud');
+      const key = extractKeyFromS3Url(
+        'https://bucket.s3.amazonaws.com/uploads/user123/abc__%C3%81rsreikningur_2025.pdf',
+      );
+      expect(key).toBe('uploads/user123/abc__Ársreikningur_2025.pdf');
+    });
+
+    it('decodes percent-encoded keys from path-style URLs', async () => {
+      const { extractKeyFromS3Url } = await import('../crud');
+      const key = extractKeyFromS3Url(
+        'https://s3.us-west-2.amazonaws.com/test-bucket/uploads/user123/%E6%97%A5%E6%9C%AC%E8%AA%9E.pdf',
+      );
+      expect(key).toBe('uploads/user123/日本語.pdf');
+    });
+
+    it('preserves a literal percent in a filename (round-trip through %25)', async () => {
+      const { extractKeyFromS3Url } = await import('../crud');
+      const key = extractKeyFromS3Url('https://bucket.s3.amazonaws.com/uploads/100%25_done.pdf');
+      expect(key).toBe('uploads/100%_done.pdf');
+    });
+
+    it('returns a raw key untouched even when it contains a percent sign', async () => {
+      const { extractKeyFromS3Url } = await import('../crud');
+      const key = 'uploads/user123/100%_done.pdf';
+      expect(extractKeyFromS3Url(key)).toBe(key);
+    });
+
+    it('falls back to the raw value on a malformed escape sequence', async () => {
+      const { extractKeyFromS3Url } = await import('../crud');
+      const key = extractKeyFromS3Url('https://bucket.s3.amazonaws.com/uploads/bad%E0%A4A.pdf');
+      expect(key).toBe('uploads/bad%E0%A4A.pdf');
+    });
+
     it('extracts key from path-style regional endpoint', async () => {
       const { extractKeyFromS3Url } = await import('../crud');
       const key = extractKeyFromS3Url(
@@ -1511,12 +1545,13 @@ describe('S3 CRUD', () => {
       expect(key).toBe('folder/file.txt');
     });
 
-    it('handles URLs with encoded characters', async () => {
+    it('decodes URLs with encoded characters back to the stored key', async () => {
       const { extractKeyFromS3Url } = await import('../crud');
       const key = extractKeyFromS3Url(
         'https://bucket.s3.amazonaws.com/test-bucket/images/user123/my%20file%20name.jpg',
       );
-      expect(key).toBe('images/user123/my%20file%20name.jpg');
+      /** The object was stored under `my file name.jpg`; `%20` is URL transport, not part of the key. */
+      expect(key).toBe('images/user123/my file name.jpg');
     });
 
     it('handles deep nested paths', async () => {

--- a/packages/api/src/storage/s3/__tests__/crud.test.ts
+++ b/packages/api/src/storage/s3/__tests__/crud.test.ts
@@ -1118,6 +1118,19 @@ describe('S3 CRUD', () => {
       expect(s3Mock.commandCalls(GetObjectCommand)).toHaveLength(1);
     });
 
+    it('requests the decoded key for a non-ASCII file name', async () => {
+      const { getS3FileStream } = await import('../crud');
+      await getS3FileStream(
+        {} as ServerRequest,
+        'https://test-bucket.s3.amazonaws.com/images/user123/%D0%94%D0%BE%D0%B3%D0%BE%D0%B2%D0%BE%D1%80.pdf',
+      );
+
+      const [call] = s3Mock.commandCalls(GetObjectCommand);
+      expect(call.args[0].input.Key).toBe(
+        'images/user123/\u0414\u043e\u0433\u043e\u0432\u043e\u0440.pdf',
+      );
+    });
+
     it('handles errors when retrieving stream', async () => {
       s3Mock.on(GetObjectCommand).rejects(new Error('Stream error'));
 

--- a/packages/api/src/storage/s3/crud.ts
+++ b/packages/api/src/storage/s3/crud.ts
@@ -638,6 +638,27 @@ export async function saveURLToS3(
   return filepath;
 }
 
+/**
+ * Decodes a key taken from a URL path.
+ *
+ * `URL.pathname` is percent-encoded, but S3 object keys are raw UTF-8 and the AWS SDK encodes
+ * them again when it signs the request. Returning the encoded pathname therefore asks S3 for a
+ * literally different key (`%C3%81rsreikningur.pdf` instead of `Ársreikningur.pdf`) and every
+ * read of a file whose name contains a non-ASCII character fails with `NoSuchKey`. Keys made of
+ * ASCII are unaffected, which is why this only shows up for non-English filenames.
+ *
+ * Malformed sequences fall back to the raw value rather than throwing — a key that cannot be
+ * decoded is still worth attempting.
+ */
+function decodeKeyFromUrlPath(key: string): string {
+  try {
+    return decodeURIComponent(key);
+  } catch {
+    logger.warn(`[extractKeyFromS3Url] Could not decode key, using it as-is: ${key}`);
+    return key;
+  }
+}
+
 export function extractKeyFromS3Url(fileUrlOrKey: string): string {
   if (!fileUrlOrKey) {
     throw new Error('Invalid input: URL or key is empty');
@@ -659,7 +680,7 @@ export function extractKeyFromS3Url(fileUrlOrKey: string): string {
         (endpointUrl.pathname.endsWith('/') ? 0 : 1) +
         bucketName.length +
         1;
-      const key = url.pathname.substring(startPos);
+      const key = decodeKeyFromUrlPath(url.pathname.substring(startPos));
       if (!key) {
         logger.warn(
           `[extractKeyFromS3Url] Extracted key is empty for endpoint path-style URL: ${fileUrlOrKey}`,
@@ -677,7 +698,7 @@ export function extractKeyFromS3Url(fileUrlOrKey: string): string {
     ) {
       const firstSlashIndex = pathname.indexOf('/');
       if (firstSlashIndex > 0) {
-        const key = pathname.substring(firstSlashIndex + 1);
+        const key = decodeKeyFromUrlPath(pathname.substring(firstSlashIndex + 1));
         if (key === '') {
           logger.warn(
             `[extractKeyFromS3Url] Extracted key is empty after removing bucket name from URL: ${fileUrlOrKey}`,
@@ -695,8 +716,9 @@ export function extractKeyFromS3Url(fileUrlOrKey: string): string {
       return '';
     }
 
-    logger.debug(`[extractKeyFromS3Url] fileUrlOrKey: ${fileUrlOrKey}, Extracted key: ${pathname}`);
-    return pathname;
+    const key = decodeKeyFromUrlPath(pathname);
+    logger.debug(`[extractKeyFromS3Url] fileUrlOrKey: ${fileUrlOrKey}, Extracted key: ${key}`);
+    return key;
   } catch (error) {
     if (fileUrlOrKey.startsWith('http://') || fileUrlOrKey.startsWith('https://')) {
       logger.error(


### PR DESCRIPTION
## Summary

`extractKeyFromS3Url` returns `URL.pathname` as the S3 object key without decoding it. The AWS SDK percent-encodes the `Key` again when it signs the request, so a file stored under the key `Ársreikningur.pdf` is fetched as `%C3%81rsreikningur.pdf` and the read fails with `NoSuchKey`. ASCII keys encode to themselves, so this is invisible in English-language deployments and breaks every file with a non-ASCII character in its name.

The upload is fine — the object is in the bucket under the correct raw key. It is the read path that asks for the wrong one, so the file uploads successfully, appears in the UI, and then fails on every use: document/context extraction, downloads, and re-signing.

Observed on a self-hosted 0.8.7 deployment with S3 (path-style, non-AWS provider) and Icelandic filenames. Verified against the live bucket:

```
extractKeyFromS3Url ->  "%C3%81rsreikningur_2024.pdf"
decodeURIComponent  ->  "Ársreikningur_2024.pdf"
GET as extracted (what the app sends): NoSuchKey
GET decoded:                           OK (149574 bytes)
```

The fix decodes keys derived from a URL path in all three branches (path-style endpoint, bucket-in-path, virtual-hosted). A key passed in raw — not a URL — is still returned untouched, and a malformed escape sequence falls back to the raw value with a warning rather than throwing.

Every caller (`getS3FileStream`, `deleteFileFromS3`, `refreshS3Url`, `getStorageMetadataForKey`) uses the result as an SDK `Key`, so decoding is correct for all of them. Newer records that carry `storageKey` already bypass this path, which is likely why it has gone unnoticed — the fallback is what older files depend on.

**One existing assertion changed.** `handles URLs with encoded characters` asserted that `.../my%20file%20name.jpg` extracts as `images/user123/my%20file%20name.jpg`. That is the bug in test form: the object was stored under `my file name.jpg`, and `%20` is URL transport, not part of the key. It is now `decodes URLs with encoded characters back to the stored key` with the decoded expectation.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added five cases to `packages/api/src/storage/s3/__tests__/crud.test.ts`: percent-decoding for virtual-hosted and path-style URLs, a literal `%` in a filename round-tripping through `%25`, a raw key containing `%` left untouched, and a malformed escape falling back to the raw value.

```sh
cd packages/api && npx jest --config jest.config.mjs src/storage/s3/__tests__/crud.test.ts --coverage=false
# Tests: 105 passed, 105 total
```

The wider `src/storage` suite is 161 passed; `src/storage/__tests__/metadata.test.ts` could not run in my environment for an unrelated reason (`Cannot find module 're2js'`), so I have not exercised that file.

### **Test Configuration**:

- Node.js v24
- Jest via `packages/api/jest.config.mjs`
- Reproduced end-to-end against a path-style S3-compatible provider (Hetzner Object Storage)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes

Closes #15688