### PR TITLE
🎖️ fix: Apply Fallback Role on Group Overage

### DIFF
--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -1679,7 +1679,7 @@ describe('createRemoteAgentAuth', () => {
       expect(req.user).toMatchObject({ role: 'user' });
     });
 
-    it('does not apply fallback when API group overage is unresolved', async () => {
+    it('applies fallback when API group overage cannot be resolved', async () => {
       enableApiRoleSync({ OPENID_ROLE_SYNC_CLAIM: 'groups' });
       setupOidcMocks({
         sub: 'sub123',
@@ -1688,11 +1688,12 @@ describe('createRemoteAgentAuth', () => {
       });
 
       const deps = makeDeps();
+      deps.findUser = makeFindUser(makeUser({ role: 'STANDARD-USER' }));
       const req = makeReq({ authorization: `Bearer ${FAKE_TOKEN}` });
       await createRemoteAgentAuth(asDeps(deps))(req as Request, makeRes().res, mockNext);
 
-      expect(deps.updateUser).not.toHaveBeenCalled();
-      expect(req.user).toMatchObject({ role: 'user' });
+      expect(deps.updateUser).toHaveBeenCalledWith('uid123', { role: 'USER' });
+      expect(req.user).toMatchObject({ role: 'USER' });
     });
 
     it('runs role lookup and persistence in the resolved user tenant context', async () => {

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -523,6 +523,7 @@ async function selectOpenIdRoleForOpenIdSync(
     options,
     accessClaims: payload,
     decodeToken: () => payload,
+    resolveGroupOverage: async () => [],
   });
   if (openIdRoleValues === undefined) {
     logger.warn(


### PR DESCRIPTION
## Summary

I fixed remote-agent API OpenID role synchronization so unresolved access-token group overage applies the configured fallback role instead of preserving stale privileges.

- Treat API group-overage markers as an empty group set when bearer authentication cannot query the identity provider.
- Reuse the existing role-selection path to apply `OPENID_ROLE_SYNC_FALLBACK_ROLE` fail-closed.
- Update the regression test to prove a stale `STANDARD-USER` role is demoted to `USER`.

## Related Security Finding

- [API OpenID role sync skips fallback on group overage](https://chatgpt.com/codex/cloud/security/findings/a7c7fde9bdec819198150644c51f7d75?sev=&repo=https%3A%2F%2Fgithub.com%2Fdanny-avila%2FLibreChat)

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `cd packages/api && npx jest src/middleware/remoteAgentAuth.spec.ts --runInBand --coverage=false` (83 tests passed).
- Ran changed-file import sorting and package validation through `npm run static-checks -- --against origin/dev`.
- Confirmed `git diff --check` passes.
- Left dependency-backed TypeScript, Prettier, circular-dependency, and complete ESLint validation to CI because this clean worktree does not contain installed dependencies.

### **Test Configuration**:

- Node.js 24.16.0
- macOS

## Checklist

- [x] My code adheres to this project style guidelines
- [x] I have performed a self-review of my own code
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes