### PR TITLE
🎯 fix: Keep the Thinking Label on the Lightbulb's Axis While Shimmering

### DIFF
--- a/client/src/components/Chat/Messages/Content/Parts/Thinking.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Thinking.tsx
@@ -98,12 +98,19 @@ export const ThinkingButton = memo(
               aria-hidden="true"
             />
           </span>
-          {/* The entrance and the shimmer both drive `animation-name`, so they
-              cannot share an element — and the nesting order is not a free
-              choice either. The clipped element paints the glyphs itself, so a
-              descendant's opacity cannot fade them: entrance outside and
-              shimmer inside fades correctly, while the reverse leaves the label
-              fully lit right through its own fade.
+          {/* The sweep rides the label row itself. That row is a flex item, so
+              `.shimmer`'s `inline-block` is blockified away and the text sits
+              exactly where the un-shimmered label sits — which matters, because
+              an `inline-block` carrying `truncate` takes its baseline from its
+              bottom margin edge, growing the line box and lifting the label off
+              the icon's axis.
+
+              Only the generated-label entrance forces a nested span: it and the
+              sweep both drive `animation-name`, so they cannot share an element.
+              There the entrance must stay outside — the clipped element paints
+              the glyphs itself, so a descendant's opacity cannot fade them — and
+              the inner span takes `align-top` to keep the baseline rule above
+              from reopening the same gap.
 
               `key` remounts the row so the entrance replays, and that restarts
               the sweep with it. Reasoning labels revise on a 3s default against
@@ -114,11 +121,16 @@ export const ThinkingButton = memo(
             key={animateLabel ? label : undefined}
             className={cn(
               'min-w-0 truncate text-left',
+              shimmerLabel && !animateLabel && 'shimmer',
               animateLabel &&
                 'duration-300 ease-out animate-in fade-in-0 slide-in-from-bottom-1 motion-reduce:animate-none',
             )}
           >
-            {shimmerLabel ? <span className="shimmer max-w-full truncate">{label}</span> : label}
+            {shimmerLabel && animateLabel ? (
+              <span className="shimmer max-w-full truncate align-top">{label}</span>
+            ) : (
+              label
+            )}
           </span>
         </button>
         {content && showCopyButton && (

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/Reasoning.spec.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/Reasoning.spec.tsx
@@ -27,6 +27,19 @@ describe('Reasoning label shimmer', () => {
     expect(screen.getByText('Thinking...')).toHaveClass('shimmer');
   });
 
+  /** The sweep has to ride the label row itself rather than a span nested inside
+   *  it. That row is a flex item, so `.shimmer`'s `inline-block` is blockified
+   *  away; nested, it is an inline-block whose `truncate` moves its baseline to
+   *  its bottom margin edge, which grew the line box 18px -> 23px and lifted the
+   *  label 2px off the lightbulb's axis for the whole of a generation. */
+  it('keeps the sweep on the label row instead of a nested span', () => {
+    renderReasoning();
+    const label = screen.getByText('Thinking...');
+
+    expect(label).toHaveClass('truncate');
+    expect(label.querySelector('.shimmer')).toBeNull();
+  });
+
   it('leaves settled thoughts unanimated', () => {
     renderReasoning({ isSubmitting: false });
     expect(screen.getByText('Thoughts')).not.toHaveClass('shimmer');


### PR DESCRIPTION
## The regression

#15431 nested the reasoning label inside a span carrying `.shimmer` together with `truncate`. `.shimmer` is `display: inline-block`, and **an inline-block whose `overflow` is not `visible` takes its baseline from its bottom margin edge instead of its last line box.** So the label row's line box grew and the text lifted, while the lightbulb — pinned to the row's 30px centre by the copy button — stayed where it was.

Every streaming reasoning header sat off its own icon's axis for the whole of a generation, snapping back only once the label settled to "Thoughts".

Measured against the real component:

| state | label box | text centre |
|---|---|---|
| shipped, streaming | **23px** | **12.5** |
| shipped, completed | 18px | 14.5 |
| this PR, streaming | **18px** | **14.5** |
| this PR, completed | 18px | 14.5 |

Same label text in both rows, so the numbers compare glyph boxes rather than different ascenders.

## The fix

The sweep rides the label row itself. That row is a flex item, so `.shimmer`'s `inline-block` is blockified away and the text lands exactly where the un-shimmered label lands — the baseline rule never comes into play.

The nested span survives only for the generated-label entrance, which cannot share an element with the sweep because both drive `animation-name`. There the entrance stays on the outer element (the clipped element paints the glyphs itself, so a descendant's opacity cannot fade them — established in #15431) and the inner span takes `align-top` so the baseline rule cannot reopen the gap.

## How it was found, and why it shipped

Rendering the real component in a browser. This is worth recording because two cheaper methods both said the code was fine:

- **The DOM assertions passed.** They check which element carries `shimmer`, not where the glyphs land.
- **A hand-built reproduction of the same class strings showed no shift**, across all five font-size settings. Only the real component — real fonts, real `@librechat/client` copy button, real style.css — reproduced it.

A regression test now asserts the sweep is on the label row rather than a span nested inside it, which is the structural property that actually matters.

## Testing

- `client` → `src/components/Chat/Messages`: **72 suites / 1018 tests pass**.
- ESLint, Prettier, and `tsc --noEmit` clean on the touched files.