### PR TITLE
🐆 perf: Build Dev Branch Images on Native ARM and Cheapen Asset Brotli

### DIFF
--- a/.github/workflows/dev-branch-images.yml
+++ b/.github/workflows/dev-branch-images.yml
@@ -33,29 +33,51 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Each platform builds on a runner of its own architecture and pushes an
+  # untagged, digest-addressed manifest. Building linux/arm64 on an amd64 runner
+  # needs QEMU, which measured 5-6x slower than native on this image
+  # (npm ci 52.6s -> 333.2s, npm run frontend 90.4s -> 442.8s) and made the
+  # emulated leg ~84% of the build. The `merge` job below stitches the digests
+  # into the multi-platform manifest lists that consumers actually pull.
   build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 130
+    name: Build ${{ matrix.image_name }} (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: api-build
             file: Dockerfile.multi
             image_name: lc-dev-api
+            platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - target: api-build
+            file: Dockerfile.multi
+            image_name: lc-dev-api
+            platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
           - target: node
             file: Dockerfile
             image_name: lc-dev
+            platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - target: node
+            file: Dockerfile
+            image_name: lc-dev
+            platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
 
     steps:
       # Check out the repository
       - name: Checkout
         uses: actions/checkout@v5
 
-      # Set up QEMU
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
-      # Set up Docker Buildx
+      # Set up Docker Buildx (no QEMU: the runner is already the target arch)
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -85,21 +107,100 @@ jobs:
           echo "BUILD_BRANCH=${{ github.ref_name }}" >> $GITHUB_ENV
           echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
 
-      # Build and push Docker images for each target
-      - name: Build and push Docker images
+      # Build and push a digest-only image for this one platform. The layer cache
+      # lives in GHCR beside the image (no 10GB Actions-cache cap, and readable
+      # from every branch and workflow, unlike type=gha which is branch-scoped).
+      # The cache ref is per-architecture so the two platform jobs cannot clobber
+      # each other's manifest.
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ matrix.file }}
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}:${{ github.sha }}
-            ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image_name }}:${{ github.sha }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image_name }}:latest
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           target: ${{ matrix.target }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}:buildcache-${{ matrix.arch }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}:buildcache-${{ matrix.arch }},mode=max
+          outputs: type=image,"name=ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }},docker.io/${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image_name }}",push-by-digest=true,name-canonical=true,push=true
           build-args: |
             BUILD_COMMIT=${{ env.BUILD_COMMIT }}
             BUILD_BRANCH=${{ env.BUILD_BRANCH }}
             BUILD_DATE=${{ env.BUILD_DATE }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.image_name }}-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Combine the per-architecture digests into one multi-platform manifest list
+  # per registry, and apply the tags consumers pull.
+  merge:
+    name: Merge manifests (${{ matrix.image_name }})
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        image_name: [lc-dev-api, lc-dev]
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v7
+        with:
+          pattern: digests-${{ matrix.image_name }}-*
+          merge-multiple: true
+          path: /tmp/digests
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # The digests are identical across registries (the manifest is
+      # content-addressed), so the same set sources both manifest lists.
+      - name: Create manifest lists and push
+        working-directory: /tmp/digests
+        env:
+          GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}
+          DOCKERHUB_IMAGE: docker.io/${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image_name }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          digests=(*)
+          if [ "${#digests[@]}" -eq 0 ]; then
+            echo "No digests downloaded; refusing to publish an empty manifest." >&2
+            exit 1
+          fi
+          echo "Merging ${#digests[@]} platform digests: ${digests[*]}"
+          for image in "$GHCR_IMAGE" "$DOCKERHUB_IMAGE"; do
+            docker buildx imagetools create \
+              -t "${image}:${{ github.sha }}" \
+              -t "${image}:latest" \
+              "${digests[@]/#/${image}@sha256:}"
+          done
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}:${{ github.sha }}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,11 +1,12 @@
 import react from '@vitejs/plugin-react';
 import fs from 'fs';
 import path from 'path';
+import { constants } from 'zlib';
 import { defineConfig } from 'vite';
 import { createRequire } from 'module';
 import { VitePWA } from 'vite-plugin-pwa';
-import { compression } from 'vite-plugin-compression2';
 import { nodePolyfills } from 'vite-plugin-node-polyfills';
+import { compression, defineAlgorithm } from 'vite-plugin-compression2';
 import type { Plugin } from 'vite';
 
 const require = createRequire(import.meta.url);
@@ -178,6 +179,20 @@ export default defineConfig(({ command }) => ({
     ...(buildSourceMap ? [sourcemapExclude({ excludeNodeModules: true })] : []),
     compression({
       threshold: 10240,
+      /**
+       * Brotli's default quality of 11 costs ~13s of single-threaded CPU on this bundle
+       * against ~0.5s for gzip, and the plugin's scheduler serializes quality >= 10 as a
+       * high-memory operation. Quality 5 compresses in ~0.2s, still lands under gzip
+       * (4.3MB vs 5.0MB), and parallelizes. `.br` is only served when
+       * ENABLE_STATIC_ASSET_BROTLI is set, so the extra 0.5MB buys far less than it costs
+       * on every build of every platform.
+       */
+      algorithms: [
+        defineAlgorithm('gzip', { level: 9 }),
+        defineAlgorithm('brotliCompress', {
+          params: { [constants.BROTLI_PARAM_QUALITY]: 5 },
+        }),
+      ],
     }),
   ],
   optimizeDeps: {


### PR DESCRIPTION
## Summary

The dev-branch image build takes 20–40 minutes and has hit its 130-minute timeout. Neither cause was in the bundler.

This is a **pilot on `dev-branch-images.yml` only**. If it proves out, the same treatment applies to `dev-images`, `dev-staging-images`, `main-image-workflow` and `tag-images`, which still use QEMU and still have no layer cache.

## Why: QEMU is ~84% of the build

Per-step timings from [run 33424998112](https://github.com/danny-avila/LibreChat/actions/runs/33424998112):

| step | platform | work | time |
|---|---|---|---|
| #30 | amd64 | `npm ci` | 52.6s |
| #41 | **arm64 (QEMU)** | `npm ci` | **333.2s** — 6.3× |
| #43 | amd64 | `npm run frontend` | 90.4s |
| #45 | **arm64 (QEMU)** | `npm run frontend` | **442.8s** — 4.9× |

Every image workflow builds `linux/amd64,linux/arm64` through `setup-qemu-action`, so the arm64 half runs the whole Node/rolldown toolchain under emulation.

## Change 1 — native ARM runners

`build` fans out to 4 jobs (2 images × 2 platforms) on `ubuntu-latest` / `ubuntu-24.04-arm`, each pushing an untagged digest-addressed manifest. A `merge` job then runs `docker buildx imagetools create` to stitch the digests into the multi-platform manifest lists. **The tags consumers pull are unchanged** — same `:${{ github.sha }}` and `:latest` on both GHCR and Docker Hub. Digests are identical across registries (manifests are content-addressed), so one digest set sources both lists.

Layer caching goes to GHCR beside the image rather than `type=gha`:

- the Actions cache is capped at 10GB repo-wide and is **branch-scoped**, so `dev` and `main` runs wouldn't share it
- a registry cache has no cap and is reusable by the other four workflows when this is rolled out

The cache ref is per-architecture (`:buildcache-amd64` / `:buildcache-arm64`) so the two platform jobs can't clobber each other. This does add those two tags per image to the GHCR namespace.

## Change 2 — brotli quality

`vite-plugin-compression2` defaults to `['gzip', 'brotliCompress']` with brotli at quality 11. Measured on the real 18.4MB bundle:

```
gzip level 9 (default)      0.47s   out=5.03MB
brotli q11 (default)       13.03s   out=3.84MB
brotli q5                   0.18s   out=4.32MB
```

Quality ≥ 10 is also classified "high memory" by the plugin's scheduler and serialized, so it can't use the runner's cores. `.br` is only served when `ENABLE_STATIC_ASSET_BROTLI` is set (`api/server/utils/staticCache.js`), which is **off by default** — so the 0.5MB the top quality buys is paid for on every build of every platform and rarely collected.

At quality 5 the client build goes **~11s → ~4s**, still producing 74 `.gz` + 74 `.br`, with gzip output byte-identical and brotli still under gzip. Anyone who enables brotli serving keeps working, just at 4.3MB instead of 3.84MB.

## Not the cause

Worth recording, since the CI log points at it: rolldown's `[PLUGIN_TIMINGS]` blames `vite:build-import-analysis generateBundle (58%, 16.3s, 1 call)`. That hook's body is **44ms**. `measureHookCost` wraps the *bindingified* hook and settles in a `.then()`, so for an `async` hook the number spans until its microtask runs — which only happens after Node's event loop regains control from the Rust bundler, so all of rolldown's own native work lands on whichever async hook was pending. No-op'ing the hook entirely changed wall clock by zero across 3 runs each. It's also not removable: it rewrites `__VITE_PRELOAD__` → `__vite__mapDeps([...])`, without which lazy `import()` sites keep a bare identifier and code-split routes lose their CSS.

## Testing

- `npm run static-checks` — passed (ESLint, Prettier, import sorting, package.json)
- `tsc --noEmit` in `client` — clean
- Full production client build — exit 0, 74 `.gz` + 74 `.br`, gzip total unchanged at 5.0MB
- Workflow YAML parses; merge shell logic dry-run produces the expected `imagetools create` invocations
- Confirmed `actions/download-artifact@v7` exposes `pattern` and `merge-multiple`
- Workflow `name:` unchanged, so `retry-docker-builds.yml` still matches it

## Risk

The manifest-merge path is the part to watch — it replaces a single buildx multi-platform push with per-platform digest pushes plus an `imagetools create`. The `merge` job ends with an `imagetools inspect` so the published manifest is visible in the run log. Worst case is a revert of one workflow file.

Left alone deliberately: `Dockerfile` still uses the sequential `npm run frontend` rather than the parallel `npm run build` (turbo). Turbo covers the identical task set and ran 12s → 8s locally, but that was on 32 cores and the gain on a 2-vCPU runner is unproven.
