### PR TITLE
🧶 fix: Preserve Multi-Agent Tool Call History

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "5.1.6",
-    "@librechat/agents": "^3.7.11",
+    "@librechat/agents": "^3.7.13",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/api/server/controllers/agents/__tests__/callbacks.spec.js
+++ b/api/server/controllers/agents/__tests__/callbacks.spec.js
@@ -124,6 +124,41 @@ describe('resumable event generation fencing', () => {
     );
   });
 
+  it('resolves MCP identity from a function-shaped root tool call', async () => {
+    const { GraphEvents } = jest.requireActual('@librechat/agents');
+    const { getDefaultHandlers } = require('../callbacks');
+    const resolveMcpServerName = jest.fn(() => 'server');
+    const data = {
+      id: 'step-function-tool',
+      index: 0,
+      stepDetails: {
+        type: 'tool_calls',
+        tool_calls: [
+          {
+            id: 'call-function-tool',
+            function: { name: 'lookup_mcp_server', arguments: '{}' },
+          },
+        ],
+      },
+    };
+    const handlers = getDefaultHandlers({
+      res: { write: jest.fn() },
+      aggregateContent: jest.fn(),
+      toolEndCallback: jest.fn(),
+      collectedUsage: [],
+      resolveMcpServerName,
+    });
+
+    await handlers[GraphEvents.ON_RUN_STEP].handle(GraphEvents.ON_RUN_STEP, data, {
+      agent_id: 'lazy-agent',
+    });
+
+    expect(resolveMcpServerName).toHaveBeenCalledWith('lookup_mcp_server', 'lazy-agent');
+    expect(data.stepDetails.tool_calls[0]).toEqual(
+      expect.objectContaining({ name: 'lookup_mcp_server', mcpServerName: 'server' }),
+    );
+  });
+
   it('publishes root event-child progress through the child activity transport', async () => {
     const { nanoid } = require('nanoid');
     nanoid.mockReturnValueOnce('invocation-1').mockReturnValueOnce('invocation-2');

--- a/api/server/controllers/agents/__tests__/openai.spec.js
+++ b/api/server/controllers/agents/__tests__/openai.spec.js
@@ -203,7 +203,7 @@ jest.mock('@librechat/api', () => ({
   buildAgentContextAttachmentsByAgentId: (...args) =>
     mockBuildAgentContextAttachmentsByAgentId(...args),
   createChunk: jest.fn().mockReturnValue({}),
-  buildToolSet: jest.fn().mockReturnValue(new Set()),
+  buildRunToolSet: jest.fn().mockReturnValue(new Set()),
   buildInitialToolSessions: jest.fn().mockReturnValue(mockInitialSessions),
   AgentRunEnvelopeError: MockAgentRunEnvelopeError,
   createAgentRunEnvelope: (...args) => mockCreateAgentRunEnvelope(...args),

--- a/api/server/controllers/agents/__tests__/responses.unit.spec.js
+++ b/api/server/controllers/agents/__tests__/responses.unit.spec.js
@@ -223,7 +223,7 @@ jest.mock('@librechat/api', () => ({
   }),
   buildInitialToolSessions: jest.fn().mockReturnValue(mockInitialSessions),
   applyContextToAgent: (...args) => mockApplyContextToAgent(...args),
-  buildToolSet: jest.fn().mockReturnValue(new Set()),
+  buildRunToolSet: jest.fn().mockReturnValue(new Set()),
   AgentRunEnvelopeError: MockAgentRunEnvelopeError,
   createAgentRunEnvelope: (...args) => mockCreateAgentRunEnvelope(...args),
   createMCPRuntimeRequestBody: ({ messageId, conversationId, parentMessageId }) => ({

--- a/api/server/controllers/agents/callbacks.js
+++ b/api/server/controllers/agents/callbacks.js
@@ -327,7 +327,7 @@ function subagentPhaseToGraphEvent(event) {
 /**
  * Folds a single {@link SubagentUpdateEvent} into the given content
  * aggregator. Silent no-op for phases outside the aggregator's domain.
- * @param {{ aggregateContent: Function }} aggregator
+ * @param {{ aggregateContent: Function, contentParts?: Array, stepMap?: Map }} aggregator
  * @param {SubagentUpdateEvent} event
  */
 function feedSubagentAggregator(aggregator, event) {
@@ -339,22 +339,16 @@ function feedSubagentAggregator(aggregator, event) {
    * public content shape, so host-only routing metadata is not copied. Restore
    * the server-owned identity by call id after that projection; otherwise the
    * persistence fallback has to parse an ambiguous delimiter-bearing name. */
-  const identities = new Map(
-    (event.data?.stepDetails?.tool_calls ?? [])
-      .filter(
-        (toolCall) =>
-          typeof toolCall?.id === 'string' && typeof toolCall?.mcpServerName === 'string',
-      )
-      .map((toolCall) => [toolCall.id, toolCall.mcpServerName]),
-  );
-  if (identities.size === 0 || !Array.isArray(aggregator.contentParts)) {
+  const toolCalls = event.data?.stepDetails?.tool_calls ?? [];
+  const stepIndex = aggregator.stepMap?.get(event.data?.id)?.index;
+  if (!Number.isInteger(stepIndex) || !Array.isArray(aggregator.contentParts)) {
     return;
   }
-  for (const part of aggregator.contentParts) {
-    const toolCall = part?.tool_call;
-    const serverName = identities.get(toolCall?.id);
-    if (serverName) {
-      toolCall.mcpServerName = serverName;
+  for (let index = 0; index < toolCalls.length; index++) {
+    const source = toolCalls[index];
+    const target = aggregator.contentParts[stepIndex + index]?.tool_call;
+    if (target?.id === source?.id && typeof source?.mcpServerName === 'string') {
+      target.mcpServerName = source.mcpServerName;
     }
   }
 }
@@ -522,8 +516,12 @@ function getDefaultHandlers({
        */
       handle: async (event, data, metadata) => {
         for (const toolCall of data?.stepDetails?.tool_calls ?? []) {
+          const toolName = toolCall?.name ?? toolCall?.function?.name;
+          if (toolCall?.name == null && typeof toolName === 'string') {
+            toolCall.name = toolName;
+          }
           const serverName = resolveMcpServerName?.(
-            toolCall?.name,
+            toolName,
             metadata?.agent_id ?? metadata?.agentId,
           );
           if (serverName) {
@@ -738,7 +736,11 @@ function getDefaultHandlers({
           ? data.memberAgentId
           : data?.subagentAgentId;
       for (const toolCall of data?.data?.stepDetails?.tool_calls ?? []) {
-        const serverName = resolveMcpServerName?.(toolCall?.name, memberAgentId);
+        const toolName = toolCall?.name ?? toolCall?.function?.name;
+        if (toolCall?.name == null && typeof toolName === 'string') {
+          toolCall.name = toolName;
+        }
+        const serverName = resolveMcpServerName?.(toolName, memberAgentId);
         if (serverName) {
           toolCall.mcpServerName = serverName;
         }

--- a/api/server/controllers/agents/callbacks.js
+++ b/api/server/controllers/agents/callbacks.js
@@ -362,6 +362,7 @@ function feedSubagentAggregator(aggregator, event) {
  *   used to persist the breakdown only when the final call emitted usage.
  * @param {Array<TTokenUsageEvent>} [options.usageEmitSink] - Array collecting each emitted
  *   `on_token_usage` payload (incl. cost) so the response's usage rollup can be persisted.
+ * @param {(toolName: string, agentId?: string) => string | undefined} [options.resolveMcpServerName]
  * @returns {Record<string, t.EventHandler>} The default handlers.
  * @throws {Error} If the request is not found.
  */
@@ -383,6 +384,7 @@ function getDefaultHandlers({
   contextUsageSink = null,
   usageEmitSink = null,
   eventChildActivity = null,
+  resolveMcpServerName = null,
 }) {
   if (!res || !aggregateContent) {
     throw new Error(
@@ -496,6 +498,15 @@ function getDefaultHandlers({
        * @param {GraphRunnableConfig['configurable']} [metadata] The runnable metadata.
        */
       handle: async (event, data, metadata) => {
+        for (const toolCall of data?.stepDetails?.tool_calls ?? []) {
+          const serverName = resolveMcpServerName?.(
+            toolCall?.name,
+            metadata?.agent_id ?? metadata?.agentId,
+          );
+          if (serverName) {
+            toolCall.mcpServerName = serverName;
+          }
+        }
         aggregateContent({ event, data });
         if (data?.stepDetails.type === StepTypes.TOOL_CALLS) {
           await emitForJob({ event, data });
@@ -699,6 +710,12 @@ function getDefaultHandlers({
        * consistent "don't record" rule for subagent traces.
        */
       if (!visible) return;
+      for (const toolCall of data?.data?.stepDetails?.tool_calls ?? []) {
+        const serverName = resolveMcpServerName?.(toolCall?.name, data?.subagentAgentId);
+        if (serverName) {
+          toolCall.mcpServerName = serverName;
+        }
+      }
       if (subagentAggregatorsByToolCallId && data?.parentToolCallId) {
         const key = data.parentToolCallId;
         let aggregator = subagentAggregatorsByToolCallId.get(key);

--- a/api/server/controllers/agents/callbacks.js
+++ b/api/server/controllers/agents/callbacks.js
@@ -711,7 +711,10 @@ function getDefaultHandlers({
        */
       if (!visible) return;
       for (const toolCall of data?.data?.stepDetails?.tool_calls ?? []) {
-        const serverName = resolveMcpServerName?.(toolCall?.name, data?.subagentAgentId);
+        const serverName = resolveMcpServerName?.(
+          toolCall?.name,
+          data?.memberAgentId ?? data?.subagentAgentId,
+        );
         if (serverName) {
           toolCall.mcpServerName = serverName;
         }

--- a/api/server/controllers/agents/callbacks.js
+++ b/api/server/controllers/agents/callbacks.js
@@ -334,6 +334,29 @@ function feedSubagentAggregator(aggregator, event) {
   const graphEvent = subagentPhaseToGraphEvent(event);
   if (!graphEvent) return;
   aggregator.aggregateContent({ event: graphEvent, data: event.data });
+
+  /** The SDK aggregator intentionally projects run-step tool calls onto its
+   * public content shape, so host-only routing metadata is not copied. Restore
+   * the server-owned identity by call id after that projection; otherwise the
+   * persistence fallback has to parse an ambiguous delimiter-bearing name. */
+  const identities = new Map(
+    (event.data?.stepDetails?.tool_calls ?? [])
+      .filter(
+        (toolCall) =>
+          typeof toolCall?.id === 'string' && typeof toolCall?.mcpServerName === 'string',
+      )
+      .map((toolCall) => [toolCall.id, toolCall.mcpServerName]),
+  );
+  if (identities.size === 0 || !Array.isArray(aggregator.contentParts)) {
+    return;
+  }
+  for (const part of aggregator.contentParts) {
+    const toolCall = part?.tool_call;
+    const serverName = identities.get(toolCall?.id);
+    if (serverName) {
+      toolCall.mcpServerName = serverName;
+    }
+  }
 }
 
 /**

--- a/api/server/controllers/agents/callbacks.js
+++ b/api/server/controllers/agents/callbacks.js
@@ -710,11 +710,12 @@ function getDefaultHandlers({
        * consistent "don't record" rule for subagent traces.
        */
       if (!visible) return;
+      const memberAgentId =
+        typeof data?.memberAgentId === 'string' && data.memberAgentId.trim() !== ''
+          ? data.memberAgentId
+          : data?.subagentAgentId;
       for (const toolCall of data?.data?.stepDetails?.tool_calls ?? []) {
-        const serverName = resolveMcpServerName?.(
-          toolCall?.name,
-          data?.memberAgentId ?? data?.subagentAgentId,
-        );
+        const serverName = resolveMcpServerName?.(toolCall?.name, memberAgentId);
         if (serverName) {
           toolCall.mcpServerName = serverName;
         }

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -127,6 +127,7 @@ const {
   hasModelBoundContentProtection,
   assertResumeRuntimeContentAllowed,
   collectReachableAgents,
+  stampMcpServerIdentities,
   getDynamicToolContexts,
   getSafeErrorMetadata,
   createInitializedAgentContextFingerprint,
@@ -162,8 +163,6 @@ const {
   isEphemeralAgentId,
   removeNullishValues,
   stripLangChainTroubleshootingUrl,
-  normalizeServerName,
-  splitMCPToolKey,
   DEFAULT_MEMORY_MAX_INPUT_TOKENS,
 } = require('librechat-data-provider');
 const { filterFilesByAgentAccess } = require('~/server/services/Files/permissions');
@@ -512,55 +511,10 @@ class AgentClient extends BaseClient {
   /** Stamps host-resolved MCP identities onto persisted calls so future replay
    * can distinguish delimiter-bearing tool names from longer server names. */
   stampMcpServerIdentities() {
-    if (!Array.isArray(this.contentParts)) {
-      return;
-    }
-    const agents = collectReachableAgents([
-      this.options.agent,
-      ...(this.agentConfigs?.values() ?? []),
-    ]);
-    const serverByToolName = new Map();
-    const boundaryNames = new Set();
-    for (const agent of agents) {
-      for (const rawName of [
-        ...(agent.accessibleMcpServerNames ?? []),
-        ...(agent.historicalMcpServerNames ?? []),
-      ]) {
-        boundaryNames.add(rawName);
-        boundaryNames.add(normalizeServerName(rawName));
-      }
-      for (const definition of agent.toolDefinitions ?? []) {
-        if (typeof definition?.name === 'string' && typeof definition?.serverName === 'string') {
-          serverByToolName.set(definition.name, definition.serverName);
-        }
-      }
-      for (const [name, tool] of agent.toolRegistry ?? []) {
-        if (typeof tool?.mcpRawServerName === 'string') {
-          serverByToolName.set(name, tool.mcpRawServerName);
-        }
-      }
-    }
-    const knownNames = [...boundaryNames];
-    const stampPart = (part) => {
-      const toolCall = part?.tool_call;
-      if (!toolCall || typeof toolCall.name !== 'string') {
-        return;
-      }
-      let serverName = toolCall.mcpServerName ?? serverByToolName.get(toolCall.name);
-      if (serverName == null && toolCall.name.includes(Constants.mcp_delimiter)) {
-        const [toolName, parsedServerName] = splitMCPToolKey(toolCall.name, knownNames);
-        if (toolName && parsedServerName) {
-          serverName = parsedServerName;
-        }
-      }
-      if (typeof serverName === 'string') {
-        toolCall.mcpServerName = normalizeServerName(serverName);
-      }
-      if (Array.isArray(toolCall.subagent_content)) {
-        toolCall.subagent_content.forEach(stampPart);
-      }
-    };
-    this.contentParts.forEach(stampPart);
+    stampMcpServerIdentities({
+      contentParts: this.contentParts,
+      roots: [this.options.agent, ...(this.agentConfigs?.values() ?? [])],
+    });
   }
 
   /**

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -3852,7 +3852,11 @@ class AgentClient extends BaseClient {
         version: 'v2',
       };
 
-      const toolSet = buildRunToolSet(this.options.agent, this.agentConfigs?.values());
+      const toolSet = buildRunToolSet(
+        this.options.agent,
+        this.agentConfigs?.values(),
+        this.options.subagentTasks == null ? undefined : [Constants.CHECK_BACKGROUND_TASK],
+      );
       const tokenCounter = await createCachedTokenCounter(this.getEncoding());
 
       /** Pre-resolve invoked skill bodies + re-prime files before formatting messages */

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -162,6 +162,8 @@ const {
   isEphemeralAgentId,
   removeNullishValues,
   stripLangChainTroubleshootingUrl,
+  normalizeServerName,
+  splitMCPToolKey,
   DEFAULT_MEMORY_MAX_INPUT_TOKENS,
 } = require('librechat-data-provider');
 const { filterFilesByAgentAccess } = require('~/server/services/Files/permissions');
@@ -505,6 +507,60 @@ class AgentClient extends BaseClient {
       }
     }
     buffer.clear();
+  }
+
+  /** Stamps host-resolved MCP identities onto persisted calls so future replay
+   * can distinguish delimiter-bearing tool names from longer server names. */
+  stampMcpServerIdentities() {
+    if (!Array.isArray(this.contentParts)) {
+      return;
+    }
+    const agents = collectReachableAgents([
+      this.options.agent,
+      ...(this.agentConfigs?.values() ?? []),
+    ]);
+    const serverByToolName = new Map();
+    const boundaryNames = new Set();
+    for (const agent of agents) {
+      for (const rawName of [
+        ...(agent.accessibleMcpServerNames ?? []),
+        ...(agent.historicalMcpServerNames ?? []),
+      ]) {
+        boundaryNames.add(rawName);
+        boundaryNames.add(normalizeServerName(rawName));
+      }
+      for (const definition of agent.toolDefinitions ?? []) {
+        if (typeof definition?.name === 'string' && typeof definition?.serverName === 'string') {
+          serverByToolName.set(definition.name, definition.serverName);
+        }
+      }
+      for (const [name, tool] of agent.toolRegistry ?? []) {
+        if (typeof tool?.mcpRawServerName === 'string') {
+          serverByToolName.set(name, tool.mcpRawServerName);
+        }
+      }
+    }
+    const knownNames = [...boundaryNames];
+    const stampPart = (part) => {
+      const toolCall = part?.tool_call;
+      if (!toolCall || typeof toolCall.name !== 'string') {
+        return;
+      }
+      let serverName = serverByToolName.get(toolCall.name);
+      if (serverName == null && toolCall.name.includes(Constants.mcp_delimiter)) {
+        const [toolName, parsedServerName] = splitMCPToolKey(toolCall.name, knownNames);
+        if (toolName && parsedServerName) {
+          serverName = parsedServerName;
+        }
+      }
+      if (typeof serverName === 'string') {
+        toolCall.mcpServerName = normalizeServerName(serverName);
+      }
+      if (Array.isArray(toolCall.subagent_content)) {
+        toolCall.subagent_content.forEach(stampPart);
+      }
+    };
+    this.contentParts.forEach(stampPart);
   }
 
   /**
@@ -4428,6 +4484,7 @@ class AgentClient extends BaseClient {
       }
 
       this.finalizeSubagentContent();
+      this.stampMcpServerIdentities();
       await this.settleActivityLabels();
 
       /** Flush subagent usage emits the sink fired without awaiting, so their
@@ -4863,6 +4920,7 @@ class AgentClient extends BaseClient {
       }
 
       this.finalizeSubagentContent();
+      this.stampMcpServerIdentities();
       await this.settleActivityLabels();
 
       if (this.pendingSubagentEmits.length > 0) {

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -9,7 +9,7 @@ const {
   createRun,
   isEnabled,
   checkAccess,
-  buildToolSet,
+  buildRunToolSet,
   logToolError,
   sanitizeTitle,
   payloadParser,
@@ -3852,7 +3852,7 @@ class AgentClient extends BaseClient {
         version: 'v2',
       };
 
-      const toolSet = buildToolSet(this.options.agent);
+      const toolSet = buildRunToolSet(this.options.agent, this.agentConfigs?.values());
       const tokenCounter = await createCachedTokenCounter(this.getEncoding());
 
       /** Pre-resolve invoked skill bodies + re-prime files before formatting messages */

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -3856,6 +3856,7 @@ class AgentClient extends BaseClient {
         this.options.agent,
         this.agentConfigs?.values(),
         this.options.subagentTasks == null ? undefined : [Constants.CHECK_BACKGROUND_TASK],
+        payload,
       );
       const tokenCounter = await createCachedTokenCounter(this.getEncoding());
 

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -546,7 +546,7 @@ class AgentClient extends BaseClient {
       if (!toolCall || typeof toolCall.name !== 'string') {
         return;
       }
-      let serverName = serverByToolName.get(toolCall.name);
+      let serverName = toolCall.mcpServerName ?? serverByToolName.get(toolCall.name);
       if (serverName == null && toolCall.name.includes(Constants.mcp_delimiter)) {
         const [toolName, parsedServerName] = splitMCPToolKey(toolCall.name, knownNames);
         if (toolName && parsedServerName) {

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -6693,7 +6693,12 @@ describe('AgentClient - finalizeSubagentContent', () => {
             index: 0,
             stepDetails: {
               type: 'tool_calls',
-              tool_calls: [{ id: 'inner_1', name: 'lookup_mcp_foo_mcp_bar', args: '{}' }],
+              tool_calls: [
+                {
+                  id: 'inner_1',
+                  function: { name: 'lookup_mcp_foo_mcp_bar', arguments: '{}' },
+                },
+              ],
             },
           }),
           memberAgentId: 'member',
@@ -6713,9 +6718,6 @@ describe('AgentClient - finalizeSubagentContent', () => {
     client.finalizeSubagentContent();
     const inner = client.contentParts[0].tool_call.subagent_content[0].tool_call;
     expect(resolveMcpServerName).toHaveBeenCalledWith('lookup_mcp_foo_mcp_bar', 'member');
-    expect(inner.mcpServerName).toBe('bar');
-
-    client.stampMcpServerIdentities();
     expect(inner.mcpServerName).toBe('bar');
 
     const emptyMemberResolver = jest.fn(() => 'bar');

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -6716,6 +6716,25 @@ describe('AgentClient - finalizeSubagentContent', () => {
     const inner = client.contentParts[0].tool_call.subagent_content[0].tool_call;
     expect(resolveMcpServerName).toHaveBeenCalledWith('lookup_mcp_foo_mcp_bar', 'member');
     expect(inner.mcpServerName).toBe('bar');
+
+    const emptyMemberResolver = jest.fn(() => 'bar');
+    await runSubagentEvents(
+      [
+        {
+          ...event('run_step', {
+            id: 'step_tool_2',
+            index: 0,
+            stepDetails: {
+              type: 'tool_calls',
+              tool_calls: [{ id: 'inner_2', name: 'lookup_mcp_foo_mcp_bar', args: '{}' }],
+            },
+          }),
+          memberAgentId: '',
+        },
+      ],
+      emptyMemberResolver,
+    );
+    expect(emptyMemberResolver).toHaveBeenCalledWith('lookup_mcp_foo_mcp_bar', 'child');
   });
 
   it('ignores tool_call parts whose name is not SUBAGENT', async () => {

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -6711,10 +6711,11 @@ describe('AgentClient - finalizeSubagentContent', () => {
     ];
 
     client.finalizeSubagentContent();
-    client.stampMcpServerIdentities();
-
     const inner = client.contentParts[0].tool_call.subagent_content[0].tool_call;
     expect(resolveMcpServerName).toHaveBeenCalledWith('lookup_mcp_foo_mcp_bar', 'member');
+    expect(inner.mcpServerName).toBe('bar');
+
+    client.stampMcpServerIdentities();
     expect(inner.mcpServerName).toBe('bar');
 
     const emptyMemberResolver = jest.fn(() => 'bar');
@@ -6895,6 +6896,7 @@ describe('AgentClient - resumeCompletion content protection', () => {
     applyHideSequentialOutputsFilter: jest.fn(),
     rebaseActivityPhaseBounds: jest.fn(),
     finalizeSubagentContent: jest.fn(),
+    stampMcpServerIdentities: jest.fn(),
     settleActivityLabels: jest.fn().mockResolvedValue(undefined),
     recordCollectedUsage: jest.fn().mockResolvedValue(undefined),
   });

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -6651,6 +6651,37 @@ describe('AgentClient - finalizeSubagentContent', () => {
     expect(buffer.size).toBe(0);
   });
 
+  it('stamps durable MCP server identity onto nested persisted tool calls', () => {
+    const client = makeClient(new Map());
+    client.options.agent.accessibleMcpServerNames = ['bar', 'foo_mcp_bar'];
+    client.options.agent.toolDefinitions = [
+      {
+        name: 'gitlab-get_mcp_server_version_mcp_bar',
+        serverName: 'bar',
+      },
+    ];
+    client.contentParts = [
+      {
+        type: 'tool_call',
+        tool_call: {
+          name: Constants.SUBAGENT,
+          subagent_content: [
+            {
+              type: 'tool_call',
+              tool_call: { name: 'gitlab-get_mcp_server_version_mcp_bar' },
+            },
+          ],
+        },
+      },
+    ];
+
+    client.stampMcpServerIdentities();
+
+    expect(client.contentParts[0].tool_call.subagent_content[0].tool_call.mcpServerName).toBe(
+      'bar',
+    );
+  });
+
   it('ignores tool_call parts whose name is not SUBAGENT', async () => {
     const buffer = await runSubagentEvents([
       event(

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -6567,7 +6567,7 @@ describe('AgentClient - finalizeSubagentContent', () => {
    *  `ON_SUBAGENT_UPDATE` handler so we exercise the same get-or-create
    *  aggregator logic the live request uses, rather than constructing
    *  aggregators directly in the test. */
-  const runSubagentEvents = async (events) => {
+  const runSubagentEvents = async (events, resolveMcpServerName) => {
     const map = new Map();
     const handlers = getDefaultHandlers({
       res: { write: jest.fn(), writableEnded: false },
@@ -6575,6 +6575,7 @@ describe('AgentClient - finalizeSubagentContent', () => {
       toolEndCallback: jest.fn(),
       collectedUsage: [],
       subagentAggregatorsByToolCallId: map,
+      resolveMcpServerName,
     });
     const handler = handlers[GraphEvents.ON_SUBAGENT_UPDATE];
     for (const e of events) {
@@ -6680,6 +6681,38 @@ describe('AgentClient - finalizeSubagentContent', () => {
     expect(client.contentParts[0].tool_call.subagent_content[0].tool_call.mcpServerName).toBe(
       'bar',
     );
+  });
+
+  it('retains the resolved lazy-agent MCP identity for an ambiguous nested key', async () => {
+    const resolveMcpServerName = jest.fn(() => 'bar');
+    const buffer = await runSubagentEvents(
+      [
+        event('run_step', {
+          id: 'step_tool',
+          index: 0,
+          stepDetails: {
+            type: 'tool_calls',
+            tool_calls: [{ id: 'inner_1', name: 'lookup_mcp_foo_mcp_bar', args: '{}' }],
+          },
+        }),
+      ],
+      resolveMcpServerName,
+    );
+    const client = makeClient(buffer);
+    client.options.agent.accessibleMcpServerNames = ['bar', 'foo_mcp_bar'];
+    client.contentParts = [
+      {
+        type: 'tool_call',
+        tool_call: { id: 'call_sub', name: Constants.SUBAGENT, args: '{}' },
+      },
+    ];
+
+    client.finalizeSubagentContent();
+    client.stampMcpServerIdentities();
+
+    const inner = client.contentParts[0].tool_call.subagent_content[0].tool_call;
+    expect(resolveMcpServerName).toHaveBeenCalledWith('lookup_mcp_foo_mcp_bar', 'child');
+    expect(inner.mcpServerName).toBe('bar');
   });
 
   it('ignores tool_call parts whose name is not SUBAGENT', async () => {

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -6687,14 +6687,17 @@ describe('AgentClient - finalizeSubagentContent', () => {
     const resolveMcpServerName = jest.fn(() => 'bar');
     const buffer = await runSubagentEvents(
       [
-        event('run_step', {
-          id: 'step_tool',
-          index: 0,
-          stepDetails: {
-            type: 'tool_calls',
-            tool_calls: [{ id: 'inner_1', name: 'lookup_mcp_foo_mcp_bar', args: '{}' }],
-          },
-        }),
+        {
+          ...event('run_step', {
+            id: 'step_tool',
+            index: 0,
+            stepDetails: {
+              type: 'tool_calls',
+              tool_calls: [{ id: 'inner_1', name: 'lookup_mcp_foo_mcp_bar', args: '{}' }],
+            },
+          }),
+          memberAgentId: 'member',
+        },
       ],
       resolveMcpServerName,
     );
@@ -6711,7 +6714,7 @@ describe('AgentClient - finalizeSubagentContent', () => {
     client.stampMcpServerIdentities();
 
     const inner = client.contentParts[0].tool_call.subagent_content[0].tool_call;
-    expect(resolveMcpServerName).toHaveBeenCalledWith('lookup_mcp_foo_mcp_bar', 'child');
+    expect(resolveMcpServerName).toHaveBeenCalledWith('lookup_mcp_foo_mcp_bar', 'member');
     expect(inner.mcpServerName).toBe('bar');
   });
 

--- a/api/server/controllers/agents/openai.js
+++ b/api/server/controllers/agents/openai.js
@@ -13,7 +13,7 @@ const {
   createRun,
   createChunk,
   applyContextToAgent,
-  buildToolSet,
+  buildRunToolSet,
   buildInitialToolSessions,
   buildAgentScopedContext,
   buildInlineMemoryContext,
@@ -806,7 +806,7 @@ const executeOpenAIChatCompletion = async (envelope, { req, res }) => {
 
       const openaiMessages = convertMessages(request.messages);
 
-      const toolSet = buildToolSet(primaryConfig);
+      const toolSet = buildRunToolSet(primaryConfig, handoffAgentConfigs.values());
       const formatted = formatAgentMessages(stripActivityLabelParts(openaiMessages), {}, toolSet);
       const formattedMessages = formatted.messages;
       const initialSummary = formatted.summary;

--- a/api/server/controllers/agents/openai.js
+++ b/api/server/controllers/agents/openai.js
@@ -806,7 +806,12 @@ const executeOpenAIChatCompletion = async (envelope, { req, res }) => {
 
       const openaiMessages = convertMessages(request.messages);
 
-      const toolSet = buildRunToolSet(primaryConfig, handoffAgentConfigs.values());
+      const toolSet = buildRunToolSet(
+        primaryConfig,
+        handoffAgentConfigs.values(),
+        undefined,
+        openaiMessages,
+      );
       const formatted = formatAgentMessages(stripActivityLabelParts(openaiMessages), {}, toolSet);
       const formattedMessages = formatted.messages;
       const initialSummary = formatted.summary;

--- a/api/server/controllers/agents/openai.js
+++ b/api/server/controllers/agents/openai.js
@@ -811,6 +811,7 @@ const executeOpenAIChatCompletion = async (envelope, { req, res }) => {
         handoffAgentConfigs.values(),
         undefined,
         openaiMessages,
+        true,
       );
       const formatted = formatAgentMessages(stripActivityLabelParts(openaiMessages), {}, toolSet);
       const formattedMessages = formatted.messages;

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -1004,7 +1004,12 @@ const executeResponse = async (envelope, { req, res }) => {
       // Merge previous messages with new input
       const allMessages = [...previousMessages, ...inputMessages];
 
-      const toolSet = buildRunToolSet(primaryConfig, handoffAgentConfigs.values());
+      const toolSet = buildRunToolSet(
+        primaryConfig,
+        handoffAgentConfigs.values(),
+        undefined,
+        allMessages,
+      );
       const formatted = formatAgentMessages(stripActivityLabelParts(allMessages), {}, toolSet);
       const formattedMessages = formatted.messages;
       const initialSummary = formatted.summary;

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -1009,6 +1009,7 @@ const executeResponse = async (envelope, { req, res }) => {
         handoffAgentConfigs.values(),
         undefined,
         allMessages,
+        true,
       );
       const formatted = formatAgentMessages(stripActivityLabelParts(allMessages), {}, toolSet);
       const formattedMessages = formatted.messages;

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -13,7 +13,7 @@ const {
   createRun,
   applyContextToAgent,
   buildInitialToolSessions,
-  buildToolSet,
+  buildRunToolSet,
   AgentRunEnvelopeError,
   createAgentRunEnvelope,
   createAgentExecutionContext,
@@ -1004,7 +1004,7 @@ const executeResponse = async (envelope, { req, res }) => {
       // Merge previous messages with new input
       const allMessages = [...previousMessages, ...inputMessages];
 
-      const toolSet = buildToolSet(primaryConfig);
+      const toolSet = buildRunToolSet(primaryConfig, handoffAgentConfigs.values());
       const formatted = formatAgentMessages(stripActivityLabelParts(allMessages), {}, toolSet);
       const formattedMessages = formatted.messages;
       const initialSummary = formatted.summary;

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -927,8 +927,10 @@ const initializeClient = async ({
 
   let historicalMcpServerNamesPromise;
   const resolveHistoricalMcpServerNames = () => {
-    historicalMcpServerNamesPromise ??= getAccessibleMcpServerNames(req.user.id, req.user.role)
-      .then((names) => [...new Set([...names, ...Object.keys(appConfig?.mcpConfig ?? {})])])
+    historicalMcpServerNamesPromise ??= Promise.resolve(
+      getAccessibleMcpServerNames(req.user.id, req.user.role),
+    )
+      .then((names) => [...new Set([...(names ?? []), ...Object.keys(appConfig?.mcpConfig ?? {})])])
       .catch((error) => {
         logger.warn(
           '[initializeClient] Failed to resolve MCP names for lazy history normalization:',

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -52,7 +52,6 @@ const {
   loadAgentTools,
   loadToolsForExecution,
   getAccessibleMcpServerNames,
-  getCachedMcpToolNamesForPlaceholders,
   isFatalAgentInitializationError,
 } = require('~/server/services/ToolService');
 const { filterFilesByAgentAccess } = require('~/server/services/Files/permissions');
@@ -1003,22 +1002,12 @@ const initializeClient = async ({
     )
       ? await resolveHistoricalMcpServerNames()
       : [];
-    const mcpWildcardToolNames = configuredAndSkillToolNames.some((name) =>
-      name.startsWith(`${Constants.mcp_all}${Constants.mcp_delimiter}`),
-    )
-      ? await getCachedMcpToolNamesForPlaceholders({
-          userId: req.user.id,
-          toolNames: configuredAndSkillToolNames,
-          rawServerNames: rawMcpServerNames,
-        })
-      : [];
     const historicalToolNames = Array.from(
       buildHistoricalToolNames({
         configuredToolNames: agent.tools,
         alwaysApplyToolNames: alwaysApplySkillPrimes.flatMap((prime) => prime.allowedTools ?? []),
         toolOptions: agent.tool_options,
         rawMcpServerNames,
-        mcpWildcardToolNames,
         codeExecutionAvailable: lazyCodeEnvAvailable,
         memoryAvailable: memoryAvailable === true && agent.tools?.includes(Tools.memory) === true,
         skillsAvailable: scopedSkillIds.length > 0,

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -34,6 +34,7 @@ const {
   MAX_SUBAGENT_DEPTH,
   isAgentsEndpoint,
   AgentCapabilities,
+  normalizeServerName,
   Constants,
   Tools,
   MAX_SUBAGENT_GRAPH_NODES,
@@ -322,6 +323,22 @@ const initializeClient = async ({
    * }>}
    */
   const agentToolContexts = new Map();
+  const resolveMcpServerName = (toolName, agentId) => {
+    if (typeof toolName !== 'string' || typeof agentId !== 'string') {
+      return undefined;
+    }
+    const context = agentToolContexts.get(agentId);
+    const registered = context?.toolRegistry?.get?.(toolName);
+    if (typeof registered?.mcpRawServerName === 'string') {
+      return normalizeServerName(registered.mcpRawServerName);
+    }
+    for (const [serverName, tools] of Object.entries(context?.mcpAvailableTools ?? {})) {
+      if (tools?.[toolName]?.function) {
+        return normalizeServerName(serverName);
+      }
+    }
+    return undefined;
+  };
   /** Attach only the host-resolved route for the actually executing agent.
    * Runnable metadata is transport data and may contain caller-controlled
    * keys, so discard any incoming route context before resolving from the
@@ -1606,6 +1623,7 @@ const initializeClient = async ({
     contextUsageSink,
     usageEmitSink,
     eventChildActivity,
+    resolveMcpServerName,
   });
 
   const client = new AgentClient({

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -14,7 +14,6 @@ const {
   discoverConnectedAgents,
   resolveAgentTokenConfig,
   resolveAgentScopedSkillIds,
-  resolveAlwaysApplySkills,
   resolveModelSpecSkillIds,
   getAgentStartupTelemetry,
   isContentFilterError,
@@ -25,7 +24,7 @@ const {
   createStatefulCodeEnvironmentPolicyError,
   buildSubagentThreadTaskConfig,
   backgroundCompletionWakeupsEnabled,
-  buildHistoricalToolNames,
+  createLazyAgentHistoryResolver,
 } = require('@librechat/api');
 const {
   ResourceType,
@@ -35,7 +34,6 @@ const {
   isAgentsEndpoint,
   AgentCapabilities,
   normalizeServerName,
-  Constants,
   Tools,
   MAX_SUBAGENT_GRAPH_NODES,
   MAX_SUBAGENT_RUN_CONFIGS,
@@ -801,10 +799,7 @@ const initializeClient = async ({
 
   const lazyMetadataByAgentId = new Map();
   const lazyMetadataLoadsByAgentId = new Map();
-  /** Request-scoped cache: lazy descriptors sharing the same Skill ACL scope
-   * reuse one history-only always-apply lookup without initializing tools,
-   * files, model clients, or MCP connections. */
-  const lazyAlwaysApplySkillsByScope = new Map();
+  const resolveLazyMetadata = createConcurrencyLimiter(SUBAGENT_GRAPH_LOAD_CONCURRENCY);
   const subagentGraphIds = new Set();
   const expandedSubagentDescriptorState = { configCount: 0, rootAgentIds: [] };
 
@@ -915,49 +910,32 @@ const initializeClient = async ({
       ),
     );
 
-  const resolveLazyAlwaysApplySkillPrimes = (agent) => {
-    const scopedSkillIds = resolveAgentScopedSkillIds({
-      agent,
-      accessibleSkillIds,
-      skillsCapabilityEnabled,
-      ephemeralSkillsToggle,
-    });
-    if (scopedSkillIds.length === 0 || typeof skillDbMethods.listAlwaysApplySkills !== 'function') {
-      return Promise.resolve([]);
-    }
-    const scopeKey = scopedSkillIds
-      .map((skillId) => skillId.toString())
-      .sort()
-      .join(':');
-    let resolution = lazyAlwaysApplySkillsByScope.get(scopeKey);
-    if (resolution == null) {
-      resolution = resolveAlwaysApplySkills({
-        listAlwaysApplySkills: skillDbMethods.listAlwaysApplySkills,
-        accessibleSkillIds: scopedSkillIds,
-        userId,
-        skillStates,
-        defaultActiveOnShare,
-      });
-      lazyAlwaysApplySkillsByScope.set(scopeKey, resolution);
-    }
-    return resolution;
-  };
-
-  let historicalMcpServerNamesPromise;
-  const resolveHistoricalMcpServerNames = () => {
-    historicalMcpServerNamesPromise ??= Promise.resolve(
-      getAccessibleMcpServerNames(req.user.id, req.user.role),
-    )
-      .then((names) => [...new Set([...(names ?? []), ...Object.keys(appConfig?.mcpConfig ?? {})])])
-      .catch((error) => {
-        logger.warn(
-          '[initializeClient] Failed to resolve MCP names for lazy history normalization:',
-          error,
-        );
-        return Object.keys(appConfig?.mcpConfig ?? {});
-      });
-    return historicalMcpServerNamesPromise;
-  };
+  const lazyHistoryResolver = createLazyAgentHistoryResolver({
+    accessibleSkillIds,
+    editableSkillIds,
+    skillsCapabilityEnabled,
+    ephemeralSkillsToggle,
+    userId,
+    userRole,
+    skillStates,
+    defaultActiveOnShare,
+    maxCatalogSkills: appConfig?.endpoints?.[EModelEndpoint.agents]?.skills?.maxCatalogSkills,
+    listSkillsByAccess: skillDbMethods.listSkillsByAccess,
+    listAlwaysApplySkills: skillDbMethods.listAlwaysApplySkills,
+    getAccessibleMcpServerNames,
+    configuredMcpServerNames: Object.keys(appConfig?.mcpConfig ?? {}),
+    canAuthorSkillFiles: ({ agent, scopedEditableSkillIds }) =>
+      canAuthorSkillFiles({
+        agent,
+        scopedEditableSkillIds,
+        skillCreateAllowed,
+        skillsCapabilityEnabled,
+        ephemeralSkillsToggle,
+      }),
+    deferredToolsAvailable,
+    programmaticToolsAvailable,
+    backgroundToolsAvailable,
+  });
 
   const toLazySubagentMetadata = async (agent) => {
     const lazyCodeEnvAvailable =
@@ -991,50 +969,12 @@ const initializeClient = async ({
             conversationId,
           })
         : undefined;
-    const scopedSkillIds = resolveAgentScopedSkillIds({
-      agent,
-      accessibleSkillIds,
-      skillsCapabilityEnabled,
-      ephemeralSkillsToggle,
-    });
-    const scopedEditableSkillIds = resolveAgentScopedSkillIds({
-      agent,
-      accessibleSkillIds: editableSkillIds,
-      skillsCapabilityEnabled,
-      ephemeralSkillsToggle,
-    });
-    const skillAuthoringAvailable = canAuthorSkillFiles({
-      agent,
-      scopedEditableSkillIds,
-      skillCreateAllowed,
-      skillsCapabilityEnabled,
-      ephemeralSkillsToggle,
-    });
-    const alwaysApplySkillPrimes = await resolveLazyAlwaysApplySkillPrimes(agent);
-    const configuredAndSkillToolNames = [
-      ...(agent.tools ?? []),
-      ...alwaysApplySkillPrimes.flatMap((prime) => prime.allowedTools ?? []),
-    ];
-    const rawMcpServerNames = configuredAndSkillToolNames.some((name) =>
-      name.includes(Constants.mcp_delimiter),
-    )
-      ? await resolveHistoricalMcpServerNames()
-      : [];
-    const historicalToolNames = Array.from(
-      buildHistoricalToolNames({
-        configuredToolNames: agent.tools,
-        alwaysApplyToolNames: alwaysApplySkillPrimes.flatMap((prime) => prime.allowedTools ?? []),
-        toolOptions: agent.tool_options,
-        rawMcpServerNames,
+    const { alwaysApplySkillPrimes, historicalToolNames, historicalMcpServerNames } =
+      await lazyHistoryResolver.resolve({
+        agent,
         codeExecutionAvailable: lazyCodeEnvAvailable,
-        memoryAvailable: memoryAvailable === true && agent.tools?.includes(Tools.memory) === true,
-        skillsAvailable: scopedSkillIds.length > 0,
-        skillAuthoringAvailable,
-        deferredToolsAvailable,
-        programmaticToolsAvailable,
-        backgroundToolsAvailable,
-      }),
-    );
+        memoryAvailable,
+      });
     return {
       id: agent.id,
       name: agent.name,
@@ -1056,7 +996,7 @@ const initializeClient = async ({
       includeReasoningHistory: getIncludeReasoningHistory(agent),
       alwaysApplySkillPrimes,
       historicalToolNames,
-      historicalMcpServerNames: rawMcpServerNames,
+      historicalMcpServerNames,
     };
   };
 
@@ -1066,7 +1006,7 @@ const initializeClient = async ({
     if (cached) return cached;
     let loading = lazyMetadataLoadsByAgentId.get(agentId);
     if (!loading) {
-      loading = (async () => {
+      loading = resolveLazyMetadata(async () => {
         const agent = await db.getAgentWithVersionCount({ id: agentId });
         if (!agent || !(await hasSubagentViewAccess(agent, agentId))) {
           skippedAgentIds.add(agentId);
@@ -1075,7 +1015,7 @@ const initializeClient = async ({
         const metadata = await toLazySubagentMetadata(agent);
         lazyMetadataByAgentId.set(agentId, metadata);
         return metadata;
-      })();
+      });
       lazyMetadataLoadsByAgentId.set(agentId, loading);
     }
     try {

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -25,10 +25,7 @@ const {
   createStatefulCodeEnvironmentPolicyError,
   buildSubagentThreadTaskConfig,
   backgroundCompletionWakeupsEnabled,
-  CREATE_FILE_TOOL_NAME,
-  DELETE_MEMORY_TOOL_NAME,
-  EDIT_FILE_TOOL_NAME,
-  SET_MEMORY_TOOL_NAME,
+  buildHistoricalToolNames,
 } = require('@librechat/api');
 const {
   ResourceType,
@@ -37,6 +34,7 @@ const {
   MAX_SUBAGENT_DEPTH,
   isAgentsEndpoint,
   AgentCapabilities,
+  Constants,
   Tools,
   MAX_SUBAGENT_GRAPH_NODES,
   MAX_SUBAGENT_RUN_CONFIGS,
@@ -232,6 +230,8 @@ const initializeClient = async ({
   const codeEnvAvailable = enabledCapabilities.has(AgentCapabilities.execute_code);
   const backgroundToolsAvailable = enabledCapabilities.has(AgentCapabilities.run_in_background);
   const toolIntentsAvailable = enabledCapabilities.has(AgentCapabilities.tool_intents);
+  const deferredToolsAvailable = enabledCapabilities.has(AgentCapabilities.deferred_tools);
+  const programmaticToolsAvailable = enabledCapabilities.has(AgentCapabilities.programmatic_tools);
   const statefulSessionsAvailable = enabledCapabilities.has(
     AgentCapabilities.stateful_code_sessions,
   );
@@ -783,10 +783,8 @@ const initializeClient = async ({
   const skippedAgentIds = new Set(discoveredSkippedIds ?? []);
 
   const lazyMetadataByAgentId = new Map();
-  const eventActorContextRequested =
-    req._isAgentTrigger === true && req._agentEventBindingParentConversationId != null;
   /** Request-scoped cache: lazy descriptors sharing the same Skill ACL scope
-   * reuse one metadata-only always-apply lookup without initializing tools,
+   * reuse one history-only always-apply lookup without initializing tools,
    * files, model clients, or MCP connections. */
   const lazyAlwaysApplySkillsByScope = new Map();
   const subagentGraphIds = new Set();
@@ -900,9 +898,6 @@ const initializeClient = async ({
     );
 
   const resolveLazyAlwaysApplySkillPrimes = (agent) => {
-    if (!eventActorContextRequested) {
-      return Promise.resolve([]);
-    }
     const scopedSkillIds = resolveAgentScopedSkillIds({
       agent,
       accessibleSkillIds,
@@ -928,6 +923,20 @@ const initializeClient = async ({
       lazyAlwaysApplySkillsByScope.set(scopeKey, resolution);
     }
     return resolution;
+  };
+
+  let historicalMcpServerNamesPromise;
+  const resolveHistoricalMcpServerNames = () => {
+    historicalMcpServerNamesPromise ??= getAccessibleMcpServerNames(req.user.id, req.user.role)
+      .then((names) => [...new Set([...names, ...Object.keys(appConfig?.mcpConfig ?? {})])])
+      .catch((error) => {
+        logger.warn(
+          '[initializeClient] Failed to resolve MCP names for lazy history normalization:',
+          error,
+        );
+        return Object.keys(appConfig?.mcpConfig ?? {});
+      });
+    return historicalMcpServerNamesPromise;
   };
 
   const toLazySubagentMetadata = async (agent) => {
@@ -962,18 +971,49 @@ const initializeClient = async ({
             conversationId,
           })
         : undefined;
+    const scopedSkillIds = resolveAgentScopedSkillIds({
+      agent,
+      accessibleSkillIds,
+      skillsCapabilityEnabled,
+      ephemeralSkillsToggle,
+    });
+    const scopedEditableSkillIds = resolveAgentScopedSkillIds({
+      agent,
+      accessibleSkillIds: editableSkillIds,
+      skillsCapabilityEnabled,
+      ephemeralSkillsToggle,
+    });
+    const skillAuthoringAvailable = canAuthorSkillFiles({
+      agent,
+      scopedEditableSkillIds,
+      skillCreateAllowed,
+      skillsCapabilityEnabled,
+      ephemeralSkillsToggle,
+    });
     const alwaysApplySkillPrimes = await resolveLazyAlwaysApplySkillPrimes(agent);
+    const configuredAndSkillToolNames = [
+      ...(agent.tools ?? []),
+      ...alwaysApplySkillPrimes.flatMap((prime) => prime.allowedTools ?? []),
+    ];
+    const rawMcpServerNames = configuredAndSkillToolNames.some((name) =>
+      name.includes(Constants.mcp_delimiter),
+    )
+      ? await resolveHistoricalMcpServerNames()
+      : [];
     const historicalToolNames = Array.from(
-      new Set([
-        ...(agent.tools ?? []),
-        ...alwaysApplySkillPrimes.flatMap((prime) => prime.allowedTools ?? []),
-        ...(lazyCodeEnvAvailable
-          ? [Tools.bash_tool, Tools.read_file, CREATE_FILE_TOOL_NAME, EDIT_FILE_TOOL_NAME]
-          : []),
-        ...(memoryAvailable === true && agent.tools?.includes(Tools.memory) === true
-          ? [SET_MEMORY_TOOL_NAME, DELETE_MEMORY_TOOL_NAME]
-          : []),
-      ]),
+      buildHistoricalToolNames({
+        configuredToolNames: agent.tools,
+        alwaysApplyToolNames: alwaysApplySkillPrimes.flatMap((prime) => prime.allowedTools ?? []),
+        toolOptions: agent.tool_options,
+        rawMcpServerNames,
+        codeExecutionAvailable: lazyCodeEnvAvailable,
+        memoryAvailable: memoryAvailable === true && agent.tools?.includes(Tools.memory) === true,
+        skillsAvailable: scopedSkillIds.length > 0,
+        skillAuthoringAvailable,
+        deferredToolsAvailable,
+        programmaticToolsAvailable,
+        backgroundToolsAvailable,
+      }),
     );
     return {
       id: agent.id,

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -25,6 +25,10 @@ const {
   createStatefulCodeEnvironmentPolicyError,
   buildSubagentThreadTaskConfig,
   backgroundCompletionWakeupsEnabled,
+  CREATE_FILE_TOOL_NAME,
+  DELETE_MEMORY_TOOL_NAME,
+  EDIT_FILE_TOOL_NAME,
+  SET_MEMORY_TOOL_NAME,
 } = require('@librechat/api');
 const {
   ResourceType,
@@ -958,6 +962,19 @@ const initializeClient = async ({
             conversationId,
           })
         : undefined;
+    const alwaysApplySkillPrimes = await resolveLazyAlwaysApplySkillPrimes(agent);
+    const historicalToolNames = Array.from(
+      new Set([
+        ...(agent.tools ?? []),
+        ...alwaysApplySkillPrimes.flatMap((prime) => prime.allowedTools ?? []),
+        ...(lazyCodeEnvAvailable
+          ? [Tools.bash_tool, Tools.read_file, CREATE_FILE_TOOL_NAME, EDIT_FILE_TOOL_NAME]
+          : []),
+        ...(memoryAvailable === true && agent.tools?.includes(Tools.memory) === true
+          ? [SET_MEMORY_TOOL_NAME, DELETE_MEMORY_TOOL_NAME]
+          : []),
+      ]),
+    );
     return {
       id: agent.id,
       name: agent.name,
@@ -977,7 +994,8 @@ const initializeClient = async ({
       codeExecutionContext,
       codeSessionKey: codeExecutionContext?.codeSessionKey,
       includeReasoningHistory: getIncludeReasoningHistory(agent),
-      alwaysApplySkillPrimes: await resolveLazyAlwaysApplySkillPrimes(agent),
+      alwaysApplySkillPrimes,
+      historicalToolNames,
     };
   };
 
@@ -1212,6 +1230,7 @@ const initializeClient = async ({
         codeSessionKey: metadata.codeSessionKey,
         includeReasoningHistory: metadata.includeReasoningHistory,
         alwaysApplySkillPrimes: metadata.alwaysApplySkillPrimes,
+        historicalToolNames: metadata.historicalToolNames,
         lazySubagentConfigs: lazyChildren,
         subagentAgentConfigs: eagerChildren,
         subagentGraphMemberMetadata,

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -800,6 +800,7 @@ const initializeClient = async ({
   const skippedAgentIds = new Set(discoveredSkippedIds ?? []);
 
   const lazyMetadataByAgentId = new Map();
+  const lazyMetadataLoadsByAgentId = new Map();
   /** Request-scoped cache: lazy descriptors sharing the same Skill ACL scope
    * reuse one history-only always-apply lookup without initializing tools,
    * files, model clients, or MCP connections. */
@@ -1063,15 +1064,22 @@ const initializeClient = async ({
     if (skippedAgentIds.has(agentId)) return null;
     const cached = lazyMetadataByAgentId.get(agentId);
     if (cached) return cached;
+    let loading = lazyMetadataLoadsByAgentId.get(agentId);
+    if (!loading) {
+      loading = (async () => {
+        const agent = await db.getAgentWithVersionCount({ id: agentId });
+        if (!agent || !(await hasSubagentViewAccess(agent, agentId))) {
+          skippedAgentIds.add(agentId);
+          return null;
+        }
+        const metadata = await toLazySubagentMetadata(agent);
+        lazyMetadataByAgentId.set(agentId, metadata);
+        return metadata;
+      })();
+      lazyMetadataLoadsByAgentId.set(agentId, loading);
+    }
     try {
-      const agent = await db.getAgentWithVersionCount({ id: agentId });
-      if (!agent || !(await hasSubagentViewAccess(agent, agentId))) {
-        skippedAgentIds.add(agentId);
-        return null;
-      }
-      const metadata = await toLazySubagentMetadata(agent);
-      lazyMetadataByAgentId.set(agentId, metadata);
-      return metadata;
+      return await loading;
     } catch (error) {
       if (isFatalAgentInitializationError(error)) {
         throw error;
@@ -1079,6 +1087,10 @@ const initializeClient = async ({
       logger.error(`[initializeClient] Error loading subagent metadata ${agentId}:`, error);
       skippedAgentIds.add(agentId);
       return null;
+    } finally {
+      if (lazyMetadataLoadsByAgentId.get(agentId) === loading) {
+        lazyMetadataLoadsByAgentId.delete(agentId);
+      }
     }
   };
 
@@ -1236,92 +1248,95 @@ const initializeClient = async ({
     }
     const nextAncestors = new Set(ancestors);
     nextAncestors.add(agent.id);
-    const descriptors = [];
-    for (const subagentId of subagentIds) {
-      if (skippedAgentIds.has(subagentId) || nextAncestors.has(subagentId)) continue;
-      if (subagentId !== primaryConfig.id) {
-        assertSubagentGraphRoom(subagentId);
-      }
-      const existing =
-        subagentId === primaryConfig.id ? primaryConfig : agentConfigs.get(subagentId);
-      if (existing) {
-        countExpandedSubagentDescriptor(subagentId);
+    const descriptors = await Promise.all(
+      subagentIds.map(async (subagentId) => {
+        if (skippedAgentIds.has(subagentId) || nextAncestors.has(subagentId)) return null;
+        const existing =
+          subagentId === primaryConfig.id ? primaryConfig : agentConfigs.get(subagentId);
+        if (existing) {
+          if (subagentId !== primaryConfig.id) {
+            assertSubagentGraphRoom(subagentId);
+            subagentGraphIds.add(subagentId);
+          }
+          countExpandedSubagentDescriptor(subagentId);
+          const existingChildren = await buildLazySubagentDescriptors(
+            existing,
+            depth + 1,
+            nextAncestors,
+          );
+          existing.lazySubagentConfigs = existingChildren.filter((child) => child.configId);
+          existing.subagentAgentConfigs = existingChildren.filter((child) => !child.configId);
+          return existing;
+        }
+        const metadata = await loadSubagentMetadata(subagentId);
+        if (!metadata) return null;
         if (subagentId !== primaryConfig.id) {
+          assertSubagentGraphRoom(subagentId);
           subagentGraphIds.add(subagentId);
         }
-        const existingChildren = await buildLazySubagentDescriptors(
-          existing,
+        countExpandedSubagentDescriptor(subagentId);
+        const childDescriptors = await buildLazySubagentDescriptors(
+          metadata,
           depth + 1,
           nextAncestors,
         );
-        existing.lazySubagentConfigs = existingChildren.filter((child) => child.configId);
-        existing.subagentAgentConfigs = existingChildren.filter((child) => !child.configId);
-        descriptors.push(existing);
-        continue;
-      }
-      const metadata = await loadSubagentMetadata(subagentId);
-      if (!metadata) continue;
-      countExpandedSubagentDescriptor(subagentId);
-      subagentGraphIds.add(subagentId);
-      const childDescriptors = await buildLazySubagentDescriptors(
-        metadata,
-        depth + 1,
-        nextAncestors,
-      );
-      const lazyChildren = childDescriptors.filter((child) => child.configId);
-      const eagerChildren = childDescriptors.filter((child) => !child.configId);
-      const subagentGraphMemberMetadata = await loadGraphMemberCapabilityMetadata(metadata);
-      descriptors.push({
-        id: metadata.id,
-        name: metadata.name,
-        description: metadata.description,
-        provider: metadata.provider,
-        model: metadata.model,
-        model_parameters: metadata.model_parameters,
-        recursion_limit: metadata.recursion_limit,
-        memory_scope: metadata.memory_scope,
-        memoryToolsRegistered: metadata.memoryToolsRegistered,
-        subagents: metadata.subagents,
-        configId: metadata.configId,
-        codeEnvAvailable: metadata.codeEnvAvailable,
-        statefulCodeSessions: metadata.statefulCodeSessions,
-        statefulCodeEnvironment: metadata.statefulCodeEnvironment,
-        codeExecutionContext: metadata.codeExecutionContext,
-        codeSessionKey: metadata.codeSessionKey,
-        includeReasoningHistory: metadata.includeReasoningHistory,
-        alwaysApplySkillPrimes: metadata.alwaysApplySkillPrimes,
-        historicalToolNames: metadata.historicalToolNames,
-        historicalMcpServerNames: metadata.historicalMcpServerNames,
-        lazySubagentConfigs: lazyChildren,
-        subagentAgentConfigs: eagerChildren,
-        subagentGraphMemberMetadata,
-        resolve: async (context) =>
-          initializeLazySubagent({
-            agentId: metadata.id,
-            configId: metadata.configId,
-            context,
-            lazyChildren,
-          }).then(async (config) => {
-            config.subagentAgentConfigs = eagerChildren;
-            graphMemberConfigsById.set(config.id, config);
-            await resolveGraphSubagentsFor(config, context.signal);
-            return config;
-          }),
-      });
-    }
-    return descriptors;
+        const lazyChildren = childDescriptors.filter((child) => child.configId);
+        const eagerChildren = childDescriptors.filter((child) => !child.configId);
+        const subagentGraphMemberMetadata = await loadGraphMemberCapabilityMetadata(metadata);
+        return {
+          id: metadata.id,
+          name: metadata.name,
+          description: metadata.description,
+          provider: metadata.provider,
+          model: metadata.model,
+          model_parameters: metadata.model_parameters,
+          recursion_limit: metadata.recursion_limit,
+          memory_scope: metadata.memory_scope,
+          memoryToolsRegistered: metadata.memoryToolsRegistered,
+          subagents: metadata.subagents,
+          configId: metadata.configId,
+          codeEnvAvailable: metadata.codeEnvAvailable,
+          statefulCodeSessions: metadata.statefulCodeSessions,
+          statefulCodeEnvironment: metadata.statefulCodeEnvironment,
+          codeExecutionContext: metadata.codeExecutionContext,
+          codeSessionKey: metadata.codeSessionKey,
+          includeReasoningHistory: metadata.includeReasoningHistory,
+          alwaysApplySkillPrimes: metadata.alwaysApplySkillPrimes,
+          historicalToolNames: metadata.historicalToolNames,
+          historicalMcpServerNames: metadata.historicalMcpServerNames,
+          lazySubagentConfigs: lazyChildren,
+          subagentAgentConfigs: eagerChildren,
+          subagentGraphMemberMetadata,
+          resolve: async (context) =>
+            initializeLazySubagent({
+              agentId: metadata.id,
+              configId: metadata.configId,
+              context,
+              lazyChildren,
+            }).then(async (config) => {
+              config.subagentAgentConfigs = eagerChildren;
+              graphMemberConfigsById.set(config.id, config);
+              await resolveGraphSubagentsFor(config, context.signal);
+              return config;
+            }),
+        };
+      }),
+    );
+    return descriptors.filter(Boolean);
   };
 
   const resolveSubagentTrees = async (rootConfigs) => {
     expandedSubagentDescriptorState.rootAgentIds = rootConfigs
       .filter((config) => config?.id)
       .map((config) => config.id);
-    for (const config of rootConfigs) {
-      if (!config?.id) continue;
-      const descriptors = await buildLazySubagentDescriptors(config);
-      config.lazySubagentConfigs = descriptors.filter((child) => child.configId);
-      config.subagentAgentConfigs = descriptors.filter((child) => !child.configId);
-    }
+    await Promise.all(
+      rootConfigs.map(async (config) => {
+        if (!config?.id) return;
+        const descriptors = await buildLazySubagentDescriptors(config);
+        config.lazySubagentConfigs = descriptors.filter((child) => child.configId);
+        config.subagentAgentConfigs = descriptors.filter((child) => !child.configId);
+      }),
+    );
   };
 
   const rootSubagentConfigs = [primaryConfig, ...agentConfigs.values()];

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -52,6 +52,7 @@ const {
   loadAgentTools,
   loadToolsForExecution,
   getAccessibleMcpServerNames,
+  getCachedMcpToolNamesForPlaceholders,
   isFatalAgentInitializationError,
 } = require('~/server/services/ToolService');
 const { filterFilesByAgentAccess } = require('~/server/services/Files/permissions');
@@ -1002,12 +1003,22 @@ const initializeClient = async ({
     )
       ? await resolveHistoricalMcpServerNames()
       : [];
+    const mcpWildcardToolNames = configuredAndSkillToolNames.some((name) =>
+      name.startsWith(`${Constants.mcp_all}${Constants.mcp_delimiter}`),
+    )
+      ? await getCachedMcpToolNamesForPlaceholders({
+          userId: req.user.id,
+          toolNames: configuredAndSkillToolNames,
+          rawServerNames: rawMcpServerNames,
+        })
+      : [];
     const historicalToolNames = Array.from(
       buildHistoricalToolNames({
         configuredToolNames: agent.tools,
         alwaysApplyToolNames: alwaysApplySkillPrimes.flatMap((prime) => prime.allowedTools ?? []),
         toolOptions: agent.tool_options,
         rawMcpServerNames,
+        mcpWildcardToolNames,
         codeExecutionAvailable: lazyCodeEnvAvailable,
         memoryAvailable: memoryAvailable === true && agent.tools?.includes(Tools.memory) === true,
         skillsAvailable: scopedSkillIds.length > 0,

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -1038,6 +1038,7 @@ const initializeClient = async ({
       includeReasoningHistory: getIncludeReasoningHistory(agent),
       alwaysApplySkillPrimes,
       historicalToolNames,
+      historicalMcpServerNames: rawMcpServerNames,
     };
   };
 
@@ -1273,6 +1274,7 @@ const initializeClient = async ({
         includeReasoningHistory: metadata.includeReasoningHistory,
         alwaysApplySkillPrimes: metadata.alwaysApplySkillPrimes,
         historicalToolNames: metadata.historicalToolNames,
+        historicalMcpServerNames: metadata.historicalMcpServerNames,
         lazySubagentConfigs: lazyChildren,
         subagentAgentConfigs: eagerChildren,
         subagentGraphMemberMetadata,

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -1301,6 +1301,57 @@ describe('initializeClient — subagent loading', () => {
     }
   });
 
+  it('bounds concurrent lazy metadata reads', async () => {
+    const subagentIds = Array.from({ length: 6 }, (_, index) => `agent_bounded_lazy_${index}`);
+    for (const id of subagentIds) {
+      await createViewableAgent(id);
+    }
+    mockInitializeAgent.mockResolvedValue(
+      makePrimaryConfig({
+        subagents: { enabled: true, allowSelf: false, agent_ids: subagentIds },
+      }),
+    );
+    const originalGetAgent = db.getAgentWithVersionCount.bind(db);
+    const fourReadsStarted = deferred();
+    let activeReads = 0;
+    let maxActiveReads = 0;
+    const getAgentSpy = jest
+      .spyOn(db, 'getAgentWithVersionCount')
+      .mockImplementation(async (...args) => {
+        activeReads += 1;
+        maxActiveReads = Math.max(maxActiveReads, activeReads);
+        if (activeReads === 4) {
+          fourReadsStarted.resolve();
+        }
+        let timer;
+        await Promise.race([
+          fourReadsStarted.promise,
+          new Promise((resolve) => {
+            timer = setTimeout(resolve, 1000);
+          }),
+        ]);
+        clearTimeout(timer);
+        try {
+          return await originalGetAgent(...args);
+        } finally {
+          activeReads -= 1;
+        }
+      });
+
+    try {
+      await initializeClient({
+        req: makeSubagentReq(),
+        res: {},
+        signal: new AbortController().signal,
+        endpointOption: makeEndpointOption(),
+      });
+      expect(agentClientArgs.agent.lazySubagentConfigs).toHaveLength(subagentIds.length);
+      expect(maxActiveReads).toBe(4);
+    } finally {
+      getAgentSpy.mockRestore();
+    }
+  });
+
   it('rejects a disallowed lazy subagent scope before exposing it for prewarm', async () => {
     const subAgent = await createAgent({
       id: SUBAGENT_ID,

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -60,13 +60,10 @@ jest.mock('~/server/controllers/agents/callbacks', () => ({
 
 const mockLoadToolsForExecution = jest.fn();
 const mockGetAccessibleMcpServerNames = jest.fn();
-const mockGetCachedMcpToolNamesForPlaceholders = jest.fn();
 jest.mock('~/server/services/ToolService', () => ({
   loadAgentTools: jest.fn(),
   loadToolsForExecution: (...args) => mockLoadToolsForExecution(...args),
   getAccessibleMcpServerNames: (...args) => mockGetAccessibleMcpServerNames(...args),
-  getCachedMcpToolNamesForPlaceholders: (...args) =>
-    mockGetCachedMcpToolNamesForPlaceholders(...args),
   isFatalAgentInitializationError: (error) =>
     [
       'AGENT_EXPECTED_MCP_TOOLS_UNAVAILABLE',
@@ -674,8 +671,6 @@ describe('initializeClient — subagent loading', () => {
     mockLoadToolsForExecution.mockResolvedValue({ loadedTools: [], configurable: {} });
     mockGetAccessibleMcpServerNames.mockReset();
     mockGetAccessibleMcpServerNames.mockResolvedValue([]);
-    mockGetCachedMcpToolNamesForPlaceholders.mockReset();
-    mockGetCachedMcpToolNamesForPlaceholders.mockResolvedValue([]);
 
     testUser = await User.create({
       email: 'subagent@example.com',
@@ -934,7 +929,7 @@ describe('initializeClient — subagent loading', () => {
       provider: 'openai',
       model: 'gpt-4',
       author: new mongoose.Types.ObjectId(),
-      tools: ['mcp_all_mcp_warehouse'],
+      tools: [`${Constants.mcp_all}${Constants.mcp_delimiter}warehouse`],
     });
     await grantView(subAgent);
 
@@ -944,7 +939,6 @@ describe('initializeClient — subagent loading', () => {
     });
     loadAgentTools.mockRejectedValueOnce(toolError);
     mockGetAccessibleMcpServerNames.mockResolvedValueOnce(['warehouse']);
-    mockGetCachedMcpToolNamesForPlaceholders.mockResolvedValueOnce(['run_query_mcp_warehouse']);
     mockInitializeAgent
       .mockResolvedValueOnce(
         makePrimaryConfig({
@@ -971,14 +965,8 @@ describe('initializeClient — subagent loading', () => {
 
     expect(mockInitializeAgent).toHaveBeenCalledTimes(1);
     expect(mockGetAccessibleMcpServerNames).toHaveBeenCalledWith(testUser._id.toString(), 'USER');
-    expect(mockGetCachedMcpToolNamesForPlaceholders).toHaveBeenCalledWith({
-      userId: testUser._id.toString(),
-      toolNames: ['mcp_all_mcp_warehouse'],
-      rawServerNames: ['warehouse'],
-    });
     expect(agentClientArgs.agent.lazySubagentConfigs[0].historicalToolNames).toEqual([
-      'mcp_all_mcp_warehouse',
-      'run_query_mcp_warehouse',
+      `${Constants.mcp_all}${Constants.mcp_delimiter}warehouse`,
     ]);
     await expect(
       agentClientArgs.agent.lazySubagentConfigs[0].resolve({

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -2300,14 +2300,18 @@ describe('initializeClient — subagent loading', () => {
       }),
     ).rejects.toThrow(`maximum of ${MAX_SUBAGENT_GRAPH_NODES} unique agents`);
     expect(mockInitializeAgent).toHaveBeenCalledTimes(1);
-    expect(logger.warn).toHaveBeenCalledWith(
-      '[initializeClient] Subagent graph node limit exceeded',
-      expect.objectContaining({
-        loadedSubagentCount: 34,
-        stagedSubagentCount: secondMemberIds.length,
-        maxSubagentGraphNodes: MAX_SUBAGENT_GRAPH_NODES,
-      }),
+    const stagedLimitWarning = logger.warn.mock.calls.find(
+      ([message, metadata]) =>
+        message === '[initializeClient] Subagent graph node limit exceeded' &&
+        Number.isInteger(metadata?.stagedSubagentCount),
     );
+    expect(stagedLimitWarning).toBeDefined();
+    expect(stagedLimitWarning[1]).toEqual(
+      expect.objectContaining({ maxSubagentGraphNodes: MAX_SUBAGENT_GRAPH_NODES }),
+    );
+    expect(
+      stagedLimitWarning[1].loadedSubagentCount + stagedLimitWarning[1].stagedSubagentCount,
+    ).toBeGreaterThan(MAX_SUBAGENT_GRAPH_NODES);
   });
 
   it('rejects a branching DAG that exceeds expanded descriptor capacity', async () => {

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -1145,9 +1145,19 @@ describe('initializeClient — subagent loading', () => {
       });
 
       expect(mockInitializeAgent).toHaveBeenCalledTimes(1);
-      expect(listAlwaysApplySkillsSpy).not.toHaveBeenCalled();
+      expect(listAlwaysApplySkillsSpy).toHaveBeenCalledTimes(1);
       for (const descriptor of agentClientArgs.agent.lazySubagentConfigs) {
-        expect(descriptor.alwaysApplySkillPrimes).toEqual([]);
+        expect(descriptor.alwaysApplySkillPrimes).toEqual([
+          expect.objectContaining({
+            _id: skill._id,
+            name: 'lazy-specialist',
+            version: 1,
+            body: '# Lazy specialist v1\n',
+          }),
+        ]);
+        expect(descriptor.historicalToolNames).toEqual(
+          expect.arrayContaining(['skill', 'read_file']),
+        );
       }
 
       const eventReq = makeSubagentReq();
@@ -1162,7 +1172,7 @@ describe('initializeClient — subagent loading', () => {
       });
 
       expect(mockInitializeAgent).toHaveBeenCalledTimes(2);
-      expect(listAlwaysApplySkillsSpy).toHaveBeenCalledTimes(1);
+      expect(listAlwaysApplySkillsSpy).toHaveBeenCalledTimes(2);
       expect(agentClientArgs.agent.lazySubagentConfigs).toHaveLength(2);
       for (const descriptor of agentClientArgs.agent.lazySubagentConfigs) {
         expect(descriptor.alwaysApplySkillPrimes).toEqual([
@@ -1173,6 +1183,9 @@ describe('initializeClient — subagent loading', () => {
             body: '# Lazy specialist v1\n',
           }),
         ]);
+        expect(descriptor.historicalToolNames).toEqual(
+          expect.arrayContaining(['skill', 'read_file']),
+        );
       }
     } finally {
       listAlwaysApplySkillsSpy.mockRestore();

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -59,9 +59,11 @@ jest.mock('~/server/controllers/agents/callbacks', () => ({
 }));
 
 const mockLoadToolsForExecution = jest.fn();
+const mockGetAccessibleMcpServerNames = jest.fn();
 jest.mock('~/server/services/ToolService', () => ({
   loadAgentTools: jest.fn(),
   loadToolsForExecution: (...args) => mockLoadToolsForExecution(...args),
+  getAccessibleMcpServerNames: (...args) => mockGetAccessibleMcpServerNames(...args),
   isFatalAgentInitializationError: (error) =>
     [
       'AGENT_EXPECTED_MCP_TOOLS_UNAVAILABLE',
@@ -667,6 +669,8 @@ describe('initializeClient — subagent loading', () => {
     capturedToolExecuteOptions = undefined;
     mockLoadToolsForExecution.mockReset();
     mockLoadToolsForExecution.mockResolvedValue({ loadedTools: [], configurable: {} });
+    mockGetAccessibleMcpServerNames.mockReset();
+    mockGetAccessibleMcpServerNames.mockResolvedValue([]);
 
     testUser = await User.create({
       email: 'subagent@example.com',
@@ -959,6 +963,7 @@ describe('initializeClient — subagent loading', () => {
     });
 
     expect(mockInitializeAgent).toHaveBeenCalledTimes(1);
+    expect(mockGetAccessibleMcpServerNames).toHaveBeenCalledWith(testUser._id.toString(), 'USER');
     await expect(
       agentClientArgs.agent.lazySubagentConfigs[0].resolve({
         signal: new AbortController().signal,

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -60,10 +60,13 @@ jest.mock('~/server/controllers/agents/callbacks', () => ({
 
 const mockLoadToolsForExecution = jest.fn();
 const mockGetAccessibleMcpServerNames = jest.fn();
+const mockGetCachedMcpToolNamesForPlaceholders = jest.fn();
 jest.mock('~/server/services/ToolService', () => ({
   loadAgentTools: jest.fn(),
   loadToolsForExecution: (...args) => mockLoadToolsForExecution(...args),
   getAccessibleMcpServerNames: (...args) => mockGetAccessibleMcpServerNames(...args),
+  getCachedMcpToolNamesForPlaceholders: (...args) =>
+    mockGetCachedMcpToolNamesForPlaceholders(...args),
   isFatalAgentInitializationError: (error) =>
     [
       'AGENT_EXPECTED_MCP_TOOLS_UNAVAILABLE',
@@ -671,6 +674,8 @@ describe('initializeClient — subagent loading', () => {
     mockLoadToolsForExecution.mockResolvedValue({ loadedTools: [], configurable: {} });
     mockGetAccessibleMcpServerNames.mockReset();
     mockGetAccessibleMcpServerNames.mockResolvedValue([]);
+    mockGetCachedMcpToolNamesForPlaceholders.mockReset();
+    mockGetCachedMcpToolNamesForPlaceholders.mockResolvedValue([]);
 
     testUser = await User.create({
       email: 'subagent@example.com',
@@ -929,7 +934,7 @@ describe('initializeClient — subagent loading', () => {
       provider: 'openai',
       model: 'gpt-4',
       author: new mongoose.Types.ObjectId(),
-      tools: ['run_query_mcp_warehouse'],
+      tools: ['mcp_all_mcp_warehouse'],
     });
     await grantView(subAgent);
 
@@ -938,6 +943,8 @@ describe('initializeClient — subagent loading', () => {
       statusCode: 503,
     });
     loadAgentTools.mockRejectedValueOnce(toolError);
+    mockGetAccessibleMcpServerNames.mockResolvedValueOnce(['warehouse']);
+    mockGetCachedMcpToolNamesForPlaceholders.mockResolvedValueOnce(['run_query_mcp_warehouse']);
     mockInitializeAgent
       .mockResolvedValueOnce(
         makePrimaryConfig({
@@ -964,6 +971,15 @@ describe('initializeClient — subagent loading', () => {
 
     expect(mockInitializeAgent).toHaveBeenCalledTimes(1);
     expect(mockGetAccessibleMcpServerNames).toHaveBeenCalledWith(testUser._id.toString(), 'USER');
+    expect(mockGetCachedMcpToolNamesForPlaceholders).toHaveBeenCalledWith({
+      userId: testUser._id.toString(),
+      toolNames: ['mcp_all_mcp_warehouse'],
+      rawServerNames: ['warehouse'],
+    });
+    expect(agentClientArgs.agent.lazySubagentConfigs[0].historicalToolNames).toEqual([
+      'mcp_all_mcp_warehouse',
+      'run_query_mcp_warehouse',
+    ]);
     await expect(
       agentClientArgs.agent.lazySubagentConfigs[0].resolve({
         signal: new AbortController().signal,

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -1204,6 +1204,103 @@ describe('initializeClient — subagent loading', () => {
     }
   });
 
+  it('loads independent lazy Skill scopes concurrently', async () => {
+    const secondSubagentId = 'agent_subagent_parallel_skill_2';
+    const skills = [];
+    for (const name of ['parallel-skill-one', 'parallel-skill-two']) {
+      const { skill } = await createSkill({
+        name,
+        description: `${name} description`,
+        body: `# ${name}\n`,
+        alwaysApply: true,
+        author: testUser._id,
+        authorName: testUser.name,
+      });
+      await AclEntry.create({
+        principalType: PrincipalType.USER,
+        principalId: testUser._id,
+        principalModel: PrincipalModel.USER,
+        resourceType: ResourceType.SKILL,
+        resourceId: skill._id,
+        permBits: PermissionBits.VIEW,
+        grantedBy: testUser._id,
+      });
+      skills.push(skill);
+    }
+    for (const [id, skill] of [
+      [SUBAGENT_ID, skills[0]],
+      [secondSubagentId, skills[1]],
+    ]) {
+      const agent = await createAgent({
+        id,
+        name: id,
+        provider: 'openai',
+        model: 'gpt-4',
+        author: testUser._id,
+        tools: [],
+        skills_enabled: true,
+        skills: [skill._id.toString()],
+      });
+      await grantView(agent);
+    }
+    mockInitializeAgent.mockResolvedValue(
+      makePrimaryConfig({
+        subagents: {
+          enabled: true,
+          allowSelf: false,
+          agent_ids: [SUBAGENT_ID, secondSubagentId],
+        },
+      }),
+    );
+    const req = makeSubagentReq();
+    req.config.endpoints.agents.capabilities.push('skills');
+    const skillDbMethods = getSkillDbMethods();
+    const listAlwaysApplySkills = skillDbMethods.listAlwaysApplySkills.bind(skillDbMethods);
+    let activeQueries = 0;
+    let maxActiveQueries = 0;
+    const bothQueriesStarted = deferred();
+    const waitForBothQueries = async () => {
+      let timer;
+      await Promise.race([
+        bothQueriesStarted.promise,
+        new Promise((resolve) => {
+          timer = setTimeout(resolve, 1000);
+        }),
+      ]);
+      clearTimeout(timer);
+    };
+    const listAlwaysApplySkillsSpy = jest
+      .spyOn(skillDbMethods, 'listAlwaysApplySkills')
+      .mockImplementation(async (...args) => {
+        activeQueries += 1;
+        maxActiveQueries = Math.max(maxActiveQueries, activeQueries);
+        if (activeQueries === 2) {
+          bothQueriesStarted.resolve();
+        }
+        await waitForBothQueries();
+        try {
+          return await listAlwaysApplySkills(...args);
+        } finally {
+          activeQueries -= 1;
+        }
+      });
+
+    try {
+      await initializeClient({
+        req,
+        res: {},
+        signal: new AbortController().signal,
+        endpointOption: makeEndpointOption(),
+      });
+
+      expect(listAlwaysApplySkillsSpy).toHaveBeenCalledTimes(2);
+      expect(maxActiveQueries).toBe(2);
+      expect(agentClientArgs.agent.lazySubagentConfigs).toHaveLength(2);
+    } finally {
+      listAlwaysApplySkillsSpy.mockRestore();
+    }
+  });
+
   it('rejects a disallowed lazy subagent scope before exposing it for prewarm', async () => {
     const subAgent = await createAgent({
       id: SUBAGENT_ID,

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -990,8 +990,10 @@ describe('initializeClient — subagent loading', () => {
       )
       .mockRejectedValueOnce(resourceRecoveryError);
 
+    const req = makeSubagentReq();
+    req.config.endpoints.agents.capabilities.push('execute_code');
     await initializeClient({
-      req: makeSubagentReq(),
+      req,
       res: {},
       signal: new AbortController().signal,
       endpointOption: makeEndpointOption(),

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -968,6 +968,9 @@ describe('initializeClient — subagent loading', () => {
     expect(agentClientArgs.agent.lazySubagentConfigs[0].historicalToolNames).toEqual([
       `${Constants.mcp_all}${Constants.mcp_delimiter}warehouse`,
     ]);
+    expect(agentClientArgs.agent.lazySubagentConfigs[0].historicalMcpServerNames).toEqual([
+      'warehouse',
+    ]);
     await expect(
       agentClientArgs.agent.lazySubagentConfigs[0].resolve({
         signal: new AbortController().signal,

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -997,6 +997,14 @@ describe('initializeClient — subagent loading', () => {
       endpointOption: makeEndpointOption(),
     });
 
+    expect(agentClientArgs.agent.lazySubagentConfigs[0].historicalToolNames).toEqual([
+      'execute_code',
+      'bash_tool',
+      'read_file',
+      'create_file',
+      'edit_file',
+    ]);
+
     await expect(
       agentClientArgs.agent.lazySubagentConfigs[0].resolve({
         signal: new AbortController().signal,
@@ -1049,6 +1057,7 @@ describe('initializeClient — subagent loading', () => {
         statefulCodeEnvironment: 'agent-user',
         memory_scope: 'agent',
         memoryToolsRegistered: false,
+        historicalToolNames: ['web'],
       }),
     );
     expect(agentClientArgs.agent.lazySubagentConfigs[0]).not.toHaveProperty('tools');

--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -39,7 +39,6 @@ const {
   normalizeActionToolName,
   ASK_USER_QUESTION_TOOL_NAME,
   splitMCPToolKey,
-  isMCPAllPlaceholder,
   buildServerNameAliases,
   findShadowedServerNames,
   isNormalizationSensitiveName,
@@ -108,31 +107,6 @@ const { getLogStores } = require('~/cache');
 const domainSeparatorRegex = new RegExp(actionDomainSeparator, 'g');
 const encryptedActionMetadataFields = ['api_key', 'oauth_client_id', 'oauth_client_secret'];
 const requiredActionContentFields = ['name', 'arguments', 'output'];
-
-/** Reads already-cached MCP catalogs for lazy wildcard history without opening connections. */
-const getCachedMcpToolNamesForPlaceholders = async ({ userId, toolNames, rawServerNames }) => {
-  const names = new Set();
-  for (const toolName of toolNames ?? []) {
-    if (!isMCPAllPlaceholder(toolName)) {
-      continue;
-    }
-    const [, serverName] = splitMCPToolKey(toolName, rawServerNames ?? []);
-    if (!serverName || !rawServerNames?.includes(serverName)) {
-      continue;
-    }
-    try {
-      const cachedTools = await getMCPServerTools(userId, serverName);
-      for (const [name, definition] of Object.entries(cachedTools ?? {})) {
-        if (definition?.function) {
-          names.add(name);
-        }
-      }
-    } catch {
-      logger.warn('[MCP Cache] Unable to read cached wildcard tools for lazy history');
-    }
-  }
-  return [...names];
-};
 
 const getActiveToolResources = (toolResources, tools) => {
   if (toolResources == null) {
@@ -2425,5 +2399,4 @@ module.exports = {
   /** Re-exported for controllers that already depend on (and mock) this
    *  module, avoiding a fresh heavy `services/MCP` require chain there. */
   getAccessibleMcpServerNames,
-  getCachedMcpToolNamesForPlaceholders,
 };

--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -39,6 +39,7 @@ const {
   normalizeActionToolName,
   ASK_USER_QUESTION_TOOL_NAME,
   splitMCPToolKey,
+  isMCPAllPlaceholder,
   buildServerNameAliases,
   findShadowedServerNames,
   isNormalizationSensitiveName,
@@ -107,6 +108,31 @@ const { getLogStores } = require('~/cache');
 const domainSeparatorRegex = new RegExp(actionDomainSeparator, 'g');
 const encryptedActionMetadataFields = ['api_key', 'oauth_client_id', 'oauth_client_secret'];
 const requiredActionContentFields = ['name', 'arguments', 'output'];
+
+/** Reads already-cached MCP catalogs for lazy wildcard history without opening connections. */
+const getCachedMcpToolNamesForPlaceholders = async ({ userId, toolNames, rawServerNames }) => {
+  const names = new Set();
+  for (const toolName of toolNames ?? []) {
+    if (!isMCPAllPlaceholder(toolName)) {
+      continue;
+    }
+    const [, serverName] = splitMCPToolKey(toolName, rawServerNames ?? []);
+    if (!serverName || !rawServerNames?.includes(serverName)) {
+      continue;
+    }
+    try {
+      const cachedTools = await getMCPServerTools(userId, serverName);
+      for (const [name, definition] of Object.entries(cachedTools ?? {})) {
+        if (definition?.function) {
+          names.add(name);
+        }
+      }
+    } catch {
+      logger.warn('[MCP Cache] Unable to read cached wildcard tools for lazy history');
+    }
+  }
+  return [...names];
+};
 
 const getActiveToolResources = (toolResources, tools) => {
   if (toolResources == null) {
@@ -2399,4 +2425,5 @@ module.exports = {
   /** Re-exported for controllers that already depend on (and mock) this
    *  module, avoiding a fresh heavy `services/MCP` require chain there. */
   getAccessibleMcpServerNames,
+  getCachedMcpToolNamesForPlaceholders,
 };

--- a/e2e/specs/mock/content-filters.persisted.spec.ts
+++ b/e2e/specs/mock/content-filters.persisted.spec.ts
@@ -2979,7 +2979,9 @@ test.describe('persisted source-aware content filters', () => {
               {
                 type: 'tool_call',
                 tool_call: {
-                  name: `e2e_${testCase.field}`,
+                  id: `e2e-${testCase.field}-${suffix}`,
+                  name: 'conditional_transfer',
+                  args: '{}',
                   output: testCase.marker,
                 },
               },

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "5.1.6",
-        "@librechat/agents": "^3.7.11",
+        "@librechat/agents": "^3.7.13",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -10633,9 +10633,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.7.11",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.7.11.tgz",
-      "integrity": "sha512-XDk71WaqpaO/746dQ3kgBcWBXY2rullysfY7yTjbjr361CVfUgMkosiqFYn7OgSdF2BbHbfzyyqurwLEGSS/Wg==",
+      "version": "3.7.13",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.7.13.tgz",
+      "integrity": "sha512-V9KGPap07qgOgAzO5yZUAhav+KxzxfETj/gXDPmDHWw7IVyv4nILBDZzJ/Bu7TnvlzmleikKgnJDa6r9TNTMkQ==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
@@ -42638,7 +42638,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "5.1.6",
-        "@librechat/agents": "^3.7.11",
+        "@librechat/agents": "^3.7.13",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/api": "^1.9.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -113,7 +113,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "5.1.6",
-    "@librechat/agents": "^3.7.11",
+    "@librechat/agents": "^3.7.13",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@opentelemetry/api": "^1.9.0",

--- a/packages/api/src/agents/history.spec.ts
+++ b/packages/api/src/agents/history.spec.ts
@@ -60,4 +60,34 @@ describe('agent tool history formatting', () => {
     expect(JSON.stringify(assistant.content)).not.toContain('Tool:');
     expect(toolMessages.map(({ name }) => name)).toEqual([transferName, 'research_database']);
   });
+
+  it('preserves an authorized MCP wildcard call without a live catalog', () => {
+    const primary = {
+      historicalToolNames: [`${Constants.mcp_all}${Constants.mcp_delimiter}warehouse`],
+    };
+    const payload: TPayload = [
+      { role: 'user', content: 'Run the saved query' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: 'query-1',
+              name: 'run_query_mcp_warehouse',
+              args: '{}',
+              output: '{"rows":1}',
+            },
+          },
+        ],
+      },
+    ];
+
+    const toolSet = buildRunToolSet(primary, null, null, payload);
+    const { messages } = formatAgentMessages(payload, undefined, toolSet);
+
+    expect(toolSet).toContain('run_query_mcp_warehouse');
+    expect(JSON.stringify(messages)).not.toContain('Tool:');
+    expect(messages.some((message) => message instanceof ToolMessage)).toBe(true);
+  });
 });

--- a/packages/api/src/agents/history.spec.ts
+++ b/packages/api/src/agents/history.spec.ts
@@ -73,10 +73,21 @@ describe('agent tool history formatting', () => {
           {
             type: ContentTypes.TOOL_CALL,
             tool_call: {
-              id: 'query-1',
-              name: 'run_query_mcp_warehouse',
+              id: 'subagent-1',
+              name: `${Constants.SUBAGENT}`,
               args: '{}',
-              output: '{"rows":1}',
+              output: 'Finished the query',
+              subagent_content: [
+                {
+                  type: ContentTypes.TOOL_CALL,
+                  tool_call: {
+                    id: 'query-1',
+                    name: 'run_query_mcp_warehouse',
+                    args: '{}',
+                    output: '{"rows":1}',
+                  },
+                },
+              ],
             },
           },
         ],

--- a/packages/api/src/agents/history.spec.ts
+++ b/packages/api/src/agents/history.spec.ts
@@ -1,0 +1,63 @@
+import { formatAgentMessages } from '@librechat/agents';
+import { Constants, ContentTypes } from 'librechat-data-provider';
+import { AIMessage, ToolMessage } from '@librechat/agents/langchain/messages';
+import type { TPayload } from '@librechat/agents';
+import { buildRunToolSet } from './tools';
+
+describe('agent tool history formatting', () => {
+  it('preserves handoff and destination-agent calls as structured pairs', () => {
+    const primary = {
+      edges: [{ from: 'primary', to: 'researcher', edgeType: 'handoff' as const }],
+      toolDefinitions: [{ name: 'primary_tool' }],
+    };
+    const researcher = {
+      toolDefinitions: [{ name: 'research_database' }],
+    };
+    const transferName = `${Constants.LC_TRANSFER_TO_}researcher`;
+    const payload: TPayload = [
+      { role: 'user', content: 'Research this topic' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.TEXT,
+            text: 'I delegated the research.',
+            tool_call_ids: ['transfer-1', 'research-1'],
+          },
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: 'transfer-1',
+              name: transferName,
+              args: '{}',
+              output: '',
+            },
+          },
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: 'research-1',
+              name: 'research_database',
+              args: '{}',
+              output: '{"result":"verified"}',
+            },
+          },
+        ],
+      },
+    ];
+
+    const toolSet = buildRunToolSet(primary, [researcher]);
+    const { messages } = formatAgentMessages(payload, undefined, toolSet);
+    const assistant = messages[1] as AIMessage;
+    const toolMessages = messages.filter(
+      (message) => message instanceof ToolMessage,
+    ) as ToolMessage[];
+
+    expect(assistant.tool_calls?.map(({ name }) => name)).toEqual([
+      transferName,
+      'research_database',
+    ]);
+    expect(JSON.stringify(assistant.content)).not.toContain('Tool:');
+    expect(toolMessages.map(({ name }) => name)).toEqual([transferName, 'research_database']);
+  });
+});

--- a/packages/api/src/agents/index.ts
+++ b/packages/api/src/agents/index.ts
@@ -25,6 +25,7 @@ export * from './backgroundCompletionWakeup';
 export * from './initialize';
 export * from './legacy';
 export * from './lazySubagents';
+export * from './lazyHistory';
 export * from './memory';
 export * from './mcpIdentity';
 export * from './orphans';

--- a/packages/api/src/agents/index.ts
+++ b/packages/api/src/agents/index.ts
@@ -26,6 +26,7 @@ export * from './initialize';
 export * from './legacy';
 export * from './lazySubagents';
 export * from './memory';
+export * from './mcpIdentity';
 export * from './orphans';
 export * from './migration';
 export * from './parameters';

--- a/packages/api/src/agents/lazyHistory.spec.ts
+++ b/packages/api/src/agents/lazyHistory.spec.ts
@@ -1,0 +1,70 @@
+import { Types } from 'mongoose';
+import { createLazyAgentHistoryResolver } from './lazyHistory';
+
+const userId = new Types.ObjectId().toString();
+
+function makeResolver(options: { skillId: Types.ObjectId; disabled?: boolean; active?: boolean }) {
+  const { skillId, disabled = false, active = true } = options;
+  return createLazyAgentHistoryResolver({
+    accessibleSkillIds: [skillId],
+    editableSkillIds: [],
+    skillsCapabilityEnabled: true,
+    ephemeralSkillsToggle: false,
+    userId,
+    skillStates: { [skillId.toString()]: active },
+    listSkillsByAccess: async () => ({
+      skills: [
+        {
+          _id: skillId,
+          name: 'analysis',
+          description: 'Analyze carefully.',
+          author: new Types.ObjectId(userId),
+          disableModelInvocation: disabled,
+        },
+      ],
+    }),
+    listAlwaysApplySkills: async () => ({ skills: [] }),
+    deferredToolsAvailable: false,
+    programmaticToolsAvailable: false,
+    backgroundToolsAvailable: false,
+  });
+}
+
+const agent = {
+  id: `agent_${new Types.ObjectId().toString()}`,
+  skills_enabled: true,
+  skills: [],
+  tools: [],
+};
+
+describe('createLazyAgentHistoryResolver', () => {
+  it('omits Skill tools when every scoped skill is inactive', async () => {
+    const metadata = await makeResolver({
+      skillId: new Types.ObjectId(),
+      active: false,
+    }).resolve({ agent, codeExecutionAvailable: false, memoryAvailable: false });
+
+    expect(metadata.historicalToolNames).not.toContain('skill');
+    expect(metadata.historicalToolNames).not.toContain('read_file');
+  });
+
+  it('keeps read_file but omits skill when only non-model-invocable skills are active', async () => {
+    const metadata = await makeResolver({
+      skillId: new Types.ObjectId(),
+      disabled: true,
+    }).resolve({ agent, codeExecutionAvailable: false, memoryAvailable: false });
+
+    expect(metadata.historicalToolNames).not.toContain('skill');
+    expect(metadata.historicalToolNames).toContain('read_file');
+  });
+
+  it('keeps skill and read_file when the active catalog is model-visible', async () => {
+    const metadata = await makeResolver({ skillId: new Types.ObjectId() }).resolve({
+      agent,
+      codeExecutionAvailable: false,
+      memoryAvailable: false,
+    });
+
+    expect(metadata.historicalToolNames).toEqual(expect.arrayContaining(['skill', 'read_file']));
+  });
+});

--- a/packages/api/src/agents/lazyHistory.ts
+++ b/packages/api/src/agents/lazyHistory.ts
@@ -1,0 +1,186 @@
+import { logger } from '@librechat/data-schemas';
+import { Constants, Tools } from 'librechat-data-provider';
+import type { Agent } from 'librechat-data-provider';
+import type { Types } from 'mongoose';
+import type {
+  ResolveAlwaysApplySkillsParams,
+  ResolvedAlwaysApplySkill,
+  ResolvedSkillCatalog,
+  TListSkillsByAccess,
+} from './skills';
+import {
+  resolveAgentScopedSkillIds,
+  resolveAlwaysApplySkills,
+  resolveSkillCatalog,
+} from './skills';
+import { buildHistoricalToolNames } from './tools';
+
+type LazyHistoryAgent = Pick<Agent, 'id' | 'skills' | 'skills_enabled' | 'tools' | 'tool_options'>;
+
+export interface LazyAgentHistoryCapabilities {
+  deferredToolsAvailable: boolean;
+  programmaticToolsAvailable: boolean;
+  backgroundToolsAvailable: boolean;
+}
+
+export interface CreateLazyAgentHistoryResolverParams extends LazyAgentHistoryCapabilities {
+  accessibleSkillIds: Types.ObjectId[];
+  editableSkillIds: Types.ObjectId[];
+  skillsCapabilityEnabled: boolean;
+  ephemeralSkillsToggle: boolean;
+  userId?: string;
+  userRole?: string;
+  skillStates?: Record<string, boolean>;
+  defaultActiveOnShare?: boolean;
+  maxCatalogSkills?: number;
+  listSkillsByAccess?: TListSkillsByAccess;
+  listAlwaysApplySkills?: ResolveAlwaysApplySkillsParams['listAlwaysApplySkills'];
+  getAccessibleMcpServerNames?: (userId?: string, role?: string) => Promise<string[]>;
+  configuredMcpServerNames?: readonly string[];
+  canAuthorSkillFiles?: (params: {
+    agent: LazyHistoryAgent;
+    scopedEditableSkillIds: Types.ObjectId[];
+  }) => boolean;
+}
+
+export interface LazyAgentHistoryMetadata {
+  alwaysApplySkillPrimes: ResolvedAlwaysApplySkill[];
+  historicalToolNames: string[];
+  historicalMcpServerNames: string[];
+}
+
+export interface LazyAgentHistoryResolver {
+  resolve(params: {
+    agent: LazyHistoryAgent;
+    codeExecutionAvailable: boolean;
+    memoryAvailable: boolean;
+  }): Promise<LazyAgentHistoryMetadata>;
+}
+
+function skillScopeKey(ids: readonly Types.ObjectId[]): string {
+  return ids
+    .map((skillId) => skillId.toString())
+    .sort()
+    .join(':');
+}
+
+/**
+ * Creates one request-scoped lazy-history policy resolver.
+ *
+ * The resolver owns Skill activation/catalog policy, per-scope query caching,
+ * MCP name auditing, and capability-to-tool expansion so the legacy host only
+ * wires request dependencies and consumes typed metadata.
+ */
+export function createLazyAgentHistoryResolver(
+  params: CreateLazyAgentHistoryResolverParams,
+): LazyAgentHistoryResolver {
+  const alwaysApplyByScope = new Map<string, Promise<ResolvedAlwaysApplySkill[]>>();
+  const catalogByScope = new Map<string, Promise<ResolvedSkillCatalog>>();
+  let mcpServerNames: Promise<string[]> | undefined;
+
+  const resolveAlwaysApply = (scopedSkillIds: Types.ObjectId[]) => {
+    if (scopedSkillIds.length === 0 || !params.listAlwaysApplySkills) {
+      return Promise.resolve([]);
+    }
+    const key = skillScopeKey(scopedSkillIds);
+    let resolution = alwaysApplyByScope.get(key);
+    if (!resolution) {
+      resolution = resolveAlwaysApplySkills({
+        listAlwaysApplySkills: params.listAlwaysApplySkills,
+        accessibleSkillIds: scopedSkillIds,
+        userId: params.userId,
+        skillStates: params.skillStates,
+        defaultActiveOnShare: params.defaultActiveOnShare,
+      });
+      alwaysApplyByScope.set(key, resolution);
+    }
+    return resolution;
+  };
+
+  const resolveCatalog = (scopedSkillIds: Types.ObjectId[]) => {
+    const key = skillScopeKey(scopedSkillIds);
+    let resolution = catalogByScope.get(key);
+    if (!resolution) {
+      resolution = resolveSkillCatalog({
+        accessibleSkillIds: scopedSkillIds,
+        listSkillsByAccess: params.listSkillsByAccess,
+        userId: params.userId,
+        skillStates: params.skillStates,
+        defaultActiveOnShare: params.defaultActiveOnShare,
+        maxCatalogSkills: params.maxCatalogSkills,
+      });
+      catalogByScope.set(key, resolution);
+    }
+    return resolution;
+  };
+
+  const resolveMcpServerNames = () => {
+    mcpServerNames ??= Promise.resolve(
+      params.getAccessibleMcpServerNames?.(params.userId, params.userRole) ?? [],
+    )
+      .then((names) => [...new Set([...(names ?? []), ...(params.configuredMcpServerNames ?? [])])])
+      .catch((error) => {
+        logger.warn(
+          '[createLazyAgentHistoryResolver] Failed to resolve MCP names for lazy history normalization:',
+          error,
+        );
+        return [...new Set(params.configuredMcpServerNames ?? [])];
+      });
+    return mcpServerNames;
+  };
+
+  return {
+    async resolve({ agent, codeExecutionAvailable, memoryAvailable }) {
+      const scopedSkillIds = resolveAgentScopedSkillIds({
+        agent,
+        accessibleSkillIds: params.accessibleSkillIds,
+        skillsCapabilityEnabled: params.skillsCapabilityEnabled,
+        ephemeralSkillsToggle: params.ephemeralSkillsToggle,
+      });
+      const scopedEditableSkillIds = resolveAgentScopedSkillIds({
+        agent,
+        accessibleSkillIds: params.editableSkillIds,
+        skillsCapabilityEnabled: params.skillsCapabilityEnabled,
+        ephemeralSkillsToggle: params.ephemeralSkillsToggle,
+      });
+      const [alwaysApplySkillPrimes, catalog] = await Promise.all([
+        resolveAlwaysApply(scopedSkillIds),
+        resolveCatalog(scopedSkillIds),
+      ]);
+      const configuredAndSkillToolNames = [
+        ...(agent.tools ?? []),
+        ...alwaysApplySkillPrimes.flatMap((prime) => prime.allowedTools ?? []),
+      ];
+      const historicalMcpServerNames = configuredAndSkillToolNames.some((name) =>
+        name.includes(Constants.mcp_delimiter),
+      )
+        ? await resolveMcpServerNames()
+        : [];
+      const skillAuthoringAvailable =
+        params.canAuthorSkillFiles?.({ agent, scopedEditableSkillIds }) === true;
+
+      return {
+        alwaysApplySkillPrimes,
+        historicalMcpServerNames,
+        historicalToolNames: Array.from(
+          buildHistoricalToolNames({
+            configuredToolNames: agent.tools,
+            alwaysApplyToolNames: alwaysApplySkillPrimes.flatMap(
+              (prime) => prime.allowedTools ?? [],
+            ),
+            toolOptions: agent.tool_options,
+            rawMcpServerNames: historicalMcpServerNames,
+            codeExecutionAvailable,
+            memoryAvailable: memoryAvailable && agent.tools?.includes(Tools.memory) === true,
+            skillsAvailable: catalog.visibleCount > 0,
+            skillFileAccessAvailable: catalog.activeSkills.length > 0,
+            skillAuthoringAvailable,
+            deferredToolsAvailable: params.deferredToolsAvailable,
+            programmaticToolsAvailable: params.programmaticToolsAvailable,
+            backgroundToolsAvailable: params.backgroundToolsAvailable,
+          }),
+        ),
+      };
+    },
+  };
+}

--- a/packages/api/src/agents/mcpIdentity.spec.ts
+++ b/packages/api/src/agents/mcpIdentity.spec.ts
@@ -1,0 +1,52 @@
+import type { PersistedMcpContentPart } from './mcpIdentity';
+import { stampMcpServerIdentities } from './mcpIdentity';
+
+describe('stampMcpServerIdentities', () => {
+  it('preserves exact nested execution identity over an ambiguous parsed boundary', () => {
+    const contentParts = [
+      {
+        tool_call: {
+          name: 'subagent',
+          subagent_content: [
+            {
+              tool_call: {
+                name: 'lookup_mcp_foo_mcp_bar',
+                mcpServerName: 'bar',
+              },
+            },
+          ],
+        },
+      },
+    ];
+
+    stampMcpServerIdentities({
+      contentParts,
+      roots: [{ accessibleMcpServerNames: ['bar', 'foo_mcp_bar'] }],
+    });
+
+    expect(contentParts[0].tool_call.subagent_content?.[0].tool_call.mcpServerName).toBe('bar');
+  });
+
+  it('uses resolved tool definitions before parsing a legacy tool key', () => {
+    const contentParts: PersistedMcpContentPart[] = [
+      { tool_call: { name: 'gitlab-get_mcp_server_version_mcp_bar' } },
+    ];
+
+    stampMcpServerIdentities({
+      contentParts,
+      roots: [
+        {
+          accessibleMcpServerNames: ['bar', 'version_mcp_bar'],
+          toolDefinitions: [
+            {
+              name: 'gitlab-get_mcp_server_version_mcp_bar',
+              serverName: 'bar',
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(contentParts[0]?.tool_call?.mcpServerName).toBe('bar');
+  });
+});

--- a/packages/api/src/agents/mcpIdentity.ts
+++ b/packages/api/src/agents/mcpIdentity.ts
@@ -1,0 +1,93 @@
+import { Constants, normalizeServerName, splitMCPToolKey } from 'librechat-data-provider';
+import type { ReachableAgent } from './traversal';
+import { collectReachableAgents } from './traversal';
+
+interface McpToolDefinitionLike {
+  name?: string;
+  serverName?: string;
+}
+
+interface McpRegisteredToolLike {
+  mcpRawServerName?: string;
+}
+
+export interface McpIdentityAgent extends ReachableAgent<McpIdentityAgent> {
+  accessibleMcpServerNames?: readonly string[];
+  historicalMcpServerNames?: readonly string[];
+  toolDefinitions?: readonly McpToolDefinitionLike[];
+  toolRegistry?: Iterable<readonly [string, McpRegisteredToolLike]>;
+}
+
+export interface PersistedMcpToolCall {
+  name?: string;
+  mcpServerName?: string;
+  subagent_content?: PersistedMcpContentPart[];
+}
+
+export interface PersistedMcpContentPart {
+  tool_call?: PersistedMcpToolCall;
+}
+
+export interface StampMcpServerIdentitiesParams {
+  contentParts?: PersistedMcpContentPart[];
+  roots: readonly (McpIdentityAgent | null | undefined)[];
+}
+
+/**
+ * Stamps durable MCP server identities onto persisted native tool calls.
+ *
+ * Exact execution metadata wins. Tool registries and definitions provide a
+ * server-owned fallback, followed by boundary-aware parsing for legacy calls.
+ */
+export function stampMcpServerIdentities({
+  contentParts,
+  roots,
+}: StampMcpServerIdentitiesParams): void {
+  if (!Array.isArray(contentParts)) {
+    return;
+  }
+
+  const serverByToolName = new Map<string, string>();
+  const boundaryNames = new Set<string>();
+  for (const agent of collectReachableAgents(roots)) {
+    for (const rawName of [
+      ...(agent.accessibleMcpServerNames ?? []),
+      ...(agent.historicalMcpServerNames ?? []),
+    ]) {
+      boundaryNames.add(rawName);
+      boundaryNames.add(normalizeServerName(rawName));
+    }
+    for (const definition of agent.toolDefinitions ?? []) {
+      if (typeof definition.name === 'string' && typeof definition.serverName === 'string') {
+        serverByToolName.set(definition.name, definition.serverName);
+      }
+    }
+    for (const [name, tool] of agent.toolRegistry ?? []) {
+      if (typeof tool?.mcpRawServerName === 'string') {
+        serverByToolName.set(name, tool.mcpRawServerName);
+      }
+    }
+  }
+
+  const knownNames = [...boundaryNames];
+  const stampPart = (part: PersistedMcpContentPart): void => {
+    const toolCall = part?.tool_call;
+    if (!toolCall || typeof toolCall.name !== 'string') {
+      return;
+    }
+
+    let serverName = toolCall.mcpServerName ?? serverByToolName.get(toolCall.name);
+    if (serverName == null && toolCall.name.includes(Constants.mcp_delimiter)) {
+      const [toolName, parsedServerName] = splitMCPToolKey(toolCall.name, knownNames);
+      if (toolName && parsedServerName) {
+        serverName = parsedServerName;
+      }
+    }
+    if (typeof serverName === 'string') {
+      toolCall.mcpServerName = normalizeServerName(serverName);
+    }
+    toolCall.subagent_content?.forEach(stampPart);
+  };
+
+  contentParts.forEach(stampPart);
+}

--- a/packages/api/src/agents/tools.spec.ts
+++ b/packages/api/src/agents/tools.spec.ts
@@ -320,6 +320,26 @@ describe('buildHistoricalToolNames', () => {
       ]),
     );
   });
+
+  it('includes cached MCP wildcard children and normalizes Action names and options', () => {
+    expect(
+      buildHistoricalToolNames({
+        configuredToolNames: ['mcp_all_mcp_warehouse', 'lookup_action_api---example---com'],
+        mcpWildcardToolNames: ['run_query_mcp_warehouse'],
+        toolOptions: {
+          'lookup_action_api---example---com': { defer_loading: true },
+        },
+        deferredToolsAvailable: true,
+      }),
+    ).toEqual(
+      new Set([
+        'mcp_all_mcp_warehouse',
+        'run_query_mcp_warehouse',
+        'lookup_action_api_example_com',
+        'tool_search',
+      ]),
+    );
+  });
 });
 
 describe('registerCodeExecutionTools', () => {

--- a/packages/api/src/agents/tools.spec.ts
+++ b/packages/api/src/agents/tools.spec.ts
@@ -146,6 +146,14 @@ describe('buildToolSet', () => {
   });
 
   describe('edge cases', () => {
+    it('includes names retained on unresolved lazy agent descriptors', () => {
+      const toolSet = buildToolSet({
+        historicalToolNames: ['lazy_search', 'lazy_calculator'],
+      });
+
+      expect(toolSet).toEqual(new Set(['lazy_search', 'lazy_calculator']));
+    });
+
     it('returns empty set when agentConfig is null', () => {
       const toolSet = buildToolSet(null);
       expect(toolSet.size).toBe(0);
@@ -205,7 +213,10 @@ describe('buildRunToolSet', () => {
 
   it('collects tools recursively across every reachable agent shape', () => {
     const eager = agent('eager', 'eager_tool');
-    const lazy = agent('lazy', 'lazy_tool');
+    const lazy = {
+      id: 'lazy',
+      historicalToolNames: ['lazy_tool'],
+    };
     const metadata = agent('metadata', 'metadata_tool');
     const graphMember = agent('graph-member', 'graph_tool');
     const primary = {

--- a/packages/api/src/agents/tools.spec.ts
+++ b/packages/api/src/agents/tools.spec.ts
@@ -43,6 +43,7 @@ import type { LCTool, LCToolRegistry } from '@librechat/agents';
 import {
   buildToolSet,
   buildRunToolSet,
+  buildHistoricalToolNames,
   BuildToolSetConfig,
   registerCodeExecutionTools,
   registerFileAuthoringTools,
@@ -230,6 +231,7 @@ describe('buildRunToolSet', () => {
     expect(buildRunToolSet(primary)).toEqual(
       new Set([
         'subagent',
+        'conditional_transfer',
         'primary_tool',
         'eager_tool',
         'lazy_tool',
@@ -254,11 +256,67 @@ describe('buildRunToolSet', () => {
     expect(toolSet).toEqual(
       new Set([
         'subagent',
+        'conditional_transfer',
         'primary_tool',
         'disconnected_tool',
         'lc_transfer_to_writer',
         'lc_transfer_to_reviewer',
         'lc_transfer_to_publisher',
+      ]),
+    );
+  });
+
+  it('includes host-generated controls supplied by the run', () => {
+    expect(buildRunToolSet(agent('primary'), null, ['check_background_task'])).toEqual(
+      new Set(['subagent', 'conditional_transfer', 'check_background_task']),
+    );
+  });
+});
+
+describe('buildHistoricalToolNames', () => {
+  it('normalizes MCP names and expands toolkits and deferred search', () => {
+    expect(
+      buildHistoricalToolNames({
+        configuredToolNames: ['search_mcp_Connector: Company', 'image_gen_oai'],
+        toolOptions: {
+          'search_mcp_Connector: Company': { defer_loading: true },
+        },
+        rawMcpServerNames: ['Connector: Company'],
+        deferredToolsAvailable: true,
+      }),
+    ).toEqual(
+      new Set(['search_mcp_Connector__Company', 'image_gen_oai', 'image_edit_oai', 'tool_search']),
+    );
+  });
+
+  it('expands code, memory, skill, programmatic, and background controls', () => {
+    expect(
+      buildHistoricalToolNames({
+        configuredToolNames: ['execute_code', 'memory', 'lookup'],
+        alwaysApplyToolNames: ['skill_allowed_tool'],
+        toolOptions: { lookup: { allowed_callers: ['code_execution'], run_in_background: true } },
+        codeExecutionAvailable: true,
+        memoryAvailable: true,
+        skillsAvailable: true,
+        skillAuthoringAvailable: true,
+        programmaticToolsAvailable: true,
+        backgroundToolsAvailable: true,
+      }),
+    ).toEqual(
+      new Set([
+        'execute_code',
+        'memory',
+        'lookup',
+        'skill_allowed_tool',
+        'bash_tool',
+        'read_file',
+        'create_file',
+        'edit_file',
+        'set_memory',
+        'delete_memory',
+        'skill',
+        'run_tools_with_bash',
+        'check_background_task',
       ]),
     );
   });

--- a/packages/api/src/agents/tools.spec.ts
+++ b/packages/api/src/agents/tools.spec.ts
@@ -346,7 +346,9 @@ describe('buildHistoricalToolNames', () => {
   it('accepts only historical calls covered by an MCP wildcard server suffix', () => {
     const primary = {
       id: 'primary',
+      accessibleMcpServerNames: ['bar', 'foo_mcp_bar', 'Connector: Company'],
       toolDefinitions: [
+        { name: `${Constants.mcp_all}${Constants.mcp_delimiter}bar` },
         { name: `${Constants.mcp_all}${Constants.mcp_delimiter}Connector: Company` },
       ],
     };
@@ -355,6 +357,12 @@ describe('buildHistoricalToolNames', () => {
         content: [
           { tool_call: { name: 'search_mcp_Connector__Company' } },
           { tool_call: { name: 'search_mcp_attacker' } },
+          {
+            tool_call: {
+              name: 'subagent',
+              subagent_content: [{ tool_call: { name: 'run_query_mcp_bar' } }],
+            },
+          },
         ],
       },
       {
@@ -363,18 +371,34 @@ describe('buildHistoricalToolNames', () => {
           tool_calls: [{ function: { name: 'legacy_mcp_Connector__Company' } }],
         },
       },
+      { tool_calls: [{ name: 'lookup_mcp_foo_mcp_bar' }] },
     ];
 
     expect(buildRunToolSet(primary, null, null, messages)).toEqual(
       new Set([
         'subagent',
         'conditional_transfer',
+        `${Constants.mcp_all}${Constants.mcp_delimiter}bar`,
         `${Constants.mcp_all}${Constants.mcp_delimiter}Connector: Company`,
         'search_mcp_Connector__Company',
+        'run_query_mcp_bar',
         'lookup_mcp_Connector__Company',
         'legacy_mcp_Connector__Company',
       ]),
     );
+  });
+
+  it('does not inspect history when the run has no MCP wildcard', () => {
+    const message = {};
+    Object.defineProperty(message, 'content', {
+      get: () => {
+        throw new Error('history should not be inspected');
+      },
+    });
+
+    expect(() =>
+      buildRunToolSet({ toolDefinitions: [{ name: 'web' }] }, null, null, [message]),
+    ).not.toThrow();
   });
 });
 

--- a/packages/api/src/agents/tools.spec.ts
+++ b/packages/api/src/agents/tools.spec.ts
@@ -372,7 +372,9 @@ describe('buildHistoricalToolNames', () => {
         },
       },
       { tool_calls: [{ name: 'lookup_mcp_foo_mcp_bar' }] },
-      { tool_calls: [{ name: 'gitlab-get_mcp_server_version_mcp_bar' }] },
+      {
+        tool_calls: [{ name: 'gitlab-get_mcp_server_version_mcp_bar', mcpServerName: 'bar' }],
+      },
     ];
 
     expect(buildRunToolSet(primary, null, null, messages)).toEqual(

--- a/packages/api/src/agents/tools.spec.ts
+++ b/packages/api/src/agents/tools.spec.ts
@@ -375,6 +375,7 @@ describe('buildHistoricalToolNames', () => {
       {
         tool_calls: [{ name: 'gitlab-get_mcp_server_version_mcp_bar', mcpServerName: 'bar' }],
       },
+      { tool_calls: [{ name: 'legacy_mcp_tool_mcp_bar' }] },
     ];
 
     expect(buildRunToolSet(primary, null, null, messages)).toEqual(
@@ -389,6 +390,9 @@ describe('buildHistoricalToolNames', () => {
         'legacy_mcp_Connector__Company',
         'gitlab-get_mcp_server_version_mcp_bar',
       ]),
+    );
+    expect(buildRunToolSet(primary, null, null, messages, true)).toContain(
+      'legacy_mcp_tool_mcp_bar',
     );
   });
 

--- a/packages/api/src/agents/tools.spec.ts
+++ b/packages/api/src/agents/tools.spec.ts
@@ -40,6 +40,7 @@ jest.mock('@librechat/agents', () => ({
 
 import { CODE_EXECUTION_TOOLS } from '@librechat/agents';
 import type { LCTool, LCToolRegistry } from '@librechat/agents';
+import { Constants } from 'librechat-data-provider';
 import {
   buildToolSet,
   buildRunToolSet,
@@ -321,11 +322,13 @@ describe('buildHistoricalToolNames', () => {
     );
   });
 
-  it('includes cached MCP wildcard children and normalizes Action names and options', () => {
+  it('normalizes Action names and their options', () => {
     expect(
       buildHistoricalToolNames({
-        configuredToolNames: ['mcp_all_mcp_warehouse', 'lookup_action_api---example---com'],
-        mcpWildcardToolNames: ['run_query_mcp_warehouse'],
+        configuredToolNames: [
+          `${Constants.mcp_all}${Constants.mcp_delimiter}warehouse`,
+          'lookup_action_api---example---com',
+        ],
         toolOptions: {
           'lookup_action_api---example---com': { defer_loading: true },
         },
@@ -333,10 +336,43 @@ describe('buildHistoricalToolNames', () => {
       }),
     ).toEqual(
       new Set([
-        'mcp_all_mcp_warehouse',
-        'run_query_mcp_warehouse',
+        `${Constants.mcp_all}${Constants.mcp_delimiter}warehouse`,
         'lookup_action_api_example_com',
         'tool_search',
+      ]),
+    );
+  });
+
+  it('accepts only historical calls covered by an MCP wildcard server suffix', () => {
+    const primary = {
+      id: 'primary',
+      toolDefinitions: [
+        { name: `${Constants.mcp_all}${Constants.mcp_delimiter}Connector: Company` },
+      ],
+    };
+    const messages = [
+      {
+        content: [
+          { tool_call: { name: 'search_mcp_Connector__Company' } },
+          { tool_call: { name: 'search_mcp_attacker' } },
+        ],
+      },
+      {
+        tool_calls: [{ name: 'lookup_mcp_Connector__Company' }],
+        additional_kwargs: {
+          tool_calls: [{ function: { name: 'legacy_mcp_Connector__Company' } }],
+        },
+      },
+    ];
+
+    expect(buildRunToolSet(primary, null, null, messages)).toEqual(
+      new Set([
+        'subagent',
+        'conditional_transfer',
+        `${Constants.mcp_all}${Constants.mcp_delimiter}Connector: Company`,
+        'search_mcp_Connector__Company',
+        'lookup_mcp_Connector__Company',
+        'legacy_mcp_Connector__Company',
       ]),
     );
   });

--- a/packages/api/src/agents/tools.spec.ts
+++ b/packages/api/src/agents/tools.spec.ts
@@ -372,6 +372,7 @@ describe('buildHistoricalToolNames', () => {
         },
       },
       { tool_calls: [{ name: 'lookup_mcp_foo_mcp_bar' }] },
+      { tool_calls: [{ name: 'gitlab-get_mcp_server_version_mcp_bar' }] },
     ];
 
     expect(buildRunToolSet(primary, null, null, messages)).toEqual(
@@ -384,6 +385,7 @@ describe('buildHistoricalToolNames', () => {
         'run_query_mcp_bar',
         'lookup_mcp_Connector__Company',
         'legacy_mcp_Connector__Company',
+        'gitlab-get_mcp_server_version_mcp_bar',
       ]),
     );
   });

--- a/packages/api/src/agents/tools.spec.ts
+++ b/packages/api/src/agents/tools.spec.ts
@@ -322,6 +322,15 @@ describe('buildHistoricalToolNames', () => {
     );
   });
 
+  it('keeps skill file access without exposing the skill invocation tool', () => {
+    expect(
+      buildHistoricalToolNames({
+        skillsAvailable: false,
+        skillFileAccessAvailable: true,
+      }),
+    ).toEqual(new Set(['read_file']));
+  });
+
   it('normalizes Action names and their options', () => {
     expect(
       buildHistoricalToolNames({

--- a/packages/api/src/agents/tools.spec.ts
+++ b/packages/api/src/agents/tools.spec.ts
@@ -42,6 +42,7 @@ import { CODE_EXECUTION_TOOLS } from '@librechat/agents';
 import type { LCTool, LCToolRegistry } from '@librechat/agents';
 import {
   buildToolSet,
+  buildRunToolSet,
   BuildToolSetConfig,
   registerCodeExecutionTools,
   registerFileAuthoringTools,
@@ -189,6 +190,66 @@ describe('buildToolSet', () => {
       expect(toolSet.has('also_valid')).toBe(true);
       expect(toolSet.has('')).toBe(false);
     });
+  });
+});
+
+describe('buildRunToolSet', () => {
+  const agent = (id: string, ...toolNames: string[]) => ({
+    id,
+    toolDefinitions: toolNames.map((name) => ({ name })),
+  });
+
+  it('returns an empty set without a primary or additional agent', () => {
+    expect(buildRunToolSet(null)).toEqual(new Set());
+  });
+
+  it('collects tools recursively across every reachable agent shape', () => {
+    const eager = agent('eager', 'eager_tool');
+    const lazy = agent('lazy', 'lazy_tool');
+    const metadata = agent('metadata', 'metadata_tool');
+    const graphMember = agent('graph-member', 'graph_tool');
+    const primary = {
+      ...agent('primary', 'primary_tool'),
+      subagentAgentConfigs: [eager],
+      lazySubagentConfigs: [lazy],
+      subagentGraphMemberMetadata: [metadata],
+      subagentGraphConfigs: [{ memberConfigs: [graphMember] }],
+    };
+
+    expect(buildRunToolSet(primary)).toEqual(
+      new Set([
+        'subagent',
+        'primary_tool',
+        'eager_tool',
+        'lazy_tool',
+        'metadata_tool',
+        'graph_tool',
+      ]),
+    );
+  });
+
+  it('adds only effective handoff destinations as transfer tools', () => {
+    const primary = {
+      ...agent('primary', 'primary_tool'),
+      edges: [
+        { from: 'primary', to: 'writer', edgeType: 'handoff' as const },
+        { from: 'writer', to: ['reviewer', 'publisher'] },
+        { from: 'publisher', to: 'archive', edgeType: 'direct' as const },
+      ],
+    };
+
+    const toolSet = buildRunToolSet(primary, [agent('disconnected', 'disconnected_tool')]);
+
+    expect(toolSet).toEqual(
+      new Set([
+        'subagent',
+        'primary_tool',
+        'disconnected_tool',
+        'lc_transfer_to_writer',
+        'lc_transfer_to_reviewer',
+        'lc_transfer_to_publisher',
+      ]),
+    );
   });
 });
 

--- a/packages/api/src/agents/tools.ts
+++ b/packages/api/src/agents/tools.ts
@@ -169,21 +169,33 @@ export interface RunToolSetConfig extends BuildToolSetConfig, ReachableAgent<Run
   readonly historicalMcpServerNames?: readonly string[];
 }
 
-function collectHistoricalToolCallNames(messages?: Iterable<unknown> | null): Set<string> {
-  const names = new Set<string>();
+interface HistoricalToolCallIdentity {
+  name: string;
+  mcpServerName?: string;
+}
+
+function collectHistoricalToolCalls(
+  messages?: Iterable<unknown> | null,
+): HistoricalToolCallIdentity[] {
+  const calls: HistoricalToolCallIdentity[] = [];
   const addCall = (value: unknown) => {
     if (value == null || typeof value !== 'object') {
       return;
     }
     const call = value as {
       name?: unknown;
+      mcpServerName?: unknown;
       function?: { name?: unknown };
-      tool_call?: { name?: unknown; subagent_content?: unknown };
+      tool_call?: { name?: unknown; mcpServerName?: unknown; subagent_content?: unknown };
       subagent_content?: unknown;
     };
     const name = call.name ?? call.function?.name ?? call.tool_call?.name;
     if (typeof name === 'string') {
-      names.add(name);
+      const mcpServerName = call.mcpServerName ?? call.tool_call?.mcpServerName;
+      calls.push({
+        name,
+        ...(typeof mcpServerName === 'string' ? { mcpServerName } : {}),
+      });
     }
     const nested = call.tool_call?.subagent_content ?? call.subagent_content;
     if (Array.isArray(nested)) {
@@ -210,7 +222,7 @@ function collectHistoricalToolCallNames(messages?: Iterable<unknown> | null): Se
       message.content.forEach(addCall);
     }
   }
-  return names;
+  return calls;
 }
 
 /** Builds the historical tool allowlist for the complete effective run topology. */
@@ -263,11 +275,19 @@ export function buildRunToolSet(
      * Resolve the longest known boundary so delimiter-bearing tool names remain valid
      * while a distinct longer server identity cannot masquerade as a selected suffix. */
     const boundaryNames = [...knownServerNames];
-    for (const name of collectHistoricalToolCallNames(historicalMessages)) {
+    for (const call of collectHistoricalToolCalls(historicalMessages)) {
+      const { name, mcpServerName } = call;
+      if (mcpServerName != null) {
+        if (wildcardServerNames.has(normalizeServerName(mcpServerName))) {
+          toolSet.add(name);
+        }
+        continue;
+      }
       const [toolName, serverName] = splitMCPToolKey(name, boundaryNames);
       if (
         serverName != null &&
         toolName.length > 0 &&
+        !toolName.includes(Constants.mcp_delimiter) &&
         wildcardServerNames.has(normalizeServerName(serverName))
       ) {
         toolSet.add(name);

--- a/packages/api/src/agents/tools.ts
+++ b/packages/api/src/agents/tools.ts
@@ -57,6 +57,7 @@ export interface BuildHistoricalToolNamesConfig {
   codeExecutionAvailable?: boolean;
   memoryAvailable?: boolean;
   skillsAvailable?: boolean;
+  skillFileAccessAvailable?: boolean;
   skillAuthoringAvailable?: boolean;
   deferredToolsAvailable?: boolean;
   programmaticToolsAvailable?: boolean;
@@ -103,6 +104,8 @@ export function buildHistoricalToolNames(config: BuildHistoricalToolNamesConfig)
   }
   if (config.skillsAvailable === true) {
     toolNames.add('skill');
+  }
+  if ((config.skillFileAccessAvailable ?? config.skillsAvailable) === true) {
     toolNames.add('read_file');
   }
   if (config.skillAuthoringAvailable === true) {

--- a/packages/api/src/agents/tools.ts
+++ b/packages/api/src/agents/tools.ts
@@ -5,9 +5,11 @@ import {
   ReadFileToolDefinition,
   buildBashExecutionToolDescription,
 } from '@librechat/agents';
+import type { AgentToolOptions, GraphEdge } from 'librechat-data-provider';
 import type { LCTool, LCToolRegistry } from '@librechat/agents';
-import type { GraphEdge } from 'librechat-data-provider';
 import type { ReachableAgent } from './traversal';
+import { toolkitExpansion } from '~/tools/toolkits/mapping';
+import { normalizeAgentToolKeys } from '~/mcp/utils';
 import { collectReachableAgents } from './traversal';
 
 export const CREATE_FILE_TOOL_NAME = 'create_file';
@@ -40,6 +42,84 @@ export interface BuildToolSetConfig {
   tools?: (ToolInstanceLike | null | undefined)[];
   /** Tool names retained on unresolved agent descriptors for history replay. */
   historicalToolNames?: readonly string[];
+}
+
+export interface BuildHistoricalToolNamesConfig {
+  configuredToolNames?: readonly string[];
+  alwaysApplyToolNames?: readonly string[];
+  toolOptions?: AgentToolOptions;
+  rawMcpServerNames?: readonly string[];
+  codeExecutionAvailable?: boolean;
+  memoryAvailable?: boolean;
+  skillsAvailable?: boolean;
+  skillAuthoringAvailable?: boolean;
+  deferredToolsAvailable?: boolean;
+  programmaticToolsAvailable?: boolean;
+  backgroundToolsAvailable?: boolean;
+}
+
+/** Derives the model-facing names an unresolved lazy agent can expose without loading it. */
+export function buildHistoricalToolNames(config: BuildHistoricalToolNamesConfig): Set<string> {
+  const configuredToolNames = [
+    ...(config.configuredToolNames ?? []),
+    ...(config.alwaysApplyToolNames ?? []),
+  ];
+  const normalized = normalizeAgentToolKeys({
+    tools: configuredToolNames,
+    toolOptions: config.toolOptions,
+    rawServerNames: config.rawMcpServerNames ?? [],
+  });
+  const toolNames = new Set(normalized.tools ?? []);
+
+  for (const name of [...toolNames]) {
+    for (const child of toolkitExpansion[name as keyof typeof toolkitExpansion] ?? []) {
+      toolNames.add(child);
+    }
+  }
+
+  if (config.codeExecutionAvailable === true) {
+    toolNames.add('bash_tool');
+    toolNames.add('read_file');
+    toolNames.add(CREATE_FILE_TOOL_NAME);
+    toolNames.add(EDIT_FILE_TOOL_NAME);
+  }
+  if (config.memoryAvailable === true) {
+    toolNames.add('set_memory');
+    toolNames.add('delete_memory');
+  }
+  if (config.skillsAvailable === true) {
+    toolNames.add('skill');
+    toolNames.add('read_file');
+  }
+  if (config.skillAuthoringAvailable === true) {
+    toolNames.add('read_file');
+    toolNames.add(CREATE_FILE_TOOL_NAME);
+    toolNames.add(EDIT_FILE_TOOL_NAME);
+  }
+
+  const options = normalized.toolOptions ?? {};
+  const hasDeferredTool = [...toolNames].some((name) => options[name]?.defer_loading === true);
+  if (config.deferredToolsAvailable === true && hasDeferredTool) {
+    toolNames.add('tool_search');
+  }
+  const hasProgrammaticTool = [...toolNames].some((name) =>
+    options[name]?.allowed_callers?.includes('code_execution'),
+  );
+  if (
+    config.programmaticToolsAvailable === true &&
+    config.codeExecutionAvailable === true &&
+    hasProgrammaticTool
+  ) {
+    toolNames.add('run_tools_with_bash');
+  }
+  const hasBackgroundTool =
+    config.codeExecutionAvailable === true ||
+    [...toolNames].some((name) => options[name]?.run_in_background === true);
+  if (config.backgroundToolsAvailable === true && hasBackgroundTool) {
+    toolNames.add(`${Constants.CHECK_BACKGROUND_TASK}`);
+  }
+
+  return toolNames;
 }
 
 /**
@@ -77,6 +157,7 @@ export interface RunToolSetConfig extends BuildToolSetConfig, ReachableAgent<Run
 export function buildRunToolSet(
   primaryConfig: RunToolSetConfig | null | undefined,
   additionalConfigs?: Iterable<RunToolSetConfig | null | undefined> | null,
+  hostGeneratedToolNames?: Iterable<string> | null,
 ): Set<string> {
   const roots = [primaryConfig];
   if (additionalConfigs) {
@@ -88,7 +169,10 @@ export function buildRunToolSet(
     return new Set();
   }
 
-  const toolSet = new Set<string>([`${Constants.SUBAGENT}`]);
+  const toolSet = new Set<string>([`${Constants.SUBAGENT}`, 'conditional_transfer']);
+  for (const name of hostGeneratedToolNames ?? []) {
+    toolSet.add(name);
+  }
   for (const agent of agents) {
     for (const name of buildToolSet(agent)) {
       toolSet.add(name);

--- a/packages/api/src/agents/tools.ts
+++ b/packages/api/src/agents/tools.ts
@@ -1,4 +1,9 @@
-import { Constants, normalizeActionToolName, normalizeServerName } from 'librechat-data-provider';
+import {
+  Constants,
+  normalizeActionToolName,
+  normalizeServerName,
+  splitMCPToolKey,
+} from 'librechat-data-provider';
 import {
   CODE_EXECUTION_TOOLS,
   BashExecutionToolDefinition,
@@ -160,6 +165,8 @@ export function buildToolSet(agentConfig: BuildToolSetConfig | null | undefined)
 
 export interface RunToolSetConfig extends BuildToolSetConfig, ReachableAgent<RunToolSetConfig> {
   readonly edges?: readonly GraphEdge[];
+  readonly accessibleMcpServerNames?: readonly string[];
+  readonly historicalMcpServerNames?: readonly string[];
 }
 
 function collectHistoricalToolCallNames(messages?: Iterable<unknown> | null): Set<string> {
@@ -171,11 +178,16 @@ function collectHistoricalToolCallNames(messages?: Iterable<unknown> | null): Se
     const call = value as {
       name?: unknown;
       function?: { name?: unknown };
-      tool_call?: { name?: unknown };
+      tool_call?: { name?: unknown; subagent_content?: unknown };
+      subagent_content?: unknown;
     };
     const name = call.name ?? call.function?.name ?? call.tool_call?.name;
     if (typeof name === 'string') {
       names.add(name);
+    }
+    const nested = call.tool_call?.subagent_content ?? call.subagent_content;
+    if (Array.isArray(nested)) {
+      nested.forEach(addCall);
     }
   };
 
@@ -219,31 +231,47 @@ export function buildRunToolSet(
   }
 
   const toolSet = new Set<string>([`${Constants.SUBAGENT}`, 'conditional_transfer']);
-  const wildcardSuffixes = new Set<string>();
+  const wildcardServerNames = new Set<string>();
+  const knownServerNames = new Set<string>();
   for (const name of hostGeneratedToolNames ?? []) {
     toolSet.add(name);
   }
   for (const agent of agents) {
+    for (const rawName of [
+      ...(agent.accessibleMcpServerNames ?? []),
+      ...(agent.historicalMcpServerNames ?? []),
+    ]) {
+      knownServerNames.add(rawName);
+      knownServerNames.add(normalizeServerName(rawName));
+    }
     for (const name of buildToolSet(agent)) {
       toolSet.add(name);
       const wildcardPrefix = `${Constants.mcp_all}${Constants.mcp_delimiter}`;
       if (name.startsWith(wildcardPrefix)) {
         const rawServerName = name.slice(wildcardPrefix.length);
         if (rawServerName) {
-          wildcardSuffixes.add(`${Constants.mcp_delimiter}${normalizeServerName(rawServerName)}`);
+          wildcardServerNames.add(normalizeServerName(rawServerName));
+          knownServerNames.add(rawServerName);
+          knownServerNames.add(normalizeServerName(rawServerName));
         }
       }
     }
   }
 
-  /** A wildcard authorizes every callable under one exact normalized server suffix.
-   * Re-derive only matching names from persisted structured calls so replay remains
-   * durable after the MCP catalog expires without trusting arbitrary history names. */
-  for (const name of collectHistoricalToolCallNames(historicalMessages)) {
-    if (
-      [...wildcardSuffixes].some((suffix) => name.length > suffix.length && name.endsWith(suffix))
-    ) {
-      toolSet.add(name);
+  if (wildcardServerNames.size > 0) {
+    /** A wildcard authorizes every callable under one exact normalized server identity.
+     * Resolve the longest known boundary and fail closed when the remaining tool half
+     * still contains a delimiter, which could hide a removed longer server name. */
+    const boundaryNames = [...knownServerNames];
+    for (const name of collectHistoricalToolCallNames(historicalMessages)) {
+      const [toolName, serverName] = splitMCPToolKey(name, boundaryNames);
+      if (
+        serverName != null &&
+        !toolName.includes(Constants.mcp_delimiter) &&
+        wildcardServerNames.has(normalizeServerName(serverName))
+      ) {
+        toolSet.add(name);
+      }
     }
   }
 

--- a/packages/api/src/agents/tools.ts
+++ b/packages/api/src/agents/tools.ts
@@ -1,4 +1,4 @@
-import { Constants, normalizeActionToolName } from 'librechat-data-provider';
+import { Constants, normalizeActionToolName, normalizeServerName } from 'librechat-data-provider';
 import {
   CODE_EXECUTION_TOOLS,
   BashExecutionToolDefinition,
@@ -49,7 +49,6 @@ export interface BuildHistoricalToolNamesConfig {
   alwaysApplyToolNames?: readonly string[];
   toolOptions?: AgentToolOptions;
   rawMcpServerNames?: readonly string[];
-  mcpWildcardToolNames?: readonly string[];
   codeExecutionAvailable?: boolean;
   memoryAvailable?: boolean;
   skillsAvailable?: boolean;
@@ -70,10 +69,7 @@ export function buildHistoricalToolNames(config: BuildHistoricalToolNamesConfig)
     toolOptions: config.toolOptions,
     rawServerNames: config.rawMcpServerNames ?? [],
   });
-  const toolNames = new Set([
-    ...(normalized.tools ?? []).map(normalizeActionToolName),
-    ...(config.mcpWildcardToolNames ?? []),
-  ]);
+  const toolNames = new Set((normalized.tools ?? []).map(normalizeActionToolName));
 
   const normalizedOptions: AgentToolOptions = {};
   for (const [name, options] of Object.entries(normalized.toolOptions ?? {})) {
@@ -166,11 +162,51 @@ export interface RunToolSetConfig extends BuildToolSetConfig, ReachableAgent<Run
   readonly edges?: readonly GraphEdge[];
 }
 
+function collectHistoricalToolCallNames(messages?: Iterable<unknown> | null): Set<string> {
+  const names = new Set<string>();
+  const addCall = (value: unknown) => {
+    if (value == null || typeof value !== 'object') {
+      return;
+    }
+    const call = value as {
+      name?: unknown;
+      function?: { name?: unknown };
+      tool_call?: { name?: unknown };
+    };
+    const name = call.name ?? call.function?.name ?? call.tool_call?.name;
+    if (typeof name === 'string') {
+      names.add(name);
+    }
+  };
+
+  for (const value of messages ?? []) {
+    if (value == null || typeof value !== 'object') {
+      continue;
+    }
+    const message = value as {
+      content?: unknown;
+      tool_calls?: unknown;
+      additional_kwargs?: { tool_calls?: unknown };
+    };
+    if (Array.isArray(message.tool_calls)) {
+      message.tool_calls.forEach(addCall);
+    }
+    if (Array.isArray(message.additional_kwargs?.tool_calls)) {
+      message.additional_kwargs.tool_calls.forEach(addCall);
+    }
+    if (Array.isArray(message.content)) {
+      message.content.forEach(addCall);
+    }
+  }
+  return names;
+}
+
 /** Builds the historical tool allowlist for the complete effective run topology. */
 export function buildRunToolSet(
   primaryConfig: RunToolSetConfig | null | undefined,
   additionalConfigs?: Iterable<RunToolSetConfig | null | undefined> | null,
   hostGeneratedToolNames?: Iterable<string> | null,
+  historicalMessages?: Iterable<unknown> | null,
 ): Set<string> {
   const roots = [primaryConfig];
   if (additionalConfigs) {
@@ -183,11 +219,30 @@ export function buildRunToolSet(
   }
 
   const toolSet = new Set<string>([`${Constants.SUBAGENT}`, 'conditional_transfer']);
+  const wildcardSuffixes = new Set<string>();
   for (const name of hostGeneratedToolNames ?? []) {
     toolSet.add(name);
   }
   for (const agent of agents) {
     for (const name of buildToolSet(agent)) {
+      toolSet.add(name);
+      const wildcardPrefix = `${Constants.mcp_all}${Constants.mcp_delimiter}`;
+      if (name.startsWith(wildcardPrefix)) {
+        const rawServerName = name.slice(wildcardPrefix.length);
+        if (rawServerName) {
+          wildcardSuffixes.add(`${Constants.mcp_delimiter}${normalizeServerName(rawServerName)}`);
+        }
+      }
+    }
+  }
+
+  /** A wildcard authorizes every callable under one exact normalized server suffix.
+   * Re-derive only matching names from persisted structured calls so replay remains
+   * durable after the MCP catalog expires without trusting arbitrary history names. */
+  for (const name of collectHistoricalToolCallNames(historicalMessages)) {
+    if (
+      [...wildcardSuffixes].some((suffix) => name.length > suffix.length && name.endsWith(suffix))
+    ) {
       toolSet.add(name);
     }
   }

--- a/packages/api/src/agents/tools.ts
+++ b/packages/api/src/agents/tools.ts
@@ -38,6 +38,8 @@ interface ToolInstanceLike {
 export interface BuildToolSetConfig {
   toolDefinitions?: ToolDefLike[];
   tools?: (ToolInstanceLike | null | undefined)[];
+  /** Tool names retained on unresolved agent descriptors for history replay. */
+  historicalToolNames?: readonly string[];
 }
 
 /**
@@ -55,14 +57,16 @@ export function buildToolSet(agentConfig: BuildToolSetConfig | null | undefined)
     return new Set();
   }
 
-  const { toolDefinitions, tools } = agentConfig;
+  const { toolDefinitions, tools, historicalToolNames } = agentConfig;
 
   const toolNames =
     toolDefinitions && toolDefinitions.length > 0
       ? toolDefinitions.map((def) => def.name)
       : (tools ?? []).map((tool) => tool?.name);
 
-  return new Set(toolNames.filter((name): name is string => Boolean(name)));
+  return new Set(
+    [...toolNames, ...(historicalToolNames ?? [])].filter((name): name is string => Boolean(name)),
+  );
 }
 
 export interface RunToolSetConfig extends BuildToolSetConfig, ReachableAgent<RunToolSetConfig> {

--- a/packages/api/src/agents/tools.ts
+++ b/packages/api/src/agents/tools.ts
@@ -1,3 +1,4 @@
+import { Constants } from 'librechat-data-provider';
 import {
   CODE_EXECUTION_TOOLS,
   BashExecutionToolDefinition,
@@ -5,6 +6,9 @@ import {
   buildBashExecutionToolDescription,
 } from '@librechat/agents';
 import type { LCTool, LCToolRegistry } from '@librechat/agents';
+import type { GraphEdge } from 'librechat-data-provider';
+import type { ReachableAgent } from './traversal';
+import { collectReachableAgents } from './traversal';
 
 export const CREATE_FILE_TOOL_NAME = 'create_file';
 export const EDIT_FILE_TOOL_NAME = 'edit_file';
@@ -59,6 +63,47 @@ export function buildToolSet(agentConfig: BuildToolSetConfig | null | undefined)
       : (tools ?? []).map((tool) => tool?.name);
 
   return new Set(toolNames.filter((name): name is string => Boolean(name)));
+}
+
+export interface RunToolSetConfig extends BuildToolSetConfig, ReachableAgent<RunToolSetConfig> {
+  readonly edges?: readonly GraphEdge[];
+}
+
+/** Builds the historical tool allowlist for the complete effective run topology. */
+export function buildRunToolSet(
+  primaryConfig: RunToolSetConfig | null | undefined,
+  additionalConfigs?: Iterable<RunToolSetConfig | null | undefined> | null,
+): Set<string> {
+  const roots = [primaryConfig];
+  if (additionalConfigs) {
+    roots.push(...additionalConfigs);
+  }
+
+  const agents = collectReachableAgents(roots);
+  if (agents.length === 0) {
+    return new Set();
+  }
+
+  const toolSet = new Set<string>([`${Constants.SUBAGENT}`]);
+  for (const agent of agents) {
+    for (const name of buildToolSet(agent)) {
+      toolSet.add(name);
+    }
+  }
+
+  for (const edge of primaryConfig?.edges ?? []) {
+    if (edge.edgeType === 'direct') {
+      continue;
+    }
+    const destinations = Array.isArray(edge.to) ? edge.to : [edge.to];
+    for (const destination of destinations) {
+      if (destination) {
+        toolSet.add(`${Constants.LC_TRANSFER_TO_}${destination}`);
+      }
+    }
+  }
+
+  return toolSet;
 }
 
 export interface RegisterCodeExecutionToolsParams {

--- a/packages/api/src/agents/tools.ts
+++ b/packages/api/src/agents/tools.ts
@@ -260,14 +260,14 @@ export function buildRunToolSet(
 
   if (wildcardServerNames.size > 0) {
     /** A wildcard authorizes every callable under one exact normalized server identity.
-     * Resolve the longest known boundary and fail closed when the remaining tool half
-     * still contains a delimiter, which could hide a removed longer server name. */
+     * Resolve the longest known boundary so delimiter-bearing tool names remain valid
+     * while a distinct longer server identity cannot masquerade as a selected suffix. */
     const boundaryNames = [...knownServerNames];
     for (const name of collectHistoricalToolCallNames(historicalMessages)) {
       const [toolName, serverName] = splitMCPToolKey(name, boundaryNames);
       if (
         serverName != null &&
-        !toolName.includes(Constants.mcp_delimiter) &&
+        toolName.length > 0 &&
         wildcardServerNames.has(normalizeServerName(serverName))
       ) {
         toolSet.add(name);

--- a/packages/api/src/agents/tools.ts
+++ b/packages/api/src/agents/tools.ts
@@ -1,4 +1,4 @@
-import { Constants } from 'librechat-data-provider';
+import { Constants, normalizeActionToolName } from 'librechat-data-provider';
 import {
   CODE_EXECUTION_TOOLS,
   BashExecutionToolDefinition,
@@ -49,6 +49,7 @@ export interface BuildHistoricalToolNamesConfig {
   alwaysApplyToolNames?: readonly string[];
   toolOptions?: AgentToolOptions;
   rawMcpServerNames?: readonly string[];
+  mcpWildcardToolNames?: readonly string[];
   codeExecutionAvailable?: boolean;
   memoryAvailable?: boolean;
   skillsAvailable?: boolean;
@@ -69,7 +70,19 @@ export function buildHistoricalToolNames(config: BuildHistoricalToolNamesConfig)
     toolOptions: config.toolOptions,
     rawServerNames: config.rawMcpServerNames ?? [],
   });
-  const toolNames = new Set(normalized.tools ?? []);
+  const toolNames = new Set([
+    ...(normalized.tools ?? []).map(normalizeActionToolName),
+    ...(config.mcpWildcardToolNames ?? []),
+  ]);
+
+  const normalizedOptions: AgentToolOptions = {};
+  for (const [name, options] of Object.entries(normalized.toolOptions ?? {})) {
+    const normalizedName = normalizeActionToolName(name);
+    normalizedOptions[normalizedName] =
+      normalizedName !== name
+        ? { ...options, ...normalizedOptions[normalizedName] }
+        : { ...normalizedOptions[name], ...options };
+  }
 
   for (const name of [...toolNames]) {
     for (const child of toolkitExpansion[name as keyof typeof toolkitExpansion] ?? []) {
@@ -97,7 +110,7 @@ export function buildHistoricalToolNames(config: BuildHistoricalToolNamesConfig)
     toolNames.add(EDIT_FILE_TOOL_NAME);
   }
 
-  const options = normalized.toolOptions ?? {};
+  const options = normalizedOptions;
   const hasDeferredTool = [...toolNames].some((name) => options[name]?.defer_loading === true);
   if (config.deferredToolsAvailable === true && hasDeferredTool) {
     toolNames.add('tool_search');

--- a/packages/api/src/agents/tools.ts
+++ b/packages/api/src/agents/tools.ts
@@ -231,6 +231,7 @@ export function buildRunToolSet(
   additionalConfigs?: Iterable<RunToolSetConfig | null | undefined> | null,
   hostGeneratedToolNames?: Iterable<string> | null,
   historicalMessages?: Iterable<unknown> | null,
+  allowAmbiguousMcpToolNamesWithoutIdentity = false,
 ): Set<string> {
   const roots = [primaryConfig];
   if (additionalConfigs) {
@@ -287,7 +288,8 @@ export function buildRunToolSet(
       if (
         serverName != null &&
         toolName.length > 0 &&
-        !toolName.includes(Constants.mcp_delimiter) &&
+        (allowAmbiguousMcpToolNamesWithoutIdentity ||
+          !toolName.includes(Constants.mcp_delimiter)) &&
         wildcardServerNames.has(normalizeServerName(serverName))
       ) {
         toolSet.add(name);

--- a/packages/data-provider/src/types/agents.ts
+++ b/packages/data-provider/src/types/agents.ts
@@ -72,6 +72,8 @@ export namespace Agents {
     type?: ToolCallTypes.TOOL_CALL | 'tool_call';
     /** The name of the tool to be called */
     name: string;
+    /** Host-derived MCP server identity retained to disambiguate historical tool keys. */
+    mcpServerName?: string;
 
     /** The arguments to the tool call */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
I fixed multi-agent conversation history so legitimate handoff and destination-agent tool calls remain structured on subsequent turns instead of being flattened into imitable assistant text.

- Build a run-wide historical tool allowlist from the primary agent and every recursively reachable eager, lazy, metadata, and graph-member configuration.
- Retain configured and always-applied skill tool names on unresolved lazy descriptors without resolving or executing the child.
- Normalize legacy MCP and Action tool keys plus their options to the model-facing runtime spelling.
- Recover wildcard-authorized MCP calls from structured persisted history using the longest known server boundary, including nested subagent content, without depending on an expiring catalog.
- Expand toolkits, code execution, memory, skills, skill authoring, deferred tools, programmatic tools, and background-task capabilities into their effective model-facing names.
- Add synthetic `subagent` history support for compatibility with the currently installed Agents SDK.
- Add transfer tool names only for destinations in the primary configuration's filtered effective handoff edges, excluding direct edges and disconnected loaded agents.
- Use the run-wide allowlist in the primary chat, OpenAI-compatible, and Responses API controller paths.
- Add real `formatAgentMessages` regressions proving handoff, destination-agent, and nested wildcard calls survive as structured call/result pairs without `Tool:` text.
- Build on the merged [Agents SDK PR #494](https://github.com/danny-avila/agents/pull/494), which preserves SDK-managed control calls and prevents genuinely unavailable tool outputs from becoming assistant-authored text.

Fixes #14623.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I ran focused helper and real-SDK formatter tests plus affected-file checks.

### **Test Configuration**:

- `cd packages/api && npx jest src/agents/tools.spec.ts src/agents/history.spec.ts --runInBand` - 50 passed
- `npm run sort-imports -- packages/api/src/agents/tools.ts packages/api/src/agents/tools.spec.ts packages/api/src/agents/history.spec.ts api/server/controllers/agents/client.js api/server/controllers/agents/openai.js api/server/controllers/agents/responses.js api/server/services/Endpoints/agents/initialize.js api/server/services/Endpoints/agents/initialize.spec.js`
- Targeted ESLint, Prettier, import sorting, and diff checks passed.
- `npm run static-checks -- --against origin/dev` passed affected ESLint, Prettier, import sorting, and package validation. The borrowed dependency tree lacks `tsdown`, so its circular-dependency subprocess could not start locally; PR CI runs it with freshly built dependencies.
- `cd packages/api && npx tsc --noEmit` reached only unrelated stale workspace-export errors in the borrowed dependency tree; PR CI provides authoritative typechecking.
- The legacy controller suite cannot start in the borrowed dependency installation because its built packages are stale; PR CI provides authoritative controller and full-workspace coverage.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes