### PR TITLE
🖼️ fix: Stop Reporting a Failed Sandbox Image Read as an Unreadable Format

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -726,8 +726,14 @@ TTS_API_KEY=
 # CODE_SANDBOX_PREWARM=true
 # Time in milliseconds before LibreChat treats a tracked sandbox as cold (default: 2100000 / 35 minutes).
 # CODE_SANDBOX_COLD_AFTER_MS=2100000
-# Bytes read per sandbox image chunk; lower this if the runner has a small stdout limit (default: 32768).
-# LIBRECHAT_CODE_IMAGE_CHUNK_BYTES=32768
+# Sandbox stdout a single /exec response may carry (default: 65536). Sandbox image reads are
+# windowed to fill this budget, so matching it to the runner's SANDBOX_OUTPUT_MAX_SIZE keeps the
+# round-trip count — and the load on the Code API's execution rate limit — as low as possible.
+# A runner with a smaller cap is also detected at runtime, at the cost of one discarded read.
+# LIBRECHAT_CODE_SANDBOX_OUTPUT_MAX_SIZE=65536
+# Bytes read per sandbox image window, overriding the size derived from the stdout budget above.
+# Prefer setting the budget; use this only to pin a window size exactly.
+# LIBRECHAT_CODE_IMAGE_CHUNK_BYTES=
 
 #==================================================#
 #                        RAG                       #

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -11,8 +11,11 @@ const {
   flattenArtifactPath,
   createAxiosInstance,
   getCodeApiAuthHeaders,
-  getCodeApiRetryAfterMs,
+  withCodeApiRateLimit,
   classifyCodeArtifact,
+  parseSandboxImageChunk,
+  readWindowedSandboxImage,
+  createCodeApiRateLimitBudget,
   codeServerHttpAgent,
   codeServerHttpsAgent,
   extractCodeArtifactText,
@@ -1454,67 +1457,19 @@ async function readSandboxFile({
 }
 
 /**
- * Sandbox stdout a single `/exec` response may carry, in bytes. The runner
- * truncates + SIGKILLs the job past its own `SANDBOX_OUTPUT_MAX_SIZE`
- * (64KB in the reference deployment), so this is the ceiling every image
- * chunk is sized against. Deployments that changed the runner's cap set
- * `LIBRECHAT_CODE_SANDBOX_OUTPUT_MAX_SIZE` to match; a smaller cap is also
- * discovered at runtime (see {@link narrowImageChunkBytes}).
- */
-const DEFAULT_SANDBOX_OUTPUT_MAX_SIZE = 64 * 1024;
-
-/** JSON envelope around the base64 window (`{"total":…,"n":…,"b64":"…"}`),
- *  plus room for a trailing newline and a stray shell banner line. */
-const IMAGE_CHUNK_ENVELOPE_BYTES = 256;
-
-/** Floor for a narrowed window; below this the round-trip count makes an
- *  inline read cost more than it is worth. */
-const MIN_IMAGE_CHUNK_BYTES = 8 * 1024;
-
-/**
- * Hard round-trip ceiling for one image read. Each chunk is an `/exec`
- * call against the Code API's per-user execution limiter (20 requests per
- * 30s in the reference deployment), so an unbounded read would stall a
- * chat turn across several limiter windows. A file that cannot be pulled
- * within this budget degrades to the same "too large to inline" result as
- * one over the byte cap.
- */
-const MAX_IMAGE_EXEC_CALLS = 24;
-
-/** Halvings allowed when the runner's stdout cap turns out to be smaller
- *  than {@link DEFAULT_SANDBOX_OUTPUT_MAX_SIZE}. */
-const MAX_IMAGE_OVERFLOW_RETRIES = 2;
-
-/** Total time one read may spend waiting out Code API rate limits. Sized
- *  to cover a single limiter window without stalling a turn indefinitely. */
-const MAX_IMAGE_RATE_LIMIT_WAIT_MS = 20_000;
-
-/** Marks the error thrown when the runner truncated a chunk's stdout, so
- *  the reader can narrow the window instead of failing the whole image. */
-const SANDBOX_OUTPUT_OVERFLOW = Symbol('sandboxOutputOverflow');
-
-/** Per-base-URL window size, narrowed in place the first time a runner
- *  reports truncation so later reads start at a size it accepts. */
-const learnedImageChunkBytes = new Map();
-
-/**
  * Reads a small image file out of the code-execution sandbox as base64 so
  * `read_file` can surface it to vision-capable models. `readSandboxFile`'s
  * `cat` round-trips stdout through codeapi's JSON transport, which lossily
- * replaces non-UTF-8 bytes and corrupts image data. Here a tiny Python
- * reader stats the file, refuses (without transferring) anything over
- * `maxBytes`, and otherwise base64-encodes the bytes IN the sandbox so the
- * payload stays ASCII-safe across the JSON `/exec` transport. Session
- * forwarding mirrors `readSandboxFile` so the read lands in the same
- * sandbox session that holds the agent's prior-turn artifacts.
+ * replaces non-UTF-8 bytes and corrupts image data. The in-sandbox reader
+ * base64-encodes the bytes instead, so the payload stays ASCII-safe across
+ * the JSON `/exec` transport. Session forwarding mirrors `readSandboxFile`
+ * so the read lands in the same sandbox session that holds the agent's
+ * prior-turn artifacts.
  *
- * The runner caps a response's stdout, so the bytes come back through
- * windowed reads — each one an `/exec` call against the Code API's
- * per-user execution limiter. The window is therefore sized to fill that
- * stdout budget (and narrowed if a runner rejects it), the read waits out
- * a rate limit it can afford rather than discarding the bytes it already
- * pulled, and a file needing more round-trips than one read may spend is
- * reported as unreadable-inline instead of stalling the turn.
+ * Windowing, window sizing, and assembly live in `@librechat/api`
+ * (`readWindowedSandboxImage`); this function is the `/exec` transport it
+ * calls, plus the rate-limit wait that keeps a multi-window read from
+ * discarding the bytes it already pulled.
  *
  * @param {Object} params
  * @param {string} params.file_path - Path inside the sandbox (e.g. `/mnt/data/chart.png`).
@@ -1542,61 +1497,16 @@ async function readSandboxImage({
     return null;
   }
 
-  const limit = typeof maxBytes === 'number' && maxBytes > 0 ? maxBytes : 5 * megabyte;
-  /** Every chunk is one `/exec` call against the Code API's per-user
+  /** Every window is one `/exec` call against the Code API's per-user
    *  execution limiter, so the read shares one wait budget: a window that
    *  resets mid-read is worth pausing for, an exhausted budget is not. */
-  const rateLimit = { remainingMs: MAX_IMAGE_RATE_LIMIT_WAIT_MS };
-  let chunkBytes = getImageChunkBytes(baseURL);
-  let overflowRetries = 0;
-
-  /** @type {Buffer[]} */
-  const parts = [];
-  let offset = 0;
-  let total = null;
-
-  for (let i = 0; i < MAX_IMAGE_EXEC_CALLS; i++) {
-    const payload = Buffer.from(
-      JSON.stringify({ file_path, limit, offset, chunk: chunkBytes }),
-      'utf8',
-    ).toString('base64');
-    const code = [
-      "python3 - <<'PY'",
-      'import base64, json, os, stat',
-      `payload = ${JSON.stringify(payload)}`,
-      "data = json.loads(base64.b64decode(payload).decode('utf-8'))",
-      "p = data['file_path']",
-      "limit = data['limit']",
-      "offset = data['offset']",
-      "chunk = data['chunk']",
-      'try:',
-      '    st = os.stat(p)',
-      'except OSError as e:',
-      '    print(json.dumps({"error": str(e)}))',
-      '    raise SystemExit(0)',
-      // Reject FIFOs, sockets, and device files (e.g. a symlink to /dev/zero):
-      // os.stat can report a small/zero size while an unbounded read blocks or
-      // streams forever until the request times out.
-      'if not stat.S_ISREG(st.st_mode):',
-      '    print(json.dumps({"error": "not a regular file"}))',
-      '    raise SystemExit(0)',
-      'if st.st_size > limit:',
-      '    print(json.dumps({"too_large": True, "bytes": st.st_size}))',
-      '    raise SystemExit(0)',
-      // Read only this window. The whole base64 payload cannot be emitted in
-      // one shot: the runner caps stdout at SANDBOX_OUTPUT_MAX_SIZE (1024
-      // bytes by default) and SIGKILLs the job on overflow, which truncates
-      // the JSON mid-string. Windowing keeps every response under that cap.
-      "with open(p, 'rb') as f:",
-      '    f.seek(offset)',
-      '    raw = f.read(chunk)',
-      'print(json.dumps({"total": st.st_size, "n": len(raw), "b64": base64.b64encode(raw).decode("ascii")}))',
-      'PY',
-    ].join('\n');
-
-    let parsed;
-    try {
-      parsed = await execSandboxImageChunk({
+  const rateLimit = createCodeApiRateLimitBudget();
+  return readWindowedSandboxImage({
+    filePath: file_path,
+    baseUrl: baseURL,
+    limit: typeof maxBytes === 'number' && maxBytes > 0 ? maxBytes : 5 * megabyte,
+    readChunk: ({ code }) =>
+      execSandboxImageChunk({
         baseURL,
         code,
         file_path,
@@ -1605,179 +1515,17 @@ async function readSandboxImage({
         executionProfile,
         files,
         req,
-        chunkBytes,
         rateLimit,
-      });
-    } catch (error) {
-      /* The runner's stdout cap is smaller than this deployment assumed.
-       * Halve the window and re-read the same offset rather than failing
-       * the whole image: the narrowed size is remembered per base URL, so
-       * only the first read of a process pays for the discovery. */
-      if (!error?.[SANDBOX_OUTPUT_OVERFLOW] || overflowRetries >= MAX_IMAGE_OVERFLOW_RETRIES) {
-        throw error;
-      }
-      overflowRetries++;
-      chunkBytes = narrowImageChunkBytes(baseURL);
-      continue;
-    }
-
-    if (parsed.error) {
-      throw new Error(String(parsed.error));
-    }
-    if (parsed.too_large === true) {
-      return { tooLarge: true, reason: 'size', bytes: Number(parsed.bytes) || 0 };
-    }
-    if (typeof parsed.b64 !== 'string' || typeof parsed.n !== 'number') {
-      return null;
-    }
-
-    if (total == null) {
-      total = Number(parsed.total) || 0;
-      if (total > limit) {
-        return { tooLarge: true, reason: 'size', bytes: total };
-      }
-    } else if (Number(parsed.total) !== total) {
-      /* The file changed underneath us; a spliced-together buffer would be
-       * a mix of two versions rather than any real image. */
-      throw new Error(`"${file_path}" changed while being read from the sandbox`);
-    }
-
-    parts.push(Buffer.from(parsed.b64, 'base64'));
-    offset += parsed.n;
-
-    if (parsed.n === 0 || offset >= total) {
-      break;
-    }
-  }
-
-  const buffer = Buffer.concat(parts);
-  if (total == null) {
-    return null;
-  }
-  if (buffer.length !== total) {
-    /* Ran out of round-trip budget (or short reads); returning a partial
-     * image would render as a corrupt file, so surface it as
-     * unreadable-inline with the reason the caller should report. */
-    return { tooLarge: true, reason: 'round_trips', bytes: total };
-  }
-  return { base64: buffer.toString('base64'), bytes: buffer.length };
+      }),
+  });
 }
 
 /**
- * Raw bytes pulled per `/exec` round-trip when inlining a sandbox image.
- * Each chunk is base64-encoded (~1.33x) into the response's stdout, so the
- * window is the largest multiple of 3 (padding-free base64) whose encoding
- * plus envelope fits the runner's stdout budget.
- * @param {string} [baseURL] - Code API base URL whose learned window applies.
- * @returns {number}
- */
-function getImageChunkBytes(baseURL) {
-  const baseline = baselineImageChunkBytes();
-  const learned = learnedImageChunkBytes.get(baseURL);
-  /* A learned narrowing only ever caps the configured size: an operator who
-   * sets a smaller window explicitly still wins. */
-  return learned == null ? baseline : Math.min(learned, baseline);
-}
-
-/** @returns {number} */
-function baselineImageChunkBytes() {
-  const override = Number(process.env.LIBRECHAT_CODE_IMAGE_CHUNK_BYTES);
-  if (Number.isFinite(override) && override > 0) {
-    return Math.floor(override);
-  }
-  const configured = Number(process.env.LIBRECHAT_CODE_SANDBOX_OUTPUT_MAX_SIZE);
-  const budget =
-    Number.isFinite(configured) && configured > 0
-      ? Math.floor(configured)
-      : DEFAULT_SANDBOX_OUTPUT_MAX_SIZE;
-  const usable = Math.max(budget - IMAGE_CHUNK_ENVELOPE_BYTES, 0);
-  return Math.max(Math.floor((usable * 3) / 4 / 3) * 3, MIN_IMAGE_CHUNK_BYTES);
-}
-
-/**
- * Halves the window for a Code API after its runner truncated a chunk, and
- * returns the size to retry the same offset with.
- * @returns {number}
- */
-function narrowImageChunkBytes(baseURL) {
-  const current = getImageChunkBytes(baseURL);
-  const narrowed = Math.max(Math.floor(current / 2 / 3) * 3, MIN_IMAGE_CHUNK_BYTES);
-  learnedImageChunkBytes.set(baseURL, narrowed);
-  logger.warn(
-    `[readSandboxImage] Sandbox stdout limit exceeded; narrowing image window to ${narrowed} bytes for ${baseURL}. ` +
-      "Set LIBRECHAT_CODE_SANDBOX_OUTPUT_MAX_SIZE to this runner's stdout cap to skip the discovery read.",
-  );
-  return narrowed;
-}
-
-/**
- * Posts one image-chunk read, waiting out a Code API rate limit when the
- * shared per-read budget still covers the server's `Retry-After`. Every
- * chunk spends one `/exec` call against a per-user limiter, so a read that
- * starts near the end of a window would otherwise abandon the bytes it had
- * already pulled.
- * @returns {Promise<Record<string, unknown>>}
- */
-async function postSandboxImageChunk({
-  baseURL,
-  postData,
-  executionProfile,
-  file_path,
-  rateLimit,
-  req,
-}) {
-  for (;;) {
-    try {
-      const authHeaders = await getCodeApiAuthHeaders(req);
-      const response = await axios({
-        method: 'post',
-        url: `${baseURL}/exec`,
-        data: postData,
-        headers: {
-          'Content-Type': 'application/json',
-          'User-Agent': 'LibreChat/1.0',
-          ...authHeaders,
-          ...(executionProfile ? { [CODE_API_EXPECTED_PROFILE_HEADER]: executionProfile } : {}),
-        },
-        httpAgent: codeServerHttpAgent,
-        httpsAgent: codeServerHttpsAgent,
-        timeout: 15000,
-      });
-      return response?.data ?? {};
-    } catch (error) {
-      if (error?.response?.status !== 429) {
-        throw error;
-      }
-      const retryAfterMs = getCodeApiRetryAfterMs(error);
-      /* Rate-limited with no delay to wait on: name the limit anyway rather
-       * than letting a bare "status code 429" reach the model, which reads
-       * as an unspecified failure instead of one that clears on its own. */
-      if (retryAfterMs == null) {
-        throw new Error(
-          `Code API rate limit reached while reading "${file_path}" from the sandbox.`,
-        );
-      }
-      /* A zero delay would spin; charge at least a second so the budget
-       * always drains and the loop terminates. */
-      const waitMs = Math.max(retryAfterMs, 1000);
-      if (rateLimit == null || waitMs > rateLimit.remainingMs) {
-        throw new Error(
-          `Code API rate limit reached while reading "${file_path}" from the sandbox ` +
-            `(retry in ${Math.ceil(waitMs / 1000)}s).`,
-        );
-      }
-      rateLimit.remainingMs -= waitMs;
-      logger.warn(
-        `[readSandboxImage] Rate-limited reading "${file_path}"; retrying in ${waitMs}ms`,
-      );
-      await new Promise((resolve) => setTimeout(resolve, waitMs));
-    }
-  }
-}
-
-/**
- * Runs one image-chunk read over `/exec` and parses its JSON line.
- * @returns {Promise<Record<string, unknown>>}
+ * Runs one image-window read over `/exec` and hands the response to the
+ * shared parser. Rate limits are waited out inside the shared budget; a
+ * truncated response comes back as a chunk the reader narrows for, not an
+ * error, so it is neither logged nor thrown here.
+ * @returns {Promise<import('@librechat/api').SandboxImageChunk>}
  */
 async function execSandboxImageChunk({
   baseURL,
@@ -1788,7 +1536,6 @@ async function execSandboxImageChunk({
   executionProfile,
   files,
   req,
-  chunkBytes,
   rateLimit,
 }) {
   /** @type {Record<string, unknown>} */
@@ -1804,54 +1551,37 @@ async function execSandboxImageChunk({
   }
 
   try {
-    const result = await postSandboxImageChunk({
-      baseURL,
-      postData,
-      executionProfile,
-      file_path,
-      rateLimit,
-      req,
+    const response = await withCodeApiRateLimit({
+      label: `reading "${file_path}" from the sandbox`,
+      budget: rateLimit,
+      onWait: (waitMs) =>
+        logger.warn(
+          `[readSandboxImage] Rate-limited reading "${file_path}"; retrying in ${waitMs}ms`,
+        ),
+      attempt: async () => {
+        const authHeaders = await getCodeApiAuthHeaders(req);
+        return axios({
+          method: 'post',
+          url: `${baseURL}/exec`,
+          data: postData,
+          headers: {
+            'Content-Type': 'application/json',
+            'User-Agent': 'LibreChat/1.0',
+            ...authHeaders,
+            ...(executionProfile ? { [CODE_API_EXPECTED_PROFILE_HEADER]: executionProfile } : {}),
+          },
+          httpAgent: codeServerHttpAgent,
+          httpsAgent: codeServerHttpsAgent,
+          timeout: 15000,
+        });
+      },
     });
-    /* The runner truncates stdout at SANDBOX_OUTPUT_MAX_SIZE and SIGKILLs the
-     * job (status `OL`). Detect that explicitly: the surviving stdout is a
-     * base64 string cut mid-flight, so parsing it yields a misleading
-     * "unexpected output" instead of naming the real, fixable cause. The
-     * marker lets the reader narrow its window and re-read the same offset. */
-    if (result.status === 'OL') {
-      const overflow = new Error(
-        `Reading "${file_path}" exceeded the sandbox stdout limit (chunk ${chunkBytes} bytes).`,
-      );
-      overflow[SANDBOX_OUTPUT_OVERFLOW] = true;
-      throw overflow;
-    }
-    if (result.stderr && (result.stdout == null || result.stdout === '')) {
-      throw new Error(String(result.stderr).trim());
-    }
-    if (result.stdout == null || String(result.stdout).trim() === '') {
-      return {};
-    }
-    /* Parse the LAST non-empty line: the reader's JSON is the final thing it
-     * prints, so anything a shell profile or library emitted ahead of it
-     * (banners, warnings) must not break the read. */
-    const lines = String(result.stdout)
-      .split('\n')
-      .map((line) => line.trim())
-      .filter(Boolean);
-    try {
-      return JSON.parse(lines[lines.length - 1]);
-    } catch {
-      throw new Error(
-        `Unexpected output while reading image bytes from the sandbox: ${String(result.stdout).slice(0, 120)}`,
-      );
-    }
+    return parseSandboxImageChunk(response?.data ?? {});
   } catch (error) {
-    /* Truncation is recovered by narrowing the window, not a read failure. */
-    if (!error?.[SANDBOX_OUTPUT_OVERFLOW]) {
-      logAxiosError({
-        message: `Error reading sandbox image "${file_path}"`,
-        error,
-      });
-    }
+    logAxiosError({
+      message: `Error reading sandbox image "${file_path}"`,
+      error,
+    });
     throw error;
   }
 }

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -11,6 +11,7 @@ const {
   flattenArtifactPath,
   createAxiosInstance,
   getCodeApiAuthHeaders,
+  getCodeApiRetryAfterMs,
   classifyCodeArtifact,
   codeServerHttpAgent,
   codeServerHttpsAgent,
@@ -1453,6 +1454,50 @@ async function readSandboxFile({
 }
 
 /**
+ * Sandbox stdout a single `/exec` response may carry, in bytes. The runner
+ * truncates + SIGKILLs the job past its own `SANDBOX_OUTPUT_MAX_SIZE`
+ * (64KB in the reference deployment), so this is the ceiling every image
+ * chunk is sized against. Deployments that changed the runner's cap set
+ * `LIBRECHAT_CODE_SANDBOX_OUTPUT_MAX_SIZE` to match; a smaller cap is also
+ * discovered at runtime (see {@link narrowImageChunkBytes}).
+ */
+const DEFAULT_SANDBOX_OUTPUT_MAX_SIZE = 64 * 1024;
+
+/** JSON envelope around the base64 window (`{"total":…,"n":…,"b64":"…"}`),
+ *  plus room for a trailing newline and a stray shell banner line. */
+const IMAGE_CHUNK_ENVELOPE_BYTES = 256;
+
+/** Floor for a narrowed window; below this the round-trip count makes an
+ *  inline read cost more than it is worth. */
+const MIN_IMAGE_CHUNK_BYTES = 8 * 1024;
+
+/**
+ * Hard round-trip ceiling for one image read. Each chunk is an `/exec`
+ * call against the Code API's per-user execution limiter (20 requests per
+ * 30s in the reference deployment), so an unbounded read would stall a
+ * chat turn across several limiter windows. A file that cannot be pulled
+ * within this budget degrades to the same "too large to inline" result as
+ * one over the byte cap.
+ */
+const MAX_IMAGE_EXEC_CALLS = 24;
+
+/** Halvings allowed when the runner's stdout cap turns out to be smaller
+ *  than {@link DEFAULT_SANDBOX_OUTPUT_MAX_SIZE}. */
+const MAX_IMAGE_OVERFLOW_RETRIES = 2;
+
+/** Total time one read may spend waiting out Code API rate limits. Sized
+ *  to cover a single limiter window without stalling a turn indefinitely. */
+const MAX_IMAGE_RATE_LIMIT_WAIT_MS = 20_000;
+
+/** Marks the error thrown when the runner truncated a chunk's stdout, so
+ *  the reader can narrow the window instead of failing the whole image. */
+const SANDBOX_OUTPUT_OVERFLOW = Symbol('sandboxOutputOverflow');
+
+/** Per-base-URL window size, narrowed in place the first time a runner
+ *  reports truncation so later reads start at a size it accepts. */
+const learnedImageChunkBytes = new Map();
+
+/**
  * Reads a small image file out of the code-execution sandbox as base64 so
  * `read_file` can surface it to vision-capable models. `readSandboxFile`'s
  * `cat` round-trips stdout through codeapi's JSON transport, which lossily
@@ -1463,6 +1508,14 @@ async function readSandboxFile({
  * forwarding mirrors `readSandboxFile` so the read lands in the same
  * sandbox session that holds the agent's prior-turn artifacts.
  *
+ * The runner caps a response's stdout, so the bytes come back through
+ * windowed reads — each one an `/exec` call against the Code API's
+ * per-user execution limiter. The window is therefore sized to fill that
+ * stdout budget (and narrowed if a runner rejects it), the read waits out
+ * a rate limit it can afford rather than discarding the bytes it already
+ * pulled, and a file needing more round-trips than one read may spend is
+ * reported as unreadable-inline instead of stalling the turn.
+ *
  * @param {Object} params
  * @param {string} params.file_path - Path inside the sandbox (e.g. `/mnt/data/chart.png`).
  * @param {string} [params.session_id] - Sandbox session id from the seeded context.
@@ -1470,7 +1523,8 @@ async function readSandboxFile({
  * @param {string} [params.runtime_session_hint] - Per-conversation stateful runtime-session hint.
  * @param {number} [params.maxBytes] - In-sandbox size cap; larger files return `{ tooLarge, bytes }`.
  * @param {ServerRequest} [params.req] - Current authenticated request, used to mint Code API auth.
- * @returns {Promise<{base64: string, bytes: number} | {tooLarge: true, bytes: number} | null>}
+ * @returns {Promise<{base64: string, bytes: number}
+ *   | {tooLarge: true, reason: 'size' | 'round_trips', bytes: number} | null>}
  *   `null` when codeapi is unavailable; throws on transport / read errors.
  */
 async function readSandboxImage({
@@ -1489,15 +1543,19 @@ async function readSandboxImage({
   }
 
   const limit = typeof maxBytes === 'number' && maxBytes > 0 ? maxBytes : 5 * megabyte;
-  const chunkBytes = getImageChunkBytes();
-  const maxChunks = Math.ceil(limit / chunkBytes) + 1;
+  /** Every chunk is one `/exec` call against the Code API's per-user
+   *  execution limiter, so the read shares one wait budget: a window that
+   *  resets mid-read is worth pausing for, an exhausted budget is not. */
+  const rateLimit = { remainingMs: MAX_IMAGE_RATE_LIMIT_WAIT_MS };
+  let chunkBytes = getImageChunkBytes(baseURL);
+  let overflowRetries = 0;
 
   /** @type {Buffer[]} */
   const parts = [];
   let offset = 0;
   let total = null;
 
-  for (let i = 0; i < maxChunks; i++) {
+  for (let i = 0; i < MAX_IMAGE_EXEC_CALLS; i++) {
     const payload = Buffer.from(
       JSON.stringify({ file_path, limit, offset, chunk: chunkBytes }),
       'utf8',
@@ -1536,23 +1594,38 @@ async function readSandboxImage({
       'PY',
     ].join('\n');
 
-    const parsed = await execSandboxImageChunk({
-      baseURL,
-      code,
-      file_path,
-      session_id,
-      runtime_session_hint,
-      executionProfile,
-      files,
-      req,
-      chunkBytes,
-    });
+    let parsed;
+    try {
+      parsed = await execSandboxImageChunk({
+        baseURL,
+        code,
+        file_path,
+        session_id,
+        runtime_session_hint,
+        executionProfile,
+        files,
+        req,
+        chunkBytes,
+        rateLimit,
+      });
+    } catch (error) {
+      /* The runner's stdout cap is smaller than this deployment assumed.
+       * Halve the window and re-read the same offset rather than failing
+       * the whole image: the narrowed size is remembered per base URL, so
+       * only the first read of a process pays for the discovery. */
+      if (!error?.[SANDBOX_OUTPUT_OVERFLOW] || overflowRetries >= MAX_IMAGE_OVERFLOW_RETRIES) {
+        throw error;
+      }
+      overflowRetries++;
+      chunkBytes = narrowImageChunkBytes(baseURL);
+      continue;
+    }
 
     if (parsed.error) {
       throw new Error(String(parsed.error));
     }
     if (parsed.too_large === true) {
-      return { tooLarge: true, bytes: Number(parsed.bytes) || 0 };
+      return { tooLarge: true, reason: 'size', bytes: Number(parsed.bytes) || 0 };
     }
     if (typeof parsed.b64 !== 'string' || typeof parsed.n !== 'number') {
       return null;
@@ -1561,7 +1634,7 @@ async function readSandboxImage({
     if (total == null) {
       total = Number(parsed.total) || 0;
       if (total > limit) {
-        return { tooLarge: true, bytes: total };
+        return { tooLarge: true, reason: 'size', bytes: total };
       }
     } else if (Number(parsed.total) !== total) {
       /* The file changed underneath us; a spliced-together buffer would be
@@ -1582,25 +1655,124 @@ async function readSandboxImage({
     return null;
   }
   if (buffer.length !== total) {
-    /* Ran out of chunk budget (or short reads); returning a partial image
-     * would render as a corrupt file, so surface it as unreadable-inline. */
-    return { tooLarge: true, bytes: total };
+    /* Ran out of round-trip budget (or short reads); returning a partial
+     * image would render as a corrupt file, so surface it as
+     * unreadable-inline with the reason the caller should report. */
+    return { tooLarge: true, reason: 'round_trips', bytes: total };
   }
   return { base64: buffer.toString('base64'), bytes: buffer.length };
 }
 
 /**
  * Raw bytes pulled per `/exec` round-trip when inlining a sandbox image.
- * Each chunk is base64-encoded (~1.33x) into the response's stdout, which
- * the runner truncates + SIGKILLs past `SANDBOX_OUTPUT_MAX_SIZE`. The
- * default leaves headroom for a runner configured at 64KB; deployments
- * with a smaller cap must lower this, and a larger cap can raise it to cut
- * round-trips.
+ * Each chunk is base64-encoded (~1.33x) into the response's stdout, so the
+ * window is the largest multiple of 3 (padding-free base64) whose encoding
+ * plus envelope fits the runner's stdout budget.
+ * @param {string} [baseURL] - Code API base URL whose learned window applies.
  * @returns {number}
  */
-function getImageChunkBytes() {
-  const parsed = Number(process.env.LIBRECHAT_CODE_IMAGE_CHUNK_BYTES);
-  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 32 * 1024;
+function getImageChunkBytes(baseURL) {
+  const baseline = baselineImageChunkBytes();
+  const learned = learnedImageChunkBytes.get(baseURL);
+  /* A learned narrowing only ever caps the configured size: an operator who
+   * sets a smaller window explicitly still wins. */
+  return learned == null ? baseline : Math.min(learned, baseline);
+}
+
+/** @returns {number} */
+function baselineImageChunkBytes() {
+  const override = Number(process.env.LIBRECHAT_CODE_IMAGE_CHUNK_BYTES);
+  if (Number.isFinite(override) && override > 0) {
+    return Math.floor(override);
+  }
+  const configured = Number(process.env.LIBRECHAT_CODE_SANDBOX_OUTPUT_MAX_SIZE);
+  const budget =
+    Number.isFinite(configured) && configured > 0
+      ? Math.floor(configured)
+      : DEFAULT_SANDBOX_OUTPUT_MAX_SIZE;
+  const usable = Math.max(budget - IMAGE_CHUNK_ENVELOPE_BYTES, 0);
+  return Math.max(Math.floor((usable * 3) / 4 / 3) * 3, MIN_IMAGE_CHUNK_BYTES);
+}
+
+/**
+ * Halves the window for a Code API after its runner truncated a chunk, and
+ * returns the size to retry the same offset with.
+ * @returns {number}
+ */
+function narrowImageChunkBytes(baseURL) {
+  const current = getImageChunkBytes(baseURL);
+  const narrowed = Math.max(Math.floor(current / 2 / 3) * 3, MIN_IMAGE_CHUNK_BYTES);
+  learnedImageChunkBytes.set(baseURL, narrowed);
+  logger.warn(
+    `[readSandboxImage] Sandbox stdout limit exceeded; narrowing image window to ${narrowed} bytes for ${baseURL}. ` +
+      "Set LIBRECHAT_CODE_SANDBOX_OUTPUT_MAX_SIZE to this runner's stdout cap to skip the discovery read.",
+  );
+  return narrowed;
+}
+
+/**
+ * Posts one image-chunk read, waiting out a Code API rate limit when the
+ * shared per-read budget still covers the server's `Retry-After`. Every
+ * chunk spends one `/exec` call against a per-user limiter, so a read that
+ * starts near the end of a window would otherwise abandon the bytes it had
+ * already pulled.
+ * @returns {Promise<Record<string, unknown>>}
+ */
+async function postSandboxImageChunk({
+  baseURL,
+  postData,
+  executionProfile,
+  file_path,
+  rateLimit,
+  req,
+}) {
+  for (;;) {
+    try {
+      const authHeaders = await getCodeApiAuthHeaders(req);
+      const response = await axios({
+        method: 'post',
+        url: `${baseURL}/exec`,
+        data: postData,
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': 'LibreChat/1.0',
+          ...authHeaders,
+          ...(executionProfile ? { [CODE_API_EXPECTED_PROFILE_HEADER]: executionProfile } : {}),
+        },
+        httpAgent: codeServerHttpAgent,
+        httpsAgent: codeServerHttpsAgent,
+        timeout: 15000,
+      });
+      return response?.data ?? {};
+    } catch (error) {
+      if (error?.response?.status !== 429) {
+        throw error;
+      }
+      const retryAfterMs = getCodeApiRetryAfterMs(error);
+      /* Rate-limited with no delay to wait on: name the limit anyway rather
+       * than letting a bare "status code 429" reach the model, which reads
+       * as an unspecified failure instead of one that clears on its own. */
+      if (retryAfterMs == null) {
+        throw new Error(
+          `Code API rate limit reached while reading "${file_path}" from the sandbox.`,
+        );
+      }
+      /* A zero delay would spin; charge at least a second so the budget
+       * always drains and the loop terminates. */
+      const waitMs = Math.max(retryAfterMs, 1000);
+      if (rateLimit == null || waitMs > rateLimit.remainingMs) {
+        throw new Error(
+          `Code API rate limit reached while reading "${file_path}" from the sandbox ` +
+            `(retry in ${Math.ceil(waitMs / 1000)}s).`,
+        );
+      }
+      rateLimit.remainingMs -= waitMs;
+      logger.warn(
+        `[readSandboxImage] Rate-limited reading "${file_path}"; retrying in ${waitMs}ms`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, waitMs));
+    }
+  }
 }
 
 /**
@@ -1617,6 +1789,7 @@ async function execSandboxImageChunk({
   files,
   req,
   chunkBytes,
+  rateLimit,
 }) {
   /** @type {Record<string, unknown>} */
   const postData = { lang: 'bash', code };
@@ -1631,31 +1804,25 @@ async function execSandboxImageChunk({
   }
 
   try {
-    const authHeaders = await getCodeApiAuthHeaders(req);
-    const response = await axios({
-      method: 'post',
-      url: `${baseURL}/exec`,
-      data: postData,
-      headers: {
-        'Content-Type': 'application/json',
-        'User-Agent': 'LibreChat/1.0',
-        ...authHeaders,
-        ...(executionProfile ? { [CODE_API_EXPECTED_PROFILE_HEADER]: executionProfile } : {}),
-      },
-      httpAgent: codeServerHttpAgent,
-      httpsAgent: codeServerHttpsAgent,
-      timeout: 15000,
+    const result = await postSandboxImageChunk({
+      baseURL,
+      postData,
+      executionProfile,
+      file_path,
+      rateLimit,
+      req,
     });
-    const result = response?.data ?? {};
     /* The runner truncates stdout at SANDBOX_OUTPUT_MAX_SIZE and SIGKILLs the
      * job (status `OL`). Detect that explicitly: the surviving stdout is a
      * base64 string cut mid-flight, so parsing it yields a misleading
-     * "unexpected output" instead of naming the real, fixable cause. */
+     * "unexpected output" instead of naming the real, fixable cause. The
+     * marker lets the reader narrow its window and re-read the same offset. */
     if (result.status === 'OL') {
-      throw new Error(
-        `Reading "${file_path}" exceeded the sandbox stdout limit (chunk ${chunkBytes} bytes). ` +
-          'Lower LIBRECHAT_CODE_IMAGE_CHUNK_BYTES or raise SANDBOX_OUTPUT_MAX_SIZE on the runner.',
+      const overflow = new Error(
+        `Reading "${file_path}" exceeded the sandbox stdout limit (chunk ${chunkBytes} bytes).`,
       );
+      overflow[SANDBOX_OUTPUT_OVERFLOW] = true;
+      throw overflow;
     }
     if (result.stderr && (result.stdout == null || result.stdout === '')) {
       throw new Error(String(result.stderr).trim());
@@ -1678,10 +1845,13 @@ async function execSandboxImageChunk({
       );
     }
   } catch (error) {
-    logAxiosError({
-      message: `Error reading sandbox image "${file_path}"`,
-      error,
-    });
+    /* Truncation is recovered by narrowing the window, not a read failure. */
+    if (!error?.[SANDBOX_OUTPUT_OVERFLOW]) {
+      logAxiosError({
+        message: `Error reading sandbox image "${file_path}"`,
+        error,
+      });
+    }
     throw error;
   }
 }

--- a/api/server/services/Files/Code/process.spec.js
+++ b/api/server/services/Files/Code/process.spec.js
@@ -68,6 +68,20 @@ jest.mock('@librechat/api', () => {
     flattenArtifactPath: jest.fn((name) => name.replace(/\//g, '__')),
     createAxiosInstance: jest.fn(() => mockAxios),
     getCodeApiAuthHeaders: jest.fn(async () => ({})),
+    /* Mirrors the real parser (packages/api/src/utils/code.ts): header
+     * first, `retry_after_seconds` body as the fallback. */
+    getCodeApiRetryAfterMs: jest.fn((error) => {
+      if (error?.response?.status !== 429) {
+        return null;
+      }
+      const header = error.response.headers?.['retry-after'];
+      const headerSeconds = Number(Array.isArray(header) ? header[0] : header);
+      if (Number.isFinite(headerSeconds) && headerSeconds >= 0) {
+        return headerSeconds * 1000;
+      }
+      const bodySeconds = Number(error.response.data?.retry_after_seconds);
+      return Number.isFinite(bodySeconds) && bodySeconds >= 0 ? bodySeconds * 1000 : null;
+    }),
     getCodeExecutionBaseUrl: jest.fn((profile) =>
       profile === 'stateful' ? 'https://code-stateful.example.com' : 'https://code-api.example.com',
     ),
@@ -2795,17 +2809,124 @@ describe('Code Process', () => {
       expect(Buffer.from(result.base64, 'base64').equals(source)).toBe(true);
     });
 
-    it('names the real cause when a chunk overflows the runner stdout cap', async () => {
+    it('names the real cause when every narrowed window overflows the stdout cap', async () => {
       /* The runner truncates stdout and SIGKILLs with status `OL`; the old
        * reader parsed the truncated base64 and reported a misleading
-       * "unexpected output" instead of the fixable limit. */
+       * "unexpected output" instead of the fixable limit. A runner that
+       * rejects every window size still has to name the limit. Isolated on
+       * its own base URL: narrowing is remembered per Code API. */
       mockAxios.mockResolvedValue({
         data: { stdout: '{"total":999999,"n":32768,"b64":"iVBORw0KGg', status: 'OL', code: 137 },
       });
 
-      await expect(readSandboxImage({ file_path: '/mnt/data/big.png' })).rejects.toThrow(
-        /exceeded the sandbox stdout limit/,
+      await expect(
+        readSandboxImage({
+          file_path: '/mnt/data/big.png',
+          codeApiBaseUrl: 'https://always-overflows.example.com',
+        }),
+      ).rejects.toThrow(/exceeded the sandbox stdout limit/);
+    });
+
+    it('narrows the window and re-reads the same offset when the runner truncates', async () => {
+      /* A runner whose stdout cap is smaller than this deployment assumed
+       * used to fail the whole image. The window halves and the read
+       * resumes, so the only cost is the truncated round-trip. */
+      const source = Buffer.concat([PNG_HEADER, crypto.randomBytes(8 * 1024)]);
+      const accepted = 32 * 1024;
+      const windows = [];
+      mockAxios.mockImplementation(async ({ data }) => {
+        const payload = JSON.parse(
+          Buffer.from(JSON.parse(/payload = ("[^"]+")/.exec(data.code)[1]), 'base64').toString(),
+        );
+        windows.push(payload.chunk);
+        if (payload.chunk > accepted) {
+          return { data: { stdout: '{"total":8200,"n":40000,"b64":"iVBOR', status: 'OL' } };
+        }
+        const slice = source.subarray(payload.offset, payload.offset + payload.chunk);
+        return {
+          data: {
+            stdout: JSON.stringify({
+              total: source.length,
+              n: slice.length,
+              b64: slice.toString('base64'),
+            }),
+          },
+        };
+      });
+
+      const result = await readSandboxImage({
+        file_path: '/mnt/data/x.png',
+        codeApiBaseUrl: 'https://small-stdout.example.com',
+      });
+
+      expect(windows[0]).toBeGreaterThan(accepted);
+      expect(windows[1]).toBeLessThanOrEqual(accepted);
+      expect(Buffer.from(result.base64, 'base64').equals(source)).toBe(true);
+    });
+
+    it('waits out a rate limit and finishes the read', async () => {
+      /* Every window is one `/exec` call against the Code API's per-user
+       * execution limiter, so a read that starts near the end of a window
+       * used to throw away the bytes it had already pulled. */
+      const source = Buffer.concat([PNG_HEADER, crypto.randomBytes(1024)]);
+      const rateLimited = Object.assign(new Error('Request failed with status code 429'), {
+        isAxiosError: true,
+        response: { status: 429, headers: { 'retry-after': '1' }, data: {} },
+      });
+      let attempts = 0;
+      mockAxios.mockImplementation(async ({ data }) => {
+        attempts++;
+        if (attempts === 1) {
+          throw rateLimited;
+        }
+        const payload = JSON.parse(
+          Buffer.from(JSON.parse(/payload = ("[^"]+")/.exec(data.code)[1]), 'base64').toString(),
+        );
+        const slice = source.subarray(payload.offset, payload.offset + payload.chunk);
+        return {
+          data: {
+            stdout: JSON.stringify({
+              total: source.length,
+              n: slice.length,
+              b64: slice.toString('base64'),
+            }),
+          },
+        };
+      });
+
+      const result = await readSandboxImage({ file_path: '/mnt/data/x.png' });
+
+      expect(attempts).toBe(2);
+      expect(Buffer.from(result.base64, 'base64').equals(source)).toBe(true);
+    });
+
+    it('names the rate limit even when the response carries no usable delay', async () => {
+      /* Otherwise a bare "Request failed with status code 429" reaches the
+       * model as an unspecified failure instead of one that clears itself. */
+      mockAxios.mockRejectedValue(
+        Object.assign(new Error('Request failed with status code 429'), {
+          isAxiosError: true,
+          response: { status: 429, headers: {}, data: {} },
+        }),
       );
+
+      await expect(readSandboxImage({ file_path: '/mnt/data/x.png' })).rejects.toThrow(
+        /rate limit reached while reading/,
+      );
+    });
+
+    it('names the rate limit when the wait exceeds what one read may spend', async () => {
+      mockAxios.mockRejectedValue(
+        Object.assign(new Error('Request failed with status code 429'), {
+          isAxiosError: true,
+          response: { status: 429, headers: {}, data: { retry_after_seconds: 300 } },
+        }),
+      );
+
+      await expect(readSandboxImage({ file_path: '/mnt/data/x.png' })).rejects.toThrow(
+        /rate limit reached while reading "\/mnt\/data\/x\.png".*retry in 300s/,
+      );
+      expect(mockAxios).toHaveBeenCalledTimes(1);
     });
 
     it('honors LIBRECHAT_CODE_IMAGE_CHUNK_BYTES', async () => {
@@ -2843,7 +2964,7 @@ describe('Code Process', () => {
 
       const result = await readSandboxImage({ file_path: '/mnt/data/huge.png' });
 
-      expect(result).toEqual({ tooLarge: true, bytes: 9 * 1024 * 1024 });
+      expect(result).toEqual({ tooLarge: true, reason: 'size', bytes: 9 * 1024 * 1024 });
       expect(mockAxios).toHaveBeenCalledTimes(1);
     });
   });

--- a/api/server/services/Files/Code/process.spec.js
+++ b/api/server/services/Files/Code/process.spec.js
@@ -55,6 +55,9 @@ const mockGetExtractedTextFormat = jest.fn((_name, _mime, text) => (text == null
  * legacy single-phase tests below (txt/png/etc) exercise the inline path
  * unchanged. The dedicated office/finalize describe block toggles it on. */
 const mockHasOfficeHtmlPath = jest.fn(() => false);
+/* Stands in for the real chunk parser so a transport test can decide what
+ * one `/exec` response means without reaching into `packages/api`. */
+const mockParseSandboxImageChunk = jest.fn((response) => response);
 /* Pass-through `withTimeout`: tests don't drive timeouts here (those live
  * in promise.spec.ts and the finalizePreview unit tests below). */
 const passthroughWithTimeout = async (promise) => promise;
@@ -68,20 +71,19 @@ jest.mock('@librechat/api', () => {
     flattenArtifactPath: jest.fn((name) => name.replace(/\//g, '__')),
     createAxiosInstance: jest.fn(() => mockAxios),
     getCodeApiAuthHeaders: jest.fn(async () => ({})),
-    /* Mirrors the real parser (packages/api/src/utils/code.ts): header
-     * first, `retry_after_seconds` body as the fallback. */
-    getCodeApiRetryAfterMs: jest.fn((error) => {
-      if (error?.response?.status !== 429) {
-        return null;
-      }
-      const header = error.response.headers?.['retry-after'];
-      const headerSeconds = Number(Array.isArray(header) ? header[0] : header);
-      if (Number.isFinite(headerSeconds) && headerSeconds >= 0) {
-        return headerSeconds * 1000;
-      }
-      const bodySeconds = Number(error.response.data?.retry_after_seconds);
-      return Number.isFinite(bodySeconds) && bodySeconds >= 0 ? bodySeconds * 1000 : null;
-    }),
+    /* Windowing, sizing and rate-limit policy are real code in
+     * `packages/api` with their own tests (`files/code/image.spec.ts`,
+     * `utils/code.spec.ts`). These stand-ins are deliberately inert
+     * passthroughs — they assert nothing about that behavior, so the
+     * transport tests below cover only what this file still owns. */
+    createCodeApiRateLimitBudget: jest.fn(() => ({ remainingMs: 20_000 })),
+    withCodeApiRateLimit: jest.fn(({ attempt }) => attempt()),
+    buildSandboxImageReaderCode: jest.fn(
+      ({ filePath, limit, offset, chunkBytes }) =>
+        `read ${filePath} ${limit} ${offset} ${chunkBytes}`,
+    ),
+    parseSandboxImageChunk: jest.fn((response) => mockParseSandboxImageChunk(response)),
+    readWindowedSandboxImage: jest.fn(({ readChunk }) => readChunk({ code: 'read-one-window' })),
     getCodeExecutionBaseUrl: jest.fn((profile) =>
       profile === 'stateful' ? 'https://code-stateful.example.com' : 'https://code-api.example.com',
     ),
@@ -2754,218 +2756,87 @@ describe('Code Process', () => {
   });
 
   /**
-   * These drive the REAL reader against a mocked `/exec` transport (rather
-   * than mocking `readSandboxImage` itself), because the bug this covers
-   * lived entirely in the transport: base64 leaves the sandbox on stdout,
-   * which the runner truncates + SIGKILLs past `SANDBOX_OUTPUT_MAX_SIZE`.
+   * Windowing, window sizing, rate-limit waiting and byte assembly moved to
+   * `packages/api` (`files/code/image.ts`, `utils/code.ts`) and are tested
+   * there against the real implementations. What remains here is the piece
+   * this file still owns: the `/exec` transport — session forwarding, the
+   * profile header, and handing the response to the shared parser.
    */
-  describe('readSandboxImage', () => {
-    const crypto = require('crypto');
-    const PNG_HEADER = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
-    /** Reply as the sandbox would: serve `buffer` through the windowed reader. */
-    const serveFile = (buffer) =>
-      mockAxios.mockImplementation(async ({ data }) => {
-        const payload = JSON.parse(
-          Buffer.from(JSON.parse(/payload = ("[^"]+")/.exec(data.code)[1]), 'base64').toString(),
-        );
-        const slice = buffer.subarray(payload.offset, payload.offset + payload.chunk);
-        return {
-          data: {
-            stdout: JSON.stringify({
-              total: buffer.length,
-              n: slice.length,
-              b64: slice.toString('base64'),
-            }),
-          },
-        };
-      });
-
+  describe('readSandboxImage transport', () => {
     beforeEach(() => {
       process.env.LIBRECHAT_CODE_BASEURL = 'http://code.test/v1';
-      delete process.env.LIBRECHAT_CODE_IMAGE_CHUNK_BYTES;
       mockAxios.mockReset();
+      mockParseSandboxImageChunk.mockReset();
+      mockParseSandboxImageChunk.mockImplementation((response) => response);
     });
 
-    it('reassembles an image larger than one chunk, byte-for-byte', async () => {
-      /* 200KB of PNG-headed noise: > 6 chunks at the 32KB default, and the
-       * exact shape that used to blow the stdout cap and SIGKILL the job. */
-      const source = Buffer.concat([PNG_HEADER, crypto.randomBytes(200 * 1024)]);
-      serveFile(source);
+    it('forwards the sandbox session, runtime hint and profile header', async () => {
+      mockAxios.mockResolvedValue({ data: { stdout: '{}' } });
 
-      const result = await readSandboxImage({ file_path: '/mnt/data/big.png' });
-
-      expect(mockAxios.mock.calls.length).toBeGreaterThan(1);
-      expect(result.bytes).toBe(source.length);
-      expect(Buffer.from(result.base64, 'base64').equals(source)).toBe(true);
-    });
-
-    it('reads a single-chunk image in one round-trip', async () => {
-      const source = Buffer.concat([PNG_HEADER, crypto.randomBytes(1024)]);
-      serveFile(source);
-
-      const result = await readSandboxImage({ file_path: '/mnt/data/small.png' });
+      await readSandboxImage({
+        file_path: '/mnt/data/chart.png',
+        session_id: 'session-abc',
+        runtime_session_hint: 'hint-xyz',
+        files: [{ id: 'file-1', name: 'seed.csv' }],
+        codeApiBaseUrl: 'https://code-stateful.example.com',
+        executionProfile: 'stateful',
+      });
 
       expect(mockAxios).toHaveBeenCalledTimes(1);
-      expect(Buffer.from(result.base64, 'base64').equals(source)).toBe(true);
+      const call = mockAxios.mock.calls[0][0];
+      expect(call.url).toBe('https://code-stateful.example.com/exec');
+      expect(call.data).toMatchObject({
+        lang: 'bash',
+        session_id: 'session-abc',
+        runtime_session_hint: 'hint-xyz',
+        files: [{ id: 'file-1', name: 'seed.csv' }],
+      });
+      expect(call.headers['X-CodeAPI-Expected-Profile']).toBe('stateful');
     });
 
-    it('names the real cause when every narrowed window overflows the stdout cap', async () => {
-      /* The runner truncates stdout and SIGKILLs with status `OL`; the old
-       * reader parsed the truncated base64 and reported a misleading
-       * "unexpected output" instead of the fixable limit. A runner that
-       * rejects every window size still has to name the limit. Isolated on
-       * its own base URL: narrowing is remembered per Code API. */
-      mockAxios.mockResolvedValue({
-        data: { stdout: '{"total":999999,"n":32768,"b64":"iVBORw0KGg', status: 'OL', code: 137 },
-      });
+    it('omits the profile header and optional session fields when unset', async () => {
+      mockAxios.mockResolvedValue({ data: { stdout: '{}' } });
 
-      await expect(
-        readSandboxImage({
-          file_path: '/mnt/data/big.png',
-          codeApiBaseUrl: 'https://always-overflows.example.com',
-        }),
-      ).rejects.toThrow(/exceeded the sandbox stdout limit/);
+      await readSandboxImage({ file_path: '/mnt/data/chart.png' });
+
+      const call = mockAxios.mock.calls[0][0];
+      expect(call.data.session_id).toBeUndefined();
+      expect(call.data.runtime_session_hint).toBeUndefined();
+      expect(call.data.files).toBeUndefined();
+      expect(call.headers['X-CodeAPI-Expected-Profile']).toBeUndefined();
     });
 
-    it('narrows the window and re-reads the same offset when the runner truncates', async () => {
-      /* A runner whose stdout cap is smaller than this deployment assumed
-       * used to fail the whole image. The window halves and the read
-       * resumes, so the only cost is the truncated round-trip. */
-      const source = Buffer.concat([PNG_HEADER, crypto.randomBytes(8 * 1024)]);
-      const accepted = 32 * 1024;
-      const windows = [];
-      mockAxios.mockImplementation(async ({ data }) => {
-        const payload = JSON.parse(
-          Buffer.from(JSON.parse(/payload = ("[^"]+")/.exec(data.code)[1]), 'base64').toString(),
-        );
-        windows.push(payload.chunk);
-        if (payload.chunk > accepted) {
-          return { data: { stdout: '{"total":8200,"n":40000,"b64":"iVBOR', status: 'OL' } };
-        }
-        const slice = source.subarray(payload.offset, payload.offset + payload.chunk);
-        return {
-          data: {
-            stdout: JSON.stringify({
-              total: source.length,
-              n: slice.length,
-              b64: slice.toString('base64'),
-            }),
-          },
-        };
-      });
-
-      const result = await readSandboxImage({
-        file_path: '/mnt/data/x.png',
-        codeApiBaseUrl: 'https://small-stdout.example.com',
-      });
-
-      expect(windows[0]).toBeGreaterThan(accepted);
-      expect(windows[1]).toBeLessThanOrEqual(accepted);
-      expect(Buffer.from(result.base64, 'base64').equals(source)).toBe(true);
-    });
-
-    it('waits out a rate limit and finishes the read', async () => {
-      /* Every window is one `/exec` call against the Code API's per-user
-       * execution limiter, so a read that starts near the end of a window
-       * used to throw away the bytes it had already pulled. */
-      const source = Buffer.concat([PNG_HEADER, crypto.randomBytes(1024)]);
-      const rateLimited = Object.assign(new Error('Request failed with status code 429'), {
-        isAxiosError: true,
-        response: { status: 429, headers: { 'retry-after': '1' }, data: {} },
-      });
-      let attempts = 0;
-      mockAxios.mockImplementation(async ({ data }) => {
-        attempts++;
-        if (attempts === 1) {
-          throw rateLimited;
-        }
-        const payload = JSON.parse(
-          Buffer.from(JSON.parse(/payload = ("[^"]+")/.exec(data.code)[1]), 'base64').toString(),
-        );
-        const slice = source.subarray(payload.offset, payload.offset + payload.chunk);
-        return {
-          data: {
-            stdout: JSON.stringify({
-              total: source.length,
-              n: slice.length,
-              b64: slice.toString('base64'),
-            }),
-          },
-        };
-      });
+    it('hands the raw `/exec` response to the shared chunk parser', async () => {
+      const data = { stdout: '{"total":3,"n":3,"b64":"AAAA"}', status: null };
+      mockAxios.mockResolvedValue({ data });
+      mockParseSandboxImageChunk.mockReturnValue({ total: 3, n: 3, b64: 'AAAA' });
 
       const result = await readSandboxImage({ file_path: '/mnt/data/x.png' });
 
-      expect(attempts).toBe(2);
-      expect(Buffer.from(result.base64, 'base64').equals(source)).toBe(true);
+      expect(mockParseSandboxImageChunk).toHaveBeenCalledWith(data);
+      expect(result).toEqual({ total: 3, n: 3, b64: 'AAAA' });
     });
 
-    it('names the rate limit even when the response carries no usable delay', async () => {
-      /* Otherwise a bare "Request failed with status code 429" reaches the
-       * model as an unspecified failure instead of one that clears itself. */
-      mockAxios.mockRejectedValue(
-        Object.assign(new Error('Request failed with status code 429'), {
-          isAxiosError: true,
-          response: { status: 429, headers: {}, data: {} },
-        }),
-      );
+    it('returns null when no code base URL is configured', async () => {
+      const { getCodeBaseURL } = require('@librechat/agents');
+      getCodeBaseURL.mockReturnValueOnce('');
+
+      await expect(readSandboxImage({ file_path: '/mnt/data/x.png' })).resolves.toBeNull();
+      expect(mockAxios).not.toHaveBeenCalled();
+    });
+
+    it('logs and rethrows a transport failure', async () => {
+      const { logAxiosError } = require('@librechat/api');
+      mockAxios.mockRejectedValue(new Error('codeapi unreachable'));
 
       await expect(readSandboxImage({ file_path: '/mnt/data/x.png' })).rejects.toThrow(
-        /rate limit reached while reading/,
+        'codeapi unreachable',
       );
-    });
-
-    it('names the rate limit when the wait exceeds what one read may spend', async () => {
-      mockAxios.mockRejectedValue(
-        Object.assign(new Error('Request failed with status code 429'), {
-          isAxiosError: true,
-          response: { status: 429, headers: {}, data: { retry_after_seconds: 300 } },
+      expect(logAxiosError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Error reading sandbox image "/mnt/data/x.png"',
         }),
       );
-
-      await expect(readSandboxImage({ file_path: '/mnt/data/x.png' })).rejects.toThrow(
-        /rate limit reached while reading "\/mnt\/data\/x\.png".*retry in 300s/,
-      );
-      expect(mockAxios).toHaveBeenCalledTimes(1);
-    });
-
-    it('honors LIBRECHAT_CODE_IMAGE_CHUNK_BYTES', async () => {
-      process.env.LIBRECHAT_CODE_IMAGE_CHUNK_BYTES = '1024';
-      const source = Buffer.concat([PNG_HEADER, crypto.randomBytes(4 * 1024)]);
-      serveFile(source);
-
-      const result = await readSandboxImage({ file_path: '/mnt/data/x.png' });
-
-      expect(mockAxios.mock.calls.length).toBe(5);
-      expect(Buffer.from(result.base64, 'base64').equals(source)).toBe(true);
-    });
-
-    it('parses the reader JSON even when the shell emits a banner first', async () => {
-      const source = Buffer.concat([PNG_HEADER, crypto.randomBytes(64)]);
-      mockAxios.mockResolvedValue({
-        data: {
-          stdout: `motd banner\n${JSON.stringify({
-            total: source.length,
-            n: source.length,
-            b64: source.toString('base64'),
-          })}`,
-        },
-      });
-
-      const result = await readSandboxImage({ file_path: '/mnt/data/x.png' });
-
-      expect(Buffer.from(result.base64, 'base64').equals(source)).toBe(true);
-    });
-
-    it('refuses an oversize file in-sandbox without transferring bytes', async () => {
-      mockAxios.mockResolvedValue({
-        data: { stdout: JSON.stringify({ too_large: true, bytes: 9 * 1024 * 1024 }) },
-      });
-
-      const result = await readSandboxImage({ file_path: '/mnt/data/huge.png' });
-
-      expect(result).toEqual({ tooLarge: true, reason: 'size', bytes: 9 * 1024 * 1024 });
-      expect(mockAxios).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/api/src/agents/handlers.spec.ts
+++ b/packages/api/src/agents/handlers.spec.ts
@@ -5601,10 +5601,40 @@ describe('createToolExecuteHandler', () => {
         expect(result.content).toContain('bash_tool');
       });
 
-      it('degrades to the image hint when decoded bytes are truncated (integrity guard)', async () => {
+      it('reports a round-trip-bound image as unreadable inline, not oversize', async () => {
+        /* Within the byte cap but needing more windowed `/exec` reads than
+         * one call may spend on the Code API's execution limiter. Saying
+         * "over the inline limit" here would misstate a fixable cause. */
+        const readSandboxImage = jest.fn(async () => ({
+          tooLarge: true as const,
+          reason: 'round_trips' as const,
+          bytes: 900_000,
+        }));
+        const handler = makeReadFileHandler({
+          codeEnvAvailable: true,
+          accessibleSkillIds: skillsInScope(),
+          readSandboxImage,
+        });
+
+        const [result] = await invokeHandler(handler, [
+          {
+            id: 'call_trips',
+            name: Constants.READ_FILE,
+            args: { path: '/mnt/data/wide.png' },
+          },
+        ]);
+
+        expect(result.status).toBe('success');
+        expect(result.content).toContain('round-trips');
+        expect(result.content).not.toContain('inline limit');
+        expect(result.content).toContain('Downscale');
+      });
+
+      it('reports a truncated transfer as a failed read, not an unreadable format', async () => {
         /* Simulate codeapi clipping a large `/exec` stdout: the reported
-         * size does not match the decoded base64 length, so the bytes are
-         * unsafe to forward and we fall back to the bash hint. */
+         * size does not match the decoded base64 length. The bytes are
+         * unsafe to forward, but the read is retryable — saying the file
+         * "cannot be read as text" would report a permanent limit. */
         const readSandboxImage = jest.fn(async () => ({ base64: PNG_B64, bytes: pngBytes + 100 }));
         const handler = makeReadFileHandler({
           codeEnvAvailable: true,
@@ -5622,11 +5652,12 @@ describe('createToolExecuteHandler', () => {
 
         expect(result.status).toBe('error');
         expect(result.artifact).toBeUndefined();
-        expect(result.errorMessage).toContain('image file');
-        expect(result.errorMessage).toContain('bash_tool');
+        expect(result.errorMessage).toContain('truncated transfer');
+        expect(result.errorMessage).toContain('Retry the read');
+        expect(result.errorMessage).not.toContain('cannot be read as text');
       });
 
-      it('degrades to the image hint when the image reader throws', async () => {
+      it('surfaces the transport failure when the image reader throws', async () => {
         const readSandboxImage = jest.fn(async () => {
           throw new Error('codeapi unreachable');
         });
@@ -5645,8 +5676,62 @@ describe('createToolExecuteHandler', () => {
         ]);
 
         expect(result.status).toBe('error');
-        expect(result.errorMessage).toContain('image file');
-        expect(result.errorMessage).toContain('bash_tool');
+        expect(result.errorMessage).toContain('codeapi unreachable');
+        expect(result.errorMessage).toContain('Retry the read');
+        expect(result.errorMessage).not.toContain('cannot be read as text');
+      });
+
+      it('tells the model to wait when the sandbox rate-limited the read', async () => {
+        /* Each window is one `/exec` call against a per-user limiter, so a
+         * chart-heavy turn can exhaust it. The old catch-all told the model
+         * images are unreadable, which stopped it from ever retrying. */
+        const readSandboxImage = jest.fn(async () => {
+          throw new Error(
+            'Code API rate limit reached while reading "/mnt/data/7_interest_gap.png" from the sandbox (retry in 17s).',
+          );
+        });
+        const handler = makeReadFileHandler({
+          codeEnvAvailable: true,
+          accessibleSkillIds: skillsInScope(),
+          readSandboxImage,
+        });
+
+        const [result] = await invokeHandler(handler, [
+          {
+            id: 'call_429',
+            name: Constants.READ_FILE,
+            args: { path: '/mnt/data/7_interest_gap.png' },
+          },
+        ]);
+
+        expect(result.status).toBe('error');
+        expect(result.errorMessage).toContain('rate limit reached');
+        expect(result.errorMessage).toContain('read it once more');
+        expect(result.errorMessage).not.toContain('cannot be read as text');
+      });
+
+      it('points a missing image at the directory listing instead of the bytes', async () => {
+        const readSandboxImage = jest.fn(async () => {
+          throw new Error("[Errno 2] No such file or directory: '/mnt/data/gone.png'");
+        });
+        const handler = makeReadFileHandler({
+          codeEnvAvailable: true,
+          accessibleSkillIds: skillsInScope(),
+          readSandboxImage,
+        });
+
+        const [result] = await invokeHandler(handler, [
+          {
+            id: 'call_missing',
+            name: Constants.READ_FILE,
+            args: { path: '/mnt/data/gone.png' },
+          },
+        ]);
+
+        expect(result.status).toBe('error');
+        expect(result.errorMessage).toContain('was not found');
+        expect(result.errorMessage).toContain('ls /mnt/data');
+        expect(result.errorMessage).not.toContain('cannot be read as text');
       });
 
       it('rejects non-image binary types with a bash-pointing message (not the image path)', async () => {

--- a/packages/api/src/agents/handlers.spec.ts
+++ b/packages/api/src/agents/handlers.spec.ts
@@ -5609,6 +5609,7 @@ describe('createToolExecuteHandler', () => {
           tooLarge: true as const,
           reason: 'round_trips' as const,
           bytes: 900_000,
+          inlineCeiling: 489_600,
         }));
         const handler = makeReadFileHandler({
           codeEnvAvailable: true,
@@ -5625,7 +5626,9 @@ describe('createToolExecuteHandler', () => {
         ]);
 
         expect(result.status).toBe('success');
-        expect(result.content).toContain('round-trips');
+        /* Names the size that would actually work, so the model has a
+         * downscale target instead of a guess. */
+        expect(result.content).toContain('489600');
         expect(result.content).not.toContain('inline limit');
         expect(result.content).toContain('Downscale');
       });
@@ -5655,6 +5658,33 @@ describe('createToolExecuteHandler', () => {
         expect(result.errorMessage).toContain('truncated transfer');
         expect(result.errorMessage).toContain('Retry the read');
         expect(result.errorMessage).not.toContain('cannot be read as text');
+      });
+
+      it('reports a missing interpreter as itself, not as a missing image path', async () => {
+        /* The sandbox reader surfaces `python3: not found` on stderr. A
+         * generic "not found" match would send the model to `ls /mnt/data`
+         * and hide the runner dependency the operator has to fix. */
+        const readSandboxImage = jest.fn(async () => {
+          throw new Error('python3: not found');
+        });
+        const handler = makeReadFileHandler({
+          codeEnvAvailable: true,
+          accessibleSkillIds: skillsInScope(),
+          readSandboxImage,
+        });
+
+        const [result] = await invokeHandler(handler, [
+          {
+            id: 'call_nopython',
+            name: Constants.READ_FILE,
+            args: { path: '/mnt/data/chart.png' },
+          },
+        ]);
+
+        expect(result.status).toBe('error');
+        expect(result.errorMessage).toContain('python3: not found');
+        expect(result.errorMessage).not.toContain('was not found in the code-execution sandbox');
+        expect(result.errorMessage).not.toContain('ls /mnt/data');
       });
 
       it('surfaces the transport failure when the image reader throws', async () => {

--- a/packages/api/src/agents/handlers.ts
+++ b/packages/api/src/agents/handlers.ts
@@ -478,7 +478,7 @@ export interface ToolExecuteOptions {
     /** `size`: over `maxBytes`. `round_trips`: within the byte cap, but more
      *  windowed `/exec` reads than one call may spend on the Code API's
      *  per-user execution limiter. */
-    | { tooLarge: true; reason?: 'size' | 'round_trips'; bytes: number }
+    | { tooLarge: true; reason?: 'size' | 'round_trips'; bytes: number; inlineCeiling?: number }
     | null
   >;
   /**
@@ -1856,6 +1856,24 @@ function looksBinary(content: string): boolean {
 }
 
 /**
+ * True for the errors a sandbox raises about the requested PATH, and only
+ * those. Deliberately narrower than {@link isSandboxMissingFileError}: that
+ * predicate also accepts a bare "not found", which the sandbox reader emits
+ * for a missing interpreter (`python3: not found`). Reporting that as a
+ * missing image would send the model to `ls /mnt/data` while hiding a
+ * runner dependency the operator needs to see.
+ */
+function isMissingSandboxPathError(reason: string): boolean {
+  const message = reason.toLowerCase();
+  return (
+    message.includes('no such file or directory') ||
+    message.includes('cannot access') ||
+    message.includes('cannot find the path') ||
+    message.includes('enoent')
+  );
+}
+
+/**
  * Model-visible error for an image the sandbox could not hand back. The
  * read is a supported operation that FAILED, so the message must not reuse
  * the "images cannot be read as text" phrasing — that reads as a permanent
@@ -1869,7 +1887,7 @@ function looksBinary(content: string): boolean {
  */
 function buildImageReadError(filePath: string, reason: string): string {
   const detail = reason.replace(/\.$/, '');
-  if (isSandboxMissingFileError(reason)) {
+  if (isMissingSandboxPathError(reason)) {
     return `"${filePath}" was not found in the code-execution sandbox (${detail}). List the directory with \`bash_tool\` (e.g. \`ls /mnt/data\`) to find the correct path.`;
   }
   if (/rate limit/i.test(reason)) {
@@ -1922,7 +1940,7 @@ async function handleSandboxImageRead(
   const ctx = tc.codeSessionContext as SandboxSessionContext | undefined;
   let read:
     | { base64: string; bytes: number }
-    | { tooLarge: true; reason?: 'size' | 'round_trips'; bytes: number }
+    | { tooLarge: true; reason?: 'size' | 'round_trips'; bytes: number; inlineCeiling?: number }
     | null;
   try {
     read = await readSandboxImage({
@@ -1944,14 +1962,22 @@ async function handleSandboxImageRead(
   }
   if ('tooLarge' in read) {
     onSuccess?.();
+    /* Name the size that would actually work: each window costs one sandbox
+     * execution, so what can be inlined depends on the runner's stdout
+     * budget, not only on the byte cap. Without a target the model can only
+     * guess how far to downscale. */
+    const ceiling =
+      read.reason === 'round_trips' && read.inlineCeiling != null
+        ? read.inlineCeiling
+        : MAX_SANDBOX_INLINE_IMAGE_BYTES;
     const overBudget =
       read.reason === 'round_trips'
-        ? 'needed more sandbox round-trips than one read may spend'
+        ? `more than this sandbox can return inline (about ${ceiling} bytes)`
         : `over the ${MAX_SANDBOX_INLINE_IMAGE_BYTES}-byte inline limit`;
     return {
       toolCallId: tc.id,
       status: 'success',
-      content: `Image "${filePath}" is ${read.bytes} bytes, ${overBudget}. Downscale it in the sandbox with \`bash_tool\` and read the smaller copy to view it, or inspect it with \`bash_tool\` (e.g. \`file ${filePath}\` for metadata).`,
+      content: `Image "${filePath}" is ${read.bytes} bytes, ${overBudget}. Downscale it under ${ceiling} bytes in the sandbox with \`bash_tool\` and read the smaller copy to view it, or inspect it with \`bash_tool\` (e.g. \`file ${filePath}\` for metadata).`,
     };
   }
 

--- a/packages/api/src/agents/handlers.ts
+++ b/packages/api/src/agents/handlers.ts
@@ -473,7 +473,14 @@ export interface ToolExecuteOptions {
     /** In-sandbox size cap; files larger than this return `tooLarge` without transferring bytes. */
     maxBytes?: number;
     req?: ServerRequest;
-  }) => Promise<{ base64: string; bytes: number } | { tooLarge: true; bytes: number } | null>;
+  }) => Promise<
+    | { base64: string; bytes: number }
+    /** `size`: over `maxBytes`. `round_trips`: within the byte cap, but more
+     *  windowed `/exec` reads than one call may spend on the Code API's
+     *  per-user execution limiter. */
+    | { tooLarge: true; reason?: 'size' | 'round_trips'; bytes: number }
+    | null
+  >;
   /**
    * Writes a UTF-8 text file into the code-execution sandbox via the
    * sandbox `/exec` endpoint. Mirrors `readSandboxFile` session forwarding
@@ -1849,14 +1856,37 @@ function looksBinary(content: string): boolean {
 }
 
 /**
+ * Model-visible error for an image the sandbox could not hand back. The
+ * read is a supported operation that FAILED, so the message must not reuse
+ * the "images cannot be read as text" phrasing — that reads as a permanent
+ * capability limit and stops the model from ever retrying. State the real
+ * cause and the affordance that matches it: a rate-limited or truncated
+ * read is worth retrying, a missing path is worth listing, and only a
+ * genuine transport dead end falls back to `bash_tool`. Classification is
+ * by message, matching how `isSandboxMissingFileError` already reads
+ * sandbox failures; the rate-limit wording is the one `readSandboxImage`
+ * throws when the Code API limiter turns a chunk away.
+ */
+function buildImageReadError(filePath: string, reason: string): string {
+  const detail = reason.replace(/\.$/, '');
+  if (isSandboxMissingFileError(reason)) {
+    return `"${filePath}" was not found in the code-execution sandbox (${detail}). List the directory with \`bash_tool\` (e.g. \`ls /mnt/data\`) to find the correct path.`;
+  }
+  if (/rate limit/i.test(reason)) {
+    return `Could not read image "${filePath}": ${detail}. Wait for the sandbox to accept requests again, then read it once more.`;
+  }
+  return `Could not read image "${filePath}" from the code-execution sandbox: ${detail}. Retry the read; if it keeps failing, inspect the file with \`bash_tool\` (e.g. \`file ${filePath}\`).`;
+}
+
+/**
  * Reads a sandbox image as a viewable artifact so `read_file` can hand the
  * bytes to vision-capable models instead of refusing them. Fetches the file
  * base64-encoded from the sandbox (`readSandboxImage`), verifies the decoded
  * length matches the size the sandbox reported (guards against codeapi
  * truncating a large `/exec` stdout into a corrupt image), sniffs the real
- * MIME, and returns the shared image-artifact result. Degrades to the
- * text-oriented binary hint when the reader is unavailable, the image is
- * over the inline cap, or the read fails — never throws.
+ * MIME, and returns the shared image-artifact result. Never throws: a
+ * mislabeled or corrupt image degrades to the binary hint, while a failed
+ * read reports what actually went wrong (see {@link buildImageReadError}).
  */
 async function handleSandboxImageRead(
   tc: ToolCallRequest,
@@ -1879,12 +1909,21 @@ async function handleSandboxImageRead(
     content: '',
     errorMessage: buildBinaryFileError(filePath, ext),
   });
+  const readFailure = (reason: string): ToolExecuteResult => ({
+    toolCallId: tc.id,
+    status: 'error',
+    content: '',
+    errorMessage: buildImageReadError(filePath, reason),
+  });
   if (!readSandboxImage) {
     return binaryHint();
   }
 
   const ctx = tc.codeSessionContext as SandboxSessionContext | undefined;
-  let read: { base64: string; bytes: number } | { tooLarge: true; bytes: number } | null;
+  let read:
+    | { base64: string; bytes: number }
+    | { tooLarge: true; reason?: 'size' | 'round_trips'; bytes: number }
+    | null;
   try {
     read = await readSandboxImage({
       file_path: filePath,
@@ -1895,9 +1934,9 @@ async function handleSandboxImageRead(
       ...(req ? { req } : {}),
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = getThrownValueMessage(error);
     logger.warn(`[handleReadFileCall] Sandbox image read failed for "${filePath}": ${message}`);
-    return binaryHint();
+    return readFailure(message);
   }
 
   if (!read) {
@@ -1905,10 +1944,14 @@ async function handleSandboxImageRead(
   }
   if ('tooLarge' in read) {
     onSuccess?.();
+    const overBudget =
+      read.reason === 'round_trips'
+        ? 'needed more sandbox round-trips than one read may spend'
+        : `over the ${MAX_SANDBOX_INLINE_IMAGE_BYTES}-byte inline limit`;
     return {
       toolCallId: tc.id,
       status: 'success',
-      content: `Image "${filePath}" is ${read.bytes} bytes, over the ${MAX_SANDBOX_INLINE_IMAGE_BYTES}-byte inline limit. Use \`bash_tool\` to process it (e.g. \`file ${filePath}\` for metadata).`,
+      content: `Image "${filePath}" is ${read.bytes} bytes, ${overBudget}. Downscale it in the sandbox with \`bash_tool\` and read the smaller copy to view it, or inspect it with \`bash_tool\` (e.g. \`file ${filePath}\` for metadata).`,
     };
   }
 
@@ -1917,7 +1960,9 @@ async function handleSandboxImageRead(
     logger.warn(
       `[handleReadFileCall] Sandbox image byte mismatch for "${filePath}" (decoded ${buffer.length} != reported ${read.bytes})`,
     );
-    return binaryHint();
+    return readFailure(
+      `the sandbox returned ${buffer.length} of ${read.bytes} bytes (truncated transfer)`,
+    );
   }
   // Resolve the MIME from the actual bytes, never the extension: a file
   // routed here by its `.png`/`.jpg`/... name whose header matches none of

--- a/packages/api/src/agents/skillFiles.ts
+++ b/packages/api/src/agents/skillFiles.ts
@@ -1,5 +1,4 @@
 import { Readable } from 'stream';
-import { isAxiosError } from 'axios';
 import { Constants } from '@librechat/agents';
 import { logger } from '@librechat/data-schemas';
 import {
@@ -19,10 +18,10 @@ import {
   inspectContent,
   UninspectableFileError,
 } from '~/protection';
+import { createConcurrencyLimiter, getCodeApiRetryAfterMs, getSafeErrorMetadata } from '~/utils';
 import { seedCodeFilesIntoSessions, type CodeExecutionProfileRoute } from './codeFilesSession';
 import { ContentFilterError, isContentFilterError } from '~/middleware/contentFilter';
 import { getCodeExecutionRouteKey, type CodeExecutionContext } from './execution';
-import { createConcurrencyLimiter, getSafeErrorMetadata } from '~/utils';
 import { assertSkillFileContentAllowed } from '~/skills/protection';
 import { createSkillContentDigest } from './compatibility';
 import { extractInvokedSkillsFromPayload } from './run';
@@ -146,25 +145,13 @@ function isCurrentSkillRef(
   return ref?.kind === 'skill' && ref.version === skillVersion;
 }
 
-function getRetryAfterMs(error: unknown): number | null {
-  if (!isAxiosError(error) || error.response?.status !== 429) {
-    return null;
-  }
-  const header = error.response.headers?.['retry-after'];
-  const seconds = Number(Array.isArray(header) ? header[0] : header);
-  if (!Number.isFinite(seconds) || seconds < 0) {
-    return null;
-  }
-  return seconds * 1000;
-}
-
 /** Single retry on 429, honoring Retry-After up to MAX_RETRY_AFTER_MS.
  *  Runs inside an upload slot so the wait also brakes queued uploads. */
 async function retryOn429<T>(attempt: () => Promise<T>, label: string): Promise<T> {
   try {
     return await attempt();
   } catch (error) {
-    const retryAfterMs = getRetryAfterMs(error);
+    const retryAfterMs = getCodeApiRetryAfterMs(error);
     if (retryAfterMs == null || retryAfterMs > MAX_RETRY_AFTER_MS) {
       throw error;
     }

--- a/packages/api/src/files/code/image.spec.ts
+++ b/packages/api/src/files/code/image.spec.ts
@@ -1,0 +1,312 @@
+import crypto from 'crypto';
+import type { SandboxImageChunk } from './image';
+import {
+  buildSandboxImageReaderCode,
+  getSandboxImageChunkBytes,
+  narrowSandboxImageChunkBytes,
+  parseSandboxImageChunk,
+  readWindowedSandboxImage,
+  MAX_SANDBOX_IMAGE_EXEC_CALLS,
+} from './image';
+
+const PNG_HEADER = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+/** Reads the window parameters back out of the generated reader script,
+ *  the same way the sandbox would. */
+function windowParams(code: string): { offset: number; chunk: number; limit: number } {
+  const encoded = /payload = ("[^"]+")/.exec(code);
+  if (!encoded) {
+    throw new Error('reader code carried no payload');
+  }
+  return JSON.parse(Buffer.from(JSON.parse(encoded[1]), 'base64').toString());
+}
+
+/** Serves `buffer` through the windowed reader, recording each window size. */
+function serveFile(buffer: Buffer, options: { acceptedWindow?: number } = {}) {
+  const windows: number[] = [];
+  const readChunk = async ({ code }: { code: string }): Promise<SandboxImageChunk> => {
+    const { offset, chunk, limit } = windowParams(code);
+    windows.push(chunk);
+    if (options.acceptedWindow != null && chunk > options.acceptedWindow) {
+      return { outputOverflow: true };
+    }
+    if (buffer.length > limit) {
+      return { too_large: true, bytes: buffer.length };
+    }
+    const slice = buffer.subarray(offset, offset + chunk);
+    return { total: buffer.length, n: slice.length, b64: slice.toString('base64') };
+  };
+  return { readChunk, windows };
+}
+
+describe('sandbox image window sizing', () => {
+  const envKeys = ['LIBRECHAT_CODE_IMAGE_CHUNK_BYTES', 'LIBRECHAT_CODE_SANDBOX_OUTPUT_MAX_SIZE'];
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of envKeys) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      if (saved[key] == null) {
+        delete process.env[key];
+      } else {
+        process.env[key] = saved[key];
+      }
+    }
+  });
+
+  it('fills the default 64KB stdout budget without exceeding it', () => {
+    const window = getSandboxImageChunkBytes('https://default.example.com');
+    /* base64 is 4 bytes per 3, and the reader wraps it in a JSON envelope. */
+    const encoded = Math.ceil(window / 3) * 4;
+    expect(window % 3).toBe(0);
+    expect(encoded).toBeLessThan(64 * 1024);
+  });
+
+  it('derives a window a small runner can actually emit', () => {
+    /* An 8KB cap used to floor at an 8KB window, whose base64 alone is
+     * ~10.9KB — every read overflowed, and narrowing was pinned to the
+     * same floor, so no retry could ever succeed. */
+    process.env.LIBRECHAT_CODE_SANDBOX_OUTPUT_MAX_SIZE = String(8 * 1024);
+    const window = getSandboxImageChunkBytes('https://small.example.com');
+    expect(Math.ceil(window / 3) * 4).toBeLessThan(8 * 1024);
+  });
+
+  it('uses an explicit chunk override verbatim', () => {
+    process.env.LIBRECHAT_CODE_IMAGE_CHUNK_BYTES = '1024';
+    expect(getSandboxImageChunkBytes('https://override.example.com')).toBe(1024);
+  });
+
+  it('narrows per base URL, and never past an explicit override', () => {
+    const url = 'https://narrowing.example.com';
+    const before = getSandboxImageChunkBytes(url);
+    const narrowed = narrowSandboxImageChunkBytes(url);
+
+    expect(narrowed).toBeLessThan(before);
+    expect(getSandboxImageChunkBytes(url)).toBe(narrowed);
+    expect(getSandboxImageChunkBytes('https://untouched.example.com')).toBe(before);
+
+    process.env.LIBRECHAT_CODE_IMAGE_CHUNK_BYTES = '512';
+    expect(getSandboxImageChunkBytes(url)).toBe(512);
+  });
+});
+
+describe('parseSandboxImageChunk', () => {
+  it('reports a truncated response as an overflow, not garbled output', () => {
+    /* The runner truncates stdout and SIGKILLs with status `OL`; parsing
+     * the clipped base64 would report a misleading "unexpected output"
+     * instead of the narrowable cause. */
+    const chunk = parseSandboxImageChunk({
+      stdout: '{"total":999999,"n":32768,"b64":"iVBORw0KGg',
+      status: 'OL',
+    });
+    expect(chunk).toEqual({ outputOverflow: true });
+  });
+
+  it('parses the reader JSON even when the shell emits a banner first', () => {
+    const chunk = parseSandboxImageChunk({
+      stdout: `motd banner\n${JSON.stringify({ total: 3, n: 3, b64: 'AAAA' })}`,
+    });
+    expect(chunk).toEqual({ total: 3, n: 3, b64: 'AAAA' });
+  });
+
+  it('surfaces stderr when the runner produced no stdout', () => {
+    expect(() => parseSandboxImageChunk({ stderr: 'python3: not found', stdout: '' })).toThrow(
+      /python3: not found/,
+    );
+  });
+
+  it('names unparseable output rather than returning junk', () => {
+    expect(() => parseSandboxImageChunk({ stdout: 'not json at all' })).toThrow(
+      /Unexpected output/,
+    );
+  });
+
+  it('returns an empty chunk when the runner printed nothing', () => {
+    expect(parseSandboxImageChunk({ stdout: '   ' })).toEqual({});
+  });
+});
+
+describe('readWindowedSandboxImage', () => {
+  const limit = 1024 * 1024;
+
+  it('reassembles an image larger than one window, byte-for-byte', async () => {
+    const source = Buffer.concat([PNG_HEADER, crypto.randomBytes(200 * 1024)]);
+    const { readChunk, windows } = serveFile(source);
+
+    const result = await readWindowedSandboxImage({
+      filePath: '/mnt/data/big.png',
+      baseUrl: 'https://assembly.example.com',
+      limit,
+      readChunk,
+    });
+
+    expect(windows.length).toBeGreaterThan(1);
+    expect(result).not.toBeNull();
+    expect(result).toMatchObject({ bytes: source.length });
+    const base64 = (result as { base64: string }).base64;
+    expect(Buffer.from(base64, 'base64').equals(source)).toBe(true);
+  });
+
+  it('reads a single-window image in one round-trip', async () => {
+    const source = Buffer.concat([PNG_HEADER, crypto.randomBytes(1024)]);
+    const { readChunk, windows } = serveFile(source);
+
+    const result = await readWindowedSandboxImage({
+      filePath: '/mnt/data/small.png',
+      baseUrl: 'https://single.example.com',
+      limit,
+      readChunk,
+    });
+
+    expect(windows).toHaveLength(1);
+    expect(Buffer.from((result as { base64: string }).base64, 'base64').equals(source)).toBe(true);
+  });
+
+  it('narrows the window and re-reads the same offset when the runner truncates', async () => {
+    const source = Buffer.concat([PNG_HEADER, crypto.randomBytes(8 * 1024)]);
+    const acceptedWindow = 32 * 1024;
+    const { readChunk, windows } = serveFile(source, { acceptedWindow });
+
+    const result = await readWindowedSandboxImage({
+      filePath: '/mnt/data/x.png',
+      baseUrl: 'https://truncating.example.com',
+      limit,
+      readChunk,
+    });
+
+    expect(windows[0]).toBeGreaterThan(acceptedWindow);
+    expect(windows[1]).toBeLessThanOrEqual(acceptedWindow);
+    expect(Buffer.from((result as { base64: string }).base64, 'base64').equals(source)).toBe(true);
+  });
+
+  it('names the stdout limit when every narrowed window still overflows', async () => {
+    const readChunk = async (): Promise<SandboxImageChunk> => ({ outputOverflow: true });
+
+    await expect(
+      readWindowedSandboxImage({
+        filePath: '/mnt/data/big.png',
+        baseUrl: 'https://always-overflows.example.com',
+        limit,
+        readChunk,
+      }),
+    ).rejects.toThrow(/exceeded the sandbox stdout limit/);
+  });
+
+  it('refuses an oversize file in-sandbox without transferring bytes', async () => {
+    let calls = 0;
+    const readChunk = async (): Promise<SandboxImageChunk> => {
+      calls++;
+      return { too_large: true, bytes: 9 * 1024 * 1024 };
+    };
+
+    const result = await readWindowedSandboxImage({
+      filePath: '/mnt/data/huge.png',
+      baseUrl: 'https://oversize.example.com',
+      limit,
+      readChunk,
+    });
+
+    expect(result).toEqual({ tooLarge: true, reason: 'size', bytes: 9 * 1024 * 1024 });
+    expect(calls).toBe(1);
+  });
+
+  it('stops at the round-trip ceiling instead of stalling across limiter windows', async () => {
+    /* A window this small needs far more `/exec` calls than one read may
+     * spend, so the read degrades rather than draining the limiter. */
+    const source = crypto.randomBytes(64 * 1024);
+    let calls = 0;
+    const readChunk = async ({ code }: { code: string }): Promise<SandboxImageChunk> => {
+      calls++;
+      const { offset } = windowParams(code);
+      const slice = source.subarray(offset, offset + 300);
+      return { total: source.length, n: slice.length, b64: slice.toString('base64') };
+    };
+
+    const result = await readWindowedSandboxImage({
+      filePath: '/mnt/data/slow.png',
+      baseUrl: 'https://ceiling.example.com',
+      limit,
+      readChunk,
+    });
+
+    expect(calls).toBe(MAX_SANDBOX_IMAGE_EXEC_CALLS);
+    expect(result).toEqual({ tooLarge: true, reason: 'round_trips', bytes: source.length });
+  });
+
+  it('refuses to splice a file that changed mid-read', async () => {
+    let call = 0;
+    const readChunk = async ({ code }: { code: string }): Promise<SandboxImageChunk> => {
+      const { chunk } = windowParams(code);
+      call++;
+      /* Second window reports a different size: the assembled buffer would
+       * be a mix of two versions rather than any real image. */
+      return {
+        total: call === 1 ? chunk * 3 : chunk * 4,
+        n: chunk,
+        b64: Buffer.alloc(chunk).toString('base64'),
+      };
+    };
+
+    await expect(
+      readWindowedSandboxImage({
+        filePath: '/mnt/data/moving.png',
+        baseUrl: 'https://changing.example.com',
+        limit,
+        readChunk,
+      }),
+    ).rejects.toThrow(/changed while being read/);
+  });
+
+  it('surfaces the in-sandbox reader error for a path it refused', async () => {
+    const readChunk = async (): Promise<SandboxImageChunk> => ({
+      error: "[Errno 2] No such file or directory: '/mnt/data/gone.png'",
+    });
+
+    await expect(
+      readWindowedSandboxImage({
+        filePath: '/mnt/data/gone.png',
+        baseUrl: 'https://missing.example.com',
+        limit,
+        readChunk,
+      }),
+    ).rejects.toThrow(/No such file or directory/);
+  });
+
+  it('returns null when the runner produced no output', async () => {
+    const readChunk = async (): Promise<SandboxImageChunk> => ({});
+
+    await expect(
+      readWindowedSandboxImage({
+        filePath: '/mnt/data/quiet.png',
+        baseUrl: 'https://silent.example.com',
+        limit,
+        readChunk,
+      }),
+    ).resolves.toBeNull();
+  });
+});
+
+describe('buildSandboxImageReaderCode', () => {
+  it('carries the window parameters base64-encoded, never as shell syntax', () => {
+    const code = buildSandboxImageReaderCode({
+      filePath: `/mnt/data/'; rm -rf /; '.png`,
+      limit: 1024,
+      offset: 96,
+      chunkBytes: 48,
+    });
+
+    expect(code).not.toContain('rm -rf');
+    expect(windowParams(code)).toEqual({
+      file_path: `/mnt/data/'; rm -rf /; '.png`,
+      limit: 1024,
+      offset: 96,
+      chunk: 48,
+    });
+  });
+});

--- a/packages/api/src/files/code/image.spec.ts
+++ b/packages/api/src/files/code/image.spec.ts
@@ -22,13 +22,20 @@ function windowParams(code: string): { offset: number; chunk: number; limit: num
 }
 
 /** Serves `buffer` through the windowed reader, recording each window size. */
-function serveFile(buffer: Buffer, options: { acceptedWindow?: number } = {}) {
+function serveFile(
+  buffer: Buffer,
+  options: { acceptedWindow?: number; reportsCap?: boolean } = {},
+) {
   const windows: number[] = [];
   const readChunk = async ({ code }: { code: string }): Promise<SandboxImageChunk> => {
     const { offset, chunk, limit } = windowParams(code);
     windows.push(chunk);
     if (options.acceptedWindow != null && chunk > options.acceptedWindow) {
-      return { outputOverflow: true };
+      /* Report the cap the way a runner does: by truncating at it. */
+      return {
+        outputOverflow: true,
+        observedStdoutBytes: options.reportsCap === false ? undefined : options.acceptedWindow,
+      };
     }
     if (buffer.length > limit) {
       return { too_large: true, bytes: buffer.length };
@@ -110,24 +117,35 @@ describe('sandbox image window sizing', () => {
     expect(getSandboxImageChunkBytes(url)).toBe(first);
   });
 
-  it('keeps halving until a small runner cap is reachable', () => {
-    /* Two halvings stop at 12,240 raw bytes — still ~16KB of base64, so an
-     * 8KB runner cap was unreachable and the read failed outright. */
-    const url = 'https://tiny-cap.example.com';
-    let window: number | null = getSandboxImageChunkBytes(url);
-    const attempts: number[] = [window];
-    while (window != null && Math.ceil(window / 3) * 4 > 8 * 1024) {
-      window = narrowSandboxImageChunkBytes(window, url);
-      if (window != null) {
-        attempts.push(window);
-      }
-    }
-    expect(window).not.toBeNull();
-    expect(attempts.length).toBeLessThan(MAX_SANDBOX_IMAGE_EXEC_CALLS);
+  it('sizes the retry from the cap a truncated response revealed', () => {
+    /* Blind halving from ~49KB needs eight round-trips to reach a 1KB
+     * runner — most of the call budget spent on discovery. The truncated
+     * response already measured the cap, so one retry lands. */
+    const url = 'https://measured.example.com';
+    const window = getSandboxImageChunkBytes(url);
+
+    const narrowed = narrowSandboxImageChunkBytes(window, url, 1024);
+
+    expect(narrowed).not.toBeNull();
+    expect(Math.ceil((narrowed as number) / 3) * 4).toBeLessThan(1024);
   });
 
-  it('stops narrowing at a window no image runner could serve', () => {
-    expect(narrowSandboxImageChunkBytes(1536, 'https://floor.example.com')).toBeNull();
+  it('keeps narrowing until an unconfigured small runner is reachable', () => {
+    /* A ~1KB stdout cap is a real runner default. A floor above it declared
+     * every image unreadable even though small ones fit. */
+    const url = 'https://tiny-cap.example.com';
+    let window: number | null = getSandboxImageChunkBytes(url);
+    let attempts = 0;
+    while (window != null && Math.ceil(window / 3) * 4 + 256 > 1024) {
+      attempts++;
+      window = narrowSandboxImageChunkBytes(window, url);
+    }
+    expect(window).not.toBeNull();
+    expect(attempts).toBeLessThan(MAX_SANDBOX_IMAGE_EXEC_CALLS);
+  });
+
+  it('stops once no smaller window exists', () => {
+    expect(narrowSandboxImageChunkBytes(3, 'https://floor.example.com')).toBeNull();
   });
 });
 
@@ -136,11 +154,11 @@ describe('parseSandboxImageChunk', () => {
     /* The runner truncates stdout and SIGKILLs with status `OL`; parsing
      * the clipped base64 would report a misleading "unexpected output"
      * instead of the narrowable cause. */
-    const chunk = parseSandboxImageChunk({
-      stdout: '{"total":999999,"n":32768,"b64":"iVBORw0KGg',
-      status: 'OL',
-    });
-    expect(chunk).toEqual({ outputOverflow: true });
+    const stdout = '{"total":999999,"n":32768,"b64":"iVBORw0KGg';
+    const chunk = parseSandboxImageChunk({ stdout, status: 'OL' });
+    /* What survived is exactly what the runner allows, so it measures the
+     * cap this deployment never declared. */
+    expect(chunk).toEqual({ outputOverflow: true, observedStdoutBytes: stdout.length });
   });
 
   it('parses the reader JSON even when the shell emits a banner first', () => {
@@ -218,6 +236,34 @@ describe('readWindowedSandboxImage', () => {
     expect(windows[0]).toBeGreaterThan(acceptedWindow);
     expect(windows[1]).toBeLessThanOrEqual(acceptedWindow);
     expect(Buffer.from((result as { base64: string }).base64, 'base64').equals(source)).toBe(true);
+  });
+
+  it('reads a small image from a runner with a ~1KB stdout cap', async () => {
+    /* A 1KB cap is a real runner default. Discovery has to reach a window
+     * that small, and the truncated response says how small in one step. */
+    const cap = 1024;
+    const source = Buffer.concat([PNG_HEADER, crypto.randomBytes(3 * 1024)]);
+    let calls = 0;
+    const readChunk = async ({ code }: { code: string }): Promise<SandboxImageChunk> => {
+      calls++;
+      const { offset, chunk } = windowParams(code);
+      const slice = source.subarray(offset, offset + chunk);
+      const encoded = Math.ceil(slice.length / 3) * 4 + 64;
+      if (encoded > cap) {
+        return { outputOverflow: true, observedStdoutBytes: cap };
+      }
+      return { total: source.length, n: slice.length, b64: slice.toString('base64') };
+    };
+
+    const result = await readWindowedSandboxImage({
+      filePath: '/mnt/data/icon.png',
+      baseUrl: 'https://kilobyte.example.com',
+      limit,
+      readChunk,
+    });
+
+    expect(Buffer.from((result as { base64: string }).base64, 'base64').equals(source)).toBe(true);
+    expect(calls).toBeLessThanOrEqual(MAX_SANDBOX_IMAGE_EXEC_CALLS);
   });
 
   it('names the stdout limit when every narrowed window still overflows', async () => {

--- a/packages/api/src/files/code/image.spec.ts
+++ b/packages/api/src/files/code/image.spec.ts
@@ -85,14 +85,49 @@ describe('sandbox image window sizing', () => {
   it('narrows per base URL, and never past an explicit override', () => {
     const url = 'https://narrowing.example.com';
     const before = getSandboxImageChunkBytes(url);
-    const narrowed = narrowSandboxImageChunkBytes(url);
+    const narrowed = narrowSandboxImageChunkBytes(before, url);
 
+    expect(narrowed).not.toBeNull();
     expect(narrowed).toBeLessThan(before);
     expect(getSandboxImageChunkBytes(url)).toBe(narrowed);
     expect(getSandboxImageChunkBytes('https://untouched.example.com')).toBe(before);
 
     process.env.LIBRECHAT_CODE_IMAGE_CHUNK_BYTES = '512';
     expect(getSandboxImageChunkBytes(url)).toBe(512);
+  });
+
+  it("halves the caller's own failing window, not the shared learned value", () => {
+    /* Reads run concurrently (one per tool call). Two reads failing at the
+     * same size used to halve the shared value twice, skipping a size the
+     * runner would have accepted and persisting it for later reads. */
+    const url = 'https://concurrent.example.com';
+    const window = getSandboxImageChunkBytes(url);
+
+    const first = narrowSandboxImageChunkBytes(window, url);
+    const second = narrowSandboxImageChunkBytes(window, url);
+
+    expect(second).toBe(first);
+    expect(getSandboxImageChunkBytes(url)).toBe(first);
+  });
+
+  it('keeps halving until a small runner cap is reachable', () => {
+    /* Two halvings stop at 12,240 raw bytes — still ~16KB of base64, so an
+     * 8KB runner cap was unreachable and the read failed outright. */
+    const url = 'https://tiny-cap.example.com';
+    let window: number | null = getSandboxImageChunkBytes(url);
+    const attempts: number[] = [window];
+    while (window != null && Math.ceil(window / 3) * 4 > 8 * 1024) {
+      window = narrowSandboxImageChunkBytes(window, url);
+      if (window != null) {
+        attempts.push(window);
+      }
+    }
+    expect(window).not.toBeNull();
+    expect(attempts.length).toBeLessThan(MAX_SANDBOX_IMAGE_EXEC_CALLS);
+  });
+
+  it('stops narrowing at a window no image runner could serve', () => {
+    expect(narrowSandboxImageChunkBytes(1536, 'https://floor.example.com')).toBeNull();
   });
 });
 
@@ -216,9 +251,11 @@ describe('readWindowedSandboxImage', () => {
     expect(calls).toBe(1);
   });
 
-  it('stops at the round-trip ceiling instead of stalling across limiter windows', async () => {
-    /* A window this small needs far more `/exec` calls than one read may
-     * spend, so the read degrades rather than draining the limiter. */
+  it('gives up from the first window rather than draining the limiter', async () => {
+    /* The first response reveals the file size, so a read that cannot
+     * finish within the round-trip ceiling is known immediately — spending
+     * the rest of the limiter window to rediscover it would leave the turn
+     * with no executions left. */
     const source = crypto.randomBytes(64 * 1024);
     let calls = 0;
     const readChunk = async ({ code }: { code: string }): Promise<SandboxImageChunk> => {
@@ -235,8 +272,32 @@ describe('readWindowedSandboxImage', () => {
       readChunk,
     });
 
-    expect(calls).toBe(MAX_SANDBOX_IMAGE_EXEC_CALLS);
-    expect(result).toEqual({ tooLarge: true, reason: 'round_trips', bytes: source.length });
+    expect(calls).toBe(1);
+    expect(result).toEqual({
+      tooLarge: true,
+      reason: 'round_trips',
+      bytes: source.length,
+      /* What this deployment could actually deliver: 300 bytes a call for
+       * the whole round-trip budget. The caller names it as a downscale
+       * target instead of leaving the model to guess. */
+      inlineCeiling: 300 * MAX_SANDBOX_IMAGE_EXEC_CALLS,
+    });
+  });
+
+  it('reads a file that exactly fills the round-trip ceiling', async () => {
+    const window = getSandboxImageChunkBytes('https://exact.example.com');
+    const source = crypto.randomBytes(window * MAX_SANDBOX_IMAGE_EXEC_CALLS);
+    const { readChunk, windows } = serveFile(source);
+
+    const result = await readWindowedSandboxImage({
+      filePath: '/mnt/data/exact.png',
+      baseUrl: 'https://exact.example.com',
+      limit: source.length,
+      readChunk,
+    });
+
+    expect(windows).toHaveLength(MAX_SANDBOX_IMAGE_EXEC_CALLS);
+    expect(Buffer.from((result as { base64: string }).base64, 'base64').equals(source)).toBe(true);
   });
 
   it('refuses to splice a file that changed mid-read', async () => {

--- a/packages/api/src/files/code/image.ts
+++ b/packages/api/src/files/code/image.ts
@@ -30,23 +30,24 @@ const DEFAULT_SANDBOX_OUTPUT_MAX_SIZE = 64 * 1024;
 const IMAGE_CHUNK_ENVELOPE_BYTES = 256;
 
 /** Base64 encodes in 3-byte groups; windowing on a multiple of 3 keeps
- *  every response padding-free. Also the floor: a runner configured with a
- *  tiny stdout cap gets a tiny window rather than one it must reject, and
- *  {@link MAX_SANDBOX_IMAGE_EXEC_CALLS} bounds what that costs. */
+ *  every response padding-free. */
 const BASE64_GROUP_BYTES = 3;
 
-/**
- * Hard round-trip ceiling for one image read. Each window is an `/exec`
- * call against the Code API's per-user execution limiter, so an unbounded
- * read would stall a chat turn across several limiter windows. A file that
- * cannot be pulled within this budget degrades to the same
- * "too large to inline" result as one over the byte cap.
- */
-export const MAX_SANDBOX_IMAGE_EXEC_CALLS = 24;
+/** Floor for a narrowed window. A runner whose stdout cap cannot hold even
+ *  this much base64 (~2KB) cannot serve images at all, so further halving
+ *  would only burn the round-trip budget on responses it must truncate. */
+const MIN_IMAGE_CHUNK_BYTES = 1536;
 
-/** Halvings allowed when a runner's stdout cap turns out to be smaller
- *  than the configured budget. */
-const MAX_IMAGE_OVERFLOW_RETRIES = 2;
+/**
+ * Hard round-trip ceiling for one image read, matched to a single window of
+ * the Code API's per-user execution limiter (20 requests per 30s in the
+ * reference deployment). Beyond it a read would have to wait out limiter
+ * windows to finish, stalling a chat turn; a file that needs more windows
+ * than this degrades to the same "too large to inline" result as one over
+ * the byte cap — and {@link readWindowedSandboxImage} detects that from the
+ * first window rather than spending the whole budget discovering it.
+ */
+export const MAX_SANDBOX_IMAGE_EXEC_CALLS = 20;
 
 /** Per-base-URL window size, narrowed in place the first time a runner
  *  reports truncation so later reads start at a size it accepts. */
@@ -75,8 +76,10 @@ export type SandboxImageChunkReader = (params: { code: string }) => Promise<Sand
 export type SandboxImageReadResult =
   | { base64: string; bytes: number }
   /** `size`: over the caller's cap. `round_trips`: within the byte cap, but
-   *  more windows than {@link MAX_SANDBOX_IMAGE_EXEC_CALLS} allows. */
-  | { tooLarge: true; reason: 'size' | 'round_trips'; bytes: number }
+   *  more windows than {@link MAX_SANDBOX_IMAGE_EXEC_CALLS} allows —
+   *  `inlineCeiling` is the largest file this deployment's window size can
+   *  actually deliver, which the caller can name as a downscale target. */
+  | { tooLarge: true; reason: 'size' | 'round_trips'; bytes: number; inlineCeiling?: number }
   | null;
 
 /**
@@ -113,18 +116,34 @@ function alignToBase64Group(bytes: number): number {
 }
 
 /**
- * Halves the window for a Code API after its runner truncated a response,
- * and returns the size to retry the same offset with. Remembered per base
- * URL so only the first read of a process pays for the discovery.
+ * Halves the window that a runner just truncated and returns the size to
+ * retry the same offset with, or `null` once the floor is reached.
+ *
+ * The halving is computed from the caller's own failing window, never from
+ * the shared learned value: reads run concurrently (one per tool call), so
+ * two reads failing at the same size would otherwise halve the shared value
+ * twice and skip a size the runner would have accepted. For the same reason
+ * the learned value only ever moves down to the narrowest size any read has
+ * needed.
  */
-export function narrowSandboxImageChunkBytes(baseUrl?: string): number {
-  const narrowed = alignToBase64Group(Math.floor(getSandboxImageChunkBytes(baseUrl) / 2));
+export function narrowSandboxImageChunkBytes(
+  failedChunkBytes: number,
+  baseUrl?: string,
+): number | null {
+  if (failedChunkBytes <= MIN_IMAGE_CHUNK_BYTES) {
+    return null;
+  }
+  const narrowed = Math.max(
+    alignToBase64Group(Math.floor(failedChunkBytes / 2)),
+    MIN_IMAGE_CHUNK_BYTES,
+  );
   if (baseUrl != null) {
-    learnedChunkBytes.set(baseUrl, narrowed);
+    const learned = learnedChunkBytes.get(baseUrl);
+    learnedChunkBytes.set(baseUrl, learned == null ? narrowed : Math.min(learned, narrowed));
   }
   logger.warn(
-    `[readSandboxImage] Sandbox stdout limit exceeded; narrowing image window to ${narrowed} bytes for ${baseUrl}. ` +
-      "Set LIBRECHAT_CODE_SANDBOX_OUTPUT_MAX_SIZE to this runner's stdout cap to skip the discovery read.",
+    `[readSandboxImage] Sandbox stdout limit exceeded at ${failedChunkBytes} bytes; retrying with ${narrowed} for ${baseUrl}. ` +
+      "Set LIBRECHAT_CODE_SANDBOX_OUTPUT_MAX_SIZE to this runner's stdout cap to skip the discovery reads.",
   );
   return narrowed;
 }
@@ -239,12 +258,12 @@ export async function readWindowedSandboxImage(params: {
 }): Promise<SandboxImageReadResult> {
   const { filePath, limit, baseUrl, readChunk } = params;
   let chunkBytes = getSandboxImageChunkBytes(baseUrl);
-  let overflowRetries = 0;
+  let sawOverflow = false;
   const parts: Buffer[] = [];
   let offset = 0;
   let total: number | null = null;
 
-  for (let i = 0; i < MAX_SANDBOX_IMAGE_EXEC_CALLS; i++) {
+  for (let call = 0; call < MAX_SANDBOX_IMAGE_EXEC_CALLS; call++) {
     const chunk = await readChunk({
       code: buildSandboxImageReaderCode({ filePath, limit, offset, chunkBytes }),
     });
@@ -252,14 +271,16 @@ export async function readWindowedSandboxImage(params: {
     if (chunk.outputOverflow === true) {
       /* The runner's stdout cap is smaller than this deployment assumed.
        * Halve the window and re-read the same offset rather than failing
-       * the whole image. */
-      if (overflowRetries >= MAX_IMAGE_OVERFLOW_RETRIES) {
+       * the whole image; keep halving until the runner accepts a size or
+       * the floor says it never will. */
+      sawOverflow = true;
+      const narrowed = narrowSandboxImageChunkBytes(chunkBytes, baseUrl);
+      if (narrowed == null) {
         throw new Error(
           `Reading "${filePath}" exceeded the sandbox stdout limit (window ${chunkBytes} bytes).`,
         );
       }
-      overflowRetries++;
-      chunkBytes = narrowSandboxImageChunkBytes(baseUrl);
+      chunkBytes = narrowed;
       continue;
     }
     if (chunk.error) {
@@ -289,17 +310,41 @@ export async function readWindowedSandboxImage(params: {
     if (chunk.n === 0 || offset >= total) {
       break;
     }
+    /* The first window reveals both the file's size and what a call really
+     * delivers, so a read that cannot finish is known now rather than after
+     * draining the limiter. Project from the bytes actually returned, not
+     * the window requested: a runner that serves short reads would other-
+     * wise look like it was keeping up. */
+    if (Math.ceil((total - offset) / chunk.n) > MAX_SANDBOX_IMAGE_EXEC_CALLS - call - 1) {
+      return {
+        tooLarge: true,
+        reason: 'round_trips',
+        bytes: total,
+        inlineCeiling: chunk.n * MAX_SANDBOX_IMAGE_EXEC_CALLS,
+      };
+    }
   }
 
   if (total == null) {
+    /* Every call was spent narrowing: the runner never accepted a window. */
+    if (sawOverflow) {
+      throw new Error(
+        `Reading "${filePath}" exceeded the sandbox stdout limit (window ${chunkBytes} bytes).`,
+      );
+    }
     return null;
   }
   const buffer = Buffer.concat(parts);
   if (buffer.length !== total) {
-    /* Ran out of round-trip budget (or short reads); returning a partial
-     * image would render as a corrupt file, so surface it as
-     * unreadable-inline with the reason the caller should report. */
-    return { tooLarge: true, reason: 'round_trips', bytes: total };
+    /* Short reads: returning a partial image would render as a corrupt
+     * file, so surface it as unreadable-inline with the reason the caller
+     * should report. */
+    return {
+      tooLarge: true,
+      reason: 'round_trips',
+      bytes: total,
+      inlineCeiling: buffer.length,
+    };
   }
   return { base64: buffer.toString('base64'), bytes: buffer.length };
 }

--- a/packages/api/src/files/code/image.ts
+++ b/packages/api/src/files/code/image.ts
@@ -33,11 +33,6 @@ const IMAGE_CHUNK_ENVELOPE_BYTES = 256;
  *  every response padding-free. */
 const BASE64_GROUP_BYTES = 3;
 
-/** Floor for a narrowed window. A runner whose stdout cap cannot hold even
- *  this much base64 (~2KB) cannot serve images at all, so further halving
- *  would only burn the round-trip budget on responses it must truncate. */
-const MIN_IMAGE_CHUNK_BYTES = 1536;
-
 /**
  * Hard round-trip ceiling for one image read, matched to a single window of
  * the Code API's per-user execution limiter (20 requests per 30s in the
@@ -63,6 +58,9 @@ const learnedChunkBytes = new Map<string, number>();
  */
 export interface SandboxImageChunk {
   outputOverflow?: boolean;
+  /** Bytes of stdout the runner did emit before truncating — its actual
+   *  cap, and a far better next window than another blind halving. */
+  observedStdoutBytes?: number;
   error?: string;
   too_large?: boolean;
   bytes?: number;
@@ -103,10 +101,15 @@ function baselineChunkBytes(): number {
     return Math.floor(override);
   }
   const configured = Number(process.env.LIBRECHAT_CODE_SANDBOX_OUTPUT_MAX_SIZE);
-  const budget =
+  return chunkBytesForBudget(
     Number.isFinite(configured) && configured > 0
       ? Math.floor(configured)
-      : DEFAULT_SANDBOX_OUTPUT_MAX_SIZE;
+      : DEFAULT_SANDBOX_OUTPUT_MAX_SIZE,
+  );
+}
+
+/** Largest window whose base64 encoding plus envelope fits `budget`. */
+function chunkBytesForBudget(budget: number): number {
   const usable = Math.max(budget - IMAGE_CHUNK_ENVELOPE_BYTES, 0);
   return alignToBase64Group(Math.floor((usable * 3) / 4));
 }
@@ -116,27 +119,38 @@ function alignToBase64Group(bytes: number): number {
 }
 
 /**
- * Halves the window that a runner just truncated and returns the size to
- * retry the same offset with, or `null` once the floor is reached.
+ * Returns the window to retry a truncated read with, or `null` when no
+ * smaller one exists.
  *
- * The halving is computed from the caller's own failing window, never from
- * the shared learned value: reads run concurrently (one per tool call), so
- * two reads failing at the same size would otherwise halve the shared value
- * twice and skip a size the runner would have accepted. For the same reason
- * the learned value only ever moves down to the narrowest size any read has
- * needed.
+ * A truncated response reveals the runner's real cap — it emitted exactly
+ * as much as it allows — so `observedStdoutBytes` sizes the retry directly
+ * and one round-trip is usually enough to land on a size that fits. Blind
+ * halving is the fallback, and bounds the result either way so every retry
+ * is strictly smaller than the window that just failed.
+ *
+ * The reduction is computed from the caller's own failing window, never
+ * from the shared learned value: reads run concurrently (one per tool
+ * call), so two reads failing at the same size would otherwise reduce the
+ * shared value twice and skip a size the runner would have accepted. For
+ * the same reason the learned value only ever moves down to the narrowest
+ * size any read has needed.
  */
 export function narrowSandboxImageChunkBytes(
   failedChunkBytes: number,
   baseUrl?: string,
+  observedStdoutBytes?: number,
 ): number | null {
-  if (failedChunkBytes <= MIN_IMAGE_CHUNK_BYTES) {
+  const halved = alignToBase64Group(Math.floor(failedChunkBytes / 2));
+  const fromObserved =
+    observedStdoutBytes != null && observedStdoutBytes > 0
+      ? chunkBytesForBudget(observedStdoutBytes)
+      : Number.POSITIVE_INFINITY;
+  const narrowed = Math.min(halved, fromObserved);
+  /* Already as small as a base64 group: this runner cannot emit an image
+   * window at all, and another attempt would only be truncated again. */
+  if (narrowed >= failedChunkBytes) {
     return null;
   }
-  const narrowed = Math.max(
-    alignToBase64Group(Math.floor(failedChunkBytes / 2)),
-    MIN_IMAGE_CHUNK_BYTES,
-  );
   if (baseUrl != null) {
     const learned = learnedChunkBytes.get(baseUrl);
     learnedChunkBytes.set(baseUrl, learned == null ? narrowed : Math.min(learned, narrowed));
@@ -218,10 +232,12 @@ export function parseSandboxImageChunk(response: {
    * job (status `OL`). Detect that explicitly: the surviving stdout is a
    * base64 string cut mid-flight, so parsing it yields a misleading
    * "unexpected output" instead of the narrowable, fixable cause. */
-  if (response.status === 'OL') {
-    return { outputOverflow: true };
-  }
   const stdout = response.stdout == null ? '' : String(response.stdout);
+  if (response.status === 'OL') {
+    /* What survived is exactly what the runner allows, so it doubles as a
+     * measurement of the cap this deployment never declared. */
+    return { outputOverflow: true, observedStdoutBytes: stdout.length };
+  }
   if (response.stderr && stdout === '') {
     throw new Error(String(response.stderr).trim());
   }
@@ -274,7 +290,7 @@ export async function readWindowedSandboxImage(params: {
        * the whole image; keep halving until the runner accepts a size or
        * the floor says it never will. */
       sawOverflow = true;
-      const narrowed = narrowSandboxImageChunkBytes(chunkBytes, baseUrl);
+      const narrowed = narrowSandboxImageChunkBytes(chunkBytes, baseUrl, chunk.observedStdoutBytes);
       if (narrowed == null) {
         throw new Error(
           `Reading "${filePath}" exceeded the sandbox stdout limit (window ${chunkBytes} bytes).`,

--- a/packages/api/src/files/code/image.ts
+++ b/packages/api/src/files/code/image.ts
@@ -1,0 +1,305 @@
+import { logger } from '@librechat/data-schemas';
+
+/**
+ * Windowed base64 reader for images living in a code-execution sandbox.
+ *
+ * The bytes can only come back through `/exec` stdout, which the runner
+ * truncates and SIGKILLs past its own `SANDBOX_OUTPUT_MAX_SIZE`. One read
+ * is therefore a series of `/exec` calls, each spending a request against
+ * the Code API's per-user execution limiter (20 per 30s in the reference
+ * deployment). Everything here exists to keep that count down and bounded:
+ * the window fills the runner's stdout budget, narrows itself if a runner
+ * rejects it, and a file that still needs more calls than one read may
+ * spend is reported as unreadable-inline rather than stalling a chat turn
+ * across limiter windows.
+ *
+ * The transport stays with the caller ({@link SandboxImageChunkReader}) so
+ * this module owns only the sizing, windowing, and assembly decisions.
+ */
+
+/**
+ * Sandbox stdout a single `/exec` response may carry, in bytes — 64KB in
+ * the reference deployment. Deployments that changed the runner's cap set
+ * `LIBRECHAT_CODE_SANDBOX_OUTPUT_MAX_SIZE` to match; a smaller cap is also
+ * discovered at runtime (see {@link narrowSandboxImageChunkBytes}).
+ */
+const DEFAULT_SANDBOX_OUTPUT_MAX_SIZE = 64 * 1024;
+
+/** JSON envelope around the base64 window (`{"total":…,"n":…,"b64":"…"}`),
+ *  plus room for a trailing newline and a stray shell banner line. */
+const IMAGE_CHUNK_ENVELOPE_BYTES = 256;
+
+/** Base64 encodes in 3-byte groups; windowing on a multiple of 3 keeps
+ *  every response padding-free. Also the floor: a runner configured with a
+ *  tiny stdout cap gets a tiny window rather than one it must reject, and
+ *  {@link MAX_SANDBOX_IMAGE_EXEC_CALLS} bounds what that costs. */
+const BASE64_GROUP_BYTES = 3;
+
+/**
+ * Hard round-trip ceiling for one image read. Each window is an `/exec`
+ * call against the Code API's per-user execution limiter, so an unbounded
+ * read would stall a chat turn across several limiter windows. A file that
+ * cannot be pulled within this budget degrades to the same
+ * "too large to inline" result as one over the byte cap.
+ */
+export const MAX_SANDBOX_IMAGE_EXEC_CALLS = 24;
+
+/** Halvings allowed when a runner's stdout cap turns out to be smaller
+ *  than the configured budget. */
+const MAX_IMAGE_OVERFLOW_RETRIES = 2;
+
+/** Per-base-URL window size, narrowed in place the first time a runner
+ *  reports truncation so later reads start at a size it accepts. */
+const learnedChunkBytes = new Map<string, number>();
+
+/**
+ * One `/exec` window's outcome, as the transport observed it. Fields are
+ * optional because the body is whatever the in-sandbox reader printed:
+ * `error` when it refused the path, `too_large` when the file is over the
+ * caller's cap, `total`/`n`/`b64` for a window of bytes, `outputOverflow`
+ * when the runner truncated the response, and nothing at all when it
+ * produced no output.
+ */
+export interface SandboxImageChunk {
+  outputOverflow?: boolean;
+  error?: string;
+  too_large?: boolean;
+  bytes?: number;
+  total?: number;
+  n?: number;
+  b64?: string;
+}
+
+export type SandboxImageChunkReader = (params: { code: string }) => Promise<SandboxImageChunk>;
+
+export type SandboxImageReadResult =
+  | { base64: string; bytes: number }
+  /** `size`: over the caller's cap. `round_trips`: within the byte cap, but
+   *  more windows than {@link MAX_SANDBOX_IMAGE_EXEC_CALLS} allows. */
+  | { tooLarge: true; reason: 'size' | 'round_trips'; bytes: number }
+  | null;
+
+/**
+ * Raw bytes to pull per `/exec` round-trip. Each window is base64-encoded
+ * (~1.33x) into the response's stdout, so the auto-derived size is the
+ * largest multiple of 3 whose encoding plus envelope fits the runner's
+ * stdout budget. `LIBRECHAT_CODE_IMAGE_CHUNK_BYTES` overrides it outright
+ * and is used verbatim, multiple of 3 or not.
+ */
+export function getSandboxImageChunkBytes(baseUrl?: string): number {
+  const baseline = baselineChunkBytes();
+  const learned = baseUrl == null ? undefined : learnedChunkBytes.get(baseUrl);
+  /* A learned narrowing only ever caps the configured size: an operator who
+   * sets a smaller window explicitly still wins. */
+  return learned == null ? baseline : Math.min(learned, baseline);
+}
+
+function baselineChunkBytes(): number {
+  const override = Number(process.env.LIBRECHAT_CODE_IMAGE_CHUNK_BYTES);
+  if (Number.isFinite(override) && override > 0) {
+    return Math.floor(override);
+  }
+  const configured = Number(process.env.LIBRECHAT_CODE_SANDBOX_OUTPUT_MAX_SIZE);
+  const budget =
+    Number.isFinite(configured) && configured > 0
+      ? Math.floor(configured)
+      : DEFAULT_SANDBOX_OUTPUT_MAX_SIZE;
+  const usable = Math.max(budget - IMAGE_CHUNK_ENVELOPE_BYTES, 0);
+  return alignToBase64Group(Math.floor((usable * 3) / 4));
+}
+
+function alignToBase64Group(bytes: number): number {
+  return Math.max(Math.floor(bytes / BASE64_GROUP_BYTES) * BASE64_GROUP_BYTES, BASE64_GROUP_BYTES);
+}
+
+/**
+ * Halves the window for a Code API after its runner truncated a response,
+ * and returns the size to retry the same offset with. Remembered per base
+ * URL so only the first read of a process pays for the discovery.
+ */
+export function narrowSandboxImageChunkBytes(baseUrl?: string): number {
+  const narrowed = alignToBase64Group(Math.floor(getSandboxImageChunkBytes(baseUrl) / 2));
+  if (baseUrl != null) {
+    learnedChunkBytes.set(baseUrl, narrowed);
+  }
+  logger.warn(
+    `[readSandboxImage] Sandbox stdout limit exceeded; narrowing image window to ${narrowed} bytes for ${baseUrl}. ` +
+      "Set LIBRECHAT_CODE_SANDBOX_OUTPUT_MAX_SIZE to this runner's stdout cap to skip the discovery read.",
+  );
+  return narrowed;
+}
+
+/**
+ * The in-sandbox reader for one window. Stats the file, refuses (without
+ * transferring) anything over `limit` or any non-regular file, and prints
+ * a single JSON line the transport hands back as a {@link SandboxImageChunk}.
+ * The parameters travel base64-encoded so neither the path nor the numbers
+ * are interpolated into shell syntax.
+ */
+export function buildSandboxImageReaderCode(params: {
+  filePath: string;
+  limit: number;
+  offset: number;
+  chunkBytes: number;
+}): string {
+  const payload = Buffer.from(
+    JSON.stringify({
+      file_path: params.filePath,
+      limit: params.limit,
+      offset: params.offset,
+      chunk: params.chunkBytes,
+    }),
+    'utf8',
+  ).toString('base64');
+  return [
+    "python3 - <<'PY'",
+    'import base64, json, os, stat',
+    `payload = ${JSON.stringify(payload)}`,
+    "data = json.loads(base64.b64decode(payload).decode('utf-8'))",
+    "p = data['file_path']",
+    "limit = data['limit']",
+    "offset = data['offset']",
+    "chunk = data['chunk']",
+    'try:',
+    '    st = os.stat(p)',
+    'except OSError as e:',
+    '    print(json.dumps({"error": str(e)}))',
+    '    raise SystemExit(0)',
+    // Reject FIFOs, sockets, and device files (e.g. a symlink to /dev/zero):
+    // os.stat can report a small/zero size while an unbounded read blocks or
+    // streams forever until the request times out.
+    'if not stat.S_ISREG(st.st_mode):',
+    '    print(json.dumps({"error": "not a regular file"}))',
+    '    raise SystemExit(0)',
+    'if st.st_size > limit:',
+    '    print(json.dumps({"too_large": True, "bytes": st.st_size}))',
+    '    raise SystemExit(0)',
+    // Read only this window. The whole base64 payload cannot be emitted in
+    // one shot: the runner caps stdout at SANDBOX_OUTPUT_MAX_SIZE and
+    // SIGKILLs the job on overflow, which truncates the JSON mid-string.
+    "with open(p, 'rb') as f:",
+    '    f.seek(offset)',
+    '    raw = f.read(chunk)',
+    'print(json.dumps({"total": st.st_size, "n": len(raw), "b64": base64.b64encode(raw).decode("ascii")}))',
+    'PY',
+  ].join('\n');
+}
+
+/**
+ * Turns one `/exec` response into a {@link SandboxImageChunk}. Throws only
+ * for output the reader could not have produced, so the caller can tell a
+ * broken transport from a file the sandbox declined to serve.
+ */
+export function parseSandboxImageChunk(response: {
+  stdout?: unknown;
+  stderr?: unknown;
+  status?: unknown;
+}): SandboxImageChunk {
+  /* The runner truncates stdout at SANDBOX_OUTPUT_MAX_SIZE and SIGKILLs the
+   * job (status `OL`). Detect that explicitly: the surviving stdout is a
+   * base64 string cut mid-flight, so parsing it yields a misleading
+   * "unexpected output" instead of the narrowable, fixable cause. */
+  if (response.status === 'OL') {
+    return { outputOverflow: true };
+  }
+  const stdout = response.stdout == null ? '' : String(response.stdout);
+  if (response.stderr && stdout === '') {
+    throw new Error(String(response.stderr).trim());
+  }
+  if (stdout.trim() === '') {
+    return {};
+  }
+  /* Parse the LAST non-empty line: the reader's JSON is the final thing it
+   * prints, so anything a shell profile or library emitted ahead of it
+   * (banners, warnings) must not break the read. */
+  const lines = stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+  try {
+    return JSON.parse(lines[lines.length - 1]);
+  } catch {
+    throw new Error(
+      `Unexpected output while reading image bytes from the sandbox: ${stdout.slice(0, 120)}`,
+    );
+  }
+}
+
+/**
+ * Pulls a sandbox image through as many windows as it takes, narrowing the
+ * window if the runner truncates and stopping at the round-trip ceiling.
+ * Returns `null` when the runner produced no output at all; throws what
+ * the transport throws.
+ */
+export async function readWindowedSandboxImage(params: {
+  filePath: string;
+  limit: number;
+  baseUrl?: string;
+  readChunk: SandboxImageChunkReader;
+}): Promise<SandboxImageReadResult> {
+  const { filePath, limit, baseUrl, readChunk } = params;
+  let chunkBytes = getSandboxImageChunkBytes(baseUrl);
+  let overflowRetries = 0;
+  const parts: Buffer[] = [];
+  let offset = 0;
+  let total: number | null = null;
+
+  for (let i = 0; i < MAX_SANDBOX_IMAGE_EXEC_CALLS; i++) {
+    const chunk = await readChunk({
+      code: buildSandboxImageReaderCode({ filePath, limit, offset, chunkBytes }),
+    });
+
+    if (chunk.outputOverflow === true) {
+      /* The runner's stdout cap is smaller than this deployment assumed.
+       * Halve the window and re-read the same offset rather than failing
+       * the whole image. */
+      if (overflowRetries >= MAX_IMAGE_OVERFLOW_RETRIES) {
+        throw new Error(
+          `Reading "${filePath}" exceeded the sandbox stdout limit (window ${chunkBytes} bytes).`,
+        );
+      }
+      overflowRetries++;
+      chunkBytes = narrowSandboxImageChunkBytes(baseUrl);
+      continue;
+    }
+    if (chunk.error) {
+      throw new Error(String(chunk.error));
+    }
+    if (chunk.too_large === true) {
+      return { tooLarge: true, reason: 'size', bytes: Number(chunk.bytes) || 0 };
+    }
+    if (typeof chunk.b64 !== 'string' || typeof chunk.n !== 'number') {
+      return null;
+    }
+
+    if (total == null) {
+      total = Number(chunk.total) || 0;
+      if (total > limit) {
+        return { tooLarge: true, reason: 'size', bytes: total };
+      }
+    } else if (Number(chunk.total) !== total) {
+      /* The file changed underneath us; a spliced-together buffer would be
+       * a mix of two versions rather than any real image. */
+      throw new Error(`"${filePath}" changed while being read from the sandbox`);
+    }
+
+    parts.push(Buffer.from(chunk.b64, 'base64'));
+    offset += chunk.n;
+
+    if (chunk.n === 0 || offset >= total) {
+      break;
+    }
+  }
+
+  if (total == null) {
+    return null;
+  }
+  const buffer = Buffer.concat(parts);
+  if (buffer.length !== total) {
+    /* Ran out of round-trip budget (or short reads); returning a partial
+     * image would render as a corrupt file, so surface it as
+     * unreadable-inline with the reason the caller should report. */
+    return { tooLarge: true, reason: 'round_trips', bytes: total };
+  }
+  return { base64: buffer.toString('base64'), bytes: buffer.length };
+}

--- a/packages/api/src/files/code/index.ts
+++ b/packages/api/src/files/code/index.ts
@@ -2,4 +2,5 @@ export * from './classify';
 export * from './extract';
 export * from './form';
 export * from './identity';
+export * from './image';
 export * from './preflight';

--- a/packages/api/src/utils/code.spec.ts
+++ b/packages/api/src/utils/code.spec.ts
@@ -1,0 +1,62 @@
+import { AxiosError, AxiosHeaders } from 'axios';
+import { getCodeApiRetryAfterMs } from './code';
+
+/** Builds the error axios raises for a Code API rate-limit response. */
+function rateLimited({
+  status = 429,
+  headers = {},
+  data = {},
+}: {
+  status?: number;
+  headers?: Record<string, string>;
+  data?: unknown;
+} = {}): AxiosError {
+  const error = new AxiosError('Request failed', 'ERR_BAD_REQUEST');
+  error.response = {
+    status,
+    statusText: '',
+    headers: new AxiosHeaders(headers),
+    config: { headers: new AxiosHeaders() },
+    data,
+  };
+  return error;
+}
+
+describe('getCodeApiRetryAfterMs', () => {
+  it('reads the standard Retry-After header', () => {
+    expect(getCodeApiRetryAfterMs(rateLimited({ headers: { 'retry-after': '17' } }))).toBe(17_000);
+  });
+
+  it('falls back to the response body when a proxy dropped the header', () => {
+    expect(getCodeApiRetryAfterMs(rateLimited({ data: { retry_after_seconds: 4 } }))).toBe(4_000);
+  });
+
+  it('prefers the header over the body', () => {
+    const error = rateLimited({
+      headers: { 'retry-after': '2' },
+      data: { retry_after_seconds: 30 },
+    });
+    expect(getCodeApiRetryAfterMs(error)).toBe(2_000);
+  });
+
+  it('returns null for a non-429 response', () => {
+    expect(getCodeApiRetryAfterMs(rateLimited({ status: 503 }))).toBeNull();
+  });
+
+  it('returns null when neither channel carries a usable delay', () => {
+    expect(getCodeApiRetryAfterMs(rateLimited({ headers: { 'retry-after': 'soon' } }))).toBeNull();
+    expect(getCodeApiRetryAfterMs(rateLimited({ data: 'rate_limited' }))).toBeNull();
+  });
+
+  it('treats a blank header as absent rather than "retry immediately"', () => {
+    /* `Number('')` is 0, which would both skip the body fallback and read
+     * as a zero-second wait. */
+    const error = rateLimited({ headers: { 'retry-after': '' }, data: { retry_after_seconds: 9 } });
+    expect(getCodeApiRetryAfterMs(error)).toBe(9_000);
+  });
+
+  it('returns null for anything that is not an axios error', () => {
+    expect(getCodeApiRetryAfterMs(new Error('boom'))).toBeNull();
+    expect(getCodeApiRetryAfterMs(undefined)).toBeNull();
+  });
+});

--- a/packages/api/src/utils/code.spec.ts
+++ b/packages/api/src/utils/code.spec.ts
@@ -1,5 +1,5 @@
 import { AxiosError, AxiosHeaders } from 'axios';
-import { getCodeApiRetryAfterMs } from './code';
+import { getCodeApiRetryAfterMs, withCodeApiRateLimit, createCodeApiRateLimitBudget } from './code';
 
 /** Builds the error axios raises for a Code API rate-limit response. */
 function rateLimited({
@@ -58,5 +58,93 @@ describe('getCodeApiRetryAfterMs', () => {
   it('returns null for anything that is not an axios error', () => {
     expect(getCodeApiRetryAfterMs(new Error('boom'))).toBeNull();
     expect(getCodeApiRetryAfterMs(undefined)).toBeNull();
+  });
+});
+
+describe('withCodeApiRateLimit', () => {
+  it('passes a successful attempt straight through', async () => {
+    const attempt = jest.fn(async () => 'ok');
+    await expect(withCodeApiRateLimit({ attempt, label: 'reading' })).resolves.toBe('ok');
+    expect(attempt).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits out a rate limit the budget can absorb, then finishes', async () => {
+    /* A multi-request operation would otherwise abandon the work already
+     * done the moment a limiter window closes mid-flight. */
+    const budget = createCodeApiRateLimitBudget(5_000);
+    const waits: number[] = [];
+    let attempts = 0;
+    const attempt = jest.fn(async () => {
+      attempts++;
+      if (attempts === 1) {
+        throw rateLimited({ headers: { 'retry-after': '1' } });
+      }
+      return 'ok';
+    });
+
+    await expect(
+      withCodeApiRateLimit({ attempt, label: 'reading', budget, onWait: (ms) => waits.push(ms) }),
+    ).resolves.toBe('ok');
+
+    expect(attempts).toBe(2);
+    expect(waits).toEqual([1_000]);
+    expect(budget.remainingMs).toBe(4_000);
+  });
+
+  it('names the limit when the wait exceeds the remaining budget', async () => {
+    const budget = createCodeApiRateLimitBudget(5_000);
+    const attempt = jest.fn(async () => {
+      throw rateLimited({ headers: { 'retry-after': '300' } });
+    });
+
+    await expect(
+      withCodeApiRateLimit({ attempt, label: 'reading "x.png"', budget }),
+    ).rejects.toThrow(/rate limit reached while reading "x\.png" \(retry in 300s\)/);
+    expect(attempt).toHaveBeenCalledTimes(1);
+    expect(budget.remainingMs).toBe(5_000);
+  });
+
+  it('names the limit even when the response carries no usable delay', async () => {
+    /* Otherwise a bare "Request failed with status code 429" surfaces as an
+     * unspecified failure instead of one that clears on its own. */
+    const attempt = jest.fn(async () => {
+      throw rateLimited();
+    });
+
+    await expect(
+      withCodeApiRateLimit({
+        attempt,
+        label: 'reading',
+        budget: createCodeApiRateLimitBudget(60_000),
+      }),
+    ).rejects.toThrow(/rate limit reached while reading\./);
+  });
+
+  it('charges at least a second so a zero delay cannot spin', async () => {
+    const budget = createCodeApiRateLimitBudget(2_500);
+    const waits: number[] = [];
+    let attempts = 0;
+    const attempt = jest.fn(async () => {
+      attempts++;
+      if (attempts < 3) {
+        throw rateLimited({ headers: { 'retry-after': '0' } });
+      }
+      return 'ok';
+    });
+
+    await expect(
+      withCodeApiRateLimit({ attempt, label: 'reading', budget, onWait: (ms) => waits.push(ms) }),
+    ).resolves.toBe('ok');
+    expect(waits).toEqual([1_000, 1_000]);
+    expect(budget.remainingMs).toBe(500);
+  });
+
+  it('rethrows anything that is not a rate limit', async () => {
+    const attempt = jest.fn(async () => {
+      throw rateLimited({ status: 500 });
+    });
+    await expect(withCodeApiRateLimit({ attempt, label: 'reading' })).rejects.toThrow(
+      'Request failed',
+    );
   });
 });

--- a/packages/api/src/utils/code.ts
+++ b/packages/api/src/utils/code.ts
@@ -30,10 +30,69 @@ export function getCodeApiRetryAfterMs(error: unknown): number | null {
   if (Number.isFinite(headerSeconds) && headerSeconds >= 0) {
     return headerSeconds * 1000;
   }
-  const body = error.response.data as { retry_after_seconds?: unknown } | undefined;
-  const bodySeconds = Number(body?.retry_after_seconds);
-  if (Number.isFinite(bodySeconds) && bodySeconds >= 0) {
-    return bodySeconds * 1000;
+  const body = error.response.data;
+  if (typeof body === 'object' && body !== null && 'retry_after_seconds' in body) {
+    const bodySeconds = Number(body.retry_after_seconds);
+    if (Number.isFinite(bodySeconds) && bodySeconds >= 0) {
+      return bodySeconds * 1000;
+    }
   }
   return null;
+}
+
+/** Total time one operation may spend waiting out Code API rate limits.
+ *  Sized to cover a single limiter window without stalling a chat turn. */
+export const MAX_CODE_API_RATE_LIMIT_WAIT_MS = 20_000;
+
+/** Remaining wait allowance, shared by every request of one operation. */
+export interface CodeApiRateLimitBudget {
+  remainingMs: number;
+}
+
+export function createCodeApiRateLimitBudget(
+  totalMs: number = MAX_CODE_API_RATE_LIMIT_WAIT_MS,
+): CodeApiRateLimitBudget {
+  return { remainingMs: totalMs };
+}
+
+/**
+ * Runs a Code API request, waiting out a rate limit whenever the shared
+ * budget still covers the server's `Retry-After`. Multi-request operations
+ * (a windowed image read, a batch upload) would otherwise abandon the work
+ * already done the moment a limiter window closes mid-flight. A 429 the
+ * budget cannot absorb throws a named error rather than a bare
+ * "status code 429", which reads as an unspecified failure instead of one
+ * that clears on its own.
+ */
+export async function withCodeApiRateLimit<T>(params: {
+  attempt: () => Promise<T>;
+  label: string;
+  budget?: CodeApiRateLimitBudget;
+  onWait?: (waitMs: number) => void;
+}): Promise<T> {
+  const { attempt, label, budget, onWait } = params;
+  for (;;) {
+    try {
+      return await attempt();
+    } catch (error) {
+      if (!isAxiosError(error) || error.response?.status !== 429) {
+        throw error;
+      }
+      const retryAfterMs = getCodeApiRetryAfterMs(error);
+      if (retryAfterMs == null) {
+        throw new Error(`Code API rate limit reached while ${label}.`);
+      }
+      /* A zero delay would spin; charge at least a second so the budget
+       * always drains and the loop terminates. */
+      const waitMs = Math.max(retryAfterMs, 1000);
+      if (budget == null || waitMs > budget.remainingMs) {
+        throw new Error(
+          `Code API rate limit reached while ${label} (retry in ${Math.ceil(waitMs / 1000)}s).`,
+        );
+      }
+      budget.remainingMs -= waitMs;
+      onWait?.(waitMs);
+      await new Promise((resolve) => setTimeout(resolve, waitMs));
+    }
+  }
 }

--- a/packages/api/src/utils/code.ts
+++ b/packages/api/src/utils/code.ts
@@ -1,5 +1,6 @@
 import http from 'http';
 import https from 'https';
+import { isAxiosError } from 'axios';
 
 /**
  * Dedicated agents for code-server requests, preventing socket pool contamination.
@@ -9,3 +10,30 @@ import https from 'https';
  */
 export const codeServerHttpAgent: http.Agent = new http.Agent({ keepAlive: false });
 export const codeServerHttpsAgent: https.Agent = new https.Agent({ keepAlive: false });
+
+/**
+ * Wait implied by a Code API 429, in milliseconds, or `null` when the error
+ * is not a rate-limit response. The service answers with both the standard
+ * `Retry-After` header and a `retry_after_seconds` body field; the header is
+ * preferred so a body the caller asked for as a stream/buffer never has to be
+ * parsed, and the body is the fallback for proxies that drop the header.
+ */
+export function getCodeApiRetryAfterMs(error: unknown): number | null {
+  if (!isAxiosError(error) || error.response?.status !== 429) {
+    return null;
+  }
+  const header = error.response.headers?.['retry-after'];
+  const raw = Array.isArray(header) ? header[0] : header;
+  /* `Number('')` is 0, which would read as "retry immediately" and skip the
+   * body fallback; treat a blank header as absent. */
+  const headerSeconds = typeof raw === 'string' && raw.trim() === '' ? NaN : Number(raw);
+  if (Number.isFinite(headerSeconds) && headerSeconds >= 0) {
+    return headerSeconds * 1000;
+  }
+  const body = error.response.data as { retry_after_seconds?: unknown } | undefined;
+  const bodySeconds = Number(body?.retry_after_seconds);
+  if (Number.isFinite(bodySeconds) && bodySeconds >= 0) {
+    return bodySeconds * 1000;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

`read_file` on a `/mnt/data` image collapsed **every** failure — rate limit, missing path, truncated transfer, transport error — into `buildBinaryFileError`, whose image branch reads as a permanent capability limit:

```
Error: "/mnt/data/7_interest_gap.png" is an image file (.png) and cannot be read as text.
To process it programmatically, use `bash_tool` ...
```

So a read that *failed* looked like a feature that was never there. The model stops retrying, and there is no way — from the message or the log — to tell which failure actually occurred.

## The failure that surfaced it

Reproduced against a live Code API deployment reporting the `stateful` profile:

- `/exec` is rate limited at **20 requests / 30s** (`ratelimit-policy: 20;w=30`, with a standard `Retry-After`).
- The image reader windows the bytes through `/exec` stdout — one call per window. At the fixed 32KB window a 122KB chart costs **4 calls**; a 1MB image costs **33**, i.e. more than an entire limiter window, so anything over ~640KB could never complete even on an idle budget.
- A turn that generates several charts (one call each) and reads them back (4+ each) exhausts the budget partway through. Firing 8 reads at that runner: 3 succeeded, 5 got 429 — and all 5 reached the model as *"is an image file and cannot be read as text"*.

Also confirmed on that runner: its stdout cap is exactly 65,536 bytes, and `runtime_session_hint` is the only thing that selects the stateful container (`session_id` alone lands in a fresh one and yields `ENOENT` — which produced the same misleading message).

## Changes

**`packages/api/src/agents/handlers.ts`** — a failed read now states the real cause and the matching next step: rate-limited → wait and read again; missing → `ls /mnt/data`; truncated transfer → retry. `"cannot be read as text"` is reserved for bytes that genuinely are not a supported image. An image past the inline budget says to downscale in the sandbox and read the smaller copy, instead of pointing at `bash_tool`, which cannot show it an image. `tooLarge` now carries a reason so "over the byte cap" and "needed too many round-trips" are not reported as the same thing.

**`api/server/services/Files/Code/process.js`** — the window is derived from the runner's stdout budget (48,960B raw → 65,321B encoded against the 65,536B cap; verified live), so a 122KB chart is 3 calls instead of 4 and 1MB is 22 instead of 33. If a runner truncates anyway, the window halves and re-reads the same offset, remembered per Code API base URL with the `LIBRECHAT_CODE_SANDBOX_OUTPUT_MAX_SIZE` remedy logged. A bounded rate-limit wait (honors `Retry-After`, 20s total per read) lets a read that crosses a window boundary finish rather than discarding the bytes it already pulled, and a hard 24-call ceiling keeps any single read from stalling a turn across limiter windows.

**`packages/api/src/utils/code.ts`** — shared `getCodeApiRetryAfterMs` (header first, `retry_after_seconds` body as fallback, blank header treated as absent); `skillFiles.ts` drops its private copy.

## Testing

- `api`: `server/services/Files` 351 passed (Code suites 163, incl. new coverage for window narrowing, rate-limit wait-and-finish, rate-limit refusal with and without a parsable delay, and reason propagation).
- `packages/api`: `src/agents` + `src/utils` 3833 passed, incl. 5 new handler cases asserting the message no longer claims images are unreadable.
- `npx tsc --noEmit` clean for the changed files; `npm run static-checks` all green.

## Follow-up (not in this PR)

The 20/30s budget is shared with everything else in the turn, so a chart-heavy turn is still tight. The structural fix is to serve these bytes from the artifact the code-execution pipeline already downloaded, at zero `/exec` calls. Related observation: in the stateful profile that runner returned `files: []` for a file created in `/mnt/data`, so generated charts are not auto-attached there — which is precisely why `read_file` on images matters in that profile.