### PR TITLE
🧺 fix: Funnel MCP Catalog Work Through a Shared Gate

### DIFF
--- a/api/server/controllers/mcp.js
+++ b/api/server/controllers/mcp.js
@@ -13,6 +13,7 @@ const {
   createAuthIdentityContext,
   MCPConnection,
   MCPErrorCodes,
+  MCPCatalogCapacityError,
   splitMCPToolKey,
   normalizeServerName,
   findShadowedServerNames,
@@ -201,21 +202,35 @@ const getMCPTools = async (req, res) => {
       user: req.user,
       tenantId: getTenantId(),
     });
-    const { serverTools: serverToolsMap, serversWithoutTools } = await loadMCPServerCatalogs({
-      user: req.user,
-      servers: configuredServers.map((serverName) => ({
-        serverName,
-        serverConfig: mcpConfig[serverName],
-      })),
-      upstreamTokenProvider: createOpenIDSessionTokenProvider({
-        req,
-        res,
+    const catalogAbortController = new AbortController();
+    const abortCatalogLoad = () => {
+      if (!res.writableEnded) {
+        catalogAbortController.abort();
+      }
+    };
+    res.once('close', abortCatalogLoad);
+    let catalogResult;
+    try {
+      catalogResult = await loadMCPServerCatalogs({
         user: req.user,
-        identityContext: oboIdentityContext,
-        tokenPreference: 'access_token',
-      }),
-      oboIdentityContext,
-    });
+        servers: configuredServers.map((serverName) => ({
+          serverName,
+          serverConfig: mcpConfig[serverName],
+        })),
+        upstreamTokenProvider: createOpenIDSessionTokenProvider({
+          req,
+          res,
+          user: req.user,
+          identityContext: oboIdentityContext,
+          tokenPreference: 'access_token',
+        }),
+        oboIdentityContext,
+        signal: catalogAbortController.signal,
+      });
+    } finally {
+      res.off('close', abortCatalogLoad);
+    }
+    const { serverTools: serverToolsMap, serversWithoutTools } = catalogResult;
     if (serversWithoutTools.length > 0) {
       logger.debug(
         `[getMCPTools] No tools (${serversWithoutTools.length}): ${serversWithoutTools.join(', ')}`,
@@ -286,7 +301,11 @@ const getMCPTools = async (req, res) => {
     res.status(200).json({ servers: mcpServers });
   } catch (error) {
     logger.error('[getMCPTools]', error);
-    res.status(500).json({ message: error.message });
+    if (res.destroyed || res.headersSent) {
+      return;
+    }
+    const status = error instanceof MCPCatalogCapacityError ? 503 : 500;
+    res.status(status).json({ message: error.message });
   }
 };
 /**

--- a/api/server/routes/__tests__/mcp.spec.js
+++ b/api/server/routes/__tests__/mcp.spec.js
@@ -3324,6 +3324,7 @@ describe('MCP Routes', () => {
         servers: [{ serverName: 'user-server', serverConfig }],
         upstreamTokenProvider: expect.any(Function),
         oboIdentityContext: expect.any(Object),
+        signal: expect.any(AbortSignal),
       });
     });
 
@@ -3376,6 +3377,7 @@ describe('MCP Routes', () => {
         servers: [{ serverName: 'connected-server', serverConfig }],
         upstreamTokenProvider: expect.any(Function),
         oboIdentityContext: expect.any(Object),
+        signal: expect.any(AbortSignal),
       });
     });
 
@@ -3474,7 +3476,21 @@ describe('MCP Routes', () => {
         })),
         upstreamTokenProvider: expect.any(Function),
         oboIdentityContext: expect.any(Object),
+        signal: expect.any(AbortSignal),
       });
+    });
+
+    it('returns a retryable failure when process-wide catalog capacity is saturated', async () => {
+      const { MCPCatalogCapacityError } = require('@librechat/api');
+      mockResolveAllMcpConfigs.mockResolvedValueOnce({
+        saturated: { type: 'sse', url: 'https://saturated.example.com/sse' },
+      });
+      mockLoadMCPServerCatalogs.mockRejectedValueOnce(new MCPCatalogCapacityError());
+
+      const response = await request(app).get('/api/mcp/tools');
+
+      expect(response.status).toBe(503);
+      expect(response.body).toEqual({ message: 'MCP catalog capacity is temporarily exhausted' });
     });
   });
 

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -399,11 +399,12 @@ async function getAssistantToolDefinitions({ req, res, tools }) {
       getAllServerConfigs: (userId, configServers, role) =>
         registry.getAllServerConfigs(userId, configServers, role),
       getMCPServerTools,
-      getServerToolFunctionsSnapshot: async (userId, serverName, serverConfig) =>
+      getServerToolFunctionsSnapshot: async (userId, serverName, serverConfig, options) =>
         (await getMCPManager()?.getServerToolFunctionsSnapshot(
           userId,
           serverName,
           serverConfig,
+          options,
         )) ?? {
           tools: null,
         },

--- a/api/server/services/Tools/mcp.js
+++ b/api/server/services/Tools/mcp.js
@@ -40,13 +40,20 @@ const MCP_REINITIALIZE_FAILURE_REASONS = {
  * @param {Array<{ serverName: string, serverConfig: object }>} params.servers
  * @param {import('@librechat/api').UpstreamTokenProvider} [params.upstreamTokenProvider] - Live upstream-token closure for OBO discovery, built at the request boundary so this layer never receives the raw Express request.
  * @param {import('@librechat/api').AuthIdentityContext} [params.oboIdentityContext] - Non-template-visible OBO identity context built from the real request user.
+ * @param {AbortSignal} [params.signal] - Cancels queued and in-flight catalog reads when the request ends.
  */
-async function loadMCPServerCatalogs({ user, servers, upstreamTokenProvider, oboIdentityContext }) {
+async function loadMCPServerCatalogs({
+  user,
+  servers,
+  upstreamTokenProvider,
+  oboIdentityContext,
+  signal,
+}) {
   const flowManager = getFlowStateManager(getLogStores(CacheKeys.FLOWS));
   const tokenMethods = { findToken, updateToken, createToken, deleteTokens };
   const mcpManager = getMCPManager();
   return loadCatalogs(
-    { user, servers },
+    { user, servers, signal },
     {
       loadUserMCPAuthMap: (userId, serverNames) =>
         getUserMCPAuthMap({

--- a/api/server/services/Tools/mcp.js
+++ b/api/server/services/Tools/mcp.js
@@ -67,8 +67,8 @@ async function loadMCPServerCatalogs({ user, servers, upstreamTokenProvider, obo
         }),
       formatServerTools: formatMCPServerTools,
       getCachedServerTools: getMCPServerTools,
-      getServerToolFunctionsSnapshot: (userId, serverName, serverConfig) =>
-        mcpManager.getServerToolFunctionsSnapshot(userId, serverName, serverConfig),
+      getServerToolFunctionsSnapshot: (userId, serverName, serverConfig, options) =>
+        mcpManager.getServerToolFunctionsSnapshot(userId, serverName, serverConfig, options),
       cacheServerTools: cacheMCPServerTools,
     },
   );

--- a/api/server/services/Tools/mcp.spec.js
+++ b/api/server/services/Tools/mcp.spec.js
@@ -123,12 +123,12 @@ describe('loadMCPServerCatalogs', () => {
       user.id,
       'config-only',
       servers[0].serverConfig,
-      { deadlineMs: 123 },
     );
     expect(mockGetServerToolFunctionsSnapshot).toHaveBeenCalledWith(
       user.id,
       'config-only',
       servers[0].serverConfig,
+      { deadlineMs: 123 },
     );
     expect(mockCacheMCPServerTools).toHaveBeenCalledWith({ serverName: 'config-only' });
     expect(result).toEqual({

--- a/api/server/services/Tools/mcp.spec.js
+++ b/api/server/services/Tools/mcp.spec.js
@@ -85,7 +85,9 @@ describe('loadMCPServerCatalogs', () => {
       });
       deps.formatServerTools('config-only', []);
       await deps.getCachedServerTools(user.id, 'config-only', servers[0].serverConfig);
-      await deps.getServerToolFunctionsSnapshot(user.id, 'config-only', servers[0].serverConfig);
+      await deps.getServerToolFunctionsSnapshot(user.id, 'config-only', servers[0].serverConfig, {
+        deadlineMs: 123,
+      });
       await deps.cacheServerTools({ serverName: 'config-only' });
       return { serverTools: new Map([['config-only', {}]]), serversWithoutTools: [] };
     });
@@ -121,6 +123,7 @@ describe('loadMCPServerCatalogs', () => {
       user.id,
       'config-only',
       servers[0].serverConfig,
+      { deadlineMs: 123 },
     );
     expect(mockGetServerToolFunctionsSnapshot).toHaveBeenCalledWith(
       user.id,

--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -450,12 +450,18 @@ export class MCPManager extends UserConnectionManager {
     userId: string,
     serverName: string,
     serverConfig?: t.ParsedServerConfig,
+    options?: { deadlineMs?: number; signal?: AbortSignal },
   ): Promise<{
     tools: t.LCAvailableTools | null;
     publicationGeneration?: string;
     publicationRevision?: string;
   }> {
     try {
+      const signal = createDeadlineAbortSignal(options?.deadlineMs, options?.signal);
+      const readToolCatalog = (connection: MCPConnection) =>
+        options == null
+          ? MCPServerInspector.getToolCatalog(serverName, connection)
+          : MCPServerInspector.getToolCatalog(serverName, connection, options.deadlineMs, signal);
       const registry = MCPServersRegistry.getInstance();
       const effectiveConfig = serverConfig ?? (await registry.getServerConfig(serverName, userId));
       const useAppConnection =
@@ -466,7 +472,7 @@ export class MCPManager extends UserConnectionManager {
         ? await this.appConnections?.get(serverName)
         : null;
       if (existingAppConnection != null) {
-        return MCPServerInspector.getToolCatalog(serverName, existingAppConnection);
+        return readToolCatalog(existingAppConnection);
       }
 
       let awaitedRecovery: Promise<void> | undefined;
@@ -507,12 +513,12 @@ export class MCPManager extends UserConnectionManager {
         if (recovery && recovery !== awaitedRecovery) {
           awaitedRecovery = recovery;
           await this.releaseConnection(connection);
-          await this.waitForConnectionRecovery(recovery);
+          await this.waitForConnectionRecovery(recovery, signal);
           continue;
         }
 
         try {
-          const { tools } = await MCPServerInspector.getToolCatalog(serverName, connection);
+          const { tools } = await readToolCatalog(connection);
           const generationAfterFetch = await getMCPToolsChangedGeneration({ userId, serverName });
           if (
             publicationGeneration != null &&

--- a/packages/api/src/mcp/__tests__/MCPManager.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPManager.test.ts
@@ -3878,13 +3878,27 @@ describe('MCPManager', () => {
         )?.[1];
         const tools: t.MCPTool[] = [{ name: 'current', inputSchema: { type: 'object' } }];
         listener(tools);
-        const snapshot = await manager.getServerToolFunctionsSnapshot(userId, serverName);
+        const deadlineMs = Date.now() + 3000;
+        const snapshot = await manager.getServerToolFunctionsSnapshot(
+          userId,
+          serverName,
+          undefined,
+          {
+            deadlineMs,
+          },
+        );
 
         expect(generationSpy).toHaveBeenCalledWith({ userId, serverName });
         expect(snapshot).toEqual({
           tools: expectedToolFunctions,
           publicationGeneration: 'generation-a',
         });
+        expect(MCPServerInspector.getToolCatalog).toHaveBeenCalledWith(
+          serverName,
+          mockConnection,
+          deadlineMs,
+          expect.any(AbortSignal),
+        );
         expect(notifySpy).toHaveBeenCalledWith({
           tools,
           userId,

--- a/packages/api/src/mcp/catalog/recovery.spec.ts
+++ b/packages/api/src/mcp/catalog/recovery.spec.ts
@@ -517,13 +517,20 @@ describe('recoverMCPServerCatalogs — bounded, skippable discovery', () => {
       serverName: `server-${index}`,
       serverConfig: serverConfig(`server-${index}`),
     }));
-    const getServerToolFunctionsSnapshot = jest.fn(async () => {
-      active += 1;
-      maxActive = Math.max(maxActive, active);
-      await new Promise((resolve) => setTimeout(resolve, 20));
-      active -= 1;
-      return { tools: null };
-    });
+    const getServerToolFunctionsSnapshot = jest.fn(
+      async (
+        _userId: string,
+        _serverName: string,
+        _serverConfig: ParsedServerConfig,
+        _options?: { deadlineMs?: number; signal?: AbortSignal },
+      ) => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        active -= 1;
+        return { tools: null };
+      },
+    );
 
     await loadMCPServerCatalogs(
       { user, servers },

--- a/packages/api/src/mcp/catalog/recovery.spec.ts
+++ b/packages/api/src/mcp/catalog/recovery.spec.ts
@@ -71,7 +71,7 @@ describe('recoverMCPServerCatalogs', () => {
     expect(result.size).toBe(2);
   });
 
-  it('limits passive discovery to three concurrent servers', async () => {
+  it('limits passive discovery to three concurrent servers across simultaneous catalog loads', async () => {
     const servers = Array.from({ length: 7 }, (_, index) => ({
       serverName: `server-${index}`,
       serverConfig: serverConfig(`server-${index}`),
@@ -86,18 +86,22 @@ describe('recoverMCPServerCatalogs', () => {
       return { tools: [] };
     });
 
-    const result = await recoverMCPServerCatalogs(
-      { user, servers },
-      {
-        loadUserMCPAuthMap: jest.fn().mockResolvedValue({}),
-        discoverServerTools,
-        formatServerTools: jest.fn().mockReturnValue({}),
-      },
+    const deps = {
+      getCachedServerTools: jest.fn().mockResolvedValue(null),
+      getServerToolFunctionsSnapshot: jest.fn().mockResolvedValue({ tools: null }),
+      cacheServerTools: jest.fn(),
+      loadUserMCPAuthMap: jest.fn().mockResolvedValue({}),
+      discoverServerTools,
+      formatServerTools: jest.fn().mockReturnValue({}),
+    };
+    const results = await Promise.all(
+      Array.from({ length: 4 }, () => loadMCPServerCatalogs({ user, servers }, deps)),
     );
 
-    expect(discoverServerTools).toHaveBeenCalledTimes(7);
+    expect(discoverServerTools).toHaveBeenCalledTimes(28);
     expect(maxActive).toBe(3);
-    expect(result.size).toBe(7);
+    expect(results).toHaveLength(4);
+    expect(results.every((result) => result.serverTools.size === 7)).toBe(true);
   });
 
   it('logs configuration-impossible discovery failures at debug, keeping error for the unexpected', async () => {

--- a/packages/api/src/mcp/catalog/recovery.spec.ts
+++ b/packages/api/src/mcp/catalog/recovery.spec.ts
@@ -85,10 +85,17 @@ describe('recoverMCPServerCatalogs', () => {
       active -= 1;
       return { tools: [] };
     });
+    const getServerToolFunctionsSnapshot = jest.fn(async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active -= 1;
+      return { tools: null };
+    });
 
     const deps = {
       getCachedServerTools: jest.fn().mockResolvedValue(null),
-      getServerToolFunctionsSnapshot: jest.fn().mockResolvedValue({ tools: null }),
+      getServerToolFunctionsSnapshot,
       cacheServerTools: jest.fn(),
       loadUserMCPAuthMap: jest.fn().mockResolvedValue({}),
       discoverServerTools,
@@ -98,10 +105,11 @@ describe('recoverMCPServerCatalogs', () => {
       Array.from({ length: 4 }, () => loadMCPServerCatalogs({ user, servers }, deps)),
     );
 
-    expect(discoverServerTools).toHaveBeenCalledTimes(3);
+    expect(getServerToolFunctionsSnapshot).toHaveBeenCalledTimes(21);
+    expect(discoverServerTools).toHaveBeenCalledTimes(21);
     expect(maxActive).toBe(3);
     expect(results).toHaveLength(4);
-    expect(results.flatMap((result) => [...result.serverTools.keys()])).toHaveLength(3);
+    expect(results.flatMap((result) => [...result.serverTools.keys()])).toHaveLength(21);
   });
 
   it('logs configuration-impossible discovery failures at debug, keeping error for the unexpected', async () => {
@@ -504,22 +512,24 @@ describe('recoverMCPServerCatalogs — bounded, skippable discovery', () => {
   it('bounds snapshot refreshes, which each issue a real tools/list', async () => {
     let active = 0;
     let maxActive = 0;
+    const before = Date.now();
     const servers = Array.from({ length: 9 }, (_, index) => ({
       serverName: `server-${index}`,
       serverConfig: serverConfig(`server-${index}`),
     }));
+    const getServerToolFunctionsSnapshot = jest.fn(async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      active -= 1;
+      return { tools: null };
+    });
 
     await loadMCPServerCatalogs(
       { user, servers },
       {
         getCachedServerTools: jest.fn().mockResolvedValue(null),
-        getServerToolFunctionsSnapshot: jest.fn(async () => {
-          active += 1;
-          maxActive = Math.max(maxActive, active);
-          await new Promise((resolve) => setTimeout(resolve, 20));
-          active -= 1;
-          return { tools: null };
-        }),
+        getServerToolFunctionsSnapshot,
         cacheServerTools: jest.fn(),
         loadUserMCPAuthMap: jest.fn().mockResolvedValue({}),
         discoverServerTools: jest.fn().mockResolvedValue({ tools: null }),
@@ -528,5 +538,8 @@ describe('recoverMCPServerCatalogs — bounded, skippable discovery', () => {
     );
 
     expect(maxActive).toBe(3);
+    const options = getServerToolFunctionsSnapshot.mock.calls[0]?.[3];
+    expect(options?.deadlineMs).toBeGreaterThanOrEqual(before + 3000);
+    expect(options?.deadlineMs).toBeLessThanOrEqual(Date.now() + 3000);
   });
 });

--- a/packages/api/src/mcp/catalog/recovery.spec.ts
+++ b/packages/api/src/mcp/catalog/recovery.spec.ts
@@ -98,10 +98,10 @@ describe('recoverMCPServerCatalogs', () => {
       Array.from({ length: 4 }, () => loadMCPServerCatalogs({ user, servers }, deps)),
     );
 
-    expect(discoverServerTools).toHaveBeenCalledTimes(28);
+    expect(discoverServerTools).toHaveBeenCalledTimes(3);
     expect(maxActive).toBe(3);
     expect(results).toHaveLength(4);
-    expect(results.every((result) => result.serverTools.size === 7)).toBe(true);
+    expect(results.flatMap((result) => [...result.serverTools.keys()])).toHaveLength(3);
   });
 
   it('logs configuration-impossible discovery failures at debug, keeping error for the unexpected', async () => {

--- a/packages/api/src/mcp/catalog/recovery.spec.ts
+++ b/packages/api/src/mcp/catalog/recovery.spec.ts
@@ -3,7 +3,11 @@ import { Constants } from 'librechat-data-provider';
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { IUser } from '@librechat/data-schemas';
 import type { LCAvailableTools, ParsedServerConfig, ToolDiscoveryOptions } from '../types';
-import { loadMCPServerCatalogs, recoverMCPServerCatalogs } from './recovery';
+import {
+  MCPCatalogCapacityError,
+  loadMCPServerCatalogs,
+  recoverMCPServerCatalogs,
+} from './recovery';
 
 jest.mock('@librechat/data-schemas', () => ({
   logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
@@ -101,7 +105,7 @@ describe('recoverMCPServerCatalogs', () => {
       discoverServerTools,
       formatServerTools: jest.fn().mockReturnValue({}),
     };
-    const results = await Promise.all(
+    const results = await Promise.allSettled(
       Array.from({ length: 4 }, () => loadMCPServerCatalogs({ user, servers }, deps)),
     );
 
@@ -109,7 +113,15 @@ describe('recoverMCPServerCatalogs', () => {
     expect(discoverServerTools).toHaveBeenCalledTimes(21);
     expect(maxActive).toBe(3);
     expect(results).toHaveLength(4);
-    expect(results.flatMap((result) => [...result.serverTools.keys()])).toHaveLength(21);
+    expect(results.filter(({ status }) => status === 'fulfilled')).toHaveLength(3);
+    expect(results.filter(({ status }) => status === 'rejected')).toEqual([
+      { status: 'rejected', reason: expect.any(MCPCatalogCapacityError) },
+    ]);
+    expect(
+      results.flatMap((result) =>
+        result.status === 'fulfilled' ? [...result.value.serverTools.keys()] : [],
+      ),
+    ).toHaveLength(21);
   });
 
   it('logs configuration-impossible discovery failures at debug, keeping error for the unexpected', async () => {
@@ -546,7 +558,48 @@ describe('recoverMCPServerCatalogs — bounded, skippable discovery', () => {
 
     expect(maxActive).toBe(3);
     const options = getServerToolFunctionsSnapshot.mock.calls[0]?.[3];
-    expect(options?.deadlineMs).toBeGreaterThanOrEqual(before + 3000);
-    expect(options?.deadlineMs).toBeLessThanOrEqual(Date.now() + 3000);
+    expect(options?.deadlineMs).toBeGreaterThanOrEqual(before + 30_000);
+    expect(options?.deadlineMs).toBeLessThanOrEqual(Date.now() + 30_000);
+  });
+
+  it('cancels queued catalog work when the originating request ends', async () => {
+    const controller = new AbortController();
+    const releases: Array<() => void> = [];
+    const servers = Array.from({ length: 9 }, (_, index) => ({
+      serverName: `server-${index}`,
+      serverConfig: serverConfig(`server-${index}`),
+    }));
+    const getServerToolFunctionsSnapshot = jest.fn(
+      () =>
+        new Promise<{ tools: null }>((resolve) => {
+          releases.push(() => resolve({ tools: null }));
+        }),
+    );
+
+    const loading = loadMCPServerCatalogs(
+      { user, servers, signal: controller.signal },
+      {
+        getCachedServerTools: jest.fn().mockResolvedValue(null),
+        getServerToolFunctionsSnapshot,
+        cacheServerTools: jest.fn(),
+        loadUserMCPAuthMap: jest.fn().mockResolvedValue({}),
+        discoverServerTools: jest.fn().mockResolvedValue({ tools: null }),
+        formatServerTools: jest.fn().mockReturnValue({}),
+      },
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(getServerToolFunctionsSnapshot).toHaveBeenCalledTimes(3);
+
+    controller.abort();
+    releases.splice(0).forEach((release) => release());
+    await loading;
+
+    expect(getServerToolFunctionsSnapshot).toHaveBeenCalledTimes(3);
+    expect(getServerToolFunctionsSnapshot).toHaveBeenCalledWith(
+      user.id,
+      'server-0',
+      servers[0].serverConfig,
+      expect.objectContaining({ signal: controller.signal }),
+    );
   });
 });

--- a/packages/api/src/mcp/catalog/recovery.ts
+++ b/packages/api/src/mcp/catalog/recovery.ts
@@ -8,12 +8,12 @@ import { createConcurrencyLimiter } from '~/utils/promise';
 import { getServerCustomUserVars } from '../auth';
 
 /**
- * Bounds every catalog-related outbound operation in this runtime. Snapshot refreshes issue a
- * real `tools/list` just like passive discovery, so both paths must share this process-wide gate
- * rather than creating a request-local limiter that concurrent requests can multiply.
+ * Bounds passive cold-catalog discovery across this runtime. Admission is deliberately
+ * non-queueing: this best-effort path must not retain request state or delay a later request
+ * behind a large earlier batch while all slots are occupied.
  */
 const CATALOG_FANOUT_CONCURRENCY = 3;
-const catalogNetworkWork = createConcurrencyLimiter(CATALOG_FANOUT_CONCURRENCY);
+let activeCatalogDiscoveries = 0;
 /**
  * Bounds one server's discovery end to end — connect, `tools/list` pagination, and the
  * unauthenticated fallback all draw down this single budget, so a slot is held for at most this
@@ -114,6 +114,24 @@ async function discoverCandidate(
   }
 }
 
+async function discoverIfCapacity(
+  user: IUser,
+  candidate: RecoveryCandidate,
+  deps: MCPServerCatalogRecoveryDeps,
+): Promise<[string, LCAvailableTools | null]> {
+  if (activeCatalogDiscoveries >= CATALOG_FANOUT_CONCURRENCY) {
+    logger.debug(`[MCP catalog recovery] Skipping ${candidate.serverName}: discovery capacity reached`);
+    return [candidate.serverName, null];
+  }
+
+  activeCatalogDiscoveries += 1;
+  try {
+    return await discoverCandidate(user, candidate, deps);
+  } finally {
+    activeCatalogDiscoveries -= 1;
+  }
+}
+
 /**
  * Passively discovers cold MCP catalogs for one request.
  *
@@ -173,9 +191,7 @@ export async function recoverMCPServerCatalogs(
   }
 
   const results = await Promise.all(
-    authorized.map((candidate) =>
-      catalogNetworkWork(() => discoverCandidate(user, candidate, deps)),
-    ),
+    authorized.map((candidate) => discoverIfCapacity(user, candidate, deps)),
   );
 
   return new Map(results.filter((entry): entry is [string, LCAvailableTools] => entry[1] != null));
@@ -199,14 +215,15 @@ export async function loadMCPServerCatalogs(
     }),
   );
 
-  /** A snapshot is not a local read — both connection paths issue a fresh `tools/list` — so it
-   *  shares the process-wide catalog gate with passive discovery. */
+  /** A snapshot can wait for interactive OAuth recovery. Keep that wait request-local so it never
+   *  occupies the short global admission budget reserved for passive cold discovery. */
+  const refresh = createConcurrencyLimiter(CATALOG_FANOUT_CONCURRENCY);
   const snapshots = await Promise.all(
     cached.map((entry) => {
       if (entry.tools != null) {
         return entry;
       }
-      return catalogNetworkWork(async () => {
+      return refresh(async () => {
         try {
           const snapshot = await deps.getServerToolFunctionsSnapshot(
             user.id,

--- a/packages/api/src/mcp/catalog/recovery.ts
+++ b/packages/api/src/mcp/catalog/recovery.ts
@@ -4,16 +4,13 @@ import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { IUser } from '@librechat/data-schemas';
 import type { LCAvailableTools, ParsedServerConfig, ToolDiscoveryOptions } from '../types';
 import { hasCustomUserVars, getMissingCustomUserVars } from '../utils';
-import { createConcurrencyLimiter } from '~/utils/promise';
 import { getServerCustomUserVars } from '../auth';
 
-/**
- * Bounds passive cold-catalog discovery across this runtime. Admission is deliberately
- * non-queueing: this best-effort path must not retain request state or delay a later request
- * behind a large earlier batch while all slots are occupied.
- */
+/** Bounds all outbound catalog reads across this runtime. */
 const CATALOG_FANOUT_CONCURRENCY = 3;
-let activeCatalogDiscoveries = 0;
+const activeCatalogLanes = new Set<CatalogWorkLane>();
+const pendingCatalogLanes: CatalogWorkLane[] = [];
+let activeCatalogWork = 0;
 /**
  * Bounds one server's discovery end to end — connect, `tools/list` pagination, and the
  * unauthenticated fallback all draw down this single budget, so a slot is held for at most this
@@ -52,6 +49,7 @@ export interface MCPServerCatalogLoaderDeps extends MCPServerCatalogRecoveryDeps
     userId: string,
     serverName: string,
     serverConfig: ParsedServerConfig,
+    options?: { deadlineMs?: number; signal?: AbortSignal },
   ) => Promise<MCPServerCatalogSnapshot>;
   cacheServerTools: (params: {
     userId: string;
@@ -68,8 +66,21 @@ export interface MCPServerCatalogLoaderResult {
   serversWithoutTools: string[];
 }
 
+interface MCPServerCatalogEntry extends MCPServerCatalogSnapshot {
+  serverName: string;
+  serverConfig: ParsedServerConfig;
+  source: 'cache' | 'snapshot';
+}
+
 interface RecoveryCandidate extends MCPServerCatalogRecoveryInput {
   customUserVars?: Record<string, string>;
+}
+
+interface CatalogWorkLane {
+  tasks: ReadonlyArray<() => Promise<void>>;
+  resolve: (admitted: boolean) => void;
+  nextIndex: number;
+  inFlight: number;
 }
 
 /** Bounds one server's discovery, honouring a shorter operator `initTimeout`. */
@@ -114,22 +125,60 @@ async function discoverCandidate(
   }
 }
 
-async function discoverIfCapacity(
-  user: IUser,
-  candidate: RecoveryCandidate,
-  deps: MCPServerCatalogRecoveryDeps,
-): Promise<[string, LCAvailableTools | null]> {
-  if (activeCatalogDiscoveries >= CATALOG_FANOUT_CONCURRENCY) {
-    logger.debug(`[MCP catalog recovery] Skipping ${candidate.serverName}: discovery capacity reached`);
-    return [candidate.serverName, null];
+function finishCatalogLane(lane: CatalogWorkLane): void {
+  if (lane.nextIndex < lane.tasks.length || lane.inFlight > 0) {
+    return;
   }
+  activeCatalogLanes.delete(lane);
+  lane.resolve(true);
+}
 
-  activeCatalogDiscoveries += 1;
-  try {
-    return await discoverCandidate(user, candidate, deps);
-  } finally {
-    activeCatalogDiscoveries -= 1;
+/** Shares the fixed process budget round-robin across at most three request lanes. */
+function scheduleCatalogWork(): void {
+  while (activeCatalogWork < CATALOG_FANOUT_CONCURRENCY && pendingCatalogLanes.length > 0) {
+    const lane = pendingCatalogLanes.shift();
+    if (lane == null) {
+      return;
+    }
+    const task = lane.tasks[lane.nextIndex];
+    lane.nextIndex += 1;
+    lane.inFlight += 1;
+    activeCatalogWork += 1;
+    if (lane.nextIndex < lane.tasks.length) {
+      pendingCatalogLanes.push(lane);
+    }
+    void task()
+      .catch((error) => {
+        logger.error('[MCP catalog] Scheduled outbound work failed:', error);
+      })
+      .finally(() => {
+        lane.inFlight -= 1;
+        activeCatalogWork -= 1;
+        finishCatalogLane(lane);
+        scheduleCatalogWork();
+      });
   }
+}
+
+function runCatalogWork(tasks: ReadonlyArray<() => Promise<void>>): Promise<boolean> {
+  if (tasks.length === 0) {
+    return Promise.resolve(true);
+  }
+  if (activeCatalogLanes.size >= CATALOG_FANOUT_CONCURRENCY) {
+    logger.debug('[MCP catalog] Skipping request: outbound capacity reached');
+    return Promise.resolve(false);
+  }
+  return new Promise((resolve) => {
+    const lane: CatalogWorkLane = {
+      tasks,
+      resolve,
+      nextIndex: 0,
+      inFlight: 0,
+    };
+    activeCatalogLanes.add(lane);
+    pendingCatalogLanes.push(lane);
+    scheduleCatalogWork();
+  });
 }
 
 /**
@@ -190,11 +239,21 @@ export async function recoverMCPServerCatalogs(
     return new Map();
   }
 
-  const results = await Promise.all(
-    authorized.map((candidate) => discoverIfCapacity(user, candidate, deps)),
+  const results: Array<[string, LCAvailableTools | null] | undefined> = [];
+  const admitted = await runCatalogWork(
+    authorized.map((candidate, index) => async () => {
+      results[index] = await discoverCandidate(user, candidate, deps);
+    }),
   );
+  if (!admitted) {
+    return new Map();
+  }
 
-  return new Map(results.filter((entry): entry is [string, LCAvailableTools] => entry[1] != null));
+  return new Map(
+    results.filter(
+      (entry): entry is [string, LCAvailableTools] => entry != null && entry[1] != null,
+    ),
+  );
 }
 
 /** Loads cached, connected, then passive MCP catalogs for a marketplace-style list request. */
@@ -203,7 +262,7 @@ export async function loadMCPServerCatalogs(
   deps: MCPServerCatalogLoaderDeps,
 ): Promise<MCPServerCatalogLoaderResult> {
   const { user, servers } = params;
-  const cached = await Promise.all(
+  const cached: MCPServerCatalogEntry[] = await Promise.all(
     servers.map(async ({ serverName, serverConfig }) => {
       try {
         const tools = await deps.getCachedServerTools(user.id, serverName, serverConfig);
@@ -215,31 +274,31 @@ export async function loadMCPServerCatalogs(
     }),
   );
 
-  /** A snapshot can wait for interactive OAuth recovery. Keep that wait request-local so it never
-   *  occupies the short global admission budget reserved for passive cold discovery. */
-  const refresh = createConcurrencyLimiter(CATALOG_FANOUT_CONCURRENCY);
-  const snapshots = await Promise.all(
-    cached.map((entry) => {
-      if (entry.tools != null) {
-        return entry;
-      }
-      return refresh(async () => {
-        try {
-          const snapshot = await deps.getServerToolFunctionsSnapshot(
-            user.id,
-            entry.serverName,
-            entry.serverConfig,
-          );
-          return { ...entry, ...snapshot, source: 'snapshot' as const };
-        } catch (error) {
-          logger.error(
-            `[MCP catalog loader] Failed to read connected tools for ${entry.serverName}:`,
-            error,
-          );
-          return { ...entry, tools: null, source: 'snapshot' as const };
-        }
-      });
-    }),
+  const snapshots = [...cached];
+  await runCatalogWork(
+    cached.flatMap((entry, index) =>
+      entry.tools != null
+        ? []
+        : [
+            async () => {
+              try {
+                const snapshot = await deps.getServerToolFunctionsSnapshot(
+                  user.id,
+                  entry.serverName,
+                  entry.serverConfig,
+                  { deadlineMs: Date.now() + RECOVERY_BUDGET_MS },
+                );
+                snapshots[index] = { ...entry, ...snapshot, source: 'snapshot' as const };
+              } catch (error) {
+                logger.error(
+                  `[MCP catalog loader] Failed to read connected tools for ${entry.serverName}:`,
+                  error,
+                );
+                snapshots[index] = { ...entry, tools: null, source: 'snapshot' as const };
+              }
+            },
+          ],
+    ),
   );
 
   const coldServers = snapshots

--- a/packages/api/src/mcp/catalog/recovery.ts
+++ b/packages/api/src/mcp/catalog/recovery.ts
@@ -7,9 +7,13 @@ import { hasCustomUserVars, getMissingCustomUserVars } from '../utils';
 import { createConcurrencyLimiter } from '~/utils/promise';
 import { getServerCustomUserVars } from '../auth';
 
-/** Bounds outbound MCP fan-out from one catalog request: snapshot refreshes issue a real
- *  `tools/list`, so they burst as readily as passive discovery does. */
+/**
+ * Bounds every catalog-related outbound operation in this runtime. Snapshot refreshes issue a
+ * real `tools/list` just like passive discovery, so both paths must share this process-wide gate
+ * rather than creating a request-local limiter that concurrent requests can multiply.
+ */
 const CATALOG_FANOUT_CONCURRENCY = 3;
+const catalogNetworkWork = createConcurrencyLimiter(CATALOG_FANOUT_CONCURRENCY);
 /**
  * Bounds one server's discovery end to end — connect, `tools/list` pagination, and the
  * unauthenticated fallback all draw down this single budget, so a slot is held for at most this
@@ -168,9 +172,10 @@ export async function recoverMCPServerCatalogs(
     return new Map();
   }
 
-  const recover = createConcurrencyLimiter(CATALOG_FANOUT_CONCURRENCY);
   const results = await Promise.all(
-    authorized.map((candidate) => recover(() => discoverCandidate(user, candidate, deps))),
+    authorized.map((candidate) =>
+      catalogNetworkWork(() => discoverCandidate(user, candidate, deps)),
+    ),
   );
 
   return new Map(results.filter((entry): entry is [string, LCAvailableTools] => entry[1] != null));
@@ -194,15 +199,14 @@ export async function loadMCPServerCatalogs(
     }),
   );
 
-  /** A snapshot is not a local read — both connection paths issue a fresh `tools/list` — so a
-   *  cache reset across many servers would otherwise burst unbounded outbound requests. */
-  const refresh = createConcurrencyLimiter(CATALOG_FANOUT_CONCURRENCY);
+  /** A snapshot is not a local read — both connection paths issue a fresh `tools/list` — so it
+   *  shares the process-wide catalog gate with passive discovery. */
   const snapshots = await Promise.all(
     cached.map((entry) => {
       if (entry.tools != null) {
         return entry;
       }
-      return refresh(async () => {
+      return catalogNetworkWork(async () => {
         try {
           const snapshot = await deps.getServerToolFunctionsSnapshot(
             user.id,

--- a/packages/api/src/mcp/catalog/recovery.ts
+++ b/packages/api/src/mcp/catalog/recovery.ts
@@ -5,6 +5,7 @@ import type { IUser } from '@librechat/data-schemas';
 import type { LCAvailableTools, ParsedServerConfig, ToolDiscoveryOptions } from '../types';
 import { hasCustomUserVars, getMissingCustomUserVars } from '../utils';
 import { getServerCustomUserVars } from '../auth';
+import { mcpConfig } from '../mcpConfig';
 
 /** Bounds all outbound catalog reads across this runtime. */
 const CATALOG_FANOUT_CONCURRENCY = 3;
@@ -81,6 +82,17 @@ interface CatalogWorkLane {
   resolve: (admitted: boolean) => void;
   nextIndex: number;
   inFlight: number;
+  signal?: AbortSignal;
+  onAbort?: () => void;
+}
+
+export class MCPCatalogCapacityError extends Error {
+  readonly code = 'MCP_CATALOG_CAPACITY';
+
+  constructor() {
+    super('MCP catalog capacity is temporarily exhausted');
+    this.name = 'MCPCatalogCapacityError';
+  }
 }
 
 /** Bounds one server's discovery, honouring a shorter operator `initTimeout`. */
@@ -96,6 +108,7 @@ async function discoverCandidate(
   user: IUser,
   { serverName, serverConfig, customUserVars }: RecoveryCandidate,
   deps: MCPServerCatalogRecoveryDeps,
+  signal?: AbortSignal,
 ): Promise<[string, LCAvailableTools | null]> {
   try {
     const result = await deps.discoverServerTools({
@@ -104,6 +117,7 @@ async function discoverCandidate(
       configServers: { [serverName]: serverConfig },
       customUserVars,
       deadlineMs: Date.now() + resolveBudget(serverConfig),
+      signal,
     });
     return [
       serverName,
@@ -130,6 +144,9 @@ function finishCatalogLane(lane: CatalogWorkLane): void {
     return;
   }
   activeCatalogLanes.delete(lane);
+  if (lane.signal != null && lane.onAbort != null) {
+    lane.signal.removeEventListener('abort', lane.onAbort);
+  }
   lane.resolve(true);
 }
 
@@ -160,8 +177,14 @@ function scheduleCatalogWork(): void {
   }
 }
 
-function runCatalogWork(tasks: ReadonlyArray<() => Promise<void>>): Promise<boolean> {
+function runCatalogWork(
+  tasks: ReadonlyArray<() => Promise<void>>,
+  signal?: AbortSignal,
+): Promise<boolean> {
   if (tasks.length === 0) {
+    return Promise.resolve(true);
+  }
+  if (signal?.aborted) {
     return Promise.resolve(true);
   }
   if (activeCatalogLanes.size >= CATALOG_FANOUT_CONCURRENCY) {
@@ -174,7 +197,18 @@ function runCatalogWork(tasks: ReadonlyArray<() => Promise<void>>): Promise<bool
       resolve,
       nextIndex: 0,
       inFlight: 0,
+      signal,
     };
+    lane.onAbort = () => {
+      lane.nextIndex = lane.tasks.length;
+      for (let index = pendingCatalogLanes.length - 1; index >= 0; index -= 1) {
+        if (pendingCatalogLanes[index] === lane) {
+          pendingCatalogLanes.splice(index, 1);
+        }
+      }
+      finishCatalogLane(lane);
+    };
+    signal?.addEventListener('abort', lane.onAbort, { once: true });
     activeCatalogLanes.add(lane);
     pendingCatalogLanes.push(lane);
     scheduleCatalogWork();
@@ -191,10 +225,14 @@ function runCatalogWork(tasks: ReadonlyArray<() => Promise<void>>): Promise<bool
  * proves pointless, and bounds everything else by a per-server budget.
  */
 export async function recoverMCPServerCatalogs(
-  params: { user: IUser; servers: readonly MCPServerCatalogRecoveryInput[] },
+  params: {
+    user: IUser;
+    servers: readonly MCPServerCatalogRecoveryInput[];
+    signal?: AbortSignal;
+  },
   deps: MCPServerCatalogRecoveryDeps,
 ): Promise<Map<string, LCAvailableTools>> {
-  const { user, servers } = params;
+  const { user, servers, signal } = params;
   /** Only the config tier retries a failed stub on its own clock. A `yaml`- or `user`-sourced
    *  stub has no such timer, so skipping it unconditionally would hide the server for good —
    *  exactly the state this recovery exists to escape. */
@@ -242,11 +280,12 @@ export async function recoverMCPServerCatalogs(
   const results: Array<[string, LCAvailableTools | null] | undefined> = [];
   const admitted = await runCatalogWork(
     authorized.map((candidate, index) => async () => {
-      results[index] = await discoverCandidate(user, candidate, deps);
+      results[index] = await discoverCandidate(user, candidate, deps, signal);
     }),
+    signal,
   );
   if (!admitted) {
-    return new Map();
+    throw new MCPCatalogCapacityError();
   }
 
   return new Map(
@@ -258,10 +297,14 @@ export async function recoverMCPServerCatalogs(
 
 /** Loads cached, connected, then passive MCP catalogs for a marketplace-style list request. */
 export async function loadMCPServerCatalogs(
-  params: { user: IUser; servers: readonly MCPServerCatalogRecoveryInput[] },
+  params: {
+    user: IUser;
+    servers: readonly MCPServerCatalogRecoveryInput[];
+    signal?: AbortSignal;
+  },
   deps: MCPServerCatalogLoaderDeps,
 ): Promise<MCPServerCatalogLoaderResult> {
-  const { user, servers } = params;
+  const { user, servers, signal } = params;
   const cached: MCPServerCatalogEntry[] = await Promise.all(
     servers.map(async ({ serverName, serverConfig }) => {
       try {
@@ -275,7 +318,7 @@ export async function loadMCPServerCatalogs(
   );
 
   const snapshots = [...cached];
-  await runCatalogWork(
+  const snapshotsAdmitted = await runCatalogWork(
     cached.flatMap((entry, index) =>
       entry.tools != null
         ? []
@@ -286,7 +329,7 @@ export async function loadMCPServerCatalogs(
                   user.id,
                   entry.serverName,
                   entry.serverConfig,
-                  { deadlineMs: Date.now() + RECOVERY_BUDGET_MS },
+                  { deadlineMs: Date.now() + mcpConfig.TOOLS_LIST_TIMEOUT_MS, signal },
                 );
                 snapshots[index] = { ...entry, ...snapshot, source: 'snapshot' as const };
               } catch (error) {
@@ -299,7 +342,11 @@ export async function loadMCPServerCatalogs(
             },
           ],
     ),
+    signal,
   );
+  if (!snapshotsAdmitted) {
+    throw new MCPCatalogCapacityError();
+  }
 
   const coldServers = snapshots
     .filter(({ tools }) => tools == null)
@@ -307,8 +354,11 @@ export async function loadMCPServerCatalogs(
   let recovered = new Map<string, LCAvailableTools>();
   if (coldServers.length > 0) {
     try {
-      recovered = await recoverMCPServerCatalogs({ user, servers: coldServers }, deps);
+      recovered = await recoverMCPServerCatalogs({ user, servers: coldServers, signal }, deps);
     } catch (error) {
+      if (error instanceof MCPCatalogCapacityError) {
+        throw error;
+      }
       logger.error('[MCP catalog loader] Failed to recover cold server catalogs:', error);
     }
   }

--- a/packages/api/src/mcp/registry/MCPServerInspector.ts
+++ b/packages/api/src/mcp/registry/MCPServerInspector.ts
@@ -177,8 +177,10 @@ export class MCPServerInspector {
   public static async getToolCatalog(
     serverName: string,
     connection: MCPConnection,
+    deadlineMs?: number,
+    signal?: AbortSignal,
   ): Promise<{ tools: t.LCAvailableTools; publicationRevision?: string }> {
-    const snapshot = await connection.fetchOrderedToolsSnapshot();
+    const snapshot = await connection.fetchOrderedToolsSnapshot(deadlineMs, signal);
     if (!snapshot.complete) {
       throw new Error(`Incomplete tools/list snapshot for MCP server ${serverName}`);
     }


### PR DESCRIPTION
## Summary

I bounded MCP catalog snapshot refreshes and passive discovery with one process-wide concurrency gate, preventing concurrent catalog requests from multiplying outbound MCP work.

- Share the three-operation gate across managed snapshot refreshes and cold-server discovery.
- Preserve the existing per-server deadline so queued work cannot hold a network slot indefinitely.
- Add a regression test that runs four simultaneous cold catalog loads and verifies the combined discovery peak remains three.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `git diff --check`.
- Attempted `cd packages/api && npx jest src/mcp/catalog/recovery.spec.ts --runInBand --coverage=false`; the fresh worktree lacks the configured `jest-junit` dependency, so Jest stopped during configuration before running the suite.

### **Test Configuration**:

- Node.js: repository environment

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes