### PR TITLE
🩹 fix: Preserve subagent & handoff tool calls in conversation history

### DIFF
--- a/api/server/controllers/agents/__tests__/openai.spec.js
+++ b/api/server/controllers/agents/__tests__/openai.spec.js
@@ -203,7 +203,7 @@ jest.mock('@librechat/api', () => ({
   buildAgentContextAttachmentsByAgentId: (...args) =>
     mockBuildAgentContextAttachmentsByAgentId(...args),
   createChunk: jest.fn().mockReturnValue({}),
-  buildToolSet: jest.fn().mockReturnValue(new Set()),
+  buildRunToolSet: jest.fn().mockReturnValue(new Set()),
   buildInitialToolSessions: jest.fn().mockReturnValue(mockInitialSessions),
   AgentRunEnvelopeError: MockAgentRunEnvelopeError,
   createAgentRunEnvelope: (...args) => mockCreateAgentRunEnvelope(...args),

--- a/api/server/controllers/agents/__tests__/responses.unit.spec.js
+++ b/api/server/controllers/agents/__tests__/responses.unit.spec.js
@@ -223,7 +223,7 @@ jest.mock('@librechat/api', () => ({
   }),
   buildInitialToolSessions: jest.fn().mockReturnValue(mockInitialSessions),
   applyContextToAgent: (...args) => mockApplyContextToAgent(...args),
-  buildToolSet: jest.fn().mockReturnValue(new Set()),
+  buildRunToolSet: jest.fn().mockReturnValue(new Set()),
   AgentRunEnvelopeError: MockAgentRunEnvelopeError,
   createAgentRunEnvelope: (...args) => mockCreateAgentRunEnvelope(...args),
   createMCPRuntimeRequestBody: ({ messageId, conversationId, parentMessageId }) => ({

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -9,7 +9,7 @@ const {
   createRun,
   isEnabled,
   checkAccess,
-  buildToolSet,
+  buildRunToolSet,
   logToolError,
   sanitizeTitle,
   payloadParser,
@@ -3852,7 +3852,10 @@ class AgentClient extends BaseClient {
         version: 'v2',
       };
 
-      const toolSet = buildToolSet(this.options.agent);
+      const toolSet = buildRunToolSet(
+        this.options.agent,
+        this.agentConfigs ? this.agentConfigs.values() : undefined,
+      );
       const tokenCounter = await createCachedTokenCounter(this.getEncoding());
 
       /** Pre-resolve invoked skill bodies + re-prime files before formatting messages */

--- a/api/server/controllers/agents/openai.js
+++ b/api/server/controllers/agents/openai.js
@@ -13,7 +13,7 @@ const {
   createRun,
   createChunk,
   applyContextToAgent,
-  buildToolSet,
+  buildRunToolSet,
   buildInitialToolSessions,
   buildAgentScopedContext,
   buildInlineMemoryContext,
@@ -806,7 +806,7 @@ const executeOpenAIChatCompletion = async (envelope, { req, res }) => {
 
       const openaiMessages = convertMessages(request.messages);
 
-      const toolSet = buildToolSet(primaryConfig);
+      const toolSet = buildRunToolSet(primaryConfig, handoffAgentConfigs.values());
       const formatted = formatAgentMessages(stripActivityLabelParts(openaiMessages), {}, toolSet);
       const formattedMessages = formatted.messages;
       const initialSummary = formatted.summary;

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -13,7 +13,7 @@ const {
   createRun,
   applyContextToAgent,
   buildInitialToolSessions,
-  buildToolSet,
+  buildRunToolSet,
   AgentRunEnvelopeError,
   createAgentRunEnvelope,
   createAgentExecutionContext,
@@ -1004,7 +1004,7 @@ const executeResponse = async (envelope, { req, res }) => {
       // Merge previous messages with new input
       const allMessages = [...previousMessages, ...inputMessages];
 
-      const toolSet = buildToolSet(primaryConfig);
+      const toolSet = buildRunToolSet(primaryConfig, handoffAgentConfigs.values());
       const formatted = formatAgentMessages(stripActivityLabelParts(allMessages), {}, toolSet);
       const formattedMessages = formatted.messages;
       const initialSummary = formatted.summary;

--- a/packages/api/src/agents/tools.spec.ts
+++ b/packages/api/src/agents/tools.spec.ts
@@ -42,6 +42,7 @@ import { CODE_EXECUTION_TOOLS } from '@librechat/agents';
 import type { LCTool, LCToolRegistry } from '@librechat/agents';
 import {
   buildToolSet,
+  buildRunToolSet,
   BuildToolSetConfig,
   registerCodeExecutionTools,
   registerFileAuthoringTools,
@@ -189,6 +190,65 @@ describe('buildToolSet', () => {
       expect(toolSet.has('also_valid')).toBe(true);
       expect(toolSet.has('')).toBe(false);
     });
+  });
+});
+
+describe('buildRunToolSet', () => {
+  const agent = (id: string, ...toolNames: string[]): BuildToolSetConfig & { id: string } => ({
+    id,
+    toolDefinitions: toolNames.map((name) => ({ name })),
+  });
+
+  it('returns an empty set when there are no agents', () => {
+    expect(buildRunToolSet(null).size).toBe(0);
+    expect(buildRunToolSet(undefined).size).toBe(0);
+  });
+
+  it("includes the primary agent's own tools", () => {
+    const toolSet = buildRunToolSet(agent('primary', 'set_memory', 'execute_code'));
+
+    expect(toolSet.has('set_memory')).toBe(true);
+    expect(toolSet.has('execute_code')).toBe(true);
+  });
+
+  it('adds the synthetic `subagent` spawn tool for any run with an agent', () => {
+    expect(buildRunToolSet(agent('primary', 'set_memory')).has('subagent')).toBe(true);
+    // even for a tool-less agent, so a historical subagent call stays structured
+    expect(buildRunToolSet(agent('primary')).has('subagent')).toBe(true);
+  });
+
+  it('adds a `lc_transfer_to_<id>` handoff tool name for each reachable agent', () => {
+    const toolSet = buildRunToolSet(agent('primary', 'set_memory'), [
+      agent('agent_writer', 'search'),
+      agent('agent_analyst', 'analytics_realdata_api'),
+    ]);
+
+    expect(toolSet.has('lc_transfer_to_primary')).toBe(true);
+    expect(toolSet.has('lc_transfer_to_agent_writer')).toBe(true);
+    expect(toolSet.has('lc_transfer_to_agent_analyst')).toBe(true);
+  });
+
+  it("unions every reachable handoff agent's own tools", () => {
+    const toolSet = buildRunToolSet(agent('primary', 'set_memory'), [
+      agent('agent_writer', 'search'),
+      agent('agent_analyst', 'analytics_realdata_api'),
+    ]);
+
+    expect(toolSet.has('set_memory')).toBe(true);
+    expect(toolSet.has('search')).toBe(true);
+    expect(toolSet.has('analytics_realdata_api')).toBe(true);
+  });
+
+  it('skips nullish agent configs and agents without an id', () => {
+    const toolSet = buildRunToolSet(agent('primary', 'set_memory'), [
+      null,
+      undefined,
+      { toolDefinitions: [{ name: 'orphan_tool' }] },
+    ]);
+
+    expect(toolSet.has('orphan_tool')).toBe(true);
+    // no id -> no synthetic transfer name, and no spurious empty transfer name
+    expect(toolSet.has('lc_transfer_to_')).toBe(false);
   });
 });
 

--- a/packages/api/src/agents/tools.ts
+++ b/packages/api/src/agents/tools.ts
@@ -1,3 +1,4 @@
+import { Constants } from 'librechat-data-provider';
 import {
   CODE_EXECUTION_TOOLS,
   BashExecutionToolDefinition,
@@ -59,6 +60,66 @@ export function buildToolSet(agentConfig: BuildToolSetConfig | null | undefined)
       : (tools ?? []).map((tool) => tool?.name);
 
   return new Set(toolNames.filter((name): name is string => Boolean(name)));
+}
+
+export interface RunAgentToolSetConfig extends BuildToolSetConfig {
+  /** Agent id, used to derive the synthetic `lc_transfer_to_<id>` handoff tool name. */
+  id?: string;
+}
+
+/**
+ * Builds the complete Set of tool names valid across an entire agent *run* —
+ * the primary agent plus every reachable handoff/added agent — including the
+ * synthetic tools that `@librechat/agents` injects at graph-build time: the
+ * `subagent` spawn tool and the `lc_transfer_to_<agentId>` handoff tools.
+ *
+ * `buildToolSet` alone only covers a single agent's own `toolDefinitions`, so
+ * when its result is passed to `formatAgentMessages`, historical `subagent` /
+ * `lc_transfer_to_*` (and handoff-destination) tool calls are treated as
+ * unknown and flattened into plain `Tool: <name>, <output>` text on every
+ * subsequent turn. Feeding this union instead preserves those calls as
+ * structured tool_call/tool_result pairs.
+ *
+ * See https://github.com/danny-avila/LibreChat/issues/14623.
+ */
+export function buildRunToolSet(
+  primaryConfig: RunAgentToolSetConfig | null | undefined,
+  additionalConfigs?: Iterable<RunAgentToolSetConfig | null | undefined> | null,
+): Set<string> {
+  const toolSet = new Set<string>();
+  let sawAgent = false;
+
+  const addAgent = (agentConfig: RunAgentToolSetConfig | null | undefined): void => {
+    if (!agentConfig) {
+      return;
+    }
+    sawAgent = true;
+    for (const name of buildToolSet(agentConfig)) {
+      toolSet.add(name);
+    }
+    if (typeof agentConfig.id === 'string' && agentConfig.id !== '') {
+      toolSet.add(`${Constants.LC_TRANSFER_TO_}${agentConfig.id}`);
+    }
+  };
+
+  addAgent(primaryConfig);
+  if (additionalConfigs) {
+    for (const agentConfig of additionalConfigs) {
+      addAgent(agentConfig);
+    }
+  }
+
+  /**
+   * The `subagent` spawn tool is injected by `@librechat/agents` at
+   * graph-build time and is never present in any agent's stored
+   * `toolDefinitions`, so add it explicitly whenever the run has at least
+   * one agent to keep historical subagent calls structured.
+   */
+  if (sawAgent) {
+    toolSet.add(Constants.SUBAGENT);
+  }
+
+  return toolSet;
 }
 
 export interface RegisterCodeExecutionToolsParams {


### PR DESCRIPTION
Fixes #14623.

In multi-agent runs, `subagent` and handoff (`lc_transfer_to_*`) tool calls are preserved
as structured `tool_call` / `tool_result` pairs on the turn they are made, but on **every
subsequent turn** they collapse into a bare text line appended to the assistant message:

Tool: subagent, {"artifact_id":"…","title":"…"}

The model then imitates that text pattern — reproducing `Tool: …` lines, fabricating
artifact IDs that were never returned, and falsely claiming completed work — because the
only surviving representation of the call *looks like* a call.

## Root cause

`formatAgentMessages` flattens any historical `tool_call` whose name is not in the tool set
it receives (`messages/format.mjs`, converting unknown calls to `Tool: ${name}, ${output}`).
All three call sites built that set from the **primary agent only**:

- `api/server/controllers/agents/client.js` — `buildToolSet(this.options.agent)`
- `api/server/controllers/agents/responses.js` — `buildToolSet(primaryConfig)`
- `api/server/controllers/agents/openai.js` — `buildToolSet(primaryConfig)`

But the `subagent` spawn tool (`Constants.SUBAGENT`) and the `lc_transfer_to_<agentId>`
handoff tools are injected by `@librechat/agents` at graph-build time and never appear in
any agent's stored `toolDefinitions`. Handoff-destination agents' own tools are missing too.
So on later turns those calls are "unknown" → flattened.

## Fix

Add `buildRunToolSet` (`packages/api/src/agents/tools.ts`), which unions:

- every reachable agent's tools (primary + handoff/added), via the existing `buildToolSet`
- the synthetic `Constants.SUBAGENT` name
- a `Constants.LC_TRANSFER_TO_<agentId>` name for each reachable agent

and use it at all three `formatAgentMessages` call sites. The change is purely additive to
the tool set (it can only preserve *more* structured pairs, never flatten more), and live-run
tool binding is untouched.

## Testing

- New unit coverage for `buildRunToolSet` (`packages/api/src/agents/tools.spec.ts`): union,
  synthetic `subagent`, per-agent `lc_transfer_to_*` names, nullish/id-less handling.
- Updated the `@librechat/api` mocks in `openai.spec.js` / `responses.unit.spec.js`.
- `packages/api` `tools.spec.ts` 38/38; agents controllers + `client.test.js` 275/275;
  typecheck and eslint clean.

## Notes

The related `@librechat/agents` defence-in-depth ideas from the issue (exempting
`lc_transfer_to_` / `subagent` from flattening, or wrapping any residual flattened text in a
non-imitable envelope) are out of scope for this app-repo PR and would be a separate change
in that package.