### PR TITLE
🧩 fix: Scope Each Image's Digest Artifacts to Its Own Manifest Merge

### DIFF
--- a/.github/workflows/dev-branch-images.yml
+++ b/.github/workflows/dev-branch-images.yml
@@ -134,10 +134,14 @@ jobs:
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
 
+      # The `-arch-` separator keeps one image's artifacts out of another's glob:
+      # `lc-dev` is a prefix of `lc-dev-api`, so a bare `digests-lc-dev-*` pattern
+      # matches all four digests and the merge resolves an API digest against the
+      # app repository.
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.image_name }}-${{ matrix.arch }}
+          name: digests-${{ matrix.image_name }}-arch-${{ matrix.arch }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -158,7 +162,7 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v7
         with:
-          pattern: digests-${{ matrix.image_name }}-*
+          pattern: digests-${{ matrix.image_name }}-arch-*
           merge-multiple: true
           path: /tmp/digests
 
@@ -189,8 +193,12 @@ jobs:
           set -euo pipefail
           shopt -s nullglob
           digests=(*)
-          if [ "${#digests[@]}" -eq 0 ]; then
-            echo "No digests downloaded; refusing to publish an empty manifest." >&2
+          # One digest per platform in the build matrix. Assert the exact count:
+          # too few would publish a manifest missing an architecture, too many
+          # means the artifact glob picked up another image's digests.
+          expected=2
+          if [ "${#digests[@]}" -ne "$expected" ]; then
+            echo "Expected $expected platform digests, found ${#digests[@]}: ${digests[*]}" >&2
             exit 1
           fi
           echo "Merging ${#digests[@]} platform digests: ${digests[*]}"


### PR DESCRIPTION
Fixes the failure in [run 33461230049](https://github.com/danny-avila/LibreChat/actions/runs/33461230049), the first run of the native-ARM pipeline from #15441.

## What broke

`lc-dev-api` merged fine. `lc-dev` failed:

```
Merging 4 platform digests: 18f83e4a... b4700f27... ca747c51... edf23a05...
ERROR: ghcr.io/danny-avila/lc-dev@sha256:ca747c51...: not found
```

Four digests, not two. `lc-dev` is a **prefix** of `lc-dev-api`, so the merge job's `pattern: digests-lc-dev-*` matched both images' artifacts, and `imagetools create` then tried to resolve an API digest against the app repository. `lc-dev-api` was unaffected because no other image name prefixes it — which is why exactly one of the two merge jobs failed.

## Fix

**1. Unambiguous artifact names.** `digests-<image>-arch-<arch>`, so `digests-lc-dev-arch-*` cannot reach `digests-lc-dev-api-arch-amd64`.

**2. Exact count assertion.** The real gap was the guard: it only rejected *zero* digests, so four went straight through. It now asserts exactly one digest per platform.

| digests found | before | after |
|---|---|---|
| 4 (the bug that shipped) | published garbage → error | **rejected** |
| 2 (correct) | ok | ok |
| 1 (a platform silently missing) | would publish a single-arch `:latest` | **rejected** |
| 0 | rejected | rejected |

Row 3 is the one I want to call out — I reasoned in #15441 that `needs: build` made a partial manifest unreachable, and that reasoning was sound for a *failed* build leg. It did not cover a digest set that was wrong for other reasons, which is precisely what happened. The count check covers both.

## Blast radius of the failed run

None. `imagetools create` failed while resolving its sources, before creating any tag, so `lc-dev:latest` still points at its previous build. The build jobs did push untagged digest manifests to both registries; those are unreferenced and harmless, though GHCR will show them as untagged versions.

## What the run did prove

The approach works, and it's fast:

| job | time |
|---|---|
| Build lc-dev (linux/amd64) | 4 min |
| Build lc-dev (linux/arm64) | **3 min** |
| Build lc-dev-api (linux/amd64) | 4 min |
| Build lc-dev-api (linux/arm64) | **3 min** |

Against 13+ minutes for the emulated arm64 leg before. And `lc-dev-api`'s manifest came out correct:

```
Name:      ghcr.io/danny-avila/lc-dev-api:283aae49...
MediaType: application/vnd.oci.image.index.v1+json
  Platform: linux/arm64
  Platform: linux/amd64
  Platform: unknown/unknown   (provenance attestations)
```

## Testing

- Reproduced the glob collision and verified the new pattern excludes the other image
- Exercised the count guard against 0/1/2/4 digests — all four rows in the table above
- Workflow YAML parses; `npm run static-checks` passed

Still a pilot on `dev-branch-images.yml`. The other four workflows are unchanged; I'll convert them once a run goes green end to end.
