### PR TITLE
fix: serialize Meilisearch index synchronization

### DIFF
--- a/api/db/indexSync.js
+++ b/api/db/indexSync.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 const { MeiliSearch } = require('meilisearch');
 const { logger } = require('@librechat/data-schemas');
 const { CacheKeys } = require('librechat-data-provider');
-const { isEnabled, FlowStateManager } = require('@librechat/api');
+const { isEnabled, FlowStateManager, runDistributedJob } = require('@librechat/api');
 const { getLogStores } = require('~/cache');
 const { batchResetMeiliFlags } = require('./utils');
 
@@ -309,11 +309,7 @@ async function performSync(flowManager, flowId, flowType) {
 /**
  * Main index sync function that uses FlowStateManager to prevent concurrent execution
  */
-async function indexSync() {
-  if (!searchEnabled) {
-    return;
-  }
-
+async function runIndexSync() {
   logger.info('[indexSync] Starting index synchronization check...');
 
   // Get or create FlowStateManager instance
@@ -352,27 +348,39 @@ async function indexSync() {
 
     if (err.message.includes('not found')) {
       logger.debug('[indexSync] Creating indices...');
-      currentTimeout = setTimeout(async () => {
-        try {
-          const Message = mongoose.models.Message;
-          const Conversation = mongoose.models.Conversation;
-          if (!Message || !Conversation) {
-            throw new Error(
-              '[indexSync] Models not registered. Ensure createModels() has been called before indexSync.',
-            );
-          }
-          await Message.syncWithMeili();
-          await Conversation.syncWithMeili();
-        } catch (err) {
-          logger.error('[indexSync] Trouble creating indices, try restarting the server.', err);
+      await new Promise((resolve) => {
+        currentTimeout = setTimeout(resolve, 750);
+      });
+      try {
+        const Message = mongoose.models.Message;
+        const Conversation = mongoose.models.Conversation;
+        if (!Message || !Conversation) {
+          throw new Error(
+            '[indexSync] Models not registered. Ensure createModels() has been called before indexSync.',
+          );
         }
-      }, 750);
+        await Message.syncWithMeili();
+        await Conversation.syncWithMeili();
+      } catch (syncError) {
+        logger.error('[indexSync] Trouble creating indices, try restarting the server.', syncError);
+        throw syncError;
+      }
     } else if (err.message.includes('Meilisearch not configured')) {
       logger.info('[indexSync] Meilisearch not configured, search will be disabled.');
     } else {
       logger.error('[indexSync] error', err);
+      throw err;
     }
   }
+}
+
+async function indexSync() {
+  if (!searchEnabled) {
+    return;
+  }
+
+  const jobs = mongoose.connection.collection('distributedJobs');
+  return runDistributedJob(jobs, 'meili-index-sync', runIndexSync);
 }
 
 process.on('exit', () => {

--- a/api/db/indexSync.spec.js
+++ b/api/db/indexSync.spec.js
@@ -18,6 +18,7 @@ const mockMeiliHealth = jest.fn();
 const mockMeiliIndex = jest.fn();
 const mockBatchResetMeiliFlags = jest.fn();
 const mockIsEnabled = jest.fn();
+const mockRunDistributedJob = jest.fn();
 const mockGetLogStores = jest.fn();
 
 // Create mock models that will be reused
@@ -49,6 +50,7 @@ jest.mock('./utils', () => ({
 
 jest.mock('@librechat/api', () => ({
   isEnabled: mockIsEnabled,
+  runDistributedJob: mockRunDistributedJob,
   FlowStateManager: jest.fn(),
 }));
 
@@ -96,6 +98,7 @@ describe('performSync() - syncThreshold logic', () => {
 
     // Mock isEnabled
     mockIsEnabled.mockImplementation((val) => val === 'true' || val === true);
+    mockRunDistributedJob.mockImplementation((_collection, _jobId, handler) => handler());
 
     // Mock MeiliSearch client responses
     mockMeiliHealth.mockResolvedValue({ status: 'available' });
@@ -115,6 +118,28 @@ describe('performSync() - syncThreshold logic', () => {
   afterAll(() => {
     mongoose.models.Message = originalMessageModel;
     mongoose.models.Conversation = originalConversationModel;
+  });
+
+  test('skips synchronization when another replica completed the distributed job', async () => {
+    mockRunDistributedJob.mockResolvedValue(undefined);
+
+    const indexSync = require('./indexSync');
+    await indexSync();
+
+    expect(mockGetLogStores).not.toHaveBeenCalled();
+    expect(mockMeiliHealth).not.toHaveBeenCalled();
+  });
+
+  test('propagates synchronization failures to the distributed job coordinator', async () => {
+    const createFlowWithHandler = jest.fn().mockRejectedValue(new Error('sync failed'));
+    const { FlowStateManager } = require('@librechat/api');
+    FlowStateManager.mockImplementationOnce(() => ({ createFlowWithHandler }));
+    mockGetLogStores.mockReturnValueOnce({});
+
+    const indexSync = require('./indexSync');
+
+    await expect(indexSync()).rejects.toThrow('sync failed');
+    expect(mockLogger.error).toHaveBeenCalledWith('[indexSync] error', expect.any(Error));
   });
 
   test('triggers sync when unindexed messages exceed syncThreshold', async () => {

--- a/packages/api/src/cluster/DistributedJob.spec.ts
+++ b/packages/api/src/cluster/DistributedJob.spec.ts
@@ -1,0 +1,174 @@
+import type { runDistributedJob as RunDistributedJob } from './DistributedJob';
+
+const mockLogger = {
+  error: jest.fn(),
+};
+
+jest.mock('@librechat/data-schemas', () => ({
+  logger: mockLogger,
+}));
+
+describe('runDistributedJob', () => {
+  let runDistributedJob: typeof RunDistributedJob;
+  let collection: {
+    findOneAndUpdate: jest.Mock;
+    findOne: jest.Mock;
+    updateOne: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    ({ runDistributedJob } = await import('./DistributedJob'));
+    collection = {
+      findOneAndUpdate: jest.fn(),
+      findOne: jest.fn(),
+      updateOne: jest.fn(),
+    };
+  });
+
+  test('atomically claims and completes a job', async () => {
+    collection.findOneAndUpdate.mockImplementation(async (_filter, update) => ({
+      owner: update.$set.owner,
+    }));
+    collection.updateOne.mockResolvedValue({ matchedCount: 1 });
+    const handler = jest.fn().mockResolvedValue('done');
+
+    await expect(
+      runDistributedJob(
+        collection as unknown as Parameters<typeof runDistributedJob>[0],
+        'test-job',
+        handler,
+      ),
+    ).resolves.toBe('done');
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(collection.updateOne).toHaveBeenLastCalledWith(
+      { _id: 'test-job', status: 'running', owner: expect.any(String) },
+      expect.objectContaining({
+        $set: expect.objectContaining({ status: 'completed' }),
+        $unset: { owner: '' },
+      }),
+    );
+  });
+
+  test('does not rerun a recently completed job', async () => {
+    collection.findOneAndUpdate.mockRejectedValue({ code: 11000 });
+    collection.findOne.mockResolvedValue({
+      status: 'completed',
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const handler = jest.fn();
+
+    await expect(
+      runDistributedJob(
+        collection as unknown as Parameters<typeof runDistributedJob>[0],
+        'test-job',
+        handler,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test('retries an expired claim and takes over the job', async () => {
+    collection.findOneAndUpdate
+      .mockRejectedValueOnce({ code: 11000 })
+      .mockImplementationOnce(async (_filter, update) => ({ owner: update.$set.owner }));
+    collection.findOne.mockResolvedValue({
+      status: 'running',
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    collection.updateOne.mockResolvedValue({ matchedCount: 1 });
+    const handler = jest.fn().mockResolvedValue('recovered');
+
+    await expect(
+      runDistributedJob(
+        collection as unknown as Parameters<typeof runDistributedJob>[0],
+        'test-job',
+        handler,
+        { pollMs: 0 },
+      ),
+    ).resolves.toBe('recovered');
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test('waits for a failed claim to expire before retrying', async () => {
+    collection.findOneAndUpdate
+      .mockRejectedValueOnce({ code: 11000 })
+      .mockImplementationOnce(async (_filter, update) => ({ owner: update.$set.owner }));
+    collection.findOne.mockResolvedValue({
+      status: 'failed',
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    collection.updateOne.mockResolvedValue({ matchedCount: 1 });
+    const handler = jest.fn().mockResolvedValue('retried');
+
+    await expect(
+      runDistributedJob(
+        collection as unknown as Parameters<typeof runDistributedJob>[0],
+        'test-job',
+        handler,
+        { pollMs: 0 },
+      ),
+    ).resolves.toBe('retried');
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test('fail-stops when lease renewal reports lost ownership', async () => {
+    jest.useFakeTimers();
+    collection.findOneAndUpdate.mockImplementation(async (_filter, update) => ({
+      owner: update.$set.owner,
+    }));
+    collection.updateOne
+      .mockResolvedValueOnce({ matchedCount: 0 })
+      .mockResolvedValue({ matchedCount: 1 });
+    const onLeaseLost = jest.fn();
+    let finish: ((value: string) => void) | undefined;
+    const handler = jest.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          finish = resolve;
+        }),
+    );
+
+    const running = runDistributedJob(
+      collection as unknown as Parameters<typeof runDistributedJob>[0],
+      'test-job',
+      handler,
+      { refreshMs: 1000, onLeaseLost },
+    );
+    await jest.advanceTimersByTimeAsync(1000);
+
+    expect(onLeaseLost).toHaveBeenCalledTimes(1);
+    finish?.('done');
+    await expect(running).resolves.toBe('done');
+    jest.useRealTimers();
+  });
+
+  test('records handler failure before propagating it', async () => {
+    collection.findOneAndUpdate.mockImplementation(async (_filter, update) => ({
+      owner: update.$set.owner,
+    }));
+    collection.updateOne.mockResolvedValue({ matchedCount: 1 });
+    const handler = jest.fn().mockRejectedValue(new Error('job failed'));
+
+    await expect(
+      runDistributedJob(
+        collection as unknown as Parameters<typeof runDistributedJob>[0],
+        'test-job',
+        handler,
+      ),
+    ).rejects.toThrow('job failed');
+
+    expect(collection.updateOne).toHaveBeenLastCalledWith(
+      { _id: 'test-job', status: 'running', owner: expect.any(String) },
+      expect.objectContaining({
+        $set: expect.objectContaining({ status: 'failed' }),
+        $unset: { owner: '' },
+      }),
+    );
+  });
+});

--- a/packages/api/src/cluster/DistributedJob.ts
+++ b/packages/api/src/cluster/DistributedJob.ts
@@ -1,0 +1,185 @@
+import crypto from 'crypto';
+import { logger } from '@librechat/data-schemas';
+import type { Collection, Document, WithId } from 'mongodb';
+
+type JobStatus = 'running' | 'completed' | 'failed';
+
+interface DistributedJobState extends Document {
+  _id: string;
+  status: JobStatus;
+  owner?: string;
+  expiresAt: Date;
+  updatedAt: Date;
+}
+
+interface DistributedJobOptions {
+  leaseMs?: number;
+  refreshMs?: number;
+  completionTtlMs?: number;
+  failureTtlMs?: number;
+  pollMs?: number;
+  onLeaseLost?: () => void;
+}
+
+const DEFAULT_LEASE_MS = 30 * 60 * 1000;
+const DEFAULT_REFRESH_MS = 60 * 1000;
+const DEFAULT_COMPLETION_TTL_MS = 10 * 60 * 1000;
+const DEFAULT_FAILURE_TTL_MS = 30 * 1000;
+const DEFAULT_POLL_MS = 2000;
+const LEASE_SAFETY_MS = 5000;
+
+const sleep = (duration: number) => new Promise((resolve) => setTimeout(resolve, duration));
+
+async function tryAcquire(
+  collection: Collection<DistributedJobState>,
+  jobId: string,
+  owner: string,
+  leaseMs: number,
+): Promise<boolean> {
+  const now = new Date();
+
+  try {
+    const state = await collection.findOneAndUpdate(
+      {
+        _id: jobId,
+        $or: [{ expiresAt: { $lte: now } }, { expiresAt: { $exists: false } }],
+      },
+      {
+        $set: {
+          status: 'running',
+          owner,
+          expiresAt: new Date(now.getTime() + leaseMs),
+          updatedAt: now,
+        },
+      },
+      { upsert: true, returnDocument: 'after', includeResultMetadata: false },
+    );
+    return state?.owner === owner;
+  } catch (error) {
+    if ((error as { code?: number }).code === 11000) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+export async function runDistributedJob<T>(
+  collection: Collection<DistributedJobState>,
+  jobId: string,
+  handler: () => Promise<T>,
+  options: DistributedJobOptions = {},
+): Promise<T | undefined> {
+  const leaseMs = options.leaseMs ?? DEFAULT_LEASE_MS;
+  const refreshMs = options.refreshMs ?? DEFAULT_REFRESH_MS;
+  const completionTtlMs = options.completionTtlMs ?? DEFAULT_COMPLETION_TTL_MS;
+  const failureTtlMs = options.failureTtlMs ?? DEFAULT_FAILURE_TTL_MS;
+  const pollMs = options.pollMs ?? DEFAULT_POLL_MS;
+  const onLeaseLost =
+    options.onLeaseLost ??
+    (() => {
+      process.exit(1);
+    });
+  const owner = crypto.randomUUID();
+
+  while (!(await tryAcquire(collection, jobId, owner, leaseMs))) {
+    const state = (await collection.findOne({ _id: jobId })) as WithId<DistributedJobState> | null;
+    if (state?.status === 'completed' && state.expiresAt > new Date()) {
+      return;
+    }
+    await sleep(pollMs);
+  }
+
+  let leaseExpiresAt = Date.now() + leaseMs;
+  let leaseLost = false;
+  let watchdogTimer: NodeJS.Timeout | undefined;
+
+  const loseLease = (message: string, error?: unknown) => {
+    if (leaseLost) {
+      return;
+    }
+    leaseLost = true;
+    clearInterval(refreshTimer);
+    clearTimeout(watchdogTimer);
+    logger.error(message, error);
+    onLeaseLost();
+  };
+
+  const scheduleWatchdog = () => {
+    clearTimeout(watchdogTimer);
+    const delay = Math.max(0, leaseExpiresAt - Date.now() - LEASE_SAFETY_MS);
+    watchdogTimer = setTimeout(() => {
+      loseLease(`[DistributedJob] Lease renewal deadline reached for ${jobId}`);
+    }, delay);
+    watchdogTimer.unref();
+  };
+
+  const refreshTimer = setInterval(async () => {
+    try {
+      const now = new Date();
+      const result = await collection.updateOne(
+        { _id: jobId, status: 'running', owner, expiresAt: { $gt: now } },
+        {
+          $set: {
+            expiresAt: new Date(now.getTime() + leaseMs),
+            updatedAt: now,
+          },
+        },
+      );
+      if (result.matchedCount !== 1) {
+        loseLease(`[DistributedJob] Lost lease for ${jobId}`);
+        return;
+      }
+      leaseExpiresAt = now.getTime() + leaseMs;
+      scheduleWatchdog();
+    } catch (error) {
+      logger.error(`[DistributedJob] Failed to refresh lease for ${jobId}`, error);
+    }
+  }, refreshMs);
+  refreshTimer.unref();
+  scheduleWatchdog();
+
+  try {
+    let result: T;
+    try {
+      result = await handler();
+    } catch (error) {
+      const now = new Date();
+      const failure = await collection.updateOne(
+        { _id: jobId, status: 'running', owner },
+        {
+          $set: {
+            status: 'failed',
+            expiresAt: new Date(now.getTime() + failureTtlMs),
+            updatedAt: now,
+          },
+          $unset: { owner: '' },
+        },
+      );
+      if (failure.matchedCount !== 1) {
+        loseLease(`[DistributedJob] Lost lease while failing ${jobId}`);
+      }
+      throw error;
+    }
+
+    const now = new Date();
+    const completion = await collection.updateOne(
+      { _id: jobId, status: 'running', owner },
+      {
+        $set: {
+          status: 'completed',
+          expiresAt: new Date(now.getTime() + completionTtlMs),
+          updatedAt: now,
+        },
+        $unset: { owner: '' },
+      },
+    );
+    if (completion.matchedCount !== 1) {
+      loseLease(`[DistributedJob] Lost lease while completing ${jobId}`);
+      throw new Error(`Lost distributed job lease for ${jobId}`);
+    }
+    return result;
+  } finally {
+    clearInterval(refreshTimer);
+    clearTimeout(watchdogTimer);
+  }
+}

--- a/packages/api/src/cluster/index.ts
+++ b/packages/api/src/cluster/index.ts
@@ -1,1 +1,2 @@
 export { isLeader } from './LeaderElection';
+export { runDistributedJob } from './DistributedJob';

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -29,6 +29,8 @@ export * from './mcp/oauth/OAuthReconnectionManager';
 export * from './crypto';
 /* Flow */
 export * from './flow/manager';
+/* Cluster */
+export * from './cluster';
 /* Middleware */
 export * from './middleware';
 /* Memory */


### PR DESCRIPTION
## Summary

Fixes the multi-replica Meilisearch synchronization race described in https://github.com/danny-avila/LibreChat/discussions/15461.

- add a reusable atomic distributed-job coordinator backed by MongoDB
- hold a renewable owner-qualified lease across the complete synchronization operation
- let followers wait for completion or take over after an expired/failed claim
- keep delayed missing-index creation inside the same lease
- propagate synchronization failures so another replica can retry
- fail-stop before lease expiry if ownership cannot be maintained, preventing overlapping stale work

No new dependencies are introduced.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

- `npm run build:api`
- `npm exec jest -- src/cluster/DistributedJob.spec.ts --runInBand` from `packages/api` — 6 tests
- `npm exec jest -- db/indexSync.spec.js --runInBand` from `api` — 17 tests on current upstream `dev`
- targeted ESLint for all changed files

### Test Configuration

- Node.js 24
- MongoDB collection interactions are mocked in coordinator unit tests
- Meilisearch and model synchronization calls are mocked in `indexSync.spec.js`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of the code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Focused local unit tests pass with my changes
