### PR TITLE
🫀 fix: Expire Aborted Background Tool Leases

### DIFF
--- a/packages/api/src/agents/backgroundCompletion.ts
+++ b/packages/api/src/agents/backgroundCompletion.ts
@@ -1,5 +1,8 @@
 /** Deadline after which an invocation owner requests cancellation. */
 export const BACKGROUND_TASK_TIMEOUT_MS: number = 30 * 60 * 1000;
+/** Gives a cooperative tool a short window to settle after cancellation before
+ * its automatic completion delivery is retired. */
+export const BACKGROUND_TASK_ABORT_GRACE_MS: number = 60 * 1000;
 /** Three missed heartbeats prove the process-local executor has been lost. */
 export const BACKGROUND_TOOL_PRODUCER_LEASE_MS: number = 30_000;
 export const BACKGROUND_TOOL_PRODUCER_HEARTBEAT_MS: number = 10_000;

--- a/packages/api/src/agents/handlers.background.spec.ts
+++ b/packages/api/src/agents/handlers.background.spec.ts
@@ -2,11 +2,8 @@ import { z } from 'zod';
 import { logger } from '@librechat/data-schemas';
 import type { StructuredToolInterface } from '@librechat/agents/langchain/tools';
 import type { FiltersConfig } from 'librechat-data-provider';
+import { BACKGROUND_TASK_ABORT_GRACE_MS, BACKGROUND_TASK_TIMEOUT_MS } from './backgroundCompletion';
 import { backgroundTaskRegistry, CHECK_BACKGROUND_TASK_NAME } from './background';
-import {
-  BACKGROUND_TASK_ABORT_GRACE_MS,
-  BACKGROUND_TASK_TIMEOUT_MS,
-} from './backgroundCompletion';
 import { ContentFilterError } from '../middleware/contentFilter';
 import { createToolExecuteHandler } from './handlers';
 
@@ -592,6 +589,7 @@ describe('createToolExecuteHandler — background tool calls', () => {
       expect(renew).toHaveBeenCalled();
       expect(retire).toHaveBeenCalledWith(
         'background task did not settle after its abort grace period',
+        { onlyIfUnclaimed: true },
       );
 
       const renewalsBefore = renew.mock.calls.length;

--- a/packages/api/src/agents/handlers.background.spec.ts
+++ b/packages/api/src/agents/handlers.background.spec.ts
@@ -3,6 +3,10 @@ import { logger } from '@librechat/data-schemas';
 import type { StructuredToolInterface } from '@librechat/agents/langchain/tools';
 import type { FiltersConfig } from 'librechat-data-provider';
 import { backgroundTaskRegistry, CHECK_BACKGROUND_TASK_NAME } from './background';
+import {
+  BACKGROUND_TASK_ABORT_GRACE_MS,
+  BACKGROUND_TASK_TIMEOUT_MS,
+} from './backgroundCompletion';
 import { ContentFilterError } from '../middleware/contentFilter';
 import { createToolExecuteHandler } from './handlers';
 
@@ -540,7 +544,7 @@ describe('createToolExecuteHandler — background tool calls', () => {
     }
   });
 
-  it('keeps an abort-resistant invocation running without a false timeout receipt', async () => {
+  it('retires the automatic wakeup after an abort-resistant invocation exceeds its grace period', async () => {
     jest.useFakeTimers({ doNotFake: ['setImmediate'] });
     try {
       const tool = {
@@ -550,12 +554,14 @@ describe('createToolExecuteHandler — background tool calls', () => {
         invoke: jest.fn(() => new Promise(() => undefined)),
       } as unknown as StructuredToolInterface;
       const persist = jest.fn(async () => true);
+      const renew = jest.fn(async () => true);
+      const retire = jest.fn(async () => true);
       const handler = createToolExecuteHandler({
         loadTools: async () => ({ loadedTools: [tool] }),
         backgroundToolCompletion: {
           preregister: jest.fn(async () => ({
-            renew: jest.fn(async () => true),
-            retire: jest.fn(async () => true),
+            renew,
+            retire,
           })),
           persist,
           claim: jest.fn(async () => ({ status: 'acquired' as const })),
@@ -576,12 +582,22 @@ describe('createToolExecuteHandler — background tool calls', () => {
         metadata: { thread_id: 'exec_convo', run_id: 'response-timeout-resistant' },
       });
 
-      jest.advanceTimersByTime(31 * 60 * 1000);
+      jest.advanceTimersByTime(BACKGROUND_TASK_TIMEOUT_MS + BACKGROUND_TASK_ABORT_GRACE_MS);
+      await flushMicrotasks();
       await flushMicrotasks();
 
       const taskId = JSON.parse(dispatch.content).background_task_id as string;
       expect(backgroundTaskRegistry.get('exec_user', 'exec_convo', taskId)?.status).toBe('running');
       expect(persist).not.toHaveBeenCalled();
+      expect(renew).toHaveBeenCalled();
+      expect(retire).toHaveBeenCalledWith(
+        'background task did not settle after its abort grace period',
+      );
+
+      const renewalsBefore = renew.mock.calls.length;
+      jest.advanceTimersByTime(3 * 60 * 1000);
+      await flushMicrotasks();
+      expect(renew).toHaveBeenCalledTimes(renewalsBefore);
     } finally {
       jest.useRealTimers();
     }

--- a/packages/api/src/agents/handlers.ts
+++ b/packages/api/src/agents/handlers.ts
@@ -75,7 +75,10 @@ import {
 } from './intent';
 import { getSafeErrorMetadata, logAxiosError, runOutsideTracing, truncateMiddle } from '~/utils';
 import { resolveCallerCapabilityProjectionSnapshot } from './callerCapabilities';
-import { BACKGROUND_TOOL_PRODUCER_HEARTBEAT_MS } from './backgroundCompletion';
+import {
+  BACKGROUND_TASK_ABORT_GRACE_MS,
+  BACKGROUND_TOOL_PRODUCER_HEARTBEAT_MS,
+} from './backgroundCompletion';
 import { buildSkillPrimeMessage, SKILL_FILE_PREFIX } from './skills';
 import { createSkillContentDigest } from './compatibility';
 import { parseFrontmatter } from '../skills/import';
@@ -4918,11 +4921,15 @@ export function createToolExecuteHandler(options: ToolExecuteOptions): EventHand
                   }
                 };
                 let producerHeartbeatInFlight: Promise<void> | undefined;
+                let producerHeartbeatStopped = false;
                 const producerAdmission = completionAdmission;
                 const producerHeartbeat =
                   producerAdmission == null
                     ? undefined
                     : setInterval(() => {
+                        if (producerHeartbeatStopped) {
+                          return;
+                        }
                         if (producerHeartbeatInFlight != null) {
                           return;
                         }
@@ -4946,12 +4953,49 @@ export function createToolExecuteHandler(options: ToolExecuteOptions): EventHand
                           });
                       }, BACKGROUND_TOOL_PRODUCER_HEARTBEAT_MS);
                 (producerHeartbeat as { unref?: () => void } | undefined)?.unref?.();
+                const stopProducerHeartbeat = async (retireReason?: string): Promise<void> => {
+                  if (!producerHeartbeatStopped) {
+                    producerHeartbeatStopped = true;
+                    if (producerHeartbeat != null) {
+                      clearInterval(producerHeartbeat);
+                    }
+                  }
+                  await producerHeartbeatInFlight;
+                  if (retireReason == null || producerAdmission == null) {
+                    return;
+                  }
+                  try {
+                    const retired = await producerAdmission.retire(retireReason);
+                    if (!retired) {
+                      logger.warn(
+                        `[background] Could not retire timed-out completion delivery for task ${task.id}.`,
+                      );
+                    }
+                  } catch (retireError) {
+                    logger.warn(
+                      `[background] Failed to retire timed-out completion delivery for task ${task.id}:`,
+                      retireError,
+                    );
+                  }
+                };
+                let producerRetirementTimeout: ReturnType<typeof setTimeout> | undefined;
+                const requestBackgroundAbort = (): void => {
+                  backgroundAbortController.abort(
+                    new DOMException('Background task timed out', 'AbortError'),
+                  );
+                  producerRetirementTimeout = setTimeout(() => {
+                    producerRetirementTimeout = undefined;
+                    void stopProducerHeartbeat(
+                      'background task did not settle after its abort grace period',
+                    );
+                  }, BACKGROUND_TASK_ABORT_GRACE_MS);
+                  producerRetirementTimeout.unref?.();
+                };
                 void (async () => {
                   try {
-                    const result = await withBackgroundTaskTimeout(invokePromise, () =>
-                      backgroundAbortController.abort(
-                        new DOMException('Background task timed out', 'AbortError'),
-                      ),
+                    const result = await withBackgroundTaskTimeout(
+                      invokePromise,
+                      requestBackgroundAbort,
                     );
                     if (isCodeCall) {
                       markCodeSandboxWarm();
@@ -5093,10 +5137,10 @@ export function createToolExecuteHandler(options: ToolExecuteOptions): EventHand
                     await persistBackgroundResult({ output: deliveredError, status: 'error' });
                     await wakeDetachedActor();
                   } finally {
-                    if (producerHeartbeat != null) {
-                      clearInterval(producerHeartbeat);
+                    if (producerRetirementTimeout != null) {
+                      clearTimeout(producerRetirementTimeout);
                     }
-                    await producerHeartbeatInFlight;
+                    await stopProducerHeartbeat();
                   }
                 })();
                 if (

--- a/packages/api/src/agents/handlers.ts
+++ b/packages/api/src/agents/handlers.ts
@@ -68,6 +68,10 @@ import {
   isContentFilterError,
 } from '~/middleware/contentFilter';
 import {
+  BACKGROUND_TASK_ABORT_GRACE_MS,
+  BACKGROUND_TOOL_PRODUCER_HEARTBEAT_MS,
+} from './backgroundCompletion';
+import {
   hasIntentArg,
   stripIntentArg,
   stripIntentLabelsFromToolDefinitions,
@@ -75,10 +79,6 @@ import {
 } from './intent';
 import { getSafeErrorMetadata, logAxiosError, runOutsideTracing, truncateMiddle } from '~/utils';
 import { resolveCallerCapabilityProjectionSnapshot } from './callerCapabilities';
-import {
-  BACKGROUND_TASK_ABORT_GRACE_MS,
-  BACKGROUND_TOOL_PRODUCER_HEARTBEAT_MS,
-} from './backgroundCompletion';
 import { buildSkillPrimeMessage, SKILL_FILE_PREFIX } from './skills';
 import { createSkillContentDigest } from './compatibility';
 import { parseFrontmatter } from '../skills/import';
@@ -4965,7 +4965,9 @@ export function createToolExecuteHandler(options: ToolExecuteOptions): EventHand
                     return;
                   }
                   try {
-                    const retired = await producerAdmission.retire(retireReason);
+                    const retired = await producerAdmission.retire(retireReason, {
+                      onlyIfUnclaimed: true,
+                    });
                     if (!retired) {
                       logger.warn(
                         `[background] Could not retire timed-out completion delivery for task ${task.id}.`,


### PR DESCRIPTION
## Summary

I bounded producer-lease activity for background tools that ignore cancellation, preventing them from renewing MongoDB-backed completion deliveries indefinitely.

- Add a one-minute post-abort grace period for background tool invocations.
- Stop the producer heartbeat and retire the automatic completion delivery when the invocation remains unsettled beyond that grace period.
- Preserve nonterminal task state so an uncertain external side effect is never presented as a false timeout failure.
- Cover the abort-resistant path, including stopped renewal and delivery retirement.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `NODE_PATH=/Users/danny/Projects/LibreChat/node_modules npx jest --runInBand --coverage=false src/agents/handlers.background.spec.ts src/agents/background.spec.ts`

### **Test Configuration**:

- Node.js v24.16.0

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.