### PR TITLE
🛞 fix: Roll Overflow Tenant Labels Into Aggregate Metrics

### DIFF
--- a/otel/langfuse-fanout/README.md
+++ b/otel/langfuse-fanout/README.md
@@ -272,10 +272,10 @@ LibreChat stamps `librechat.tenant.id`, `librechat.langfuse.export_plan`, and
 `librechat.langfuse.export_reason` on Langfuse run spans. The gateway reads the
 tenant ID from each OTLP batch for the trace export counter. Batches without a
 tenant ID use `<unknown>`; batches containing more than one tenant use `<multiple>`.
-Angle brackets keep these synthetic values outside LibreChat's accepted tenant-ID grammar.
-The `tenant_id` label is intentionally high-cardinality and must only receive
-traffic from trusted LibreChat deployments. Each distinct tenant creates a
-Prometheus time series for every destination and result combination.
+Invalid tenant IDs use `<invalid>`. The gateway retains up to 1,000 valid tenant
+labels and aggregates additional IDs under `<overflow>`, bounding the trace
+counter's cardinality. Angle brackets keep these synthetic values outside
+LibreChat's accepted tenant-ID grammar.
 
 Successful admin connection updates emit the structured log event
 `librechat.langfuse.connection.changed`. It includes the tenant, configuration

--- a/otel/langfuse-fanout/cmd/langfuse-fanout/main.go
+++ b/otel/langfuse-fanout/cmd/langfuse-fanout/main.go
@@ -748,7 +748,11 @@ func (g *gateway) recordTraceExport(route route, result string, tenantID string)
 	if g.metrics == nil {
 		return
 	}
-	g.metrics.recordTraceExport(routeDestinationLabel(route), result, tenantID)
+	destination := centralName
+	if _, ok := g.cfg.tenants[route.destination]; ok {
+		destination = routeDestinationLabel(route)
+	}
+	g.metrics.recordTraceExport(destination, result, tenantID)
 }
 
 func (g *gateway) recordMediaDivergence(kind string, destination string) {

--- a/otel/langfuse-fanout/cmd/langfuse-fanout/main_test.go
+++ b/otel/langfuse-fanout/cmd/langfuse-fanout/main_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -1065,6 +1066,56 @@ func TestTraceProxyRecordsPrometheusMetrics(t *testing.T) {
 	}
 	if !strings.Contains(metrics, `langfuse_fanout_upstream_requests_total{destination="collector",operation="trace_collector",status_class="2xx"} 1`) {
 		t.Fatalf("missing upstream collector metric:\n%s", metrics)
+	}
+}
+
+func TestTraceProxyBoundsTenantMetricLabels(t *testing.T) {
+	t.Parallel()
+
+	metrics := newGatewayMetrics()
+	for i := 0; i < maxTenantMetricLabels+10; i++ {
+		metrics.recordTraceExport(centralName, "success", fmt.Sprintf("tenant-%d", i))
+	}
+	metrics.recordTraceExport(centralName, "success", strings.Repeat("x", 129))
+
+	metricFamilies, err := metrics.registry.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, family := range metricFamilies {
+		if family.GetName() != "langfuse_fanout_trace_exports_total" {
+			continue
+		}
+		if got, want := len(family.Metric), maxTenantMetricLabels+2; got != want {
+			t.Fatalf("trace metric children = %d, want %d", got, want)
+		}
+		labels := make(map[string]struct{}, len(family.Metric))
+		for _, metric := range family.Metric {
+			for _, label := range metric.Label {
+				if label.GetName() == "tenant_id" {
+					labels[label.GetValue()] = struct{}{}
+				}
+			}
+		}
+		for _, label := range []string{overflowTenantID, invalidTenantID} {
+			if _, ok := labels[label]; !ok {
+				t.Fatalf("missing bounded tenant label %q", label)
+			}
+		}
+		return
+	}
+	t.Fatal("missing trace export metric family")
+}
+
+func TestTraceProxyBoundsUnknownDestinationLabel(t *testing.T) {
+	t.Parallel()
+
+	gw := newTestGatewayWithCollector("http://collector.invalid")
+	gw.recordTraceExport(route{destination: "attacker-controlled"}, "error", "tenant-123")
+
+	metrics := scrapeMetrics(t, gw)
+	if !strings.Contains(metrics, `langfuse_fanout_trace_exports_total{destination="central",result="error",tenant_id="tenant-123"} 1`) {
+		t.Fatalf("missing bounded trace destination metric:\n%s", metrics)
 	}
 }
 

--- a/otel/langfuse-fanout/cmd/langfuse-fanout/metrics.go
+++ b/otel/langfuse-fanout/cmd/langfuse-fanout/metrics.go
@@ -4,10 +4,17 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
+)
+
+const (
+	maxTenantMetricLabels = 1000
+	invalidTenantID       = "<invalid>"
+	overflowTenantID      = "<overflow>"
 )
 
 type gatewayMetrics struct {
@@ -23,6 +30,8 @@ type gatewayMetrics struct {
 	uploadPlanMisses      prometheus.Counter
 	uploadPlanStoreErrors *prometheus.CounterVec
 	uploadBytes           prometheus.Histogram
+	tenantLabelsMu        sync.Mutex
+	tenantLabels          map[string]struct{}
 }
 
 func newGatewayMetrics() *gatewayMetrics {
@@ -33,7 +42,8 @@ func newGatewayMetrics() *gatewayMetrics {
 	)
 
 	metrics := &gatewayMetrics{
-		registry: registry,
+		registry:     registry,
+		tenantLabels: make(map[string]struct{}, maxTenantMetricLabels),
 		httpRequests: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "langfuse_fanout_http_requests_total",
 			Help: "Total HTTP requests handled by the Langfuse fanout gateway.",
@@ -129,15 +139,48 @@ func (m *gatewayMetrics) recordTraceExport(destination string, result string, te
 	if m == nil {
 		return
 	}
-	m.traceExports.WithLabelValues(normalizeMetricLabel(destination), result, tenantMetricLabel(tenantID)).Inc()
+	m.traceExports.WithLabelValues(normalizeMetricLabel(destination), result, m.tenantMetricLabel(tenantID)).Inc()
 }
 
-func tenantMetricLabel(tenantID string) string {
+func (m *gatewayMetrics) tenantMetricLabel(tenantID string) string {
 	tenantID = strings.TrimSpace(tenantID)
 	if tenantID == "" {
-		return "unknown"
+		return unknownTenantID
 	}
+	if tenantID == unknownTenantID || tenantID == multipleTenantIDs {
+		return tenantID
+	}
+	if !validTenantMetricID(tenantID) {
+		return invalidTenantID
+	}
+
+	m.tenantLabelsMu.Lock()
+	defer m.tenantLabelsMu.Unlock()
+	if _, ok := m.tenantLabels[tenantID]; ok {
+		return tenantID
+	}
+	if len(m.tenantLabels) >= maxTenantMetricLabels {
+		return overflowTenantID
+	}
+	m.tenantLabels[tenantID] = struct{}{}
 	return tenantID
+}
+
+func validTenantMetricID(tenantID string) bool {
+	if len(tenantID) > 128 {
+		return false
+	}
+	for _, r := range tenantID {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '-' || r == '_' || r == '.':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func (m *gatewayMetrics) recordMediaDivergence(kind string, destination string) {


### PR DESCRIPTION
I bounded request-controlled tenant labels in the Langfuse fanout Prometheus trace counter to prevent unbounded memory and scrape growth.

- Validate metric tenant IDs against LibreChat’s 128-character tenant grammar.
- Retain at most 1,000 distinct valid tenant labels and aggregate excess values under `<overflow>`.
- Aggregate malformed tenant values under `<invalid>` instead of retaining attacker-controlled strings.
- Constrain trace metric destination labels to central and configured tenant routes.
- Document the bounded label behavior and synthetic metric values.
- Add regression coverage for label-cap enforcement, malformed IDs, overflow aggregation, and unconfigured route labels.

## Security Report

Resolves [Unbounded tenant metric labels enable fanout gateway memory DoS](https://chatgpt.com/codex/cloud/security/findings/21f09f4751048191afe5cc673fee0be8?sev=&repo=https%3A%2F%2Fgithub.com%2Fdanny-avila%2FLibreChat).

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Testing

- Ran `go test ./cmd/langfuse-fanout -count=1` with Go 1.25 in the repository container.
- Ran `go test -race ./...` with Go 1.25 in the repository container.
- Verified all Go files pass `gofmt -l .`.
- Verified `git diff --check` passes.

### **Test Configuration**:

- Go 1.25 Docker image
- macOS host with Docker

## Checklist

- [x] My code adheres to this project’s style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes