### PR TITLE
🧲 fix: Draw OpenID Refresh Lookups Into System Context

### DIFF
--- a/api/server/controllers/AuthController.js
+++ b/api/server/controllers/AuthController.js
@@ -380,99 +380,103 @@ const refreshController = async (req, res) => {
 
       const refreshUserId =
         req.session?.openidTokens?.appUserId ?? getValidOpenIDReuseUserId(parsedCookies);
-      const refreshUser = refreshUserId
-        ? await runAsSystem(() => getUserById(refreshUserId, AUTH_REFRESH_USER_PROJECTION))
-        : null;
-      if (!refreshUser) {
+      if (!refreshUserId) {
         return res.status(403).send('Invalid OpenID refresh token');
       }
 
-      let successfulRefreshToken = refreshToken;
-      let refreshResult;
-      try {
-        refreshResult = await refreshOpenIDUser({
-          req,
-          res,
-          user: refreshUser,
-          refreshToken,
-          browserRefreshToken: parsedCookies.refreshToken,
-          strategyName: 'refreshController',
-          deferPublication: true,
-        });
-      } catch (error) {
-        if (!fallbackRefreshToken || !isInvalidGrantError(error)) {
-          throw error;
+      return await runAsSystem(async () => {
+        const refreshUser = await getUserById(refreshUserId, AUTH_REFRESH_USER_PROJECTION);
+        if (!refreshUser) {
+          return res.status(403).send('Invalid OpenID refresh token');
         }
-        logger.info(
-          '[refreshController] Session refresh token was rejected; retrying the distinct browser token',
-        );
-        successfulRefreshToken = fallbackRefreshToken;
-        refreshResult = await refreshOpenIDUser({
+
+        let successfulRefreshToken = refreshToken;
+        let refreshResult;
+        try {
+          refreshResult = await refreshOpenIDUser({
+            req,
+            res,
+            user: refreshUser,
+            refreshToken,
+            browserRefreshToken: parsedCookies.refreshToken,
+            strategyName: 'refreshController',
+            deferPublication: true,
+          });
+        } catch (error) {
+          if (!fallbackRefreshToken || !isInvalidGrantError(error)) {
+            throw error;
+          }
+          logger.info(
+            '[refreshController] Session refresh token was rejected; retrying the distinct browser token',
+          );
+          successfulRefreshToken = fallbackRefreshToken;
+          refreshResult = await refreshOpenIDUser({
+            req,
+            res,
+            user: refreshUser,
+            refreshToken: fallbackRefreshToken,
+            browserRefreshToken: parsedCookies.refreshToken,
+            strategyName: 'refreshController (browser fallback)',
+            deferPublication: true,
+          });
+        }
+        const { tokenset, claims, openidIssuer, user, error, migration } = refreshResult;
+
+        if (error || !user) {
+          logger.warn(
+            `[refreshController] Redirecting to /login: error=${error ?? 'null'}, user=${user ? 'exists' : 'null'}`,
+          );
+          return res.status(401).redirect('/login');
+        }
+
+        // Handle migration: update user with openidId if found by email without openidId
+        // Also handle case where user has mismatched openidId (e.g., after database switch)
+        if (migration || user.openidId !== claims.sub) {
+          const reason = migration ? 'migration' : 'openidId mismatch';
+          await updateUser(user._id.toString(), {
+            provider: 'openid',
+            openidId: claims.sub,
+            ...(openidIssuer ? { openidIssuer } : {}),
+          });
+          logger.info(
+            `[refreshController] Updated user ${user.email} openidId (${reason}): ${user.openidId ?? 'null'} -> ${claims.sub}`,
+          );
+        }
+
+        if (
+          successfulRefreshToken !== refreshToken &&
+          req.session?.openidTokens?.refreshToken === refreshToken
+        ) {
+          delete req.session.openidTokens;
+        }
+
+        const token = await sendOpenIDAuthResponse({
+          tokenset,
+          user,
+          existingRefreshToken: successfulRefreshToken,
+          openidSubject: claims?.sub,
+          openidIssuer,
+          predecessorIdentity: {
+            userId: refreshUser._id.toString(),
+            tenantId: refreshUser.tenantId,
+            openidIssuer: refreshUser.openidIssuer,
+          },
+          rejectedRefreshTokens: successfulRefreshToken === refreshToken ? [] : [refreshToken],
           req,
           res,
-          user: refreshUser,
-          refreshToken: fallbackRefreshToken,
-          browserRefreshToken: parsedCookies.refreshToken,
-          strategyName: 'refreshController (browser fallback)',
-          deferPublication: true,
         });
-      }
-      const { tokenset, claims, openidIssuer, user, error, migration } = refreshResult;
-
-      if (error || !user) {
-        logger.warn(
-          `[refreshController] Redirecting to /login: error=${error ?? 'null'}, user=${user ? 'exists' : 'null'}`,
+        return await withOpenIDResponseDelivery(
+          {
+            res,
+            openidTokens: req.session?.openidTokens,
+            context: 'refreshController',
+          },
+          (sendAuthorized) =>
+            sendAuthorized(() =>
+              res.status(200).send({ token, user: sanitizeUserForAuthResponse(user) }),
+            ),
         );
-        return res.status(401).redirect('/login');
-      }
-
-      // Handle migration: update user with openidId if found by email without openidId
-      // Also handle case where user has mismatched openidId (e.g., after database switch)
-      if (migration || user.openidId !== claims.sub) {
-        const reason = migration ? 'migration' : 'openidId mismatch';
-        await updateUser(user._id.toString(), {
-          provider: 'openid',
-          openidId: claims.sub,
-          ...(openidIssuer ? { openidIssuer } : {}),
-        });
-        logger.info(
-          `[refreshController] Updated user ${user.email} openidId (${reason}): ${user.openidId ?? 'null'} -> ${claims.sub}`,
-        );
-      }
-
-      if (
-        successfulRefreshToken !== refreshToken &&
-        req.session?.openidTokens?.refreshToken === refreshToken
-      ) {
-        delete req.session.openidTokens;
-      }
-
-      const token = await sendOpenIDAuthResponse({
-        tokenset,
-        user,
-        existingRefreshToken: successfulRefreshToken,
-        openidSubject: claims?.sub,
-        openidIssuer,
-        predecessorIdentity: {
-          userId: refreshUser._id.toString(),
-          tenantId: refreshUser.tenantId,
-          openidIssuer: refreshUser.openidIssuer,
-        },
-        rejectedRefreshTokens: successfulRefreshToken === refreshToken ? [] : [refreshToken],
-        req,
-        res,
       });
-      return await withOpenIDResponseDelivery(
-        {
-          res,
-          openidTokens: req.session?.openidTokens,
-          context: 'refreshController',
-        },
-        (sendAuthorized) =>
-          sendAuthorized(() =>
-            res.status(200).send({ token, user: sanitizeUserForAuthResponse(user) }),
-          ),
-      );
     } catch (error) {
       if (isOpenIDRefreshOwnershipError(error)) {
         clearOpenIDAuthTokens(

--- a/api/server/controllers/AuthController.js
+++ b/api/server/controllers/AuthController.js
@@ -1,7 +1,7 @@
 const cookies = require('cookie');
 const jwt = require('jsonwebtoken');
 const crypto = require('node:crypto');
-const { logger } = require('@librechat/data-schemas');
+const { logger, runAsSystem } = require('@librechat/data-schemas');
 const {
   math,
   isEnabled,
@@ -345,7 +345,9 @@ const refreshController = async (req, res) => {
               context: 'refreshController',
             },
             async (sendAuthorized) => {
-              const user = await getUserById(reuseUserId, AUTH_REFRESH_USER_PROJECTION);
+              const user = await runAsSystem(() =>
+                getUserById(reuseUserId, AUTH_REFRESH_USER_PROJECTION),
+              );
               if (!user || !isReusableOpenIDSessionIdentity(reuseSessionTokens, user)) {
                 return undefined;
               }
@@ -379,7 +381,7 @@ const refreshController = async (req, res) => {
       const refreshUserId =
         req.session?.openidTokens?.appUserId ?? getValidOpenIDReuseUserId(parsedCookies);
       const refreshUser = refreshUserId
-        ? await getUserById(refreshUserId, AUTH_REFRESH_USER_PROJECTION)
+        ? await runAsSystem(() => getUserById(refreshUserId, AUTH_REFRESH_USER_PROJECTION))
         : null;
       if (!refreshUser) {
         return res.status(403).send('Invalid OpenID refresh token');

--- a/api/server/controllers/AuthController.js
+++ b/api/server/controllers/AuthController.js
@@ -1,7 +1,7 @@
 const cookies = require('cookie');
 const jwt = require('jsonwebtoken');
 const crypto = require('node:crypto');
-const { logger, runAsSystem } = require('@librechat/data-schemas');
+const { logger, runAsSystem, tenantStorage } = require('@librechat/data-schemas');
 const {
   math,
   isEnabled,
@@ -71,6 +71,14 @@ const sanitizeUserForAuthResponse = (user) => {
   } = source;
   return safeUser;
 };
+
+const runInUserTenant = (user, fn) =>
+  user.tenantId
+    ? tenantStorage.run(
+        { tenantId: user.tenantId, userId: user._id.toString() },
+        async () => await fn(),
+      )
+    : runAsSystem(fn);
 
 const getValidOpenIDReuseUserId = (parsedCookies, refreshToken) => {
   const openidUserId = parsedCookies.openid_user_id;
@@ -345,7 +353,7 @@ const refreshController = async (req, res) => {
               context: 'refreshController',
             },
             async (sendAuthorized) => {
-              const user = await runAsSystem(() =>
+              const user = await runAsSystem(async () =>
                 getUserById(reuseUserId, AUTH_REFRESH_USER_PROJECTION),
               );
               if (!user || !isReusableOpenIDSessionIdentity(reuseSessionTokens, user)) {
@@ -384,12 +392,14 @@ const refreshController = async (req, res) => {
         return res.status(403).send('Invalid OpenID refresh token');
       }
 
-      return await runAsSystem(async () => {
-        const refreshUser = await getUserById(refreshUserId, AUTH_REFRESH_USER_PROJECTION);
-        if (!refreshUser) {
-          return res.status(403).send('Invalid OpenID refresh token');
-        }
+      const refreshUser = await runAsSystem(async () =>
+        getUserById(refreshUserId, AUTH_REFRESH_USER_PROJECTION),
+      );
+      if (!refreshUser) {
+        return res.status(403).send('Invalid OpenID refresh token');
+      }
 
+      return await runInUserTenant(refreshUser, async () => {
         let successfulRefreshToken = refreshToken;
         let refreshResult;
         try {
@@ -425,6 +435,17 @@ const refreshController = async (req, res) => {
         if (error || !user) {
           logger.warn(
             `[refreshController] Redirecting to /login: error=${error ?? 'null'}, user=${user ? 'exists' : 'null'}`,
+          );
+          return res.status(401).redirect('/login');
+        }
+
+        if (user._id.toString() !== refreshUser._id.toString()) {
+          logger.warn(
+            '[refreshController] Refreshed identity resolved a different user; refusing token issuance',
+            {
+              refreshUserId: refreshUser._id.toString(),
+              resolvedUserId: user._id.toString(),
+            },
           );
           return res.status(401).redirect('/login');
         }
@@ -500,53 +521,60 @@ const refreshController = async (req, res) => {
         const userId = getValidOpenIDReuseUserId(parsedCookies, bridgeSourceToken);
         if (userId) {
           try {
-            const bridgeUser = await getUserById(userId, AUTH_REFRESH_USER_PROJECTION);
+            const bridgeUser = await runAsSystem(async () =>
+              getUserById(userId, AUTH_REFRESH_USER_PROJECTION),
+            );
             if (!bridgeUser) {
               return res.status(403).send('Invalid OpenID refresh token');
             }
 
-            const bridgedRefreshToken = await getRefreshTokenBridge({
-              oldRefreshToken: bridgeSourceToken,
-              userId,
-              tenantId: bridgeUser.tenantId,
-              openidIssuer: bridgeUser.openidIssuer,
-            });
+            const bridgeResponse = await runInUserTenant(bridgeUser, async () => {
+              const bridgedRefreshToken = await getRefreshTokenBridge({
+                oldRefreshToken: bridgeSourceToken,
+                userId,
+                tenantId: bridgeUser.tenantId,
+                openidIssuer: bridgeUser.openidIssuer,
+              });
 
-            if (bridgedRefreshToken) {
-              logger.info(
-                '[refreshController] Recovered via refresh-token bridge after invalid_grant',
-                {
-                  userId,
-                },
-              );
-
-              try {
-                const { appAuthToken } = await recoverOpenIDRefreshBridge({
-                  req,
-                  res,
-                  refreshToken: bridgeSourceToken,
-                  bridgedRefreshToken,
-                  bridgeUser,
-                });
-
-                return await withOpenIDResponseDelivery(
+              if (bridgedRefreshToken) {
+                logger.info(
+                  '[refreshController] Recovered via refresh-token bridge after invalid_grant',
                   {
-                    res,
-                    openidTokens: req.session?.openidTokens,
-                    context: 'refreshController',
+                    userId,
                   },
-                  (sendAuthorized) =>
-                    sendAuthorized(() =>
-                      res.status(200).send({
-                        token: appAuthToken,
-                        user: sanitizeUserForAuthResponse(bridgeUser),
-                      }),
-                    ),
                 );
-              } catch (retryError) {
-                logger.error('[refreshController] Bridge recovery retry failed', retryError);
-                // Fall through to generic error response
+
+                try {
+                  const { appAuthToken } = await recoverOpenIDRefreshBridge({
+                    req,
+                    res,
+                    refreshToken: bridgeSourceToken,
+                    bridgedRefreshToken,
+                    bridgeUser,
+                  });
+
+                  return await withOpenIDResponseDelivery(
+                    {
+                      res,
+                      openidTokens: req.session?.openidTokens,
+                      context: 'refreshController',
+                    },
+                    (sendAuthorized) =>
+                      sendAuthorized(() =>
+                        res.status(200).send({
+                          token: appAuthToken,
+                          user: sanitizeUserForAuthResponse(bridgeUser),
+                        }),
+                      ),
+                  );
+                } catch (retryError) {
+                  logger.error('[refreshController] Bridge recovery retry failed', retryError);
+                  // Fall through to generic error response
+                }
               }
+            });
+            if (bridgeResponse !== undefined) {
+              return bridgeResponse;
             }
           } catch (bridgeError) {
             logger.warn('[refreshController] Refresh-token bridge lookup failed', {

--- a/api/server/controllers/AuthController.spec.js
+++ b/api/server/controllers/AuthController.spec.js
@@ -1,4 +1,12 @@
-const mockRunAsSystem = jest.fn((fn) => fn());
+let mockSystemContextActive = false;
+const mockRunAsSystem = jest.fn(async (fn) => {
+  mockSystemContextActive = true;
+  try {
+    return await fn();
+  } finally {
+    mockSystemContextActive = false;
+  }
+});
 jest.mock('@librechat/data-schemas', () => ({
   logger: { error: jest.fn(), debug: jest.fn(), warn: jest.fn(), info: jest.fn() },
   runAsSystem: (fn) => mockRunAsSystem(fn),
@@ -508,6 +516,7 @@ describe('refreshController – OpenID path', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSystemContextActive = false;
     delete process.env.OPENID_SCOPE;
     delete process.env.OPENID_REFRESH_AUDIENCE;
     process.env.JWT_REFRESH_SECRET = 'test-refresh-secret';
@@ -1052,6 +1061,10 @@ describe('refreshController – OpenID path', () => {
         openidIssuer: baseClaims.iss,
       },
     };
+    findOpenIDUser.mockImplementationOnce(async () => {
+      expect(mockSystemContextActive).toBe(true);
+      return { user: { ...defaultUser }, error: null, migration: false };
+    });
 
     await refreshController(req, res);
 

--- a/api/server/controllers/AuthController.spec.js
+++ b/api/server/controllers/AuthController.spec.js
@@ -1,15 +1,26 @@
-let mockSystemContextActive = false;
+let mockActiveTenantId;
 const mockRunAsSystem = jest.fn(async (fn) => {
-  mockSystemContextActive = true;
+  const previousTenantId = mockActiveTenantId;
+  mockActiveTenantId = '__SYSTEM__';
   try {
     return await fn();
   } finally {
-    mockSystemContextActive = false;
+    mockActiveTenantId = previousTenantId;
+  }
+});
+const mockTenantStorageRun = jest.fn(async (context, fn) => {
+  const previousTenantId = mockActiveTenantId;
+  mockActiveTenantId = context.tenantId;
+  try {
+    return await fn();
+  } finally {
+    mockActiveTenantId = previousTenantId;
   }
 });
 jest.mock('@librechat/data-schemas', () => ({
   logger: { error: jest.fn(), debug: jest.fn(), warn: jest.fn(), info: jest.fn() },
   runAsSystem: (fn) => mockRunAsSystem(fn),
+  tenantStorage: { run: (context, fn) => mockTenantStorageRun(context, fn) },
 }));
 jest.mock('~/server/services/GraphTokenService', () => ({
   getGraphApiToken: jest.fn(),
@@ -516,7 +527,7 @@ describe('refreshController – OpenID path', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockSystemContextActive = false;
+    mockActiveTenantId = undefined;
     delete process.env.OPENID_SCOPE;
     delete process.env.OPENID_REFRESH_AUDIENCE;
     process.env.JWT_REFRESH_SECRET = 'test-refresh-secret';
@@ -1062,7 +1073,7 @@ describe('refreshController – OpenID path', () => {
       },
     };
     findOpenIDUser.mockImplementationOnce(async () => {
-      expect(mockSystemContextActive).toBe(true);
+      expect(mockActiveTenantId).toBe('tenant-1');
       return { user: { ...defaultUser }, error: null, migration: false };
     });
 
@@ -1406,6 +1417,27 @@ describe('refreshController – OpenID path', () => {
     expect(res.redirect).toHaveBeenCalledWith('/login');
   });
 
+  it('rejects a refreshed identity that resolves to a different user', async () => {
+    findOpenIDUser.mockResolvedValue({
+      user: { ...defaultUser, _id: 'different-user-id' },
+      error: null,
+      migration: false,
+    });
+
+    await refreshController(req, res);
+
+    expect(setOpenIDAuthTokens).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[refreshController] Refreshed identity resolved a different user; refusing token issuance',
+      {
+        refreshUserId: 'user-db-id',
+        resolvedUserId: 'different-user-id',
+      },
+    );
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.redirect).toHaveBeenCalledWith('/login');
+  });
+
   it('should preserve invalid OpenID refresh token behavior', async () => {
     openIdClient.refreshTokenGrant.mockRejectedValue(new Error('invalid_grant'));
 
@@ -1463,7 +1495,10 @@ describe('refreshController – OpenID path', () => {
       tenantId: 'tenant-1',
       openidIssuer: 'https://issuer.example.com',
     });
-    getRefreshTokenBridge.mockResolvedValue('bridged-refresh');
+    getRefreshTokenBridge.mockImplementationOnce(async () => {
+      expect(mockActiveTenantId).toBe('tenant-1');
+      return 'bridged-refresh';
+    });
     const nonRotatingTokenset = { ...mockTokenset };
     delete nonRotatingTokenset.refresh_token;
     openIdClient.refreshTokenGrant

--- a/api/server/controllers/AuthController.spec.js
+++ b/api/server/controllers/AuthController.spec.js
@@ -1,5 +1,7 @@
+const mockRunAsSystem = jest.fn((fn) => fn());
 jest.mock('@librechat/data-schemas', () => ({
   logger: { error: jest.fn(), debug: jest.fn(), warn: jest.fn(), info: jest.fn() },
+  runAsSystem: (fn) => mockRunAsSystem(fn),
 }));
 jest.mock('~/server/services/GraphTokenService', () => ({
   getGraphApiToken: jest.fn(),
@@ -900,6 +902,7 @@ describe('refreshController – OpenID path', () => {
       'user-db-id',
       '-password -__v -totpSecret -backupCodes -federatedTokens',
     );
+    expect(mockRunAsSystem).toHaveBeenCalledTimes(1);
     expect(setCloudFrontAuthCookies).toHaveBeenCalledWith(req, res, user);
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.send).toHaveBeenCalledWith({
@@ -1053,6 +1056,7 @@ describe('refreshController – OpenID path', () => {
     await refreshController(req, res);
 
     expect(getUserById).toHaveBeenCalled();
+    expect(mockRunAsSystem).toHaveBeenCalledTimes(1);
     expect(setCloudFrontAuthCookies).not.toHaveBeenCalled();
     expectOpenIDRefreshGrant();
   });


### PR DESCRIPTION
I fixed OpenID refresh failures under strict tenant isolation by resolving signed user IDs in system context, then binding downstream refresh and recovery work to the resolved user's tenant.

- Wrap the recent OpenID session-reuse user lookup in `runAsSystem` while preserving session identity validation.
- Load full-refresh and bridge-recovery users in `runAsSystem` before tenant context is available.
- Run downstream token identity resolution, migration, auth publication, and bridge recovery in the resolved user's tenant context.
- Reject token issuance if refreshed identity resolution returns a different user than the signed refresh user.
- Add regression coverage for system-scoped lookups, tenant-bound refresh and bridge queries, and cross-user rejection.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npx jest server/controllers/AuthController.spec.js --runInBand` from `api`: 74 tests passed.
- Ran `npm run static-checks -- --against origin/dev`: all affected checks passed.

### **Test Configuration**:

- Node.js v24.16.0
- Focused OpenID auth controller test suite

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
