### PR TITLE
🧿 fix: Restore Shared IP Limits for Generation Retries

### DIFF
--- a/api/server/routes/agents/__tests__/idempotencyLimiter.spec.js
+++ b/api/server/routes/agents/__tests__/idempotencyLimiter.spec.js
@@ -87,15 +87,16 @@ describe('start-generation idempotency before message limiters', () => {
     mockExemptSchedule.mockReturnValue(false);
   });
 
-  it('lets a confirmed retry reach the controller without consuming either limiter', async () => {
+  it('keeps a confirmed retry behind the shared IP limiter', async () => {
     mockHasGenerationClaim.mockResolvedValue(true);
+    mockIpLimiter.mockImplementationOnce((_req, _res, next) => next());
 
     const response = await request(app).post('/agents/chat').send({ clientRequestId: 'request-1' });
 
     expect(response.status).toBe(201);
     expect(mockRetryProbeLimiter).toHaveBeenCalledTimes(1);
     expect(mockRetryLimiter).toHaveBeenCalledTimes(1);
-    expect(mockIpLimiter).not.toHaveBeenCalled();
+    expect(mockIpLimiter).toHaveBeenCalledTimes(1);
     expect(mockUserLimiter).not.toHaveBeenCalled();
   });
 

--- a/api/server/routes/agents/__tests__/idempotencyLimiter.spec.js
+++ b/api/server/routes/agents/__tests__/idempotencyLimiter.spec.js
@@ -141,12 +141,9 @@ describe('start-generation idempotency before message limiters', () => {
     expect(mockUserLimiter).not.toHaveBeenCalled();
   });
 
-  it.each([
-    ['an agent-trigger delivery', mockExemptAgentTrigger],
-    ['a scheduled delivery', mockExemptSchedule],
-  ])('keeps %s outside the human retry bucket', async (_label, exemption) => {
+  it('keeps an agent-trigger delivery outside the human retry bucket', async () => {
     mockHasGenerationClaim.mockResolvedValue(true);
-    exemption.mockReturnValue(true);
+    mockExemptAgentTrigger.mockReturnValue(true);
 
     const response = await request(app).post('/agents/chat').send({ clientRequestId: 'request-4' });
 
@@ -154,6 +151,20 @@ describe('start-generation idempotency before message limiters', () => {
     expect(mockRetryProbeLimiter).not.toHaveBeenCalled();
     expect(mockRetryLimiter).not.toHaveBeenCalled();
     expect(mockIpLimiter).not.toHaveBeenCalled();
+    expect(mockUserLimiter).not.toHaveBeenCalled();
+  });
+
+  it('keeps a scheduled delivery outside the user retry bucket', async () => {
+    mockHasGenerationClaim.mockResolvedValue(true);
+    mockExemptSchedule.mockReturnValue(true);
+
+    const response = await request(app).post('/agents/chat').send({ clientRequestId: 'request-4' });
+
+    expect(response.status).toBe(429);
+    expect(response.body).toEqual({ limited: 'ip' });
+    expect(mockRetryProbeLimiter).not.toHaveBeenCalled();
+    expect(mockRetryLimiter).not.toHaveBeenCalled();
+    expect(mockIpLimiter).toHaveBeenCalledTimes(1);
     expect(mockUserLimiter).not.toHaveBeenCalled();
   });
 

--- a/api/server/routes/agents/index.js
+++ b/api/server/routes/agents/index.js
@@ -1136,10 +1136,7 @@ if (useMessageIpLimiter || useMessageUserLimiter) {
 
 if (useMessageIpLimiter) {
   chatRouter.use(
-    unless(
-      (req) => exemptAgentTriggerFromIpLimiter(req) || isConfirmedGenerationRetry(req),
-      messageIpLimiter,
-    ),
+    unless(exemptAgentTriggerFromIpLimiter, messageIpLimiter),
   );
 }
 

--- a/api/server/routes/agents/index.js
+++ b/api/server/routes/agents/index.js
@@ -1135,9 +1135,7 @@ if (useMessageIpLimiter || useMessageUserLimiter) {
 }
 
 if (useMessageIpLimiter) {
-  chatRouter.use(
-    unless(exemptAgentTriggerFromIpLimiter, messageIpLimiter),
-  );
+  chatRouter.use(unless(exemptAgentTriggerFromIpLimiter, messageIpLimiter));
 }
 
 if (useMessageUserLimiter) {


### PR DESCRIPTION
## Summary

I restored the shared message IP limiter for confirmed agent-generation retries, preventing account multiplication from bypassing the configured IP abuse boundary while retaining retry-specific user admission.

- Route confirmed retries through `messageIpLimiter` unless they are trusted agent-trigger deliveries.
- Preserve the bounded confirmed-retry limiter and ordinary user-limiter exemption for retry recovery.
- Cover confirmed retries with a route test that verifies shared IP limiter participation.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `git diff --check`
- `node --check api/server/routes/agents/index.js`
- `cd api && npx jest server/routes/agents/__tests__/idempotencyLimiter.spec.js --runInBand --coverage=false` *(blocked: this fresh worktree has no installed dependencies; Jest cannot resolve `@babel/preset-env`.)*

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works