### PR TITLE
🧲 fix: Anchor Memory Partitions to Accessible Agents

### DIFF
--- a/api/server/routes/memories.js
+++ b/api/server/routes/memories.js
@@ -1,8 +1,9 @@
 const express = require('express');
-const { ResourceCapabilityMap } = require('@librechat/data-schemas');
 const {
   Tokenizer,
   generateCheckAccess,
+  getMemoryAgentIdParam,
+  createAgentMemoryPartitionMiddleware,
   blockFilteredMemoryContent,
   projectStoredMemories,
   createMemoryManagementHandlers,
@@ -68,58 +69,31 @@ const opaqueMemoryHandlers = createMemoryManagementHandlers({
 
 router.use(requireJwtAuth);
 
-/** Normalizes the optional agent partition param; undefined = shared personal pool */
-const getAgentIdParam = (value) =>
-  typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined;
-
-/** Resolves whether the requester can use a client-selected agent partition. */
-const getAgentPartitionAccess = async (user, agentId) => {
-  const agent = await getAgent({ id: agentId });
-  if (!agent) {
-    return 'not_found';
-  }
-
-  let canManageAgents = false;
-  try {
-    canManageAgents = await hasCapability(user, ResourceCapabilityMap[ResourceType.AGENT]);
-  } catch (_error) {
-    canManageAgents = false;
-  }
-  if (canManageAgents) {
-    return 'allowed';
-  }
-
-  const canViewAgent = await checkPermission({
-    userId: user.id,
-    role: user.role,
-    resourceType: ResourceType.AGENT,
-    resourceId: agent._id,
-    requiredPermission: PermissionBits.VIEW,
-  });
-  return canViewAgent ? 'allowed' : 'denied';
+const agentPartitionDependencies = {
+  getAgent,
+  getRoleByName,
+  hasCapability,
+  checkPermission,
 };
-
-const validateAgentPartition = (source) => async (req, res, next) => {
-  const agentId = getAgentIdParam(req[source]?.agentId);
-  if (!agentId) {
-    return next();
-  }
-
-  try {
-    const agentAccess = await getAgentPartitionAccess(req.user, agentId);
-    if (agentAccess === 'not_found') {
-      return res.status(404).json({ error: 'Agent not found.' });
-    }
-    if (agentAccess === 'denied') {
-      return res.status(403).json({ error: 'Agent access denied.' });
-    }
-    return next();
-  } catch (_error) {
-    return res.status(500).json({ error: 'Failed to validate agent access.' });
-  }
-};
-
-const validateQueryAgentPartition = validateAgentPartition('query');
+const validateBodyAgentPartition = createAgentMemoryPartitionMiddleware({
+  source: 'body',
+  ...agentPartitionDependencies,
+});
+const validateQueryAgentPartition = createAgentMemoryPartitionMiddleware({
+  source: 'query',
+  ...agentPartitionDependencies,
+});
+const validateDeletedAgentPartition = createAgentMemoryPartitionMiddleware({
+  source: 'query',
+  allowMissingAgent: true,
+  ...agentPartitionDependencies,
+});
+const createMemoryMiddleware = [
+  memoryPayloadLimit,
+  checkMemoryCreate,
+  validateBodyAgentPartition,
+  configMiddleware,
+];
 const updateMemoryMiddleware = [
   memoryPayloadLimit,
   checkMemoryUpdate,
@@ -202,9 +176,9 @@ router.get('/', checkMemoryRead, configMiddleware, async (req, res) => {
  * Body: { key: string, value: string }
  * Returns 201 and { created: true, memory: <createdDoc> } when successful.
  */
-router.post('/', memoryPayloadLimit, checkMemoryCreate, configMiddleware, async (req, res) => {
+router.post('/', createMemoryMiddleware, async (req, res) => {
   const { key, value } = req.body;
-  const agentId = getAgentIdParam(req.body.agentId);
+  const agentId = getMemoryAgentIdParam(req.body.agentId);
 
   if (typeof key !== 'string' || key.trim() === '') {
     return res.status(400).json({ error: 'Key is required and must be a non-empty string.' });
@@ -212,20 +186,6 @@ router.post('/', memoryPayloadLimit, checkMemoryCreate, configMiddleware, async 
 
   if (typeof value !== 'string' || value.trim() === '') {
     return res.status(400).json({ error: 'Value is required and must be a non-empty string.' });
-  }
-
-  try {
-    if (agentId) {
-      const agentAccess = await getAgentPartitionAccess(req.user, agentId);
-      if (agentAccess === 'not_found') {
-        return res.status(404).json({ error: 'Agent not found.' });
-      }
-      if (agentAccess === 'denied') {
-        return res.status(403).json({ error: 'Agent access denied.' });
-      }
-    }
-  } catch (_error) {
-    return res.status(500).json({ error: 'Failed to validate agent access.' });
   }
 
   const appConfig = req.config;
@@ -336,7 +296,7 @@ router.patch(
 router.delete(
   '/id/:id',
   checkMemoryDelete,
-  validateQueryAgentPartition,
+  validateDeletedAgentPartition,
   opaqueMemoryHandlers.deleteById,
 );
 
@@ -349,7 +309,7 @@ router.delete(
 router.patch('/:key', updateMemoryMiddleware, async (req, res) => {
   const { key: urlKey } = req.params;
   const { key: bodyKey, value } = req.body || {};
-  const agentId = getAgentIdParam(req.query.agentId);
+  const agentId = getMemoryAgentIdParam(req.query.agentId);
 
   if (typeof value !== 'string' || value.trim() === '') {
     return res.status(400).json({ error: 'Value is required and must be a non-empty string.' });
@@ -436,9 +396,9 @@ router.patch('/:key', updateMemoryMiddleware, async (req, res) => {
  * Deletes a memory entry for the authenticated user.
  * Returns 200 and { deleted: true } when successful.
  */
-router.delete('/:key', checkMemoryDelete, validateQueryAgentPartition, async (req, res) => {
+router.delete('/:key', checkMemoryDelete, validateDeletedAgentPartition, async (req, res) => {
   const { key } = req.params;
-  const agentId = getAgentIdParam(req.query.agentId);
+  const agentId = getMemoryAgentIdParam(req.query.agentId);
 
   try {
     const result = await deleteMemory({ userId: req.user.id, key, agentId });

--- a/api/server/routes/memories.js
+++ b/api/server/routes/memories.js
@@ -99,6 +99,34 @@ const getAgentPartitionAccess = async (user, agentId) => {
   return canViewAgent ? 'allowed' : 'denied';
 };
 
+const validateAgentPartition = (source) => async (req, res, next) => {
+  const agentId = getAgentIdParam(req[source]?.agentId);
+  if (!agentId) {
+    return next();
+  }
+
+  try {
+    const agentAccess = await getAgentPartitionAccess(req.user, agentId);
+    if (agentAccess === 'not_found') {
+      return res.status(404).json({ error: 'Agent not found.' });
+    }
+    if (agentAccess === 'denied') {
+      return res.status(403).json({ error: 'Agent access denied.' });
+    }
+    return next();
+  } catch (_error) {
+    return res.status(500).json({ error: 'Failed to validate agent access.' });
+  }
+};
+
+const validateQueryAgentPartition = validateAgentPartition('query');
+const updateMemoryMiddleware = [
+  memoryPayloadLimit,
+  checkMemoryUpdate,
+  validateQueryAgentPartition,
+  configMiddleware,
+];
+
 /** Resolves agent display names for agent-partitioned memories, restricted
  *  to agents the requester can VIEW — `agentId` is caller-supplied on write,
  *  so an unrestricted lookup would leak private agents' names. */
@@ -301,10 +329,16 @@ router.patch(
   '/id/:id',
   memoryPayloadLimit,
   checkMemoryUpdate,
+  validateQueryAgentPartition,
   configMiddleware,
   opaqueMemoryHandlers.updateById,
 );
-router.delete('/id/:id', checkMemoryDelete, opaqueMemoryHandlers.deleteById);
+router.delete(
+  '/id/:id',
+  checkMemoryDelete,
+  validateQueryAgentPartition,
+  opaqueMemoryHandlers.deleteById,
+);
 
 /**
  * PATCH /memories/:key
@@ -312,7 +346,7 @@ router.delete('/id/:id', checkMemoryDelete, opaqueMemoryHandlers.deleteById);
  * Body: { key?: string, value: string }
  * Returns 200 and { updated: true, memory: <updatedDoc> } when successful.
  */
-router.patch('/:key', memoryPayloadLimit, checkMemoryUpdate, configMiddleware, async (req, res) => {
+router.patch('/:key', updateMemoryMiddleware, async (req, res) => {
   const { key: urlKey } = req.params;
   const { key: bodyKey, value } = req.body || {};
   const agentId = getAgentIdParam(req.query.agentId);
@@ -402,7 +436,7 @@ router.patch('/:key', memoryPayloadLimit, checkMemoryUpdate, configMiddleware, a
  * Deletes a memory entry for the authenticated user.
  * Returns 200 and { deleted: true } when successful.
  */
-router.delete('/:key', checkMemoryDelete, async (req, res) => {
+router.delete('/:key', checkMemoryDelete, validateQueryAgentPartition, async (req, res) => {
   const { key } = req.params;
   const agentId = getAgentIdParam(req.query.agentId);
 

--- a/api/server/routes/memories.js
+++ b/api/server/routes/memories.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const { ResourceCapabilityMap } = require('@librechat/data-schemas');
 const {
   Tokenizer,
   generateCheckAccess,
@@ -12,7 +13,8 @@ const {
   ResourceType,
   Permissions,
 } = require('librechat-data-provider');
-const { findAccessibleResources } = require('~/server/services/PermissionService');
+const { checkPermission, findAccessibleResources } = require('~/server/services/PermissionService');
+const { hasCapability } = require('~/server/middleware/roles/capabilities');
 const {
   getAllUserMemories,
   getUserMemories,
@@ -23,6 +25,7 @@ const {
   setMemory,
   setMemoryById,
   deleteMemoryById,
+  getAgent,
   getAgents,
 } = require('~/models');
 const { requireJwtAuth, configMiddleware } = require('~/server/middleware');
@@ -68,6 +71,33 @@ router.use(requireJwtAuth);
 /** Normalizes the optional agent partition param; undefined = shared personal pool */
 const getAgentIdParam = (value) =>
   typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined;
+
+/** Resolves whether the requester can use a client-selected agent partition. */
+const getAgentPartitionAccess = async (user, agentId) => {
+  const agent = await getAgent({ id: agentId });
+  if (!agent) {
+    return 'not_found';
+  }
+
+  let canManageAgents = false;
+  try {
+    canManageAgents = await hasCapability(user, ResourceCapabilityMap[ResourceType.AGENT]);
+  } catch (_error) {
+    canManageAgents = false;
+  }
+  if (canManageAgents) {
+    return 'allowed';
+  }
+
+  const canViewAgent = await checkPermission({
+    userId: user.id,
+    role: user.role,
+    resourceType: ResourceType.AGENT,
+    resourceId: agent._id,
+    requiredPermission: PermissionBits.VIEW,
+  });
+  return canViewAgent ? 'allowed' : 'denied';
+};
 
 /** Resolves agent display names for agent-partitioned memories, restricted
  *  to agents the requester can VIEW — `agentId` is caller-supplied on write,
@@ -154,6 +184,20 @@ router.post('/', memoryPayloadLimit, checkMemoryCreate, configMiddleware, async 
 
   if (typeof value !== 'string' || value.trim() === '') {
     return res.status(400).json({ error: 'Value is required and must be a non-empty string.' });
+  }
+
+  try {
+    if (agentId) {
+      const agentAccess = await getAgentPartitionAccess(req.user, agentId);
+      if (agentAccess === 'not_found') {
+        return res.status(404).json({ error: 'Agent not found.' });
+      }
+      if (agentAccess === 'denied') {
+        return res.status(403).json({ error: 'Agent access denied.' });
+      }
+    }
+  } catch (_error) {
+    return res.status(500).json({ error: 'Failed to validate agent access.' });
   }
 
   const appConfig = req.config;

--- a/api/server/routes/memories.test.js
+++ b/api/server/routes/memories.test.js
@@ -32,7 +32,7 @@ jest.mock('@librechat/api', () => ({
       if (!agentId) {
         return next();
       }
-      const agent = await mockGetAgent({ id: agentId });
+      const agent = await mockGetAgent({ id: agentId }, { _id: 1 });
       if (!agent) {
         return allowMissingAgent ? next() : res.status(404).json({ error: 'Agent not found.' });
       }
@@ -132,7 +132,7 @@ describe('agent memory partition authorization', () => {
 
     expect(response.status).toBe(404);
     expect(response.body).toEqual({ error: 'Agent not found.' });
-    expect(mockGetAgent).toHaveBeenCalledWith({ id: 'attacker-partition' });
+    expect(mockGetAgent).toHaveBeenCalledWith({ id: 'attacker-partition' }, { _id: 1 });
     expect(mockGetUserMemories).not.toHaveBeenCalled();
     expect(mockCreateMemory).not.toHaveBeenCalled();
   });

--- a/api/server/routes/memories.test.js
+++ b/api/server/routes/memories.test.js
@@ -149,6 +149,24 @@ describe('agent memory partition authorization', () => {
       expect.objectContaining({ userId: 'user-1', agentId: 'agent-1' }),
     );
   });
+
+  it.each([
+    ['patch', '/api/memories/id/507f1f77bcf86cd799439011?agentId=agent-1'],
+    ['delete', '/api/memories/id/507f1f77bcf86cd799439011?agentId=agent-1'],
+    ['patch', '/api/memories/timezone?agentId=agent-1'],
+    ['delete', '/api/memories/timezone?agentId=agent-1'],
+  ])('rejects unauthorized %s mutations of an agent partition', async (method, path) => {
+    mockCheckPermission.mockResolvedValue(false);
+
+    const pendingRequest = request(buildApp())[method](path);
+    const response =
+      method === 'patch' ? await pendingRequest.send({ value: 'UTC' }) : await pendingRequest;
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({ error: 'Agent access denied.' });
+    expect(mockOpaqueUpdateById).not.toHaveBeenCalled();
+    expect(mockOpaqueDeleteById).not.toHaveBeenCalled();
+  });
 });
 
 describe('GET /api/memories content policy', () => {
@@ -245,6 +263,9 @@ describe('GET /api/memories content policy', () => {
 describe('opaque memory management routes', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetAgent.mockResolvedValue({ _id: 'agent-object-id', id: 'agent-1' });
+    mockCheckPermission.mockResolvedValue(true);
+    mockHasCapability.mockResolvedValue(false);
     mockFilters = {
       memories: {
         pii: {

--- a/api/server/routes/memories.test.js
+++ b/api/server/routes/memories.test.js
@@ -150,6 +150,25 @@ describe('agent memory partition authorization', () => {
     );
   });
 
+  it('allows agent managers without consulting the resource ACL', async () => {
+    mockHasCapability.mockResolvedValue(true);
+    mockCheckPermission.mockResolvedValue(false);
+    mockGetUserMemories
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ key: 'timezone', value: 'UTC', agentId: 'agent-1' }]);
+    mockCreateMemory.mockResolvedValue({ ok: true });
+
+    const response = await request(buildApp())
+      .post('/api/memories')
+      .send({ key: 'timezone', value: 'UTC', agentId: 'agent-1' });
+
+    expect(response.status).toBe(201);
+    expect(mockCheckPermission).not.toHaveBeenCalled();
+    expect(mockCreateMemory).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-1', agentId: 'agent-1' }),
+    );
+  });
+
   it.each([
     ['patch', '/api/memories/id/507f1f77bcf86cd799439011?agentId=agent-1'],
     ['delete', '/api/memories/id/507f1f77bcf86cd799439011?agentId=agent-1'],

--- a/api/server/routes/memories.test.js
+++ b/api/server/routes/memories.test.js
@@ -2,9 +2,14 @@ const express = require('express');
 const request = require('supertest');
 
 const mockGetAllUserMemories = jest.fn();
+const mockGetUserMemories = jest.fn();
+const mockCreateMemory = jest.fn();
 const mockProjectStoredMemories = jest.fn((memories) => memories);
 const mockSetMemoryById = jest.fn();
 const mockDeleteMemoryById = jest.fn();
+const mockGetAgent = jest.fn();
+const mockCheckPermission = jest.fn();
+const mockHasCapability = jest.fn();
 const mockOpaqueUpdateById = jest.fn((_req, res) => res.status(202).json({ delegated: 'update' }));
 const mockOpaqueDeleteById = jest.fn((_req, res) => res.status(202).json({ delegated: 'delete' }));
 let mockFilters;
@@ -15,11 +20,16 @@ jest.mock('@librechat/api', () => ({
   inspectContent: jest.fn(() => null),
   extractMemoryContent: jest.fn(() => []),
   projectStoredMemories: (...args) => mockProjectStoredMemories(...args),
+  blockFilteredMemoryContent: jest.fn(() => false),
   createMemoryManagementHandlers: jest.fn(() => ({
     updateById: (...args) => mockOpaqueUpdateById(...args),
     deleteById: (...args) => mockOpaqueDeleteById(...args),
   })),
   contentFilterBlockResponse: jest.fn(),
+}));
+
+jest.mock('@librechat/data-schemas', () => ({
+  ResourceCapabilityMap: { agent: 'manage:agents' },
 }));
 
 jest.mock('librechat-data-provider', () => ({
@@ -36,19 +46,25 @@ jest.mock('librechat-data-provider', () => ({
 }));
 
 jest.mock('~/server/services/PermissionService', () => ({
+  checkPermission: (...args) => mockCheckPermission(...args),
   findAccessibleResources: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('~/server/middleware/roles/capabilities', () => ({
+  hasCapability: (...args) => mockHasCapability(...args),
 }));
 
 jest.mock('~/models', () => ({
   getAllUserMemories: (...args) => mockGetAllUserMemories(...args),
-  getUserMemories: jest.fn(),
+  getUserMemories: (...args) => mockGetUserMemories(...args),
   toggleUserMemories: jest.fn(),
   getRoleByName: jest.fn(),
-  createMemory: jest.fn(),
+  createMemory: (...args) => mockCreateMemory(...args),
   deleteMemory: jest.fn(),
   setMemory: jest.fn(),
   setMemoryById: (...args) => mockSetMemoryById(...args),
   deleteMemoryById: (...args) => mockDeleteMemoryById(...args),
+  getAgent: (...args) => mockGetAgent(...args),
   getAgents: jest.fn(),
 }));
 
@@ -74,6 +90,66 @@ const buildApp = () => {
   app.use('/api/memories', memoriesRouter);
   return app;
 };
+
+describe('agent memory partition authorization', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFilters = undefined;
+    mockGetAgent.mockResolvedValue({ _id: 'agent-object-id', id: 'agent-1' });
+    mockCheckPermission.mockResolvedValue(true);
+    mockHasCapability.mockResolvedValue(false);
+  });
+
+  it('rejects a nonexistent client-selected agent partition', async () => {
+    mockGetAgent.mockResolvedValue(null);
+
+    const response = await request(buildApp())
+      .post('/api/memories')
+      .send({ key: 'timezone', value: 'UTC', agentId: ' attacker-partition ' });
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'Agent not found.' });
+    expect(mockGetAgent).toHaveBeenCalledWith({ id: 'attacker-partition' });
+    expect(mockGetUserMemories).not.toHaveBeenCalled();
+    expect(mockCreateMemory).not.toHaveBeenCalled();
+  });
+
+  it('rejects an agent partition the requester cannot view', async () => {
+    mockCheckPermission.mockResolvedValue(false);
+
+    const response = await request(buildApp())
+      .post('/api/memories')
+      .send({ key: 'timezone', value: 'UTC', agentId: 'agent-1' });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({ error: 'Agent access denied.' });
+    expect(mockCheckPermission).toHaveBeenCalledWith({
+      userId: 'user-1',
+      role: 'USER',
+      resourceType: 'agent',
+      resourceId: 'agent-object-id',
+      requiredPermission: 1,
+    });
+    expect(mockGetUserMemories).not.toHaveBeenCalled();
+    expect(mockCreateMemory).not.toHaveBeenCalled();
+  });
+
+  it('allows a partition for an agent the requester can view', async () => {
+    mockGetUserMemories
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ key: 'timezone', value: 'UTC', agentId: 'agent-1' }]);
+    mockCreateMemory.mockResolvedValue({ ok: true });
+
+    const response = await request(buildApp())
+      .post('/api/memories')
+      .send({ key: 'timezone', value: 'UTC', agentId: 'agent-1' });
+
+    expect(response.status).toBe(201);
+    expect(mockCreateMemory).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-1', agentId: 'agent-1' }),
+    );
+  });
+});
 
 describe('GET /api/memories content policy', () => {
   beforeEach(() => {

--- a/api/server/routes/memories.test.js
+++ b/api/server/routes/memories.test.js
@@ -4,6 +4,7 @@ const request = require('supertest');
 const mockGetAllUserMemories = jest.fn();
 const mockGetUserMemories = jest.fn();
 const mockCreateMemory = jest.fn();
+const mockDeleteMemory = jest.fn();
 const mockProjectStoredMemories = jest.fn((memories) => memories);
 const mockSetMemoryById = jest.fn();
 const mockDeleteMemoryById = jest.fn();
@@ -21,15 +22,37 @@ jest.mock('@librechat/api', () => ({
   extractMemoryContent: jest.fn(() => []),
   projectStoredMemories: (...args) => mockProjectStoredMemories(...args),
   blockFilteredMemoryContent: jest.fn(() => false),
+  getMemoryAgentIdParam: (value) =>
+    typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined,
+  createAgentMemoryPartitionMiddleware:
+    ({ source, allowMissingAgent = false }) =>
+    async (req, res, next) => {
+      const value = req[source]?.agentId;
+      const agentId = typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined;
+      if (!agentId) {
+        return next();
+      }
+      const agent = await mockGetAgent({ id: agentId });
+      if (!agent) {
+        return allowMissingAgent ? next() : res.status(404).json({ error: 'Agent not found.' });
+      }
+      if (await mockHasCapability(req.user, 'manage:agents')) {
+        return next();
+      }
+      const allowed = await mockCheckPermission({
+        userId: req.user.id,
+        role: req.user.role,
+        resourceType: 'agent',
+        resourceId: agent._id,
+        requiredPermission: 1,
+      });
+      return allowed ? next() : res.status(403).json({ error: 'Agent access denied.' });
+    },
   createMemoryManagementHandlers: jest.fn(() => ({
     updateById: (...args) => mockOpaqueUpdateById(...args),
     deleteById: (...args) => mockOpaqueDeleteById(...args),
   })),
   contentFilterBlockResponse: jest.fn(),
-}));
-
-jest.mock('@librechat/data-schemas', () => ({
-  ResourceCapabilityMap: { agent: 'manage:agents' },
 }));
 
 jest.mock('librechat-data-provider', () => ({
@@ -60,7 +83,7 @@ jest.mock('~/models', () => ({
   toggleUserMemories: jest.fn(),
   getRoleByName: jest.fn(),
   createMemory: (...args) => mockCreateMemory(...args),
-  deleteMemory: jest.fn(),
+  deleteMemory: (...args) => mockDeleteMemory(...args),
   setMemory: jest.fn(),
   setMemoryById: (...args) => mockSetMemoryById(...args),
   deleteMemoryById: (...args) => mockDeleteMemoryById(...args),
@@ -185,6 +208,33 @@ describe('agent memory partition authorization', () => {
     expect(response.body).toEqual({ error: 'Agent access denied.' });
     expect(mockOpaqueUpdateById).not.toHaveBeenCalled();
     expect(mockOpaqueDeleteById).not.toHaveBeenCalled();
+  });
+
+  it('allows deleting a user-owned partition after its agent is removed', async () => {
+    mockGetAgent.mockResolvedValue(null);
+    mockDeleteMemory.mockResolvedValue({ ok: true });
+
+    const response = await request(buildApp()).delete(
+      '/api/memories/timezone?agentId=removed-agent',
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockDeleteMemory).toHaveBeenCalledWith({
+      userId: 'user-1',
+      key: 'timezone',
+      agentId: 'removed-agent',
+    });
+  });
+
+  it('allows deleting a user-owned opaque memory after its agent is removed', async () => {
+    mockGetAgent.mockResolvedValue(null);
+
+    const response = await request(buildApp()).delete(
+      '/api/memories/id/507f1f77bcf86cd799439011?agentId=removed-agent',
+    );
+
+    expect(response.status).toBe(202);
+    expect(mockOpaqueDeleteById).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/api/src/memory/authorization.spec.ts
+++ b/packages/api/src/memory/authorization.spec.ts
@@ -1,0 +1,148 @@
+import { Types } from 'mongoose';
+import { Permissions, PermissionTypes } from 'librechat-data-provider';
+import type { IRole, IUser } from '@librechat/data-schemas';
+import type { Request, Response } from 'express';
+import {
+  getMemoryAgentIdParam,
+  getAgentMemoryPartitionAccess,
+  createAgentMemoryPartitionMiddleware,
+} from './authorization';
+
+const user = { id: new Types.ObjectId().toString(), role: 'USER' } as IUser;
+const agent = { _id: new Types.ObjectId() };
+const req = {} as Request;
+
+function createRole(canUseAgents: boolean): IRole {
+  return {
+    permissions: {
+      [PermissionTypes.AGENTS]: {
+        [Permissions.USE]: canUseAgents,
+      },
+    },
+  } as IRole;
+}
+
+function createDependencies({
+  canUseAgents = true,
+  canManageAgents = false,
+  canViewAgent = true,
+} = {}) {
+  return {
+    getAgent: jest.fn().mockResolvedValue(agent),
+    getRoleByName: jest.fn().mockResolvedValue(createRole(canUseAgents)),
+    hasCapability: jest.fn().mockResolvedValue(canManageAgents),
+    checkPermission: jest.fn().mockResolvedValue(canViewAgent),
+  };
+}
+
+function createResponse(): Response {
+  const response = {} as Response;
+  response.status = jest.fn(() => response);
+  response.json = jest.fn(() => response);
+  return response;
+}
+
+describe('getAgentMemoryPartitionAccess', () => {
+  it('normalizes only non-empty string partition IDs', () => {
+    expect(getMemoryAgentIdParam(' agent-1 ')).toBe('agent-1');
+    expect(getMemoryAgentIdParam('   ')).toBeUndefined();
+    expect(getMemoryAgentIdParam(['agent-1'])).toBeUndefined();
+  });
+
+  it('starts independent agent, capability, and role reads concurrently', async () => {
+    let resolveAgent!: (value: typeof agent) => void;
+    const agentPromise = new Promise<typeof agent>((resolve) => {
+      resolveAgent = resolve;
+    });
+    const dependencies = createDependencies();
+    dependencies.getAgent.mockReturnValue(agentPromise);
+
+    const accessPromise = getAgentMemoryPartitionAccess({
+      req,
+      user,
+      agentId: 'agent-1',
+      ...dependencies,
+    });
+
+    expect(dependencies.getAgent).toHaveBeenCalledTimes(1);
+    expect(dependencies.hasCapability).toHaveBeenCalledTimes(1);
+    expect(dependencies.getRoleByName).toHaveBeenCalledTimes(1);
+
+    resolveAgent(agent);
+    await expect(accessPromise).resolves.toBe('allowed');
+  });
+
+  it('denies access when the role cannot use agents', async () => {
+    const dependencies = createDependencies({ canUseAgents: false });
+
+    await expect(
+      getAgentMemoryPartitionAccess({ req, user, agentId: 'agent-1', ...dependencies }),
+    ).resolves.toBe('denied');
+    expect(dependencies.checkPermission).not.toHaveBeenCalled();
+  });
+
+  it('allows agent managers without consulting the resource ACL', async () => {
+    const dependencies = createDependencies({ canManageAgents: true, canViewAgent: false });
+
+    await expect(
+      getAgentMemoryPartitionAccess({ req, user, agentId: 'agent-1', ...dependencies }),
+    ).resolves.toBe('allowed');
+    expect(dependencies.checkPermission).not.toHaveBeenCalled();
+  });
+
+  it('uses the agent VIEW ACL for non-managers', async () => {
+    const dependencies = createDependencies({ canViewAgent: false });
+
+    await expect(
+      getAgentMemoryPartitionAccess({ req, user, agentId: 'agent-1', ...dependencies }),
+    ).resolves.toBe('denied');
+    expect(dependencies.checkPermission).toHaveBeenCalledWith(
+      expect.objectContaining({ resourceId: agent._id }),
+    );
+  });
+
+  it('reports a missing agent without consulting its resource ACL', async () => {
+    const dependencies = createDependencies();
+    dependencies.getAgent.mockResolvedValue(null);
+
+    await expect(
+      getAgentMemoryPartitionAccess({ req, user, agentId: 'missing-agent', ...dependencies }),
+    ).resolves.toBe('not_found');
+    expect(dependencies.checkPermission).not.toHaveBeenCalled();
+  });
+
+  it('allows deletion middleware to clean up a missing agent partition', async () => {
+    const dependencies = createDependencies();
+    dependencies.getAgent.mockResolvedValue(null);
+    const middleware = createAgentMemoryPartitionMiddleware({
+      source: 'query',
+      allowMissingAgent: true,
+      ...dependencies,
+    });
+    const request = { user, query: { agentId: 'missing-agent' } } as Request;
+    const response = createResponse();
+    const next = jest.fn();
+
+    await middleware(request, response, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(response.status).not.toHaveBeenCalled();
+  });
+
+  it('returns forbidden before mutation middleware proceeds when agent use is disabled', async () => {
+    const dependencies = createDependencies({ canUseAgents: false });
+    const middleware = createAgentMemoryPartitionMiddleware({
+      source: 'body',
+      ...dependencies,
+    });
+    const request = { user, body: { agentId: 'agent-1' } } as Request;
+    const response = createResponse();
+    const next = jest.fn();
+
+    await middleware(request, response, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(response.status).toHaveBeenCalledWith(403);
+    expect(response.json).toHaveBeenCalledWith({ error: 'Agent access denied.' });
+  });
+});

--- a/packages/api/src/memory/authorization.spec.ts
+++ b/packages/api/src/memory/authorization.spec.ts
@@ -10,7 +10,10 @@ import {
 
 const user = { id: new Types.ObjectId().toString(), role: 'USER' } as IUser;
 const agent = { _id: new Types.ObjectId() };
-const req = {} as Request;
+
+function createRequest(): Request {
+  return {} as Request;
+}
 
 function createRole(canUseAgents: boolean): IRole {
   return {
@@ -58,13 +61,14 @@ describe('getAgentMemoryPartitionAccess', () => {
     dependencies.getAgent.mockReturnValue(agentPromise);
 
     const accessPromise = getAgentMemoryPartitionAccess({
-      req,
+      req: createRequest(),
       user,
       agentId: 'agent-1',
       ...dependencies,
     });
 
     expect(dependencies.getAgent).toHaveBeenCalledTimes(1);
+    expect(dependencies.getAgent).toHaveBeenCalledWith({ id: 'agent-1' }, { _id: 1 });
     expect(dependencies.hasCapability).toHaveBeenCalledTimes(1);
     expect(dependencies.getRoleByName).toHaveBeenCalledTimes(1);
 
@@ -76,7 +80,12 @@ describe('getAgentMemoryPartitionAccess', () => {
     const dependencies = createDependencies({ canUseAgents: false });
 
     await expect(
-      getAgentMemoryPartitionAccess({ req, user, agentId: 'agent-1', ...dependencies }),
+      getAgentMemoryPartitionAccess({
+        req: createRequest(),
+        user,
+        agentId: 'agent-1',
+        ...dependencies,
+      }),
     ).resolves.toBe('denied');
     expect(dependencies.checkPermission).not.toHaveBeenCalled();
   });
@@ -85,7 +94,12 @@ describe('getAgentMemoryPartitionAccess', () => {
     const dependencies = createDependencies({ canManageAgents: true, canViewAgent: false });
 
     await expect(
-      getAgentMemoryPartitionAccess({ req, user, agentId: 'agent-1', ...dependencies }),
+      getAgentMemoryPartitionAccess({
+        req: createRequest(),
+        user,
+        agentId: 'agent-1',
+        ...dependencies,
+      }),
     ).resolves.toBe('allowed');
     expect(dependencies.checkPermission).not.toHaveBeenCalled();
   });
@@ -94,7 +108,12 @@ describe('getAgentMemoryPartitionAccess', () => {
     const dependencies = createDependencies({ canViewAgent: false });
 
     await expect(
-      getAgentMemoryPartitionAccess({ req, user, agentId: 'agent-1', ...dependencies }),
+      getAgentMemoryPartitionAccess({
+        req: createRequest(),
+        user,
+        agentId: 'agent-1',
+        ...dependencies,
+      }),
     ).resolves.toBe('denied');
     expect(dependencies.checkPermission).toHaveBeenCalledWith(
       expect.objectContaining({ resourceId: agent._id }),
@@ -106,20 +125,40 @@ describe('getAgentMemoryPartitionAccess', () => {
     dependencies.getAgent.mockResolvedValue(null);
 
     await expect(
-      getAgentMemoryPartitionAccess({ req, user, agentId: 'missing-agent', ...dependencies }),
+      getAgentMemoryPartitionAccess({
+        req: createRequest(),
+        user,
+        agentId: 'missing-agent',
+        ...dependencies,
+      }),
     ).resolves.toBe('not_found');
     expect(dependencies.checkPermission).not.toHaveBeenCalled();
   });
 
+  it('does not disclose missing agents when the role cannot use agents', async () => {
+    const dependencies = createDependencies({ canUseAgents: false });
+    dependencies.getAgent.mockResolvedValue(null);
+
+    await expect(
+      getAgentMemoryPartitionAccess({
+        req: createRequest(),
+        user,
+        agentId: 'missing-agent',
+        ...dependencies,
+      }),
+    ).resolves.toBe('denied');
+    expect(dependencies.checkPermission).not.toHaveBeenCalled();
+  });
+
   it('allows deletion middleware to clean up a missing agent partition', async () => {
-    const dependencies = createDependencies();
+    const dependencies = createDependencies({ canUseAgents: false });
     dependencies.getAgent.mockResolvedValue(null);
     const middleware = createAgentMemoryPartitionMiddleware({
       source: 'query',
       allowMissingAgent: true,
       ...dependencies,
     });
-    const request = { user, query: { agentId: 'missing-agent' } } as Request;
+    const request = { user, query: { agentId: 'missing-agent' } } as unknown as Request;
     const response = createResponse();
     const next = jest.fn();
 
@@ -135,7 +174,7 @@ describe('getAgentMemoryPartitionAccess', () => {
       source: 'body',
       ...dependencies,
     });
-    const request = { user, body: { agentId: 'agent-1' } } as Request;
+    const request = { user, body: { agentId: 'agent-1' } } as unknown as Request;
     const response = createResponse();
     const next = jest.fn();
 

--- a/packages/api/src/memory/authorization.ts
+++ b/packages/api/src/memory/authorization.ts
@@ -21,7 +21,7 @@ interface CheckPermissionParams {
 }
 
 interface AgentMemoryPartitionAccessDependencies {
-  getAgent: (query: { id: string }) => Promise<Pick<IAgent, '_id'> | null>;
+  getAgent: (query: { id: string }, projection: { _id: 1 }) => Promise<Pick<IAgent, '_id'> | null>;
   getRoleByName: CheckAccessParams['getRoleByName'];
   hasCapability: (
     user: IUser,
@@ -34,6 +34,7 @@ interface AgentMemoryPartitionAccessParams extends AgentMemoryPartitionAccessDep
   req: Request;
   user: IUser;
   agentId: string;
+  allowMissingAgent?: boolean;
 }
 
 interface AgentMemoryPartitionMiddlewareParams extends AgentMemoryPartitionAccessDependencies {
@@ -49,13 +50,14 @@ export async function getAgentMemoryPartitionAccess({
   req,
   user,
   agentId,
+  allowMissingAgent = false,
   getAgent,
   getRoleByName,
   hasCapability,
   checkPermission,
 }: AgentMemoryPartitionAccessParams): Promise<AgentMemoryPartitionAccess> {
   const [agent, canManageAgents, canUseAgents] = await Promise.all([
-    getAgent({ id: agentId }),
+    getAgent({ id: agentId }, { _id: 1 }),
     hasCapability(user, ResourceCapabilityMap[ResourceType.AGENT]).catch(() => false),
     checkAccess({
       req,
@@ -66,11 +68,11 @@ export async function getAgentMemoryPartitionAccess({
     }).catch(() => false),
   ]);
 
+  if (!canUseAgents && !(allowMissingAgent && !agent)) {
+    return 'denied';
+  }
   if (!agent) {
     return 'not_found';
-  }
-  if (!canUseAgents) {
-    return 'denied';
   }
   if (canManageAgents) {
     return 'allowed';
@@ -107,6 +109,7 @@ export function createAgentMemoryPartitionMiddleware({
         req,
         user: req.user as IUser,
         agentId,
+        allowMissingAgent,
         ...dependencies,
       });
       if (agentAccess === 'not_found') {

--- a/packages/api/src/memory/authorization.ts
+++ b/packages/api/src/memory/authorization.ts
@@ -1,0 +1,123 @@
+import { ResourceCapabilityMap } from '@librechat/data-schemas';
+import {
+  Permissions,
+  PermissionBits,
+  ResourceType,
+  PermissionTypes,
+} from 'librechat-data-provider';
+import type { NextFunction, Request, Response } from 'express';
+import type { IAgent, IUser } from '@librechat/data-schemas';
+import type { CheckAccessParams } from '../middleware/access';
+import { checkAccess } from '../middleware/access';
+
+export type AgentMemoryPartitionAccess = 'allowed' | 'denied' | 'not_found';
+
+interface CheckPermissionParams {
+  userId: string;
+  role?: string;
+  resourceType: ResourceType;
+  resourceId: IAgent['_id'];
+  requiredPermission: number;
+}
+
+interface AgentMemoryPartitionAccessDependencies {
+  getAgent: (query: { id: string }) => Promise<Pick<IAgent, '_id'> | null>;
+  getRoleByName: CheckAccessParams['getRoleByName'];
+  hasCapability: (
+    user: IUser,
+    capability: (typeof ResourceCapabilityMap)[ResourceType.AGENT],
+  ) => Promise<boolean>;
+  checkPermission: (params: CheckPermissionParams) => Promise<boolean>;
+}
+
+interface AgentMemoryPartitionAccessParams extends AgentMemoryPartitionAccessDependencies {
+  req: Request;
+  user: IUser;
+  agentId: string;
+}
+
+interface AgentMemoryPartitionMiddlewareParams extends AgentMemoryPartitionAccessDependencies {
+  source: 'body' | 'query';
+  allowMissingAgent?: boolean;
+}
+
+export function getMemoryAgentIdParam(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined;
+}
+
+export async function getAgentMemoryPartitionAccess({
+  req,
+  user,
+  agentId,
+  getAgent,
+  getRoleByName,
+  hasCapability,
+  checkPermission,
+}: AgentMemoryPartitionAccessParams): Promise<AgentMemoryPartitionAccess> {
+  const [agent, canManageAgents, canUseAgents] = await Promise.all([
+    getAgent({ id: agentId }),
+    hasCapability(user, ResourceCapabilityMap[ResourceType.AGENT]).catch(() => false),
+    checkAccess({
+      req,
+      user,
+      permissionType: PermissionTypes.AGENTS,
+      permissions: [Permissions.USE],
+      getRoleByName,
+    }).catch(() => false),
+  ]);
+
+  if (!agent) {
+    return 'not_found';
+  }
+  if (!canUseAgents) {
+    return 'denied';
+  }
+  if (canManageAgents) {
+    return 'allowed';
+  }
+
+  const canViewAgent = await checkPermission({
+    userId: user.id,
+    role: user.role,
+    resourceType: ResourceType.AGENT,
+    resourceId: agent._id,
+    requiredPermission: PermissionBits.VIEW,
+  });
+  return canViewAgent ? 'allowed' : 'denied';
+}
+
+export function createAgentMemoryPartitionMiddleware({
+  source,
+  allowMissingAgent = false,
+  ...dependencies
+}: AgentMemoryPartitionMiddlewareParams): (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => Promise<unknown> {
+  return async (req, res, next) => {
+    const value = source === 'body' ? req.body?.agentId : req.query.agentId;
+    const agentId = getMemoryAgentIdParam(value);
+    if (!agentId) {
+      return next();
+    }
+
+    try {
+      const agentAccess = await getAgentMemoryPartitionAccess({
+        req,
+        user: req.user as IUser,
+        agentId,
+        ...dependencies,
+      });
+      if (agentAccess === 'not_found') {
+        return allowMissingAgent ? next() : res.status(404).json({ error: 'Agent not found.' });
+      }
+      if (agentAccess === 'denied') {
+        return res.status(403).json({ error: 'Agent access denied.' });
+      }
+      return next();
+    } catch (_error) {
+      return res.status(500).json({ error: 'Failed to validate agent access.' });
+    }
+  };
+}

--- a/packages/api/src/memory/index.ts
+++ b/packages/api/src/memory/index.ts
@@ -1,3 +1,4 @@
 export * from './config';
+export * from './authorization';
 export * from './handlers';
 export * from './protection';

--- a/packages/api/src/middleware/access.spec.ts
+++ b/packages/api/src/middleware/access.spec.ts
@@ -367,7 +367,7 @@ describe('access middleware', () => {
       expect(defaultParams.getRoleByName).toHaveBeenCalledTimes(1);
     });
 
-    it('should reuse the role lookup across different permission types', async () => {
+    it('should reuse a synchronous role lookup across different permission types', async () => {
       const role = {
         name: 'user',
         permissions: {
@@ -375,7 +375,7 @@ describe('access middleware', () => {
           [PermissionTypes.AGENTS]: { [Permissions.USE]: true },
         },
       } as unknown as IRole;
-      defaultParams.getRoleByName.mockResolvedValue(role);
+      defaultParams.getRoleByName.mockReturnValue(role);
       const req = mockReq as Request;
 
       await expect(

--- a/packages/api/src/middleware/access.spec.ts
+++ b/packages/api/src/middleware/access.spec.ts
@@ -364,7 +364,36 @@ describe('access middleware', () => {
         }),
       ).resolves.toBe(true);
 
-      expect(defaultParams.getRoleByName).toHaveBeenCalledTimes(2);
+      expect(defaultParams.getRoleByName).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reuse the role lookup across different permission types', async () => {
+      const role = {
+        name: 'user',
+        permissions: {
+          [PermissionTypes.MEMORIES]: { [Permissions.USE]: true },
+          [PermissionTypes.AGENTS]: { [Permissions.USE]: true },
+        },
+      } as unknown as IRole;
+      defaultParams.getRoleByName.mockResolvedValue(role);
+      const req = mockReq as Request;
+
+      await expect(
+        checkAccess({
+          ...defaultParams,
+          req,
+          permissionType: PermissionTypes.MEMORIES,
+        }),
+      ).resolves.toBe(true);
+      await expect(
+        checkAccess({
+          ...defaultParams,
+          req,
+          permissionType: PermissionTypes.AGENTS,
+        }),
+      ).resolves.toBe(true);
+
+      expect(defaultParams.getRoleByName).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/api/src/middleware/access.ts
+++ b/packages/api/src/middleware/access.ts
@@ -82,7 +82,12 @@ async function getRoleForAccess({
 
   let cachedRole = cache.get(roleName);
   if (!cachedRole) {
-    cachedRole = getRoleByName(roleName).catch((error) => {
+    try {
+      cachedRole = Promise.resolve(getRoleByName(roleName));
+    } catch (error) {
+      cachedRole = Promise.reject(error);
+    }
+    cachedRole = cachedRole.catch((error) => {
       cache.delete(roleName);
       throw error;
     });

--- a/packages/api/src/middleware/access.ts
+++ b/packages/api/src/middleware/access.ts
@@ -42,8 +42,55 @@ export type CheckAccessWithRequestCacheParams = Omit<
 >;
 
 type RequestPermissionCache = Map<string, Promise<boolean>>;
+type RequestRoleCache = Map<string, Promise<IRole | null>>;
 
 const requestPermissionCacheKey = '__librechatRequestPermissionCache';
+const requestRoleCacheKey = '__librechatRequestRoleCache';
+
+function getRequestRoleCache(req?: ServerRequest): RequestRoleCache | null {
+  if (!req) {
+    return null;
+  }
+
+  const reqWithCache = req as ServerRequest & {
+    [requestRoleCacheKey]?: RequestRoleCache;
+  };
+
+  if (!reqWithCache[requestRoleCacheKey]) {
+    Object.defineProperty(reqWithCache, requestRoleCacheKey, {
+      value: new Map<string, Promise<IRole | null>>(),
+      enumerable: false,
+    });
+  }
+
+  return reqWithCache[requestRoleCacheKey] ?? null;
+}
+
+async function getRoleForAccess({
+  req,
+  roleName,
+  getRoleByName,
+}: {
+  req?: ServerRequest;
+  roleName: string;
+  getRoleByName: CheckAccessParams['getRoleByName'];
+}): Promise<IRole | null> {
+  const cache = getRequestRoleCache(req);
+  if (!cache) {
+    return await getRoleByName(roleName);
+  }
+
+  let cachedRole = cache.get(roleName);
+  if (!cachedRole) {
+    cachedRole = getRoleByName(roleName).catch((error) => {
+      cache.delete(roleName);
+      throw error;
+    });
+    cache.set(roleName, cachedRole);
+  }
+
+  return await cachedRole;
+}
 
 function getRequestPermissionCache(req?: ServerRequest): RequestPermissionCache | null {
   if (!req) {
@@ -100,7 +147,7 @@ export const checkAccess = async ({
     return false;
   }
 
-  const role = await getRoleByName(user.role);
+  const role = await getRoleForAccess({ req, roleName: user.role, getRoleByName });
   const permissionValue = role?.permissions?.[permissionType as keyof typeof role.permissions];
   if (role && role.permissions && permissionValue) {
     const hasAnyPermission = permissions.every((permission) => {


### PR DESCRIPTION
## Summary

I prevented client-controlled memory partition IDs from bypassing per-agent memory quotas by requiring every supplied agent ID to resolve to an existing agent that the requester can view.

- Validate normalized agent IDs before querying or writing an agent memory partition.
- Require role-level AGENTS:USE and honor unrestricted agent-management capability alongside normal agent VIEW ACLs.
- Keep removed-agent partitions deletable through user-scoped cleanup routes.
- Reject nonexistent partitions with 404 and inaccessible partitions with 403.
- Gate key-based and ID-based memory updates and deletes with the same agent authorization.
- Reuse request-level role lookups, avoid agent-existence disclosure, and project only agent identifiers during authorization.

## Security Finding

- Resolves [Arbitrary memory partitions bypass memory quotas](https://chatgpt.com/codex/cloud/security/findings/150c8a53034881918ca79a4fdc083fc7?sev=&repo=https%3A%2F%2Fgithub.com%2Fdanny-avila%2FLibreChat).

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Ran the focused memory route suite (15 tests passed).
- [x] Ran the focused package authorization and access middleware suites (42 tests passed).
- [x] Ran ESLint and Prettier on all touched files.
- [x] Ran scoped import sorting on the touched TypeScript files.
- [x] Confirmed the package typecheck reports no errors in touched files; the full workspace check remains blocked by 47 unrelated stale dependency errors in agent queued-turn modules.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes