### PR TITLE
✔️ style: Anchor the Applied Steer Receipt and Name Tool Calls in Its Interrupt Copy

### DIFF
--- a/client/src/components/Chat/Messages/Content/Parts/SteerPart.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/SteerPart.tsx
@@ -155,9 +155,13 @@ const SteerPart = memo(function SteerPart({
             </div>
           </CollapsibleText>
         </div>
-        <div className="mt-1 flex min-h-8 items-center justify-end text-text-secondary">
+        {/* The receipt trails the timestamp so the always-visible checks sit
+         *  flush under the bubble's bottom-right corner. Leading them would
+         *  park them wherever the hover-revealed time happens to end, and that
+         *  width changes as the relative string ticks. */}
+        <div className="mt-1 flex min-h-8 items-center justify-end gap-2 text-text-secondary">
+          <MessageTimestamp value={timestamp} className="ml-0" />
           <SteerReceipt state="applied" live={isSubmitting} animateIn={animateIn} />
-          <MessageTimestamp value={timestamp} />
         </div>
       </div>
       {otherFiles.length > 0 && (

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/SteerPart.test.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/SteerPart.test.tsx
@@ -17,7 +17,7 @@ jest.mock('~/Providers', () => ({
 
 jest.mock('~/components/Chat/Messages/ui/MessageTimestamp', () => ({
   __esModule: true,
-  default: () => null,
+  default: () => <time data-testid="steer-timestamp" />,
 }));
 
 jest.mock('~/components/Chat/Messages/Content/MarkdownLite', () => ({
@@ -118,6 +118,19 @@ describe('SteerPart author label', () => {
     // hunting: no hover-capable-pointer opacity gate like the old "?" had.
     const receipt = screen.getByTestId('steer-receipt');
     expect(receipt.className).not.toContain('opacity-0');
+  });
+
+  it('anchors the receipt after the timestamp, at the trailing edge of the row', () => {
+    renderPart();
+    // The timestamp is the hover-revealed half of the row and its width changes
+    // as the relative string ticks; leading the checks with it would park the
+    // one always-visible mark at a moving offset from the bubble's corner.
+    const row = screen.getByTestId('steer-receipt').parentElement;
+    const children = Array.from(row?.children ?? []);
+    expect(children.map((child) => child.getAttribute('data-testid'))).toEqual([
+      'steer-timestamp',
+      'steer-receipt',
+    ]);
   });
 });
 

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -2196,7 +2196,7 @@
   "com_ui_steer_failed": "Steering failed",
   "com_ui_steer_in_flight": "Steering",
   "com_ui_steer_in_flight_preempt": "Interrupting",
-  "com_ui_steer_interrupting_info": "Interrupt requested. The response will stop at the next safe point, then your message takes over. Reasoning is not interrupted. To interrupt reasoning, stop the response instead.",
+  "com_ui_steer_interrupting_info": "Interrupt requested. The response will stop at the next safe point, then your message takes over. Reasoning and tool calls are not interrupted. To interrupt them, stop the response instead.",
   "com_ui_steer_interrupts_default": "Steering interrupts generation",
   "com_ui_steer_interrupts_default_info": "When on, Enter stops the response at the next safe point instead of waiting for the agent's next tool step. Either way the partial answer is kept and the response continues.",
   "com_ui_steer_interrupts_enable_info": "Switches the during-run default to steering and stops the response at the next safe point. The partial answer is kept and the response continues.",


### PR DESCRIPTION
## Summary

Swaps the order of the applied steer receipt and the timestamp in the meta row under a steer bubble, so the row reads `11 seconds ago ✓✓` instead of `✓✓ 11 seconds ago`.

## Why

The timestamp in that row is hover-revealed (`.message-render .message-timestamp { opacity: 0 }` in `client/src/style.css`, under `@media (hover: hover)`), and opacity keeps its layout box. So on a hover-capable pointer at rest, the checks were the only visible thing in the row, sitting at an offset determined entirely by an invisible string. That offset moved on its own: `getMessageTimestamp` re-renders recent rows on a shared minute ticker, so "11 seconds ago" becomes "1 minute ago" becomes the absolute date once the message stops being recent, and the one always-on glyph in the row drifted horizontally each time.

Trailing the receipt pins it under the bubble's `rounded-br` corner where it stays put, and the timestamp fades in leftward into space that was already reserved, so hover causes no shift either. It also matches how every messaging client orders the pair (time then checks), which is what touch devices now see, since the timestamp never hides there.

`ml-0` overrides `MessageTimestamp`'s built-in `ml-2`, which is now on the wrong side; `gap-2` on the row preserves the same 8px separation.

Deliberately unchanged: the composer chip's `✓ Delivered` / `✓✓ Interrupting` in `InFlightSteers.tsx` keeps its check *before* the label. That is an icon-label pair that reads as a phrase, not a right-anchored status glyph.

## Testing

- `client`: `SteerPart.test.tsx` 19/19 pass, including a new DOM-order assertion. The file's `MessageTimestamp` mock rendered `null`, so it now renders a stub the assertion can order against.
- `npm run static-checks -- --against origin/dev`: all affected checks pass.

## Also: the interrupt blurb now names tool calls

`com_ui_steer_interrupting_info` already told you reasoning survives a preempt. The same is true of an in-flight tool call: the preempt seals the model stream at a `PreemptBoundary` (`packages/api/src/agents/run.ts`), it does not abort a tool that is already executing. Folded both into one clause rather than adding a fourth sentence:

> Reasoning **and tool calls are** not interrupted. To interrupt **them**, stop the response instead.

Only the English key is touched. `InFlightSteers.test.tsx` 66/66 (it asserts the key, not the copy).
