### PR TITLE
🩹 fix: Stop the Subagent Composer Unmounting, and Give It Main Chat's Shape

### DIFF
--- a/client/src/components/Chat/Input/DuringRunSendButton.tsx
+++ b/client/src/components/Chat/Input/DuringRunSendButton.tsx
@@ -125,7 +125,7 @@ const DuringRunSendButton = React.memo(
       key: 'steer',
       label: localize('com_ui_steer'),
       kbd: steerKbd,
-      icon: <Zap className="h-4 w-4 text-amber-500" aria-hidden="true" />,
+      icon: <Zap className="h-4 w-4 text-status-warning" aria-hidden="true" />,
       // Gate on availability, not the default action — the row exists to
       // override a queue-preferring default with an explicit steer.
       disabled: !steering.canSteer,
@@ -135,7 +135,7 @@ const DuringRunSendButton = React.memo(
       key: 'queue',
       label: localize('com_ui_queue'),
       kbd: primary === 'queue' ? submitHint : alternateHint,
-      icon: <Clock className="h-4 w-4 text-cyan-500" aria-hidden="true" />,
+      icon: <Clock className="h-4 w-4 text-status-info" aria-hidden="true" />,
       onClick: () => runAction((text) => steering.queueFromComposer(text)),
     };
     /** Keeps the half-written answer, unlike interrupt & send below it. */
@@ -143,7 +143,7 @@ const DuringRunSendButton = React.memo(
       key: 'interrupt-steer',
       label: localize('com_ui_interrupt_steer'),
       kbd: interruptSteerKbd,
-      icon: <ZapOff className="h-4 w-4 text-amber-500" aria-hidden="true" />,
+      icon: <ZapOff className="h-4 w-4 text-status-warning" aria-hidden="true" />,
       // Matches the standalone button's gate, and deliberately NOT
       // `!canSteer` like the steer row above: `canSteer` is also false before
       // a conversation exists, where `interruptSteer` falls back to interrupt
@@ -155,7 +155,7 @@ const DuringRunSendButton = React.memo(
       key: 'interrupt',
       label: localize('com_ui_interrupt_send'),
       kbd: verdicts.altEnter === 'interrupt' ? altEnter : undefined,
-      icon: <OctagonPause className="h-4 w-4 text-red-500" aria-hidden="true" />,
+      icon: <OctagonPause className="h-4 w-4 text-status-error" aria-hidden="true" />,
       disabled: !steering.canControlGeneration,
       onClick: () => runAction((text) => steering.interruptAndSend(text)),
     };

--- a/client/src/components/Chat/Input/DuringRunSendButton.tsx
+++ b/client/src/components/Chat/Input/DuringRunSendButton.tsx
@@ -1,9 +1,9 @@
 import React, { forwardRef, useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
-import * as Ariakit from '@ariakit/react';
 import { useWatch } from 'react-hook-form';
-import { SendIcon } from '@librechat/client';
+import { SendActions, SendIcon } from '@librechat/client';
 import { Zap, Clock, OctagonPause, ZapOff } from 'lucide-react';
+import type { SendAction } from '@librechat/client';
 import type { Control } from 'react-hook-form';
 import type { ComposerKeyContext, KeyChordSource } from '~/utils/shortcuts';
 import type { SteeringControls } from '~/hooks/Chat/useSteering';
@@ -13,25 +13,9 @@ import { useLocalize } from '~/hooks';
 import { cn } from '~/utils';
 import store from '~/store';
 
-const ROW_CLASS =
-  'flex w-full cursor-pointer items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm text-text-primary hover:bg-surface-tertiary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-xheavy aria-disabled:cursor-not-allowed aria-disabled:opacity-50';
-
-function Kbd({ children }: { children: React.ReactNode }) {
-  return (
-    <kbd className="ml-auto rounded-md bg-surface-tertiary px-1.5 py-0.5 font-sans text-xs text-text-secondary">
-      {children}
-    </kbd>
-  );
-}
-
-type ActionRow = {
-  key: string;
-  label: string;
-  kbd?: string;
-  icon: React.ReactNode;
-  disabled?: boolean;
-  onClick: () => void;
-};
+/** The rows, the popover and the chord chips are shared with every other chat
+ *  surface that can submit more than one way — see `SendActions`. */
+type ActionRow = SendAction;
 
 type DuringRunSendButtonProps = {
   control: Control<{ text: string }>;
@@ -182,50 +166,28 @@ const DuringRunSendButton = React.memo(
       primary === 'steer' ? localize('com_ui_steer_send') : localize('com_ui_queue_send');
 
     return (
-      <Ariakit.HovercardProvider placement="top-end" showTimeout={100} hideTimeout={150}>
-        <Ariakit.HovercardAnchor
-          render={
-            <button
-              ref={ref}
-              aria-label={label}
-              id="during-run-send-button"
-              disabled={!content || props.disabled === true}
-              className={cn(
-                'size-theme-control rounded-theme-control-round bg-text-primary p-theme-compact text-text-primary outline-offset-4 transition-all duration-theme-normal disabled:cursor-not-allowed disabled:text-text-secondary disabled:opacity-10',
-              )}
-              data-testid="during-run-send-button"
-              data-during-run-action={primary}
-              type="submit"
-            >
-              <span data-state="closed">
-                <SendIcon size={24} />
-              </span>
-            </button>
-          }
-        />
-        <Ariakit.Hovercard
-          portal
-          gutter={8}
-          unmountOnHide
-          aria-label={localize('com_ui_during_run_actions')}
-          className="z-50 min-w-[12rem] rounded-xl border border-border-light bg-surface-secondary p-1.5 text-text-primary shadow-lg outline-none"
-        >
-          {rows.map((row) => (
-            <button
-              key={row.key}
-              type="button"
-              className={ROW_CLASS}
-              aria-disabled={row.disabled === true}
-              onClick={row.disabled === true ? undefined : row.onClick}
-            >
-              {row.icon}
-              {row.label}
-              {/* A disabled row's action refuses its chord too, so no hint. */}
-              {row.kbd != null && row.disabled !== true && <Kbd>{row.kbd}</Kbd>}
-            </button>
-          ))}
-        </Ariakit.Hovercard>
-      </Ariakit.HovercardProvider>
+      <SendActions
+        actions={rows}
+        label={localize('com_ui_during_run_actions')}
+        anchor={
+          <button
+            ref={ref}
+            aria-label={label}
+            id="during-run-send-button"
+            disabled={!content || props.disabled === true}
+            className={cn(
+              'size-theme-control rounded-theme-control-round bg-text-primary p-theme-compact text-text-primary outline-offset-4 transition-all duration-theme-normal disabled:cursor-not-allowed disabled:text-text-secondary disabled:opacity-10',
+            )}
+            data-testid="during-run-send-button"
+            data-during-run-action={primary}
+            type="submit"
+          >
+            <span data-state="closed">
+              <SendIcon size={24} />
+            </span>
+          </button>
+        }
+      />
     );
   }),
 );

--- a/client/src/components/Chat/Subagents/SubagentActivity.tsx
+++ b/client/src/components/Chat/Subagents/SubagentActivity.tsx
@@ -127,9 +127,13 @@ function SubagentControlHistory({
 export function SubagentActivityScrollSurface({
   children,
   padded = true,
+  headerInset = false,
 }: {
   children: React.ReactNode;
   padded?: boolean;
+  /** Clears the panel's overlay header, which floats above this surface so the
+   *  thread scrolls under it rather than starting below a solid bar. */
+  headerInset?: boolean;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -172,7 +176,9 @@ export function SubagentActivityScrollSurface({
         className={cn('min-h-0 flex-1 overflow-y-auto', padded && 'px-4 py-4')}
         data-subagent-activity-scroll-surface
       >
-        <div ref={contentRef}>{children}</div>
+        <div ref={contentRef} className={cn(headerInset && 'pt-[52px]')}>
+          {children}
+        </div>
       </div>
       <CSSTransition
         in={!isAtBottom && scrollButtonPreference}
@@ -395,6 +401,7 @@ export default function SubagentActivity({
   state = 'ready',
   embedded = false,
   showPrompt = true,
+  headerInset = false,
   onCancelControl,
 }: {
   activity: ChildActivity;
@@ -402,6 +409,7 @@ export default function SubagentActivity({
   state?: 'ready' | 'loading' | 'error';
   embedded?: boolean;
   showPrompt?: boolean;
+  headerInset?: boolean;
   onCancelControl?: (controlId: string) => void;
 }) {
   const statusHeader = isAbnormalTerminalStatus(activity.status) ? (
@@ -431,7 +439,9 @@ export default function SubagentActivity({
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       {statusHeader}
-      <SubagentActivityScrollSurface>{content}</SubagentActivityScrollSurface>
+      <SubagentActivityScrollSurface headerInset={headerInset}>
+        {content}
+      </SubagentActivityScrollSurface>
     </div>
   );
 }

--- a/client/src/components/Chat/Subagents/SubagentThreadPanel.test.tsx
+++ b/client/src/components/Chat/Subagents/SubagentThreadPanel.test.tsx
@@ -286,6 +286,7 @@ jest.mock('@librechat/client', () => ({
     maxLength,
     onStop,
     stopLabel,
+    submitActions,
   }: {
     value: string;
     onChange: (value: string) => void;
@@ -304,6 +305,12 @@ jest.mock('@librechat/client', () => ({
     maxLength?: number;
     onStop?: () => void;
     stopLabel?: string;
+    submitActions?: Array<{
+      key: string;
+      label: string;
+      disabled?: boolean;
+      onClick: () => void;
+    }>;
   }) => (
     <div>
       <textarea
@@ -324,6 +331,18 @@ jest.mock('@librechat/client', () => ({
         }}
       />
       {actions}
+      {/* The real composer hides these behind the send control until it is
+          hovered; rendering them inline keeps them reachable to assertions. */}
+      {(submitActions ?? []).map((action) => (
+        <button
+          key={action.key}
+          type="button"
+          aria-disabled={action.disabled === true}
+          onClick={action.disabled === true ? undefined : action.onClick}
+        >
+          {action.label}
+        </button>
+      ))}
       {onStop != null && value.trim() === '' ? (
         <button type="button" aria-label={stopLabel} onClick={onStop}>
           {stopLabel}
@@ -642,7 +661,7 @@ describe('SubagentThreadPanel', () => {
 
     expect(screen.getByLabelText('com_ui_message_input')).toHaveValue('Half-typed steer.');
     /** Present, but not submittable until the new task's own view arrives. */
-    expect(screen.getByRole('button', { name: 'com_ui_steer' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'com_ui_steer_send' })).toBeDisabled();
   });
 
   /** A task on its way to an executor is live: withdrawing the composer until
@@ -715,7 +734,7 @@ describe('SubagentThreadPanel', () => {
     expect(mockControlMutate).not.toHaveBeenCalled();
 
     fireEvent.change(composer, { target: { value: 'Check the primary source.' } });
-    fireEvent.click(screen.getByRole('button', { name: 'com_ui_steer' }));
+    fireEvent.click(screen.getByRole('button', { name: 'com_ui_steer_send' }));
 
     expect(mockControlMutate).toHaveBeenCalledTimes(1);
     expect(mockControlMutate.mock.calls[0][0].command.action).toBe('steer');
@@ -821,14 +840,14 @@ describe('SubagentThreadPanel', () => {
     fireEvent.change(screen.getByLabelText('com_ui_message_input'), {
       target: { value: 'Use the primary source.' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'com_ui_steer' }));
+    fireEvent.click(screen.getByRole('button', { name: 'com_ui_steer_send' }));
     const firstCommand = mockControlMutate.mock.calls[0][0].command;
     act(() => {
       mockControlMutate.mock.calls[0][1].onError({ response: { status: 503 } });
     });
 
     expect(screen.getByLabelText('com_ui_message_input')).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'com_ui_steer' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'com_ui_steer_send' })).toBeDisabled();
     expect(screen.getByTestId('shared-activity')).toHaveAttribute('data-can-withdraw', 'false');
 
     fireEvent.click(screen.getByRole('button', { name: 'com_ui_retry' }));
@@ -853,7 +872,7 @@ describe('SubagentThreadPanel', () => {
     fireEvent.change(screen.getByLabelText('com_ui_message_input'), {
       target: { value: 'Blocked guidance.' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'com_ui_steer' }));
+    fireEvent.click(screen.getByRole('button', { name: 'com_ui_steer_send' }));
     act(() => {
       mockControlMutate.mock.calls[0][1].onError({ response: { status: 400 } });
     });
@@ -861,7 +880,7 @@ describe('SubagentThreadPanel', () => {
     expect(screen.getByText('com_ui_subagent_control_reason_invalid_command')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'com_ui_retry' })).not.toBeInTheDocument();
     expect(screen.getByLabelText('com_ui_message_input')).toBeEnabled();
-    expect(screen.getByRole('button', { name: 'com_ui_steer' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'com_ui_steer_send' })).toBeEnabled();
   });
 
   it('retains an ambiguous invocation across closing and reopening the panel', () => {
@@ -1002,7 +1021,7 @@ describe('SubagentThreadPanel', () => {
     fireEvent.change(screen.getByLabelText('com_ui_message_input'), {
       target: { value: 'Use the primary source.' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'com_ui_steer' }));
+    fireEvent.click(screen.getByRole('button', { name: 'com_ui_steer_send' }));
     act(() => {
       mockControlMutate.mock.calls[0][1].onError({ response: { status: 503 } });
     });
@@ -1025,7 +1044,7 @@ describe('SubagentThreadPanel', () => {
     expect(screen.getByRole('button', { name: 'com_ui_retry' })).toBeInTheDocument();
     /** The settled child leaves the composer standing — Enter continues the
      *  thread from here — but nothing in it still addresses the finished run. */
-    expect(screen.queryByRole('button', { name: 'com_ui_steer' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'com_ui_steer_send' })).not.toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: 'com_ui_subagent_cancel_task' }),
     ).not.toBeInTheDocument();
@@ -1093,7 +1112,7 @@ describe('SubagentThreadPanel', () => {
     fireEvent.change(screen.getByLabelText('com_ui_message_input'), {
       target: { value: 'Use the primary source.' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'com_ui_steer' }));
+    fireEvent.click(screen.getByRole('button', { name: 'com_ui_steer_send' }));
     const command = mockControlMutate.mock.calls[0][0].command;
     act(() => {
       mockControlMutate.mock.calls[0][1].onError({ response: { status: 503 } });
@@ -1252,7 +1271,7 @@ describe('SubagentThreadPanel', () => {
       </RecoilRoot>,
     );
 
-    expect(screen.queryByRole('button', { name: 'com_ui_steer' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'com_ui_steer_send' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'com_ui_queue' })).not.toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: 'com_ui_subagent_cancel_task' }),

--- a/client/src/components/Chat/Subagents/SubagentThreadPanel.test.tsx
+++ b/client/src/components/Chat/Subagents/SubagentThreadPanel.test.tsx
@@ -28,6 +28,7 @@ const mockGetSubagentThread = jest.fn();
 const mockApprovalProviderMounted = jest.fn();
 const mockApprovalProviderUnmounted = jest.fn();
 let mockIsMobile = false;
+let mockCoarsePointer = false;
 let mockParentChildrenByMessage = new Map<string, ParentSubagentSummary[]>();
 let mockParentChildrenByThread = new Map<string, ParentSubagentSummary>();
 const mockRefreshParentChildren = jest.fn().mockResolvedValue(undefined);
@@ -359,7 +360,7 @@ jest.mock('@librechat/client', () => ({
       )}
     </div>
   ),
-  useMediaQuery: () => mockIsMobile,
+  useMediaQuery: (query: string) => (query.includes('hover') ? mockCoarsePointer : mockIsMobile),
   useToastContext: () => ({ showToast: mockShowToast }),
 }));
 
@@ -367,10 +368,10 @@ jest.mock('lucide-react', () => ({
   AlertCircle: () => null,
   CornerUpLeft: () => null,
   CheckCircle2: () => null,
+  Clock: () => null,
   Clock3: () => null,
   Feather: () => null,
-  ListEnd: () => null,
-  OctagonX: () => null,
+  OctagonPause: () => null,
   X: () => null,
   XCircle: () => null,
   Zap: () => null,
@@ -423,6 +424,7 @@ describe('SubagentThreadPanel', () => {
   beforeEach(() => {
     window.sessionStorage.clear();
     mockIsMobile = false;
+    mockCoarsePointer = false;
     mockApprovalProviderMounted.mockClear();
     mockApprovalProviderUnmounted.mockClear();
     mockForkMutate.mockClear();
@@ -665,10 +667,16 @@ describe('SubagentThreadPanel', () => {
   });
 
   /** A task on its way to an executor is live: withdrawing the composer until
-   *  the first token lands is the swap this panel exists to avoid. */
-  it('keeps the composer in control mode while the task is only dispatched', () => {
+   *  the first token lands is the swap this panel exists to avoid. But the
+   *  server can only address a task that has a durable input row — it answers
+   *  404 otherwise, which this panel reads as inaccessible and closes controls
+   *  for good — so the field stays and submission waits instead. */
+  it.each([
+    ['has its durable input row', completedView.messages, 1],
+    ['has not been written yet', [], 0],
+  ])('keeps the composer while a dispatched task %s', (_label, messages, invocations) => {
     mockUseSubagentThreadQuery.mockReturnValue({
-      data: { ...completedView, status: 'dispatched', controlReceipts: [] },
+      data: { ...completedView, status: 'dispatched', messages, controlReceipts: [] },
       isLoading: false,
       isError: false,
       isReadinessPending: false,
@@ -680,8 +688,11 @@ describe('SubagentThreadPanel', () => {
       </RecoilRoot>,
     );
 
-    expect(screen.getByLabelText('com_ui_message_input')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'com_ui_subagent_cancel_task' })).toBeInTheDocument();
+    const composer = screen.getByLabelText('com_ui_message_input');
+    expect(composer).toBeInTheDocument();
+    fireEvent.change(composer, { target: { value: 'Check the primary source.' } });
+    fireEvent.keyDown(composer, { key: 'Enter' });
+    expect(mockControlMutate).toHaveBeenCalledTimes(invocations);
   });
 
   /** Queue and interrupt keep the chords main chat gives them instead of
@@ -738,6 +749,34 @@ describe('SubagentThreadPanel', () => {
 
     expect(mockControlMutate).toHaveBeenCalledTimes(1);
     expect(mockControlMutate.mock.calls[0][0].command.action).toBe('steer');
+  });
+
+  /** Where there is no hover, the send control's action list cannot be opened —
+   *  a tap on that anchor submits — so those readers get the actions as
+   *  controls of their own instead. */
+  it('offers the alternate submissions inline when the pointer cannot hover', () => {
+    mockIsMobile = true;
+    mockCoarsePointer = true;
+    mockUseSubagentThreadQuery.mockReturnValue({
+      data: { ...completedView, status: 'running', controlReceipts: [] },
+      isLoading: false,
+      isError: false,
+      isReadinessPending: false,
+    });
+
+    render(
+      <RecoilRoot initializeState={({ set }) => set(activeSubagentPanel, selection)}>
+        <SubagentThreadPanel selection={selection} />
+      </RecoilRoot>,
+    );
+
+    fireEvent.change(screen.getByLabelText('com_ui_message_input'), {
+      target: { value: 'Check the primary source.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'com_ui_queue' }));
+
+    expect(mockControlMutate).toHaveBeenCalledTimes(1);
+    expect(mockControlMutate.mock.calls[0][0].command.action).toBe('queue');
   });
 
   /** Queue and interrupt keep a pointer of their own — a touch reader, or one

--- a/client/src/components/Chat/Subagents/SubagentThreadPanel.test.tsx
+++ b/client/src/components/Chat/Subagents/SubagentThreadPanel.test.tsx
@@ -690,9 +690,70 @@ describe('SubagentThreadPanel', () => {
 
     const composer = screen.getByLabelText('com_ui_message_input');
     expect(composer).toBeInTheDocument();
+    /** Stop is a command too: on an unaddressable task it would 404 and close
+     *  this task's controls for good, so the retained surface withholds it. It
+     *  occupies the send slot only while the field is empty. */
+    expect(screen.queryByRole('button', { name: 'com_ui_subagent_cancel_task' }) != null).toBe(
+      invocations === 1,
+    );
+
     fireEvent.change(composer, { target: { value: 'Check the primary source.' } });
     fireEvent.keyDown(composer, { key: 'Enter' });
     expect(mockControlMutate).toHaveBeenCalledTimes(invocations);
+  });
+
+  /** Every door onto a command answers to the same gate — including the inline
+   *  controls a touch reader gets instead of the hovercard. */
+  it('withholds the inline actions while a dispatched task is unaddressable', () => {
+    mockCoarsePointer = true;
+    mockUseSubagentThreadQuery.mockReturnValue({
+      data: { ...completedView, status: 'dispatched', messages: [], controlReceipts: [] },
+      isLoading: false,
+      isError: false,
+      isReadinessPending: false,
+    });
+
+    render(
+      <RecoilRoot initializeState={({ set }) => set(activeSubagentPanel, selection)}>
+        <SubagentThreadPanel selection={selection} />
+      </RecoilRoot>,
+    );
+
+    fireEvent.change(screen.getByLabelText('com_ui_message_input'), {
+      target: { value: 'Check the primary source.' },
+    });
+    const queue = screen.getByRole('button', { name: 'com_ui_queue' });
+    expect(queue).toBeDisabled();
+    fireEvent.click(queue);
+    expect(mockControlMutate).not.toHaveBeenCalled();
+  });
+
+  /** While the panel is a focus-trapped modal the portaled list sits outside
+   *  the `aside` the trap knows, so Tab never reaches it — the actions come
+   *  inside the panel instead, hover or no hover. */
+  it('keeps the actions inside the panel while it is a modal', () => {
+    mockIsMobile = true;
+    mockCoarsePointer = false;
+    mockUseSubagentThreadQuery.mockReturnValue({
+      data: { ...completedView, status: 'running', controlReceipts: [] },
+      isLoading: false,
+      isError: false,
+      isReadinessPending: false,
+    });
+
+    render(
+      <RecoilRoot initializeState={({ set }) => set(activeSubagentPanel, selection)}>
+        <SubagentThreadPanel selection={selection} />
+      </RecoilRoot>,
+    );
+
+    fireEvent.change(screen.getByLabelText('com_ui_message_input'), {
+      target: { value: 'Check the primary source.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'com_ui_queue' }));
+
+    expect(mockControlMutate).toHaveBeenCalledTimes(1);
+    expect(mockControlMutate.mock.calls[0][0].command.action).toBe('queue');
   });
 
   /** Queue and interrupt keep the chords main chat gives them instead of

--- a/client/src/components/Chat/Subagents/SubagentThreadPanel.test.tsx
+++ b/client/src/components/Chat/Subagents/SubagentThreadPanel.test.tsx
@@ -223,6 +223,9 @@ jest.mock('@librechat/client', () => ({
     <button {...props}>{children}</button>
   ),
   Skeleton: () => null,
+  /** Renders the anchored control itself; the tooltip text is the control's
+   *  accessible name here, which is what the assertions read. */
+  TooltipAnchor: ({ render }: { render: React.ReactElement }) => render,
   ControlCombobox: ({
     items,
     setValue,
@@ -286,7 +289,7 @@ jest.mock('@librechat/client', () => ({
   }: {
     value: string;
     onChange: (value: string) => void;
-    onSubmit: () => void;
+    onSubmit: (event?: React.KeyboardEvent<HTMLTextAreaElement>) => void;
     canSubmit: boolean;
     submitLabel: string;
     ariaLabel: string;
@@ -315,7 +318,9 @@ jest.mock('@librechat/client', () => ({
             resolveKeyVerdict?.(event, false) ?? mockComposerVerdict(event, submitOnEnter);
           if (verdict !== 'submit') return;
           event.preventDefault();
-          if (canSubmit && value.trim() !== '') onSubmit();
+          /** The real composer hands the submitting event to the host, which is
+           *  how a chord picks its control; a pointer click passes nothing. */
+          if (canSubmit && value.trim() !== '') onSubmit(event);
         }}
       />
       {actions}
@@ -328,7 +333,7 @@ jest.mock('@librechat/client', () => ({
           type="button"
           aria-label={submitLabel}
           disabled={disabled === true || !canSubmit}
-          onClick={onSubmit}
+          onClick={() => onSubmit()}
         >
           {submitLabel}
         </button>
@@ -683,6 +688,62 @@ describe('SubagentThreadPanel', () => {
     const composer = screen.getByLabelText('com_ui_message_input');
     fireEvent.change(composer, { target: { value: 'Check the primary source.' } });
     fireEvent.keyDown(composer, event);
+
+    expect(mockControlMutate).toHaveBeenCalledTimes(1);
+    expect(mockControlMutate.mock.calls[0][0].command.action).toBe(action);
+  });
+
+  /** A chord the composer refuses must leave nothing behind: the next pointer
+   *  click carries no event and therefore always means the default steer. */
+  it('does not let a refused chord decide a later pointer submission', () => {
+    mockUseSubagentThreadQuery.mockReturnValue({
+      data: { ...completedView, status: 'running', controlReceipts: [] },
+      isLoading: false,
+      isError: false,
+      isReadinessPending: false,
+    });
+
+    render(
+      <RecoilRoot initializeState={({ set }) => set(activeSubagentPanel, selection)}>
+        <SubagentThreadPanel selection={selection} />
+      </RecoilRoot>,
+    );
+
+    const composer = screen.getByLabelText('com_ui_message_input');
+    /** Refused: the field is empty, so the composer never submits it. */
+    fireEvent.keyDown(composer, { key: 'Enter', altKey: true });
+    expect(mockControlMutate).not.toHaveBeenCalled();
+
+    fireEvent.change(composer, { target: { value: 'Check the primary source.' } });
+    fireEvent.click(screen.getByRole('button', { name: 'com_ui_steer' }));
+
+    expect(mockControlMutate).toHaveBeenCalledTimes(1);
+    expect(mockControlMutate.mock.calls[0][0].command.action).toBe('steer');
+  });
+
+  /** Queue and interrupt keep a pointer of their own — a touch reader, or one
+   *  whose shortcuts are off or rebound, still has to reach them. */
+  it.each([
+    ['com_ui_queue', 'queue'],
+    ['com_ui_subagent_interrupt', 'interrupt'],
+  ])('offers %s to a pointer', (label, action) => {
+    mockUseSubagentThreadQuery.mockReturnValue({
+      data: { ...completedView, status: 'running', controlReceipts: [] },
+      isLoading: false,
+      isError: false,
+      isReadinessPending: false,
+    });
+
+    render(
+      <RecoilRoot initializeState={({ set }) => set(activeSubagentPanel, selection)}>
+        <SubagentThreadPanel selection={selection} />
+      </RecoilRoot>,
+    );
+
+    fireEvent.change(screen.getByLabelText('com_ui_message_input'), {
+      target: { value: 'Check the primary source.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: label }));
 
     expect(mockControlMutate).toHaveBeenCalledTimes(1);
     expect(mockControlMutate.mock.calls[0][0].command.action).toBe(action);

--- a/client/src/components/Chat/Subagents/SubagentThreadPanel.test.tsx
+++ b/client/src/components/Chat/Subagents/SubagentThreadPanel.test.tsx
@@ -281,6 +281,8 @@ jest.mock('@librechat/client', () => ({
     submitOnEnter = true,
     resolveKeyVerdict,
     maxLength,
+    onStop,
+    stopLabel,
   }: {
     value: string;
     onChange: (value: string) => void;
@@ -297,6 +299,8 @@ jest.mock('@librechat/client', () => ({
       isComposing: boolean,
     ) => 'submit' | 'block' | 'newline' | 'none';
     maxLength?: number;
+    onStop?: () => void;
+    stopLabel?: string;
   }) => (
     <div>
       <textarea
@@ -315,14 +319,20 @@ jest.mock('@librechat/client', () => ({
         }}
       />
       {actions}
-      <button
-        type="button"
-        aria-label={submitLabel}
-        disabled={disabled === true || !canSubmit}
-        onClick={onSubmit}
-      >
-        {submitLabel}
-      </button>
+      {onStop != null && value.trim() === '' ? (
+        <button type="button" aria-label={stopLabel} onClick={onStop}>
+          {stopLabel}
+        </button>
+      ) : (
+        <button
+          type="button"
+          aria-label={submitLabel}
+          disabled={disabled === true || !canSubmit}
+          onClick={onSubmit}
+        >
+          {submitLabel}
+        </button>
+      )}
     </div>
   ),
   useMediaQuery: () => mockIsMobile,
@@ -591,6 +601,93 @@ describe('SubagentThreadPanel', () => {
     expect(mockControlMutate.mock.calls[0][0].command.action).toBe('steer');
   });
 
+  /** A delivery re-keys the query to its new task and the task view blanks for
+   *  the render or two that takes. Measured against the live panel, the
+   *  composer used to unmount and remount inside 10ms there — taking focus and
+   *  a half-typed steer with it. */
+  it('keeps the composer mounted while a delivery re-keys the task view', () => {
+    mockUseSubagentThreadQuery.mockReturnValue({
+      data: { ...completedView, status: 'running', controlReceipts: [] },
+      isLoading: false,
+      isError: false,
+      isReadinessPending: false,
+    });
+    /** A fresh element each time: React bails out of an update whose element is
+     *  the very same object, so a reused tree would assert nothing. */
+    const tree = () => (
+      <RecoilRoot initializeState={({ set }) => set(activeSubagentPanel, selection)}>
+        <SubagentThreadPanel selection={selection} />
+      </RecoilRoot>
+    );
+    const { rerender } = render(tree());
+
+    const composer = screen.getByLabelText('com_ui_message_input');
+    fireEvent.change(composer, { target: { value: 'Half-typed steer.' } });
+
+    /** The new task's view has not landed: `isPreviousData` withholds the task
+     *  view precisely so task-scoped fields are not misattributed. */
+    mockUseSubagentThreadQuery.mockReturnValue({
+      data: { ...completedView, status: 'running', controlReceipts: [] },
+      isLoading: false,
+      isError: false,
+      isPreviousData: true,
+      isReadinessPending: false,
+    });
+    rerender(tree());
+
+    expect(screen.getByLabelText('com_ui_message_input')).toHaveValue('Half-typed steer.');
+    /** Present, but not submittable until the new task's own view arrives. */
+    expect(screen.getByRole('button', { name: 'com_ui_steer' })).toBeDisabled();
+  });
+
+  /** A task on its way to an executor is live: withdrawing the composer until
+   *  the first token lands is the swap this panel exists to avoid. */
+  it('keeps the composer in control mode while the task is only dispatched', () => {
+    mockUseSubagentThreadQuery.mockReturnValue({
+      data: { ...completedView, status: 'dispatched', controlReceipts: [] },
+      isLoading: false,
+      isError: false,
+      isReadinessPending: false,
+    });
+
+    render(
+      <RecoilRoot initializeState={({ set }) => set(activeSubagentPanel, selection)}>
+        <SubagentThreadPanel selection={selection} />
+      </RecoilRoot>,
+    );
+
+    expect(screen.getByLabelText('com_ui_message_input')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'com_ui_subagent_cancel_task' })).toBeInTheDocument();
+  });
+
+  /** Queue and interrupt keep the chords main chat gives them instead of
+   *  spelling themselves out beside the field. */
+  it.each([
+    ['queue', { key: 'Enter', ctrlKey: true }, 'queue'],
+    ['interrupt', { key: 'Enter', altKey: true }, 'interrupt'],
+    ['steer', { key: 'Enter' }, 'steer'],
+  ])('submits a %s from its chord', (_label, event, action) => {
+    mockUseSubagentThreadQuery.mockReturnValue({
+      data: { ...completedView, status: 'running', controlReceipts: [] },
+      isLoading: false,
+      isError: false,
+      isReadinessPending: false,
+    });
+
+    render(
+      <RecoilRoot initializeState={({ set }) => set(activeSubagentPanel, selection)}>
+        <SubagentThreadPanel selection={selection} />
+      </RecoilRoot>,
+    );
+
+    const composer = screen.getByLabelText('com_ui_message_input');
+    fireEvent.change(composer, { target: { value: 'Check the primary source.' } });
+    fireEvent.keyDown(composer, event);
+
+    expect(mockControlMutate).toHaveBeenCalledTimes(1);
+    expect(mockControlMutate.mock.calls[0][0].command.action).toBe(action);
+  });
+
   it('submits one command invocation, blocks duplicate clicks, and shows its receipt', async () => {
     mockUseSubagentThreadQuery.mockReturnValue({
       data: { ...completedView, status: 'running', controlReceipts: [] },
@@ -607,9 +704,9 @@ describe('SubagentThreadPanel', () => {
     fireEvent.change(screen.getByLabelText('com_ui_message_input'), {
       target: { value: 'Check the primary source.' },
     });
-    const queue = screen.getByRole('button', { name: 'com_ui_queue' });
-    fireEvent.click(queue);
-    fireEvent.click(queue);
+    const composer = screen.getByLabelText('com_ui_message_input');
+    fireEvent.keyDown(composer, { key: 'Enter', ctrlKey: true });
+    fireEvent.keyDown(composer, { key: 'Enter', ctrlKey: true });
 
     expect(mockControlMutate).toHaveBeenCalledTimes(1);
     const [variables, callbacks] = mockControlMutate.mock.calls[0] as [
@@ -670,7 +767,7 @@ describe('SubagentThreadPanel', () => {
     });
 
     expect(screen.getByLabelText('com_ui_message_input')).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'com_ui_subagent_cancel_task' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'com_ui_steer' })).toBeDisabled();
     expect(screen.getByTestId('shared-activity')).toHaveAttribute('data-can-withdraw', 'false');
 
     fireEvent.click(screen.getByRole('button', { name: 'com_ui_retry' }));
@@ -703,7 +800,7 @@ describe('SubagentThreadPanel', () => {
     expect(screen.getByText('com_ui_subagent_control_reason_invalid_command')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'com_ui_retry' })).not.toBeInTheDocument();
     expect(screen.getByLabelText('com_ui_message_input')).toBeEnabled();
-    expect(screen.getByRole('button', { name: 'com_ui_subagent_cancel_task' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'com_ui_steer' })).toBeEnabled();
   });
 
   it('retains an ambiguous invocation across closing and reopening the panel', () => {
@@ -733,7 +830,10 @@ describe('SubagentThreadPanel', () => {
     fireEvent.change(screen.getByLabelText('com_ui_message_input'), {
       target: { value: 'Use the primary source.' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'com_ui_queue' }));
+    fireEvent.keyDown(screen.getByLabelText('com_ui_message_input'), {
+      key: 'Enter',
+      ctrlKey: true,
+    });
     const firstCommand = mockControlMutate.mock.calls[0][0].command;
     act(() => {
       mockControlMutate.mock.calls[0][1].onError({ response: { status: 503 } });
@@ -762,7 +862,10 @@ describe('SubagentThreadPanel', () => {
     fireEvent.change(screen.getByLabelText('com_ui_message_input'), {
       target: { value: 'Keep the same invocation.' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'com_ui_queue' }));
+    fireEvent.keyDown(screen.getByLabelText('com_ui_message_input'), {
+      key: 'Enter',
+      ctrlKey: true,
+    });
     const firstCommand = mockControlMutate.mock.calls[0][0].command;
     act(() => {
       mockControlMutate.mock.calls[0][1].onError({ response: { status: 503 } });
@@ -806,7 +909,10 @@ describe('SubagentThreadPanel', () => {
     fireEvent.change(screen.getByLabelText('com_ui_message_input'), {
       target: { value: 'Retry after closing.' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'com_ui_queue' }));
+    fireEvent.keyDown(screen.getByLabelText('com_ui_message_input'), {
+      key: 'Enter',
+      ctrlKey: true,
+    });
     const firstCommand = mockControlMutate.mock.calls[0][0].command;
     fireEvent.click(screen.getByRole('button', { name: 'com_ui_close' }));
     act(() => {
@@ -1358,13 +1464,15 @@ describe('SubagentThreadPanel', () => {
       event: { actorId: 'actor-1', progressKey: 'event-task:child-thread:task' },
     };
 
-    const tree = (
+    /** A fresh element each time: React bails out of an update whose element is
+     *  the very same object, so a reused tree would assert nothing. */
+    const tree = () => (
       <RecoilRoot initializeState={({ set }) => set(activeSubagentPanel, eventSelection)}>
         <Observer />
         <SubagentThreadPanel selection={eventSelection} />
       </RecoilRoot>
     );
-    const { rerender } = render(tree);
+    const { rerender } = render(tree());
 
     fireEvent.change(screen.getByLabelText('com_ui_message_input'), {
       target: { value: 'Try that again.' },
@@ -1375,18 +1483,18 @@ describe('SubagentThreadPanel', () => {
 
     mockParentChildrenByThread = new Map([[actor.threadId, withNewerTask]]);
     mockParentChildrenByMessage = new Map([['parent-message', [withNewerTask]]]);
-    rerender(tree);
+    rerender(tree());
     if (submitAndFail) {
       act(() => mockForkMutate.mock.calls[0][1].onError());
     }
-    rerender(tree);
+    rerender(tree());
 
     expect(screen.getByLabelText('com_ui_message_input')).toHaveValue('Try that again.');
     expect((active as ActiveSubagentPanel | null)?.durable?.taskId).toBe('task');
 
     /** Draft gone, nothing left to protect: the panel follows the actor again. */
     fireEvent.change(screen.getByLabelText('com_ui_message_input'), { target: { value: '' } });
-    rerender(tree);
+    rerender(tree());
     expect((active as ActiveSubagentPanel | null)?.durable?.taskId).toBe('task-newer');
   });
 

--- a/client/src/components/Chat/Subagents/SubagentThreadPanel.tsx
+++ b/client/src/components/Chat/Subagents/SubagentThreadPanel.tsx
@@ -120,6 +120,10 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
   const { navigateToConvo } = useNavigateToConvo();
   const panelRef = useRef<HTMLDivElement>(null);
   const isMobile = useMediaQuery('(max-width: 767px)');
+  /** No hover means the send control's action list cannot be reached: a tap on
+   *  that anchor submits. Those readers get the same actions as controls of
+   *  their own instead. */
+  const coarsePointer = useMediaQuery('(hover: none)');
   const enterToSend = useRecoilValue(store.enterToSend);
   const { shortcutsEnabled, submitOverride, yieldedChords } = useComposerBindings();
   const [actorPickerOpen, setActorPickerOpen] = useState(false);
@@ -985,16 +989,19 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
   const hasConversationProjection =
     selection.durable == null || threadView == null || Array.isArray(threadView.turns);
   const taskInaccessible = controlInaccessible || transientControl?.reason === 'task_inaccessible';
-  /** `dispatched` counts as live. The task is on its way to an executor, and a
-   *  reader who types into a run that has only just started means it for that
-   *  run — withdrawing the composer until the first token lands is the swap
-   *  this panel exists to avoid. */
-  const controlAvailable =
-    selection.durable != null &&
+  const taskIsLive = taskView != null && isLiveSubagentStatus(taskView.status);
+  /** A command can only be addressed once the task has a durable input row or a
+   *  live lease — `control.ts` answers 404 otherwise, which this panel reads as
+   *  an inaccessible task and closes its controls for good. A `dispatched` task
+   *  without that evidence is live but not yet controllable: the composer stays
+   *  (withdrawing it as a run starts is the swap this panel exists to avoid),
+   *  while submission waits. */
+  const controlAddressable =
     taskView != null &&
-    isLiveSubagentStatus(taskView.status) &&
-    !taskInaccessible &&
-    !controlsClosed;
+    (taskView.status === 'running' ||
+      (taskView.status === 'dispatched' && subagentThreadHasTaskEvidence(taskView, taskId)));
+  const controlAvailable =
+    selection.durable != null && controlAddressable && !taskInaccessible && !controlsClosed;
   const controlPending =
     controlTask.isLoading || transientControl?.status === 'submitted' || retryControl != null;
   const showControlFooter =
@@ -1040,9 +1047,19 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
   } else if (retainedModeRef.current != null && retainedModeRef.current.threadId !== threadId) {
     retainedModeRef.current = null;
   }
-  const composerSettling = liveComposerMode == null && taskView == null;
-  const composerMode =
-    liveComposerMode ?? (composerSettling ? retainedModeRef.current?.mode : null);
+  /** Hold the surface both while a delivery re-keys the view and while a live
+   *  task is not yet addressable; submission waits in either case. A task whose
+   *  controls are definitively closed holds nothing — there is no command left
+   *  for the field to carry. */
+  const composerSettling =
+    liveComposerMode == null &&
+    (taskView == null || (taskIsLive && !controlsClosed && !taskInaccessible));
+  /** While settling, the surface the thread last showed — or, on a first render
+   *  that has never had one, the surface a live task would have. */
+  let composerMode: 'control' | 'continue' | null = liveComposerMode;
+  if (composerMode == null && composerSettling) {
+    composerMode = retainedModeRef.current?.mode ?? (taskIsLive ? 'control' : null);
+  }
   const composerPlaceholder = localize('com_endpoint_message_new', { 0: panelTitle });
   /** The send control names what IT does, distinct from the `Steer` row it
    *  offers — the same pairing main chat uses for its during-run send. */
@@ -1109,7 +1126,7 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
         key: 'steer',
         label: localize('com_ui_steer'),
         kbd: steerKbd,
-        icon: <Zap className="h-4 w-4 text-amber-500" aria-hidden="true" />,
+        icon: <Zap className="h-4 w-4 text-status-warning" aria-hidden="true" />,
         disabled: blocked,
         onClick: () => submitControl('steer'),
       },
@@ -1117,7 +1134,7 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
         key: 'queue',
         label: localize('com_ui_queue'),
         kbd: modEnter === 'other' ? modSymbol : undefined,
-        icon: <Clock className="h-4 w-4 text-cyan-500" aria-hidden="true" />,
+        icon: <Clock className="h-4 w-4 text-status-info" aria-hidden="true" />,
         disabled: blocked,
         onClick: () => submitControl('queue'),
       },
@@ -1125,7 +1142,7 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
         key: 'interrupt',
         label: localize('com_ui_subagent_interrupt'),
         kbd: altEnter === 'interrupt' ? altSymbol : undefined,
-        icon: <OctagonPause className="h-4 w-4 text-red-500" aria-hidden="true" />,
+        icon: <OctagonPause className="h-4 w-4 text-status-error" aria-hidden="true" />,
         disabled: blocked,
         onClick: () => submitControl('interrupt'),
       },
@@ -1490,8 +1507,28 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
                *  continuation is ordinary chat text bound for an ordinary
                *  composer, which caps nothing. */
               maxLength={composerMode === 'control' ? 4 * 1024 : undefined}
-              submitActions={submitActions}
+              submitActions={coarsePointer ? [] : submitActions}
               submitActionsLabel={localize('com_ui_during_run_actions')}
+              actions={
+                coarsePointer
+                  ? submitActions
+                      .filter((action) => action.key !== 'steer')
+                      .map((action) => (
+                        <Button
+                          key={action.key}
+                          type="button"
+                          size="icon"
+                          variant="ghost"
+                          aria-label={action.label}
+                          disabled={action.disabled}
+                          onClick={action.onClick}
+                          className="size-9 rounded-full text-text-secondary hover:text-text-primary"
+                        >
+                          {action.icon}
+                        </Button>
+                      ))
+                  : null
+              }
             />
           )}
         </div>

--- a/client/src/components/Chat/Subagents/SubagentThreadPanel.tsx
+++ b/client/src/components/Chat/Subagents/SubagentThreadPanel.tsx
@@ -3,13 +3,6 @@ import { v4 } from 'uuid';
 import { Clock, OctagonPause, X, Zap } from 'lucide-react';
 import { dataService, ForkOptions } from 'librechat-data-provider';
 import {
-  useRecoilCallback,
-  useRecoilState,
-  useRecoilValue,
-  useResetRecoilState,
-  useSetRecoilState,
-} from 'recoil';
-import {
   Alert,
   Button,
   Composer,
@@ -17,6 +10,13 @@ import {
   useMediaQuery,
   useToastContext,
 } from '@librechat/client';
+import {
+  useRecoilCallback,
+  useRecoilState,
+  useRecoilValue,
+  useResetRecoilState,
+  useSetRecoilState,
+} from 'recoil';
 import type {
   ParentSubagentTaskSummary,
   SubagentControlAction,

--- a/client/src/components/Chat/Subagents/SubagentThreadPanel.tsx
+++ b/client/src/components/Chat/Subagents/SubagentThreadPanel.tsx
@@ -1,15 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { v4 } from 'uuid';
-import { X } from 'lucide-react';
+import { ListEnd, X, Zap } from 'lucide-react';
 import { dataService, ForkOptions } from 'librechat-data-provider';
-import {
-  Alert,
-  Button,
-  Composer,
-  ControlCombobox,
-  useMediaQuery,
-  useToastContext,
-} from '@librechat/client';
 import {
   useRecoilCallback,
   useRecoilState,
@@ -17,15 +9,25 @@ import {
   useResetRecoilState,
   useSetRecoilState,
 } from 'recoil';
+import {
+  Alert,
+  Button,
+  Composer,
+  ControlCombobox,
+  TooltipAnchor,
+  useMediaQuery,
+  useToastContext,
+} from '@librechat/client';
 import type {
   ParentSubagentTaskSummary,
   SubagentControlAction,
   SubagentControlReceipt,
   SubagentControlRequest,
 } from 'librechat-data-provider';
+import type { ComposerKeyVerdict, ComposerStopProps } from '@librechat/client';
 import type { KeyboardEvent as ReactKeyboardEvent, ReactNode } from 'react';
-import type { ComposerKeyVerdict } from '@librechat/client';
 import type { ActiveSubagentPanel, SubagentControlUiState } from '~/store/subagents';
+import type { ComposerKeyAction } from '~/utils/shortcuts';
 import type { OptionWithIcon } from '~/common';
 import {
   adaptDurableThreadActivity,
@@ -96,6 +98,16 @@ const failedControlReason = (
   if (retryable) return 'owner_unavailable';
   return 'invalid_command';
 };
+
+/** Which control a during-run verdict asks for. `submit` is whatever the
+ *  reader's own key policy treats as the default — with Enter-to-send off that
+ *  is ⌘/Ctrl+Enter, which is why the chord is never read raw. */
+const CONTROL_FOR_ACTION = {
+  submit: 'steer',
+  other: 'queue',
+  interrupt: 'interrupt',
+  preempt: 'interrupt',
+} as const satisfies Partial<Record<ComposerKeyAction, SubagentControlAction>>;
 
 const failedControlLocaleKey = (reason?: string) => {
   if (reason === 'task_inaccessible') return 'com_ui_subagent_control_reason_task_inaccessible';
@@ -1038,11 +1050,17 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
       ? localize('com_ui_steer')
       : localize('com_ui_subagent_continue_new_chat');
   const cancelTask = useCallback(() => submitControl('cancel'), [submitControl]);
-  /** Which control the next submission is, decided by the chord that asked for
-   *  it. Read at submission and reset immediately, so a pointer click — which
-   *  never passes through the key policy — always means the default. */
-  const pendingSubmitActionRef = useRef<SubagentControlAction>('steer');
+  /** Handler and label travel as one value, so the Stop control can never
+   *  render without an accessible name. */
+  const stopProps: ComposerStopProps =
+    composerMode === 'control' && !controlPending
+      ? { onStop: cancelTask, stopLabel: localize('com_ui_subagent_cancel_task') }
+      : {};
   const controlModeRef = useRef(false);
+  const chordControlRef = useRef<{
+    event: ReactKeyboardEvent<HTMLTextAreaElement>;
+    control: SubagentControlAction;
+  } | null>(null);
   controlModeRef.current = composerMode === 'control';
   let composerCanSubmit: boolean;
   if (composerSettling) {
@@ -1072,16 +1090,11 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
         submitOverride,
         yieldedChords,
       });
-      if (action === 'submit') {
-        pendingSubmitActionRef.current = 'steer';
-        return 'submit';
-      }
-      if (action === 'other') {
-        pendingSubmitActionRef.current = 'queue';
-        return 'submit';
-      }
-      if (action === 'interrupt' || action === 'preempt') {
-        pendingSubmitActionRef.current = 'interrupt';
+      const control = CONTROL_FOR_ACTION[action as keyof typeof CONTROL_FOR_ACTION];
+      if (control != null) {
+        /** Bound to THIS event, so a chord the composer then refuses leaves
+         *  nothing a later pointer click could pick up. */
+        chordControlRef.current = { event, control };
         return 'submit';
       }
       if (action === 'newline') return 'newline';
@@ -1090,15 +1103,21 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
     },
     [enterToSend, shortcutsEnabled, submitOverride, yieldedChords],
   );
-  const submitComposer = useCallback(() => {
-    if (controlAvailable) {
-      const action = pendingSubmitActionRef.current;
-      pendingSubmitActionRef.current = 'steer';
-      submitControl(action);
-      return;
-    }
-    continueAsChat();
-  }, [continueAsChat, controlAvailable, submitControl]);
+  /** The submitting event decides which control this is, so a chord that was
+   *  refused (empty field, settling, a command already in flight) leaves
+   *  nothing behind for the next pointer click to pick up. */
+  const submitComposer = useCallback(
+    (event?: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+      if (!controlAvailable) {
+        continueAsChat();
+        return;
+      }
+      const chord = chordControlRef.current;
+      chordControlRef.current = null;
+      submitControl(event != null && chord?.event === event ? chord.control : 'steer');
+    },
+    [continueAsChat, controlAvailable, submitControl],
+  );
   const selectActor = useCallback(
     (nextThreadId: string) => {
       const next = eventSiblings.find((child) => child.threadId === nextThreadId);
@@ -1392,8 +1411,7 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
               canSubmit={composerCanSubmit}
               disabled={composerMode === 'control' && controlPending}
               submitLabel={composerSubmitLabel}
-              onStop={composerMode === 'control' && !controlPending ? cancelTask : undefined}
-              stopLabel={localize('com_ui_subagent_cancel_task')}
+              {...stopProps}
               ariaLabel={localize('com_ui_message_input')}
               placeholder={composerPlaceholder}
               submitOnEnter={enterToSend}
@@ -1402,6 +1420,48 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
                *  continuation is ordinary chat text bound for an ordinary
                *  composer, which caps nothing. */
               maxLength={composerMode === 'control' ? 4 * 1024 : undefined}
+              /** Queue and interrupt keep a pointer of their own. They carry no
+               *  word label — the tooltip and the accessible name say what they
+               *  are — but a touch reader, or one whose shortcuts are off or
+               *  rebound, still has to be able to reach them. */
+              actions={
+                composerMode === 'control' ? (
+                  <>
+                    <TooltipAnchor
+                      description={localize('com_ui_queue')}
+                      render={
+                        <Button
+                          type="button"
+                          size="icon"
+                          variant="ghost"
+                          aria-label={localize('com_ui_queue')}
+                          disabled={controlPending || controlMessage.trim() === ''}
+                          onClick={() => submitControl('queue')}
+                          className="size-9 rounded-full text-text-secondary hover:text-text-primary"
+                        >
+                          <ListEnd size={16} aria-hidden />
+                        </Button>
+                      }
+                    />
+                    <TooltipAnchor
+                      description={localize('com_ui_subagent_interrupt')}
+                      render={
+                        <Button
+                          type="button"
+                          size="icon"
+                          variant="ghost"
+                          aria-label={localize('com_ui_subagent_interrupt')}
+                          disabled={controlPending || controlMessage.trim() === ''}
+                          onClick={() => submitControl('interrupt')}
+                          className="size-9 rounded-full text-text-secondary hover:text-text-primary"
+                        >
+                          <Zap size={16} aria-hidden />
+                        </Button>
+                      }
+                    />
+                  </>
+                ) : null
+              }
             />
           )}
         </div>

--- a/client/src/components/Chat/Subagents/SubagentThreadPanel.tsx
+++ b/client/src/components/Chat/Subagents/SubagentThreadPanel.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { v4 } from 'uuid';
-import { ListEnd, OctagonX, X, Zap } from 'lucide-react';
+import { X } from 'lucide-react';
 import { dataService, ForkOptions } from 'librechat-data-provider';
 import {
   Alert,
@@ -58,6 +58,7 @@ import { resolveComposerKeyDown } from '~/utils/shortcuts';
 import SubagentConversation from './SubagentConversation';
 import { eventSubagentSelection } from './eventSelection';
 import { useAgentsMapContext } from '~/Providers';
+import { isLiveSubagentStatus } from './status';
 import { renderAgentAvatar } from '~/utils';
 import store from '~/store';
 
@@ -973,9 +974,14 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
   const hasConversationProjection =
     selection.durable == null || threadView == null || Array.isArray(threadView.turns);
   const taskInaccessible = controlInaccessible || transientControl?.reason === 'task_inaccessible';
+  /** `dispatched` counts as live. The task is on its way to an executor, and a
+   *  reader who types into a run that has only just started means it for that
+   *  run — withdrawing the composer until the first token lands is the swap
+   *  this panel exists to avoid. */
   const controlAvailable =
     selection.durable != null &&
-    taskView?.status === 'running' &&
+    taskView != null &&
+    isLiveSubagentStatus(taskView.status) &&
     !taskInaccessible &&
     !controlsClosed;
   const controlPending =
@@ -1004,33 +1010,80 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
   /** `control` steers the live run, `continue` carries the thread into a chat
    *  of the reader's own. Both compose into the same field, with the same
    *  placeholder the main chat composer shows for this agent. */
-  let composerMode: 'control' | 'continue' | null = null;
+  let liveComposerMode: 'control' | 'continue' | null = null;
   if (controlAvailable) {
-    composerMode = 'control';
+    liveComposerMode = 'control';
   } else if (canContinueAsChat) {
-    composerMode = 'continue';
+    liveComposerMode = 'continue';
   }
+  /** A delivery re-keys the query to its new task, and the task view blanks for
+   *  the render or two that takes — deliberately, so task-scoped fields are
+   *  never attributed to the wrong task. Presence must not follow it down: the
+   *  composer would unmount and remount within the same tenth of a second,
+   *  taking focus and the reader's half-typed words with it. The last mode this
+   *  thread showed carries the surface across that gap, holding submission
+   *  until the new task's own view arrives. */
+  const retainedModeRef = useRef<{ threadId: string; mode: 'control' | 'continue' } | null>(null);
+  if (liveComposerMode != null) {
+    retainedModeRef.current = { threadId, mode: liveComposerMode };
+  } else if (retainedModeRef.current != null && retainedModeRef.current.threadId !== threadId) {
+    retainedModeRef.current = null;
+  }
+  const composerSettling = liveComposerMode == null && taskView == null;
+  const composerMode =
+    liveComposerMode ?? (composerSettling ? retainedModeRef.current?.mode : null);
   const composerPlaceholder = localize('com_endpoint_message_new', { 0: panelTitle });
-  const composerCanSubmit =
+  const composerSubmitLabel =
     composerMode === 'control'
-      ? !controlPending && controlMessage.trim() !== ''
-      : !continueChat.isLoading;
+      ? localize('com_ui_steer')
+      : localize('com_ui_subagent_continue_new_chat');
+  const cancelTask = useCallback(() => submitControl('cancel'), [submitControl]);
+  /** Which control the next submission is, decided by the chord that asked for
+   *  it. Read at submission and reset immediately, so a pointer click — which
+   *  never passes through the key policy — always means the default. */
+  const pendingSubmitActionRef = useRef<SubagentControlAction>('steer');
+  const controlModeRef = useRef(false);
+  controlModeRef.current = composerMode === 'control';
+  let composerCanSubmit: boolean;
+  if (composerSettling) {
+    composerCanSubmit = false;
+  } else if (composerMode === 'control') {
+    composerCanSubmit = !controlPending && controlMessage.trim() !== '';
+  } else {
+    composerCanSubmit = !continueChat.isLoading;
+  }
   /** The main chat form's own Enter decision table, so a reader who rebound or
    *  unbound the submit shortcut gets the same contract here, and chords
    *  claimed by global shortcuts are left for the window handler. */
   const resolveKeyVerdict = useCallback(
     (event: ReactKeyboardEvent<HTMLTextAreaElement>, isComposing: boolean): ComposerKeyVerdict => {
+      /** A live run is exactly the condition main chat calls "during run", so
+       *  its during-run chords carry over verbatim: the default submits a
+       *  steer, ⌘/Ctrl+Enter takes the other queueing action, and the
+       *  interrupting chords interrupt. */
+      const duringRun = controlModeRef.current;
       const action = resolveComposerKeyDown(event, {
         isComposing,
-        isSubmitting: false,
-        allowSubmitWhileGenerating: false,
-        hasDuringRunModifier: false,
+        isSubmitting: duringRun,
+        allowSubmitWhileGenerating: duringRun,
+        hasDuringRunModifier: duringRun,
         shortcutsEnabled,
         enterToSend,
         submitOverride,
         yieldedChords,
       });
-      if (action === 'submit') return 'submit';
+      if (action === 'submit') {
+        pendingSubmitActionRef.current = 'steer';
+        return 'submit';
+      }
+      if (action === 'other') {
+        pendingSubmitActionRef.current = 'queue';
+        return 'submit';
+      }
+      if (action === 'interrupt' || action === 'preempt') {
+        pendingSubmitActionRef.current = 'interrupt';
+        return 'submit';
+      }
       if (action === 'newline') return 'newline';
       if (action === 'block') return 'block';
       return 'none';
@@ -1039,7 +1092,9 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
   );
   const submitComposer = useCallback(() => {
     if (controlAvailable) {
-      submitControl('steer');
+      const action = pendingSubmitActionRef.current;
+      pendingSubmitActionRef.current = 'steer';
+      submitControl(action);
       return;
     }
     continueAsChat();
@@ -1133,7 +1188,7 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
   let activityPanel: ReactNode;
   if (hasConversationProjection) {
     activityPanel = (
-      <SubagentActivityScrollSurface padded={false}>
+      <SubagentActivityScrollSurface padded={false} headerInset>
         {showUnavailableHistoryBoundary && (
           <div
             role="status"
@@ -1191,7 +1246,7 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
     ((eventSummary?.tasks.length ?? 0) > 1 || eventSummary?.tasksTruncated === true)
   ) {
     activityPanel = (
-      <SubagentActivityScrollSurface padded={false}>
+      <SubagentActivityScrollSurface padded={false} headerInset>
         <div data-subagent-thread-timeline>
           {timelinePrefix}
           {visibleEventTasks.map(renderEventTask)}
@@ -1206,6 +1261,7 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
         activity={activity}
         state={panelState}
         showPrompt={false}
+        headerInset
         onCancelControl={
           controlAvailable && !controlPending
             ? (controlId) => submitControl('cancel_message', controlId)
@@ -1222,9 +1278,13 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
       aria-modal={isMobile || undefined}
       aria-label={localize('com_ui_subagent_thread_panel')}
       onKeyDown={handlePanelKeyDown}
-      className="flex h-full w-full flex-col overflow-hidden bg-surface-primary-alt text-text-primary"
+      className="relative flex h-full w-full flex-col overflow-hidden bg-surface-primary-alt text-text-primary"
     >
-      <header className="flex h-14 shrink-0 items-center gap-2 border-b border-border-light px-3">
+      {/* The main chat header's own shape: a 52px bar that floats over the
+          thread and fades into it, so the conversation scrolls under it and
+          more of it is on screen. Gradient stops track THIS surface rather
+          than the chat's, since the panel sits on its own background. */}
+      <header className="absolute top-0 z-10 flex h-[52px] w-full items-center gap-2 bg-gradient-to-b from-surface-primary-alt via-surface-primary-alt/70 to-transparent p-2 font-semibold text-text-primary">
         {actorOptions.length > 1 ? (
           /* The agent builder's picker, so switching actors here reads as the
              same control as every other agent selection in the app — avatar,
@@ -1293,8 +1353,12 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
       >
         {activityPanel}
       </ApprovalProvider>
-      {(showControlFooter || canContinueAsChat) && (
-        <div className="shrink-0 p-3 pt-2">
+      {(showControlFooter || composerMode != null) && (
+        /* The main chat form's own bottom rhythm: its composer clears the
+           viewport floor by the height of the disclaimer beneath it, and this
+           one clears it by the same, so the two surfaces end on one line when
+           the panel is open beside the thread. */
+        <div className="shrink-0 px-3 pb-10 pt-2">
           {transientControl?.status === 'failed' && (
             <Alert variant="error" className="mb-2 flex items-center gap-2">
               <span className="min-w-0 flex-1">
@@ -1316,20 +1380,20 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
             </Alert>
           )}
           {composerMode != null && (
-            /* One surface across the run's whole life. A settled thread swaps
-               what Enter DOES, never the control the reader is looking at, so
-               nothing under the pointer moves as the run completes. */
+            /* One surface across the run's whole life, and one control on it:
+               submitting IS the steer, and with nothing to send the send button
+               becomes main chat's Stop, which cancels the task. Queue and
+               interrupt keep the chords main chat gives them rather than
+               spelling themselves out beside the field. */
             <Composer
               value={controlMessage}
               onChange={setControlMessage}
               onSubmit={submitComposer}
               canSubmit={composerCanSubmit}
               disabled={composerMode === 'control' && controlPending}
-              submitLabel={
-                composerMode === 'control'
-                  ? localize('com_ui_steer')
-                  : localize('com_ui_subagent_continue_new_chat')
-              }
+              submitLabel={composerSubmitLabel}
+              onStop={composerMode === 'control' && !controlPending ? cancelTask : undefined}
+              stopLabel={localize('com_ui_subagent_cancel_task')}
               ariaLabel={localize('com_ui_message_input')}
               placeholder={composerPlaceholder}
               submitOnEnter={enterToSend}
@@ -1338,45 +1402,6 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
                *  continuation is ordinary chat text bound for an ordinary
                *  composer, which caps nothing. */
               maxLength={composerMode === 'control' ? 4 * 1024 : undefined}
-              actions={
-                composerMode === 'control' ? (
-                  <>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="outline"
-                      disabled={controlPending || controlMessage.trim() === ''}
-                      onClick={() => submitControl('queue')}
-                      className="rounded-full"
-                    >
-                      <ListEnd size={14} aria-hidden />
-                      {localize('com_ui_queue')}
-                    </Button>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="outline"
-                      disabled={controlPending || controlMessage.trim() === ''}
-                      onClick={() => submitControl('interrupt')}
-                      className="rounded-full"
-                    >
-                      <Zap size={14} aria-hidden />
-                      {localize('com_ui_subagent_interrupt')}
-                    </Button>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="ghost"
-                      disabled={controlPending}
-                      onClick={() => submitControl('cancel')}
-                      className="rounded-full text-status-error"
-                    >
-                      <OctagonX size={14} aria-hidden />
-                      {localize('com_ui_subagent_cancel_task')}
-                    </Button>
-                  </>
-                ) : null
-              }
             />
           )}
         </div>

--- a/client/src/components/Chat/Subagents/SubagentThreadPanel.tsx
+++ b/client/src/components/Chat/Subagents/SubagentThreadPanel.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { v4 } from 'uuid';
-import { ListEnd, X, Zap } from 'lucide-react';
+import { Clock, OctagonPause, X, Zap } from 'lucide-react';
 import { dataService, ForkOptions } from 'librechat-data-provider';
 import {
   useRecoilCallback,
@@ -14,7 +14,6 @@ import {
   Button,
   Composer,
   ControlCombobox,
-  TooltipAnchor,
   useMediaQuery,
   useToastContext,
 } from '@librechat/client';
@@ -24,7 +23,7 @@ import type {
   SubagentControlReceipt,
   SubagentControlRequest,
 } from 'librechat-data-provider';
-import type { ComposerKeyVerdict, ComposerStopProps } from '@librechat/client';
+import type { ComposerKeyVerdict, ComposerStopProps, SendAction } from '@librechat/client';
 import type { KeyboardEvent as ReactKeyboardEvent, ReactNode } from 'react';
 import type { ActiveSubagentPanel, SubagentControlUiState } from '~/store/subagents';
 import type { ComposerKeyAction } from '~/utils/shortcuts';
@@ -53,10 +52,10 @@ import {
 import useSubagentActivityStream from '~/data-provider/Subagents/useSubagentActivityStream';
 import SubagentActivity, { SubagentActivityScrollSurface } from './SubagentActivity';
 import ApprovalProvider from '~/components/Chat/Messages/Content/ApprovalContext';
+import { isMacPlatform, resolveComposerKeyDown } from '~/utils/shortcuts';
 import { useFocusTrap, useLocalize, useNavigateToConvo } from '~/hooks';
 import useComposerBindings from '~/hooks/Input/useComposerBindings';
 import { useParentSubagents } from './ParentSubagentsProvider';
-import { resolveComposerKeyDown } from '~/utils/shortcuts';
 import SubagentConversation from './SubagentConversation';
 import { eventSubagentSelection } from './eventSelection';
 import { useAgentsMapContext } from '~/Providers';
@@ -1045,9 +1044,11 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
   const composerMode =
     liveComposerMode ?? (composerSettling ? retainedModeRef.current?.mode : null);
   const composerPlaceholder = localize('com_endpoint_message_new', { 0: panelTitle });
+  /** The send control names what IT does, distinct from the `Steer` row it
+   *  offers — the same pairing main chat uses for its during-run send. */
   const composerSubmitLabel =
     composerMode === 'control'
-      ? localize('com_ui_steer')
+      ? localize('com_ui_steer_send')
       : localize('com_ui_subagent_continue_new_chat');
   const cancelTask = useCallback(() => submitControl('cancel'), [submitControl]);
   /** Handler and label travel as one value, so the Stop control can never
@@ -1070,6 +1071,76 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
   } else {
     composerCanSubmit = !continueChat.isLoading;
   }
+  /** The alternate submissions, offered from the send control exactly as main
+   *  chat offers its during-run actions — never as a row of controls beside the
+   *  field repeating what submitting already does. Each chord is advertised
+   *  only while it still reaches its action, read from the same decision table
+   *  that will execute it. */
+  const submitActions = useMemo<SendAction[]>(() => {
+    if (composerMode !== 'control') return [];
+    const context = {
+      isComposing: false,
+      isSubmitting: true,
+      allowSubmitWhileGenerating: true,
+      hasDuringRunModifier: true,
+      shortcutsEnabled,
+      enterToSend,
+      submitOverride,
+      yieldedChords,
+    };
+    const base = { key: 'Enter', altKey: false, ctrlKey: false, metaKey: false, shiftKey: false };
+    const plainEnter = resolveComposerKeyDown(base, context);
+    const modEnter = resolveComposerKeyDown(
+      { ...base, ctrlKey: !isMacPlatform, metaKey: isMacPlatform },
+      context,
+    );
+    const altEnter = resolveComposerKeyDown({ ...base, altKey: true }, context);
+    const modSymbol = isMacPlatform ? '\u2318\u23CE' : 'Ctrl \u23CE';
+    const altSymbol = isMacPlatform ? '\u2325\u23CE' : 'Alt \u23CE';
+    let steerKbd: string | undefined;
+    if (plainEnter === 'submit') {
+      steerKbd = '\u23CE';
+    } else if (modEnter === 'submit') {
+      steerKbd = modSymbol;
+    }
+    const blocked = controlPending || controlMessage.trim() === '';
+    return [
+      {
+        key: 'steer',
+        label: localize('com_ui_steer'),
+        kbd: steerKbd,
+        icon: <Zap className="h-4 w-4 text-amber-500" aria-hidden="true" />,
+        disabled: blocked,
+        onClick: () => submitControl('steer'),
+      },
+      {
+        key: 'queue',
+        label: localize('com_ui_queue'),
+        kbd: modEnter === 'other' ? modSymbol : undefined,
+        icon: <Clock className="h-4 w-4 text-cyan-500" aria-hidden="true" />,
+        disabled: blocked,
+        onClick: () => submitControl('queue'),
+      },
+      {
+        key: 'interrupt',
+        label: localize('com_ui_subagent_interrupt'),
+        kbd: altEnter === 'interrupt' ? altSymbol : undefined,
+        icon: <OctagonPause className="h-4 w-4 text-red-500" aria-hidden="true" />,
+        disabled: blocked,
+        onClick: () => submitControl('interrupt'),
+      },
+    ];
+  }, [
+    composerMode,
+    controlMessage,
+    controlPending,
+    enterToSend,
+    localize,
+    shortcutsEnabled,
+    submitControl,
+    submitOverride,
+    yieldedChords,
+  ]);
   /** The main chat form's own Enter decision table, so a reader who rebound or
    *  unbound the submit shortcut gets the same contract here, and chords
    *  claimed by global shortcuts are left for the window handler. */
@@ -1400,10 +1471,9 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
           )}
           {composerMode != null && (
             /* One surface across the run's whole life, and one control on it:
-               submitting IS the steer, and with nothing to send the send button
-               becomes main chat's Stop, which cancels the task. Queue and
-               interrupt keep the chords main chat gives them rather than
-               spelling themselves out beside the field. */
+               submitting IS the steer, with nothing to send the send button
+               becomes main chat's Stop, and every alternate submission hangs
+               off that same control the way main chat's during-run actions do. */
             <Composer
               value={controlMessage}
               onChange={setControlMessage}
@@ -1420,48 +1490,8 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
                *  continuation is ordinary chat text bound for an ordinary
                *  composer, which caps nothing. */
               maxLength={composerMode === 'control' ? 4 * 1024 : undefined}
-              /** Queue and interrupt keep a pointer of their own. They carry no
-               *  word label — the tooltip and the accessible name say what they
-               *  are — but a touch reader, or one whose shortcuts are off or
-               *  rebound, still has to be able to reach them. */
-              actions={
-                composerMode === 'control' ? (
-                  <>
-                    <TooltipAnchor
-                      description={localize('com_ui_queue')}
-                      render={
-                        <Button
-                          type="button"
-                          size="icon"
-                          variant="ghost"
-                          aria-label={localize('com_ui_queue')}
-                          disabled={controlPending || controlMessage.trim() === ''}
-                          onClick={() => submitControl('queue')}
-                          className="size-9 rounded-full text-text-secondary hover:text-text-primary"
-                        >
-                          <ListEnd size={16} aria-hidden />
-                        </Button>
-                      }
-                    />
-                    <TooltipAnchor
-                      description={localize('com_ui_subagent_interrupt')}
-                      render={
-                        <Button
-                          type="button"
-                          size="icon"
-                          variant="ghost"
-                          aria-label={localize('com_ui_subagent_interrupt')}
-                          disabled={controlPending || controlMessage.trim() === ''}
-                          onClick={() => submitControl('interrupt')}
-                          className="size-9 rounded-full text-text-secondary hover:text-text-primary"
-                        >
-                          <Zap size={16} aria-hidden />
-                        </Button>
-                      }
-                    />
-                  </>
-                ) : null
-              }
+              submitActions={submitActions}
+              submitActionsLabel={localize('com_ui_during_run_actions')}
             />
           )}
         </div>

--- a/client/src/components/Chat/Subagents/SubagentThreadPanel.tsx
+++ b/client/src/components/Chat/Subagents/SubagentThreadPanel.tsx
@@ -120,9 +120,11 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
   const { navigateToConvo } = useNavigateToConvo();
   const panelRef = useRef<HTMLDivElement>(null);
   const isMobile = useMediaQuery('(max-width: 767px)');
-  /** No hover means the send control's action list cannot be reached: a tap on
-   *  that anchor submits. Those readers get the same actions as controls of
-   *  their own instead. */
+  /** Two reasons the send control's action list cannot be used where it hangs.
+   *  Without hover, a tap on its anchor submits instead of opening it. And
+   *  while the panel is a focus-trapped modal, the list is portaled outside the
+   *  `aside` the trap knows, so Tab never reaches it. Either way those readers
+   *  get the same actions as controls of their own, inside the panel. */
   const coarsePointer = useMediaQuery('(hover: none)');
   const enterToSend = useRecoilValue(store.enterToSend);
   const { shortcutsEnabled, submitOverride, yieldedChords } = useComposerBindings();
@@ -1060,6 +1062,7 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
   if (composerMode == null && composerSettling) {
     composerMode = retainedModeRef.current?.mode ?? (taskIsLive ? 'control' : null);
   }
+  const actionsInline = coarsePointer || isMobile;
   const composerPlaceholder = localize('com_endpoint_message_new', { 0: panelTitle });
   /** The send control names what IT does, distinct from the `Steer` row it
    *  offers — the same pairing main chat uses for its during-run send. */
@@ -1071,7 +1074,7 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
   /** Handler and label travel as one value, so the Stop control can never
    *  render without an accessible name. */
   const stopProps: ComposerStopProps =
-    composerMode === 'control' && !controlPending
+    controlAvailable && !controlPending
       ? { onStop: cancelTask, stopLabel: localize('com_ui_subagent_cancel_task') }
       : {};
   const controlModeRef = useRef(false);
@@ -1120,7 +1123,10 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
     } else if (modEnter === 'submit') {
       steerKbd = modSymbol;
     }
-    const blocked = controlPending || controlMessage.trim() === '';
+    /** The same gate the send button answers to: a retained surface over a task
+     *  the server cannot address yet must not offer a command through any of
+     *  its doors — every 404 here closes this task's controls for good. */
+    const blocked = !controlAvailable || controlPending || controlMessage.trim() === '';
     return [
       {
         key: 'steer',
@@ -1149,6 +1155,7 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
     ];
   }, [
     composerMode,
+    controlAvailable,
     controlMessage,
     controlPending,
     enterToSend,
@@ -1507,10 +1514,10 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
                *  continuation is ordinary chat text bound for an ordinary
                *  composer, which caps nothing. */
               maxLength={composerMode === 'control' ? 4 * 1024 : undefined}
-              submitActions={coarsePointer ? [] : submitActions}
+              submitActions={actionsInline ? [] : submitActions}
               submitActionsLabel={localize('com_ui_during_run_actions')}
               actions={
-                coarsePointer
+                actionsInline
                   ? submitActions
                       .filter((action) => action.key !== 'steer')
                       .map((action) => (

--- a/packages/client/src/components/Composer.spec.tsx
+++ b/packages/client/src/components/Composer.spec.tsx
@@ -178,6 +178,48 @@ describe('Composer', () => {
     expect(resolveKeyVerdict).toHaveBeenCalledWith(expect.anything(), false);
   });
 
+  /** Main chat's trade: one slot, showing Stop when there is nothing to send
+   *  and Send the moment there is. */
+  it('swaps the send control for Stop while the field is empty', () => {
+    const onSubmit = jest.fn();
+    const onStop = jest.fn();
+    const Hosted = () => {
+      const [value, setValue] = useState('');
+      return (
+        <Composer
+          value={value}
+          onChange={setValue}
+          onSubmit={onSubmit}
+          onStop={onStop}
+          stopLabel="Cancel task"
+          canSubmit
+          submitLabel="Steer"
+          ariaLabel="Message input"
+        />
+      );
+    };
+    render(<Hosted />);
+
+    expect(screen.queryByLabelText('Steer')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('Cancel task'));
+    expect(onStop).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(screen.getByLabelText('Message input'), {
+      target: { value: 'Try the file.' },
+    });
+    expect(screen.queryByLabelText('Cancel task')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('Steer'));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the send control when the surface has nothing to stop', () => {
+    const onSubmit = jest.fn();
+    render(<Harness onSubmit={onSubmit} />);
+
+    expect(screen.getByLabelText('Send it')).toBeInTheDocument();
+    expect(screen.queryByTestId('composer-stop-button')).not.toBeInTheDocument();
+  });
+
   it('sends from the button and keeps the caller actions alongside it', () => {
     const onSubmit = jest.fn();
     render(<Harness onSubmit={onSubmit} />);

--- a/packages/client/src/components/Composer.tsx
+++ b/packages/client/src/components/Composer.tsx
@@ -34,6 +34,14 @@ export interface ComposerProps {
   /** Secondary controls, laid out inline-start of the send button. */
   actions?: ReactNode;
   /**
+   * Stops whatever this surface is running. When supplied, an empty field
+   * shows main chat's Stop in the send button's place — the same trade the
+   * main composer makes, so "nothing to send" and "stop what is running" never
+   * need two separate controls.
+   */
+  onStop?: () => void;
+  stopLabel?: string;
+  /**
    * The reader's "Press Enter to send" preference. When false, Enter inserts a
    * newline and ⌘/Ctrl+Enter submits — the same bargain the main chat composer
    * strikes, so a reader who turned the preference off cannot steer a run or
@@ -53,6 +61,10 @@ export interface ComposerProps {
   ) => ComposerKeyVerdict;
   className?: string;
 }
+
+/** Main chat's send/stop button shape, shared by both states of the slot. */
+const CONTROL_CLASS =
+  'size-theme-control rounded-theme-control-round bg-text-primary p-theme-compact text-text-primary outline-offset-4 transition-all duration-theme-normal disabled:cursor-not-allowed disabled:text-text-secondary disabled:opacity-10';
 
 /**
  * The chat composer at panel scale: one persistent surface with a text field, a
@@ -79,6 +91,8 @@ const Composer: ForwardRefExoticComponent<ComposerProps & RefAttributes<HTMLText
       minRows = 1,
       maxRows = 6,
       actions,
+      onStop,
+      stopLabel,
       submitOnEnter = true,
       resolveKeyVerdict,
       className,
@@ -86,6 +100,9 @@ const Composer: ForwardRefExoticComponent<ComposerProps & RefAttributes<HTMLText
     ref: Ref<HTMLTextAreaElement>,
   ) {
     const [isComposing, setIsComposing] = useState(false);
+    /** Nothing to send and something to stop: main chat swaps the same slot
+     *  rather than standing a second control beside it. */
+    const showStop = onStop != null && value.trim() === '';
 
     const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
       /**
@@ -140,28 +157,59 @@ const Composer: ForwardRefExoticComponent<ComposerProps & RefAttributes<HTMLText
           minRows={minRows}
           maxRows={maxRows}
           disabled={disabled}
-          className="w-full resize-none bg-transparent px-1.5 py-1 text-sm text-text-primary placeholder:text-text-secondary focus:outline-none disabled:cursor-not-allowed"
+          /** Main chat's own field metrics (`ChatForm`'s `baseClasses`), so the
+           *  two composers stand the same height and their surfaces line up
+           *  when this panel is open beside the thread. */
+          className="m-0 w-full resize-none bg-transparent px-3 py-[13px] text-text-primary placeholder:text-text-tertiary focus:outline-none disabled:cursor-not-allowed md:py-3.5"
         />
         {/* The row holds its height whether or not it carries secondary actions,
           so the surface cannot resize as a run changes what it offers. */}
         <div className="flex min-h-9 flex-wrap items-center gap-1.5">
           {actions}
-          <TooltipAnchor
-            description={submitLabel}
-            className="ml-auto"
-            render={
-              <button
-                type="button"
-                aria-label={submitLabel}
-                disabled={disabled || !canSubmit}
-                onClick={onSubmit}
-                data-testid="composer-send-button"
-                className="size-theme-control rounded-theme-control-round bg-text-primary p-theme-compact text-text-primary outline-offset-4 transition-all duration-theme-normal disabled:cursor-not-allowed disabled:text-text-secondary disabled:opacity-10"
-              >
-                <SendIcon size={24} />
-              </button>
-            }
-          />
+          {showStop ? (
+            <TooltipAnchor
+              description={stopLabel ?? ''}
+              className="ml-auto"
+              render={
+                <button
+                  type="button"
+                  aria-label={stopLabel ?? ''}
+                  onClick={onStop}
+                  data-testid="composer-stop-button"
+                  className={CONTROL_CLASS}
+                >
+                  <svg
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="icon-lg text-surface-primary"
+                    aria-hidden="true"
+                  >
+                    <rect x="7" y="7" width="10" height="10" rx="1.25" fill="currentColor" />
+                  </svg>
+                </button>
+              }
+            />
+          ) : (
+            <TooltipAnchor
+              description={submitLabel}
+              className="ml-auto"
+              render={
+                <button
+                  type="button"
+                  aria-label={submitLabel}
+                  disabled={disabled || !canSubmit}
+                  onClick={onSubmit}
+                  data-testid="composer-send-button"
+                  className={CONTROL_CLASS}
+                >
+                  <SendIcon size={24} />
+                </button>
+              }
+            />
+          )}
         </div>
       </div>
     );

--- a/packages/client/src/components/Composer.tsx
+++ b/packages/client/src/components/Composer.tsx
@@ -6,8 +6,10 @@ import type {
   Ref,
   RefAttributes,
 } from 'react';
+import type { SendAction } from './SendActions';
 import { composerSurfaceClasses, composerSurfaceShadow } from '~/utils/composer';
 import { TextareaAutosize } from './TextareaAutosize';
+import { SendActions } from './SendActions';
 import { TooltipAnchor } from './Tooltip';
 import { SendIcon } from '~/svgs';
 import { cn } from '~/utils';
@@ -36,6 +38,14 @@ export interface ComposerProps {
   maxRows?: number;
   /** Secondary controls, laid out inline-start of the send button. */
   actions?: ReactNode;
+  /**
+   * Alternate submissions, revealed from the send control on hover or focus —
+   * the same trade main chat's during-run send button makes, so the field is
+   * never lined with controls that repeat what submitting already does. The
+   * primary submission stays the button's own click.
+   */
+  submitActions?: SendAction[];
+  submitActionsLabel?: string;
 
   /**
    * The reader's "Press Enter to send" preference. When false, Enter inserts a
@@ -101,6 +111,8 @@ const Composer: ForwardRefExoticComponent<
     minRows = 1,
     maxRows = 6,
     actions,
+    submitActions,
+    submitActionsLabel,
     onStop,
     stopLabel,
     submitOnEnter = true,
@@ -203,20 +215,26 @@ const Composer: ForwardRefExoticComponent<
             }
           />
         ) : (
-          <TooltipAnchor
-            description={submitLabel}
-            className="ml-auto"
-            render={
-              <button
-                type="button"
-                aria-label={submitLabel}
-                disabled={disabled || !canSubmit}
-                onClick={() => onSubmit()}
-                data-testid="composer-send-button"
-                className={CONTROL_CLASS}
-              >
-                <SendIcon size={24} />
-              </button>
+          <SendActions
+            actions={canSubmit ? (submitActions ?? []) : []}
+            label={submitActionsLabel ?? submitLabel}
+            anchor={
+              <TooltipAnchor
+                description={submitLabel}
+                className="ml-auto"
+                render={
+                  <button
+                    type="button"
+                    aria-label={submitLabel}
+                    disabled={disabled || !canSubmit}
+                    onClick={() => onSubmit()}
+                    data-testid="composer-send-button"
+                    className={CONTROL_CLASS}
+                  >
+                    <SendIcon size={24} />
+                  </button>
+                }
+              />
             }
           />
         )}

--- a/packages/client/src/components/Composer.tsx
+++ b/packages/client/src/components/Composer.tsx
@@ -20,7 +20,10 @@ export type ComposerKeyVerdict = 'submit' | 'block' | 'newline' | 'none';
 export interface ComposerProps {
   value: string;
   onChange: (value: string) => void;
-  onSubmit: () => void;
+  /** Given the key event that asked for the submission, or nothing when a
+   *  pointer asked. Hosts that vary the action by chord resolve it from this
+   *  event rather than from state left behind by an earlier keypress. */
+  onSubmit: (event?: KeyboardEvent<HTMLTextAreaElement>) => void;
   /** Blocks submission without disabling the field, so a reader can still type
    *  and read back a draft the surface is not ready to accept. */
   canSubmit: boolean;
@@ -33,14 +36,7 @@ export interface ComposerProps {
   maxRows?: number;
   /** Secondary controls, laid out inline-start of the send button. */
   actions?: ReactNode;
-  /**
-   * Stops whatever this surface is running. When supplied, an empty field
-   * shows main chat's Stop in the send button's place — the same trade the
-   * main composer makes, so "nothing to send" and "stop what is running" never
-   * need two separate controls.
-   */
-  onStop?: () => void;
-  stopLabel?: string;
+
   /**
    * The reader's "Press Enter to send" preference. When false, Enter inserts a
    * newline and ⌘/Ctrl+Enter submits — the same bargain the main chat composer
@@ -62,6 +58,19 @@ export interface ComposerProps {
   className?: string;
 }
 
+/**
+ * Stops whatever this surface is running. When supplied, an empty field shows
+ * main chat's Stop in the send button's place — the same trade the main
+ * composer makes, so "nothing to send" and "stop what is running" never need
+ * two separate controls. The label travels with the handler so the control can
+ * never render without an accessible name.
+ */
+export type ComposerStopProps =
+  | { onStop: () => void; stopLabel: string }
+  | { onStop?: undefined; stopLabel?: undefined };
+
+export type ComposerPropsWithStop = ComposerProps & ComposerStopProps;
+
 /** Main chat's send/stop button shape, shared by both states of the slot. */
 const CONTROL_CLASS =
   'size-theme-control rounded-theme-control-round bg-text-primary p-theme-compact text-text-primary outline-offset-4 transition-all duration-theme-normal disabled:cursor-not-allowed disabled:text-text-secondary disabled:opacity-10';
@@ -76,143 +85,144 @@ const CONTROL_CLASS =
  * out for a different control when a run settles — which is what makes the
  * footer shift under the reader.
  */
-const Composer: ForwardRefExoticComponent<ComposerProps & RefAttributes<HTMLTextAreaElement>> =
-  forwardRef(function Composer(
-    {
-      value,
-      onChange,
-      onSubmit,
-      canSubmit,
-      submitLabel,
-      ariaLabel,
-      placeholder,
-      disabled = false,
-      maxLength,
-      minRows = 1,
-      maxRows = 6,
-      actions,
-      onStop,
-      stopLabel,
-      submitOnEnter = true,
-      resolveKeyVerdict,
-      className,
-    }: ComposerProps,
-    ref: Ref<HTMLTextAreaElement>,
-  ) {
-    const [isComposing, setIsComposing] = useState(false);
-    /** Nothing to send and something to stop: main chat swaps the same slot
-     *  rather than standing a second control beside it. */
-    const showStop = onStop != null && value.trim() === '';
+const Composer: ForwardRefExoticComponent<
+  ComposerPropsWithStop & RefAttributes<HTMLTextAreaElement>
+> = forwardRef(function Composer(
+  {
+    value,
+    onChange,
+    onSubmit,
+    canSubmit,
+    submitLabel,
+    ariaLabel,
+    placeholder,
+    disabled = false,
+    maxLength,
+    minRows = 1,
+    maxRows = 6,
+    actions,
+    onStop,
+    stopLabel,
+    submitOnEnter = true,
+    resolveKeyVerdict,
+    className,
+  }: ComposerPropsWithStop,
+  ref: Ref<HTMLTextAreaElement>,
+) {
+  const [isComposing, setIsComposing] = useState(false);
+  /** Nothing to send and something to stop: main chat swaps the same slot
+   *  rather than standing a second control beside it. */
+  const showStop = onStop != null && value.trim() === '';
 
-    const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
-      /**
-       * `isComposing` alone does not settle the IME question: Safari reports it
-       * as false on the very Enter that commits a candidate, so the tracked
-       * composition state and the legacy `Process`/229 signals stand in for it,
-       * as the main chat composer's own guard does. Committed here rather than
-       * left to the host so every caller inherits it.
-       */
-      const composing =
-        isComposing ||
-        event.nativeEvent.isComposing ||
-        event.key === 'Process' ||
-        event.keyCode === 229;
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    /**
+     * `isComposing` alone does not settle the IME question: Safari reports it
+     * as false on the very Enter that commits a candidate, so the tracked
+     * composition state and the legacy `Process`/229 signals stand in for it,
+     * as the main chat composer's own guard does. Committed here rather than
+     * left to the host so every caller inherits it.
+     */
+    const composing =
+      isComposing ||
+      event.nativeEvent.isComposing ||
+      event.key === 'Process' ||
+      event.keyCode === 229;
 
-      const defaultVerdict = (): ComposerKeyVerdict => {
-        if (composing || event.key !== 'Enter' || event.shiftKey) return 'none';
-        if (!submitOnEnter && !(event.metaKey || event.ctrlKey)) return 'newline';
-        return 'submit';
-      };
-
-      const verdict = resolveKeyVerdict?.(event, composing) ?? defaultVerdict();
-      if (verdict === 'newline' || verdict === 'none') return;
-      event.preventDefault();
-      /** An empty field never submits, even where the surface would accept it:
-       *  a caller whose action needs no text (continuing a settled thread)
-       *  still wants that to be a deliberate press of the button, not a stray
-       *  Enter that navigates the reader somewhere. */
-      if (verdict === 'block' || !canSubmit || value.trim() === '') return;
-      onSubmit();
+    const defaultVerdict = (): ComposerKeyVerdict => {
+      if (composing || event.key !== 'Enter' || event.shiftKey) return 'none';
+      if (!submitOnEnter && !(event.metaKey || event.ctrlKey)) return 'newline';
+      return 'submit';
     };
 
-    return (
-      <div
-        className={cn(
-          'flex w-full flex-col gap-1.5 rounded-3xl p-2.5',
-          composerSurfaceClasses(),
-          composerSurfaceShadow.within,
-          className,
-        )}
-      >
-        <TextareaAutosize
-          ref={ref}
-          value={value}
-          onChange={(event) => onChange(event.target.value)}
-          onKeyDown={handleKeyDown}
-          onCompositionStart={() => setIsComposing(true)}
-          onCompositionEnd={() => setIsComposing(false)}
-          placeholder={placeholder}
-          aria-label={ariaLabel}
-          maxLength={maxLength}
-          minRows={minRows}
-          maxRows={maxRows}
-          disabled={disabled}
-          /** Main chat's own field metrics (`ChatForm`'s `baseClasses`), so the
-           *  two composers stand the same height and their surfaces line up
-           *  when this panel is open beside the thread. */
-          className="m-0 w-full resize-none bg-transparent px-3 py-[13px] text-text-primary placeholder:text-text-tertiary focus:outline-none disabled:cursor-not-allowed md:py-3.5"
-        />
-        {/* The row holds its height whether or not it carries secondary actions,
+    const verdict = resolveKeyVerdict?.(event, composing) ?? defaultVerdict();
+    if (verdict === 'newline' || verdict === 'none') return;
+    event.preventDefault();
+    /** An empty field never submits, even where the surface would accept it:
+     *  a caller whose action needs no text (continuing a settled thread)
+     *  still wants that to be a deliberate press of the button, not a stray
+     *  Enter that navigates the reader somewhere. */
+    if (verdict === 'block' || !canSubmit || value.trim() === '') return;
+    onSubmit(event);
+  };
+
+  return (
+    <div
+      className={cn(
+        'flex w-full flex-col gap-1.5 rounded-3xl p-2.5',
+        composerSurfaceClasses(),
+        composerSurfaceShadow.within,
+        className,
+      )}
+    >
+      <TextareaAutosize
+        ref={ref}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        onKeyDown={handleKeyDown}
+        onCompositionStart={() => setIsComposing(true)}
+        onCompositionEnd={() => setIsComposing(false)}
+        placeholder={placeholder}
+        aria-label={ariaLabel}
+        maxLength={maxLength}
+        minRows={minRows}
+        maxRows={maxRows}
+        disabled={disabled}
+        /** Main chat's own field metrics (`ChatForm`'s `baseClasses`), so the
+         *  two composers stand the same height and their surfaces line up
+         *  when this panel is open beside the thread. */
+        className="m-0 w-full resize-none bg-transparent px-3 py-[13px] text-text-primary placeholder:text-text-tertiary focus:outline-none disabled:cursor-not-allowed md:py-3.5"
+      />
+      {/* The row holds its height whether or not it carries secondary actions,
           so the surface cannot resize as a run changes what it offers. */}
-        <div className="flex min-h-9 flex-wrap items-center gap-1.5">
-          {actions}
-          {showStop ? (
-            <TooltipAnchor
-              description={stopLabel ?? ''}
-              className="ml-auto"
-              render={
-                <button
-                  type="button"
-                  aria-label={stopLabel ?? ''}
-                  onClick={onStop}
-                  data-testid="composer-stop-button"
-                  className={CONTROL_CLASS}
+      <div className="flex min-h-9 flex-wrap items-center gap-1.5">
+        {actions}
+        {showStop ? (
+          <TooltipAnchor
+            description={stopLabel}
+            className="ml-auto"
+            render={
+              <button
+                type="button"
+                aria-label={stopLabel}
+                onClick={onStop}
+                data-testid="composer-stop-button"
+                className={CONTROL_CLASS}
+              >
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="icon-lg text-surface-primary"
+                  aria-hidden="true"
                 >
-                  <svg
-                    width="24"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                    className="icon-lg text-surface-primary"
-                    aria-hidden="true"
-                  >
-                    <rect x="7" y="7" width="10" height="10" rx="1.25" fill="currentColor" />
-                  </svg>
-                </button>
-              }
-            />
-          ) : (
-            <TooltipAnchor
-              description={submitLabel}
-              className="ml-auto"
-              render={
-                <button
-                  type="button"
-                  aria-label={submitLabel}
-                  disabled={disabled || !canSubmit}
-                  onClick={onSubmit}
-                  data-testid="composer-send-button"
-                  className={CONTROL_CLASS}
-                >
-                  <SendIcon size={24} />
-                </button>
-              }
-            />
-          )}
-        </div>
+                  <rect x="7" y="7" width="10" height="10" rx="1.25" fill="currentColor" />
+                </svg>
+              </button>
+            }
+          />
+        ) : (
+          <TooltipAnchor
+            description={submitLabel}
+            className="ml-auto"
+            render={
+              <button
+                type="button"
+                aria-label={submitLabel}
+                disabled={disabled || !canSubmit}
+                onClick={() => onSubmit()}
+                data-testid="composer-send-button"
+                className={CONTROL_CLASS}
+              >
+                <SendIcon size={24} />
+              </button>
+            }
+          />
+        )}
       </div>
-    );
-  });
+    </div>
+  );
+});
 
 export default Composer;

--- a/packages/client/src/components/Composer.tsx
+++ b/packages/client/src/components/Composer.tsx
@@ -125,6 +125,19 @@ const Composer: ForwardRefExoticComponent<
   /** Nothing to send and something to stop: main chat swaps the same slot
    *  rather than standing a second control beside it. */
   const showStop = onStop != null && value.trim() === '';
+  const offeredActions = canSubmit ? (submitActions ?? []) : [];
+  const sendButton = (
+    <button
+      type="button"
+      aria-label={submitLabel}
+      disabled={disabled || !canSubmit}
+      onClick={() => onSubmit()}
+      data-testid="composer-send-button"
+      className={cn(CONTROL_CLASS, offeredActions.length > 0 && 'ml-auto')}
+    >
+      <SendIcon size={24} />
+    </button>
+  );
 
   const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
     /**
@@ -216,25 +229,18 @@ const Composer: ForwardRefExoticComponent<
           />
         ) : (
           <SendActions
-            actions={canSubmit ? (submitActions ?? []) : []}
+            actions={offeredActions}
             label={submitActionsLabel ?? submitLabel}
             anchor={
-              <TooltipAnchor
-                description={submitLabel}
-                className="ml-auto"
-                render={
-                  <button
-                    type="button"
-                    aria-label={submitLabel}
-                    disabled={disabled || !canSubmit}
-                    onClick={() => onSubmit()}
-                    data-testid="composer-send-button"
-                    className={CONTROL_CLASS}
-                  >
-                    <SendIcon size={24} />
-                  </button>
-                }
-              />
+              /** One popup over this control. With actions to offer, the list
+               *  names them and carries the primary; a tooltip would open on
+               *  the same focus, above the same button, and at a higher
+               *  z-index than the list it would cover. */
+              offeredActions.length > 0 ? (
+                sendButton
+              ) : (
+                <TooltipAnchor description={submitLabel} className="ml-auto" render={sendButton} />
+              )
             }
           />
         )}

--- a/packages/client/src/components/MultiSearch.tsx
+++ b/packages/client/src/components/MultiSearch.tsx
@@ -32,7 +32,7 @@ export default function MultiSearch({
   return (
     <div
       className={cn(
-        'focus:to-surface-primary/50 group sticky left-0 top-0 z-10 flex h-12 items-center gap-2 bg-gradient-to-b from-surface-tertiary-alt from-65% to-transparent px-3 py-2 text-text-primary transition-colors duration-300 focus:bg-gradient-to-b focus:from-surface-primary',
+        'group sticky left-0 top-0 z-10 flex h-12 items-center gap-2 bg-gradient-to-b from-surface-tertiary-alt from-65% to-transparent px-3 py-2 text-text-primary transition-colors duration-300 focus:bg-gradient-to-b focus:from-surface-primary focus:to-surface-primary/50',
         className,
       )}
     >

--- a/packages/client/src/components/MultiSearch.tsx
+++ b/packages/client/src/components/MultiSearch.tsx
@@ -32,7 +32,7 @@ export default function MultiSearch({
   return (
     <div
       className={cn(
-        'group sticky left-0 top-0 z-10 flex h-12 items-center gap-2 bg-gradient-to-b from-surface-tertiary-alt from-65% to-transparent px-3 py-2 text-text-primary transition-colors duration-300 focus:bg-gradient-to-b focus:from-surface-primary focus:to-surface-primary/50',
+        'focus:to-surface-primary/50 group sticky left-0 top-0 z-10 flex h-12 items-center gap-2 bg-gradient-to-b from-surface-tertiary-alt from-65% to-transparent px-3 py-2 text-text-primary transition-colors duration-300 focus:bg-gradient-to-b focus:from-surface-primary',
         className,
       )}
     >

--- a/packages/client/src/components/SendActions.spec.tsx
+++ b/packages/client/src/components/SendActions.spec.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { SendActions } from './SendActions';
+
+/**
+ * Renders the hovercard eagerly. Ariakit's real show path depends on pointer
+ * timers and layout, and these assertions are about which rows this module
+ * renders, not about Ariakit's hover behavior. The same substitution is made in
+ * `DuringRunSendButton.test.tsx`, whose 13 tests cover the populated rows
+ * through this module's other host.
+ */
+jest.mock('@ariakit/react', () => ({
+  HovercardProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  HovercardAnchor: ({ render }: { render: React.ReactElement }) => render,
+  Hovercard: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const anchor = (
+  <button type="button" aria-label="Send">
+    send
+  </button>
+);
+
+describe('SendActions', () => {
+  /** A host may pass a list that is sometimes empty — a settled run offers no
+   *  alternate submission — and must not have to branch for it. */
+  it('renders the anchor alone when there is nothing else to offer', () => {
+    const { container } = render(<SendActions anchor={anchor} actions={[]} label="More" />);
+
+    expect(screen.getByLabelText('Send')).toBeInTheDocument();
+    expect(container.querySelectorAll('button')).toHaveLength(1);
+  });
+
+  it('offers each action beside the anchor', () => {
+    const steer = jest.fn();
+    const queue = jest.fn();
+    render(
+      <SendActions
+        anchor={anchor}
+        label="More"
+        actions={[
+          { key: 'steer', label: 'Steer', kbd: '⏎', onClick: steer },
+          { key: 'queue', label: 'Queue', onClick: queue },
+        ]}
+      />,
+    );
+
+    expect(screen.getByLabelText('Send')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Queue').closest('button') as HTMLButtonElement);
+    expect(queue).toHaveBeenCalledTimes(1);
+    expect(steer).not.toHaveBeenCalled();
+  });
+
+  /** A disabled row's action refuses its chord too, so the hint would advertise
+   *  a key that does nothing. */
+  it('withholds a disabled row and its chord', () => {
+    const onClick = jest.fn();
+    render(
+      <SendActions
+        anchor={anchor}
+        label="More"
+        actions={[{ key: 'queue', label: 'Queue', kbd: '⌘⏎', disabled: true, onClick }]}
+      />,
+    );
+
+    const row = screen.getByText('Queue').closest('button') as HTMLButtonElement;
+    expect(row).toHaveAttribute('aria-disabled', 'true');
+    expect(row.querySelector('kbd')).toBeNull();
+    fireEvent.click(row);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/packages/client/src/components/SendActions.tsx
+++ b/packages/client/src/components/SendActions.tsx
@@ -1,0 +1,81 @@
+import * as Ariakit from '@ariakit/react';
+import type { ReactElement, ReactNode } from 'react';
+import type { JSX } from 'react/jsx-runtime';
+
+/** One alternate way to submit, offered from the send control rather than
+ *  standing beside the field. */
+export interface SendAction {
+  key: string;
+  label: string;
+  /** The chord that still reaches this action, when one does. Omitted rather
+   *  than guessed: advertising a key that has been rebound, yielded to a global
+   *  shortcut, or disabled is worse than advertising none. */
+  kbd?: string;
+  icon?: ReactNode;
+  disabled?: boolean;
+  onClick: () => void;
+}
+
+const ROW_CLASS =
+  'flex w-full cursor-pointer items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm text-text-primary hover:bg-surface-tertiary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-xheavy aria-disabled:cursor-not-allowed aria-disabled:opacity-50';
+
+function Kbd({ children }: { children: ReactNode }): JSX.Element {
+  return (
+    <kbd className="ml-auto rounded-md bg-surface-tertiary px-1.5 py-0.5 font-sans text-xs text-text-secondary">
+      {children}
+    </kbd>
+  );
+}
+
+/**
+ * The alternate submissions a send control offers on hover or focus.
+ *
+ * Every chat surface that can submit more than one way shows the same list in
+ * the same place — hung off the send control, never lined up beside the field,
+ * where a row would repeat what submitting already does. The anchor is passed
+ * in whole so each host keeps its own button: its ref (Enter's synthetic click
+ * routes through it), its submit type, and its own identifying attributes.
+ *
+ * With no actions the anchor renders alone, so a host can pass a list that is
+ * sometimes empty without branching.
+ */
+export function SendActions({
+  anchor,
+  actions,
+  label,
+}: {
+  anchor: ReactElement;
+  actions: SendAction[];
+  label: string;
+}): JSX.Element {
+  if (actions.length === 0) return anchor;
+  return (
+    <Ariakit.HovercardProvider placement="top-end" showTimeout={100} hideTimeout={150}>
+      <Ariakit.HovercardAnchor render={anchor} />
+      <Ariakit.Hovercard
+        portal
+        gutter={8}
+        unmountOnHide
+        aria-label={label}
+        className="z-50 min-w-[12rem] rounded-xl border border-border-light bg-surface-secondary p-1.5 text-text-primary shadow-lg outline-none"
+      >
+        {actions.map((action) => (
+          <button
+            key={action.key}
+            type="button"
+            className={ROW_CLASS}
+            aria-disabled={action.disabled === true}
+            onClick={action.disabled === true ? undefined : action.onClick}
+          >
+            {action.icon}
+            {action.label}
+            {/* A disabled row's action refuses its chord too, so no hint. */}
+            {action.kbd != null && action.disabled !== true && <Kbd>{action.kbd}</Kbd>}
+          </button>
+        ))}
+      </Ariakit.Hovercard>
+    </Ariakit.HovercardProvider>
+  );
+}
+
+export default SendActions;

--- a/packages/client/src/components/index.ts
+++ b/packages/client/src/components/index.ts
@@ -44,6 +44,8 @@ export { default as Badge } from './Badge';
 export { default as Avatar } from './Avatar';
 export { default as Combobox } from './Combobox';
 export { default as Composer } from './Composer';
+export { SendActions } from './SendActions';
+export type { SendAction } from './SendActions';
 export type {
   ComposerProps,
   ComposerPropsWithStop,

--- a/packages/client/src/components/index.ts
+++ b/packages/client/src/components/index.ts
@@ -44,7 +44,12 @@ export { default as Badge } from './Badge';
 export { default as Avatar } from './Avatar';
 export { default as Combobox } from './Combobox';
 export { default as Composer } from './Composer';
-export type { ComposerProps, ComposerKeyVerdict } from './Composer';
+export type {
+  ComposerProps,
+  ComposerPropsWithStop,
+  ComposerStopProps,
+  ComposerKeyVerdict,
+} from './Composer';
 export { default as Dropdown } from './Dropdown';
 export { default as DataTable } from './DataTable';
 export { default as SplitText } from './SplitText';


### PR DESCRIPTION
Follow-up to #15436, from four things Danny hit while using it.

## The flicker was a real unmount, and react-scan found it

Measured against the live panel with react-scan (the repo's own `e2e/perf/scan.ts` instrumentation) plus a `requestAnimationFrame` probe recording every mount and unmount of the panel's composer:

```
before   {at: 7531, present: true}    composer mounted
         {at: 11552, present: false}  ← external delivery: composer UNMOUNTS
         {at: 11562, present: true}   ← 10ms later it is back

after    {at: 8030, present: true}    ...and stays, across the same delivery
```

**Cause.** A delivery re-keys the thread query to its new task, and `taskView` blanks for the render or two that takes — deliberately, so task-scoped fields are never attributed to the wrong task. But composer *presence* was derived from that same view, so it followed it down and back up, taking focus and any half-typed steer with it. Presence now rides the last mode the thread showed and holds submission until the new task's own view lands. `dispatched` also counts as live now, which is the second half of what Danny saw: a run that had only just started withdrew the field until its first token arrived.

**Residual renders.** Every turn row re-renders ~2.8×/s while a child is live: the per-second timestamp and elapsed tickers, plus the 2s poll both the index and thread queries run (`ACTIVE_THREAD_REFRESH_MS`). That is ~2ms of render time across a 14s window and is shared with main chat's own rows, so I left it alone.

## One control instead of three labels

Submitting **is** the steer. With nothing to send, the send button becomes main chat's Stop, which cancels the task — the same slot-swap the main composer makes. Queue and interrupt keep the chords main chat gives them (⌘/Ctrl+Enter and ⌥/Alt+Enter, routed through the same `resolveComposerKeyDown` table) rather than standing beside the field spelling themselves out. Nothing carries a word label; each control says what it is through its tooltip and accessible name.

## The composers line up

The field takes `ChatForm`'s own metrics and the footer clears the viewport floor by the height of main chat's disclaimer. Measured in a 950px viewport:

| | main chat | panel |
|---|---|---|
| textarea top | 805 | 805 |
| textarea height | 52 | 52 |
| surface bottom | 910 | 910 |

(Before: panel textarea top 857, height 28.)

## The header is main chat's header

A 52px bar that floats over the thread and fades into it — same gradient technique, resolved against the panel's own surface — so the conversation scrolls under it rather than starting below a solid bordered bar, and more of the thread is on screen.

## Verification

- 3085 client tests across 213 suites; 345 in `packages/client`; clean `tsc` and eslint.
- New coverage: the composer survives a re-keyed delivery, stays in control mode while dispatched, each chord submits its own control, and the send/stop slot swaps on an empty field.
- Two existing tests were reusing one JSX element across `rerender`, which React bails out of — they were asserting nothing at those points and now build a fresh element.