### PR TITLE
🚧 fix: Narrow Chat MCP Selections to What the Picker May Offer

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -169,12 +169,17 @@ const { filterFilesByAgentAccess } = require('~/server/services/Files/permission
 const { encodeAndFormat } = require('~/server/services/Files/images/encode');
 const { createContextHandlers } = require('~/app/clients/prompts');
 const { resolveConfigServers, getAccessibleMcpServerNames } = require('~/server/services/MCP');
-const { getMCPServerTools } = require('~/server/services/Config');
+const { getMCPServerTools, getMCPServerConfigForUser } = require('~/server/services/Config');
 const BaseClient = require('~/app/clients/BaseClient');
 const { getMCPManager } = require('~/config');
 const db = require('~/models');
 
-const loadAgent = (params) => loadAgentFn(params, { getAgent: db.getAgent, getMCPServerTools });
+const loadAgent = (params) =>
+  loadAgentFn(params, {
+    getAgent: db.getAgent,
+    getMCPServerTools,
+    getServerConfig: getMCPServerConfigForUser,
+  });
 
 const MEMORY_INPUT_CHARS_PER_TOKEN = 8;
 

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -169,7 +169,8 @@ const { filterFilesByAgentAccess } = require('~/server/services/Files/permission
 const { encodeAndFormat } = require('~/server/services/Files/images/encode');
 const { createContextHandlers } = require('~/app/clients/prompts');
 const { resolveConfigServers, getAccessibleMcpServerNames } = require('~/server/services/MCP');
-const { getMCPServerTools, getMCPServerConfigForUser } = require('~/server/services/Config');
+const { getMCPServerTools } = require('~/server/services/Config');
+const { getAccessibleMCPServers } = require('~/server/services/MCP');
 const BaseClient = require('~/app/clients/BaseClient');
 const { getMCPManager } = require('~/config');
 const db = require('~/models');
@@ -178,7 +179,7 @@ const loadAgent = (params) =>
   loadAgentFn(params, {
     getAgent: db.getAgent,
     getMCPServerTools,
-    getServerConfig: getMCPServerConfigForUser,
+    getAccessibleMCPServers,
   });
 
 const MEMORY_INPUT_CHARS_PER_TOKEN = 8;

--- a/api/server/services/Config/mcp.js
+++ b/api/server/services/Config/mcp.js
@@ -31,10 +31,22 @@ const {
     MCPServersRegistry.getInstance().isAppServerConfig(serverName, effectiveConfig),
 });
 
+/**
+ * A server's effective config for one user, argument-ordered like the other MCP
+ * tool dependencies. Resolves `consumeOnly` for servers the user reaches only
+ * through an agent, and returns undefined when the user cannot reach it at all.
+ * @param {string} userId
+ * @param {string} serverName
+ * @returns {Promise<import('@librechat/api').ParsedServerConfig | undefined>}
+ */
+const getMCPServerConfigForUser = (userId, serverName) =>
+  MCPServersRegistry.getInstance().getServerConfig(serverName, userId);
+
 module.exports = {
   syncStaticTools,
   mergeAppTools,
   getMCPServerTools,
+  getMCPServerConfigForUser,
   cacheMCPServerTools,
   updateMCPServerTools,
   getMCPToolsCacheGeneration,

--- a/api/server/services/Config/mcp.js
+++ b/api/server/services/Config/mcp.js
@@ -31,22 +31,10 @@ const {
     MCPServersRegistry.getInstance().isAppServerConfig(serverName, effectiveConfig),
 });
 
-/**
- * A server's effective config for one user, argument-ordered like the other MCP
- * tool dependencies. Resolves `consumeOnly` for servers the user reaches only
- * through an agent, and returns undefined when the user cannot reach it at all.
- * @param {string} userId
- * @param {string} serverName
- * @returns {Promise<import('@librechat/api').ParsedServerConfig | undefined>}
- */
-const getMCPServerConfigForUser = (userId, serverName) =>
-  MCPServersRegistry.getInstance().getServerConfig(serverName, userId);
-
 module.exports = {
   syncStaticTools,
   mergeAppTools,
   getMCPServerTools,
-  getMCPServerConfigForUser,
   cacheMCPServerTools,
   updateMCPServerTools,
   getMCPToolsCacheGeneration,

--- a/api/server/services/Endpoints/agents/addedConvo.js
+++ b/api/server/services/Endpoints/agents/addedConvo.js
@@ -9,8 +9,8 @@ const {
 } = require('@librechat/api');
 const { isEphemeralAgentId } = require('librechat-data-provider');
 const { filterFilesByAgentAccess } = require('~/server/services/Files/permissions');
-const { getMCPServerTools, getMCPServerConfigForUser } = require('~/server/services/Config');
-const { getAccessibleMcpServerNames } = require('~/server/services/MCP');
+const { getMCPServerTools } = require('~/server/services/Config');
+const { getAccessibleMcpServerNames, getAccessibleMCPServers } = require('~/server/services/MCP');
 const { isFatalAgentInitializationError } = require('~/server/services/ToolService');
 const { getSkillDbMethods, canAuthorSkillFiles } = require('./skillDeps');
 const db = require('~/models');
@@ -19,7 +19,7 @@ const loadAddedAgent = (params) =>
   loadAddedAgentFn(params, {
     getAgent: db.getAgent,
     getMCPServerTools,
-    getServerConfig: getMCPServerConfigForUser,
+    getAccessibleMCPServers,
   });
 
 /**

--- a/api/server/services/Endpoints/agents/addedConvo.js
+++ b/api/server/services/Endpoints/agents/addedConvo.js
@@ -9,14 +9,18 @@ const {
 } = require('@librechat/api');
 const { isEphemeralAgentId } = require('librechat-data-provider');
 const { filterFilesByAgentAccess } = require('~/server/services/Files/permissions');
-const { getMCPServerTools } = require('~/server/services/Config');
+const { getMCPServerTools, getMCPServerConfigForUser } = require('~/server/services/Config');
 const { getAccessibleMcpServerNames } = require('~/server/services/MCP');
 const { isFatalAgentInitializationError } = require('~/server/services/ToolService');
 const { getSkillDbMethods, canAuthorSkillFiles } = require('./skillDeps');
 const db = require('~/models');
 
 const loadAddedAgent = (params) =>
-  loadAddedAgentFn(params, { getAgent: db.getAgent, getMCPServerTools });
+  loadAddedAgentFn(params, {
+    getAgent: db.getAgent,
+    getMCPServerTools,
+    getServerConfig: getMCPServerConfigForUser,
+  });
 
 /**
  * Process addedConvo for parallel agent execution.

--- a/api/server/services/Endpoints/agents/build.js
+++ b/api/server/services/Endpoints/agents/build.js
@@ -1,10 +1,15 @@
 const { logger } = require('@librechat/data-schemas');
 const { loadAgent: loadAgentFn } = require('@librechat/api');
 const { isAgentsEndpoint, removeNullishValues, Constants } = require('librechat-data-provider');
-const { getMCPServerTools } = require('~/server/services/Config');
+const { getMCPServerTools, getMCPServerConfigForUser } = require('~/server/services/Config');
 const db = require('~/models');
 
-const loadAgent = (params) => loadAgentFn(params, { getAgent: db.getAgent, getMCPServerTools });
+const loadAgent = (params) =>
+  loadAgentFn(params, {
+    getAgent: db.getAgent,
+    getMCPServerTools,
+    getServerConfig: getMCPServerConfigForUser,
+  });
 
 const buildOptions = (req, endpoint, parsedBody, endpointType) => {
   const { spec, iconURL, agent_id, chatProjectId, ...model_parameters } = parsedBody;

--- a/api/server/services/Endpoints/agents/build.js
+++ b/api/server/services/Endpoints/agents/build.js
@@ -1,14 +1,15 @@
 const { logger } = require('@librechat/data-schemas');
 const { loadAgent: loadAgentFn } = require('@librechat/api');
 const { isAgentsEndpoint, removeNullishValues, Constants } = require('librechat-data-provider');
-const { getMCPServerTools, getMCPServerConfigForUser } = require('~/server/services/Config');
+const { getMCPServerTools } = require('~/server/services/Config');
+const { getAccessibleMCPServers } = require('~/server/services/MCP');
 const db = require('~/models');
 
 const loadAgent = (params) =>
   loadAgentFn(params, {
     getAgent: db.getAgent,
     getMCPServerTools,
-    getServerConfig: getMCPServerConfigForUser,
+    getAccessibleMCPServers,
   });
 
 const buildOptions = (req, endpoint, parsedBody, endpointType) => {

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -467,6 +467,18 @@ async function resolveCollisionAuditNames({ rawServerNames, accessibleServerName
   }
 }
 
+/**
+ * The MCP servers a user can reach, keyed by name, with the registry's tier
+ * precedence already applied. This is the resolution behind `GET /api/mcp/servers`,
+ * so anything derived from it agrees with the catalog the client was given.
+ * @param {string} userId
+ * @param {string} [role]
+ * @returns {Promise<Record<string, import('@librechat/api').ParsedServerConfig>>}
+ */
+async function getAccessibleMCPServers(userId, role) {
+  return await resolveAllMcpConfigs(userId, role != null ? { role } : undefined);
+}
+
 async function resolveAllMcpConfigs(userId, user) {
   const registry = getMCPServersRegistry();
   const appConfig = await getAppConfigForUser(userId, user);
@@ -1648,6 +1660,7 @@ module.exports = {
   resolveCollisionAuditNames,
   resolveMcpConfigNames,
   resolveAllMcpConfigs,
+  getAccessibleMCPServers,
   createOAuthStart,
   checkOAuthFlowStatus,
   getServerConnectionStatus,

--- a/packages/api/src/agents/__tests__/load.spec.ts
+++ b/packages/api/src/agents/__tests__/load.spec.ts
@@ -19,10 +19,12 @@ let createAgent: ReturnType<typeof createMethods>['createAgent'];
 let getAgent: ReturnType<typeof createMethods>['getAgent'];
 
 const mockGetMCPServerTools = jest.fn();
+const mockGetServerConfig = jest.fn();
 
 const deps: LoadAgentDeps = {
   getAgent: (searchParameter) => getAgent(searchParameter) as Promise<LibreChatAgent | null>,
   getMCPServerTools: mockGetMCPServerTools,
+  getServerConfig: mockGetServerConfig,
 };
 
 describe('loadAgent', () => {
@@ -165,6 +167,111 @@ describe('loadAgent', () => {
     expect(mockGetMCPServerTools).toHaveBeenCalledWith('user123', 'server1', undefined);
     expect(result?.tools).toContain(`${Constants.mcp_all}${Constants.mcp_delimiter}body-scoped`);
     expect(result?.tools).toContain('tool1_mcp_server1');
+  });
+
+  describe('chat-selectable MCP narrowing', () => {
+    const { EPHEMERAL_AGENT_ID } = Constants;
+
+    const loadEphemeral = (config: Record<string, unknown>, mcp: string[], spec?: string) =>
+      loadAgent(
+        {
+          req: {
+            user: { id: 'user123' },
+            config: config as unknown as AppConfig,
+            body: { ephemeralAgent: { mcp } },
+          },
+          spec,
+          agent_id: EPHEMERAL_AGENT_ID as string,
+          endpoint: 'openai',
+          model_parameters: { model: 'gpt-4' } as unknown as AgentModelParameters,
+        },
+        deps,
+      );
+
+    const selectedServerNames = () => mockGetMCPServerTools.mock.calls.map((call) => call[1]);
+
+    beforeEach(() => {
+      mockGetServerConfig.mockResolvedValue(undefined);
+      mockGetMCPServerTools.mockImplementation(async (_userId: string, server: string) => ({
+        [`tool_mcp_${server}`]: {},
+      }));
+    });
+
+    test('drops a server the chat menu hides', async () => {
+      const result = await loadEphemeral(
+        {
+          mcpConfig: {
+            visible: { type: 'streamable-http', url: 'https://mcp.example.com/visible/mcp' },
+            hidden: {
+              type: 'streamable-http',
+              url: 'https://mcp.example.com/hidden/mcp',
+              chatMenu: false,
+            },
+          },
+        },
+        ['visible', 'hidden'],
+      );
+
+      expect(selectedServerNames()).toEqual(['visible']);
+      expect(result?.tools).toContain('tool_mcp_visible');
+      expect(result?.tools).not.toContain('tool_mcp_hidden');
+    });
+
+    test('drops a server the user only reaches through an agent', async () => {
+      mockGetServerConfig.mockImplementation(async (_userId: string, server: string) =>
+        server === 'agent-only' ? { consumeOnly: true } : undefined,
+      );
+
+      const result = await loadEphemeral({ mcpConfig: {} }, ['direct', 'agent-only']);
+
+      expect(selectedServerNames()).toEqual(['direct']);
+      expect(result?.tools).not.toContain('tool_mcp_agent-only');
+    });
+
+    test('keeps a spec-pinned server even when the chat menu hides it', async () => {
+      const result = await loadEphemeral(
+        {
+          mcpConfig: {
+            hidden: {
+              type: 'streamable-http',
+              url: 'https://mcp.example.com/hidden/mcp',
+              chatMenu: false,
+            },
+          },
+          modelSpecs: {
+            list: [
+              {
+                name: 'pins-hidden',
+                label: 'Pins Hidden',
+                preset: { endpoint: 'openai', model: 'gpt-4' },
+                mcpServers: ['hidden'],
+              },
+            ],
+          },
+        },
+        [],
+        'pins-hidden',
+      );
+
+      expect(selectedServerNames()).toEqual(['hidden']);
+      expect(result?.tools).toContain('tool_mcp_hidden');
+    });
+
+    test('keeps a request-tier server the registry cannot resolve', async () => {
+      const result = await loadEphemeral({ mcpConfig: {} }, ['body-scoped']);
+
+      expect(selectedServerNames()).toEqual(['body-scoped']);
+      expect(result?.tools).toContain('tool_mcp_body-scoped');
+    });
+
+    test('keeps a server whose config lookup fails', async () => {
+      mockGetServerConfig.mockRejectedValue(new Error('registry unavailable'));
+
+      const result = await loadEphemeral({ mcpConfig: {} }, ['flaky']);
+
+      expect(selectedServerNames()).toEqual(['flaky']);
+      expect(result?.tools).toContain('tool_mcp_flaky');
+    });
   });
 
   test('addresses cached tools with a non-ephemeral request overlay', async () => {

--- a/packages/api/src/agents/__tests__/load.spec.ts
+++ b/packages/api/src/agents/__tests__/load.spec.ts
@@ -19,12 +19,12 @@ let createAgent: ReturnType<typeof createMethods>['createAgent'];
 let getAgent: ReturnType<typeof createMethods>['getAgent'];
 
 const mockGetMCPServerTools = jest.fn();
-const mockGetServerConfig = jest.fn();
+const mockGetAccessibleMCPServers = jest.fn();
 
 const deps: LoadAgentDeps = {
   getAgent: (searchParameter) => getAgent(searchParameter) as Promise<LibreChatAgent | null>,
   getMCPServerTools: mockGetMCPServerTools,
-  getServerConfig: mockGetServerConfig,
+  getAccessibleMCPServers: mockGetAccessibleMCPServers,
 };
 
 describe('loadAgent', () => {
@@ -172,13 +172,17 @@ describe('loadAgent', () => {
   describe('chat-selectable MCP narrowing', () => {
     const { EPHEMERAL_AGENT_ID } = Constants;
 
-    const loadEphemeral = (config: Record<string, unknown>, mcp: string[], spec?: string) =>
+    const loadEphemeral = (
+      config: Record<string, unknown>,
+      body: { ephemeralAgent: { mcp: string[] } },
+      spec?: string,
+    ) =>
       loadAgent(
         {
           req: {
-            user: { id: 'user123' },
+            user: { id: 'user123', role: 'USER' },
             config: config as unknown as AppConfig,
-            body: { ephemeralAgent: { mcp } },
+            body,
           },
           spec,
           agent_id: EPHEMERAL_AGENT_ID as string,
@@ -191,7 +195,11 @@ describe('loadAgent', () => {
     const selectedServerNames = () => mockGetMCPServerTools.mock.calls.map((call) => call[1]);
 
     beforeEach(() => {
-      mockGetServerConfig.mockResolvedValue(undefined);
+      mockGetAccessibleMCPServers.mockResolvedValue({
+        visible: { chatMenu: true },
+        hidden: { chatMenu: false },
+        'agent-only': { consumeOnly: true },
+      });
       mockGetMCPServerTools.mockImplementation(async (_userId: string, server: string) => ({
         [`tool_mcp_${server}`]: {},
       }));
@@ -199,17 +207,10 @@ describe('loadAgent', () => {
 
     test('drops a server the chat menu hides', async () => {
       const result = await loadEphemeral(
+        { mcpConfig: {} },
         {
-          mcpConfig: {
-            visible: { type: 'streamable-http', url: 'https://mcp.example.com/visible/mcp' },
-            hidden: {
-              type: 'streamable-http',
-              url: 'https://mcp.example.com/hidden/mcp',
-              chatMenu: false,
-            },
-          },
+          ephemeralAgent: { mcp: ['visible', 'hidden'] },
         },
-        ['visible', 'hidden'],
       );
 
       expect(selectedServerNames()).toEqual(['visible']);
@@ -218,26 +219,26 @@ describe('loadAgent', () => {
     });
 
     test('drops a server the user only reaches through an agent', async () => {
-      mockGetServerConfig.mockImplementation(async (_userId: string, server: string) =>
-        server === 'agent-only' ? { consumeOnly: true } : undefined,
+      const result = await loadEphemeral(
+        { mcpConfig: {} },
+        {
+          ephemeralAgent: { mcp: ['visible', 'agent-only'] },
+        },
       );
 
-      const result = await loadEphemeral({ mcpConfig: {} }, ['direct', 'agent-only']);
-
-      expect(selectedServerNames()).toEqual(['direct']);
+      expect(selectedServerNames()).toEqual(['visible']);
       expect(result?.tools).not.toContain('tool_mcp_agent-only');
+    });
+
+    test('resolves the accessible catalog with the requesting user role', async () => {
+      await loadEphemeral({ mcpConfig: {} }, { ephemeralAgent: { mcp: ['visible'] } });
+      expect(mockGetAccessibleMCPServers).toHaveBeenCalledWith('user123', 'USER');
     });
 
     test('keeps a spec-pinned server even when the chat menu hides it', async () => {
       const result = await loadEphemeral(
         {
-          mcpConfig: {
-            hidden: {
-              type: 'streamable-http',
-              url: 'https://mcp.example.com/hidden/mcp',
-              chatMenu: false,
-            },
-          },
+          mcpConfig: {},
           modelSpecs: {
             list: [
               {
@@ -249,7 +250,7 @@ describe('loadAgent', () => {
             ],
           },
         },
-        [],
+        { ephemeralAgent: { mcp: [] } },
         'pins-hidden',
       );
 
@@ -257,48 +258,57 @@ describe('loadAgent', () => {
       expect(result?.tools).toContain('tool_mcp_hidden');
     });
 
-    test('narrows the request body, so the instruction path cannot see a hidden server', async () => {
-      const config = {
-        mcpConfig: {
-          visible: { type: 'streamable-http', url: 'https://mcp.example.com/visible/mcp' },
-          hidden: {
-            type: 'streamable-http',
-            url: 'https://mcp.example.com/hidden/mcp',
-            chatMenu: false,
-          },
-        },
-      };
-      const body = { ephemeralAgent: { mcp: ['visible', 'hidden'] } };
-
-      await loadAgent(
-        {
-          req: { user: { id: 'user123' }, config: config as unknown as AppConfig, body },
-          agent_id: EPHEMERAL_AGENT_ID as string,
-          endpoint: 'openai',
-          model_parameters: { model: 'gpt-4' } as unknown as AgentModelParameters,
-        },
-        deps,
-      );
-
-      /** `applyContextToAgent` reads this straight off the body and prefers it
-       *  over the agent's tools when loading `serverInstructions`. */
-      expect(body.ephemeralAgent.mcp).toEqual(['visible']);
-    });
-
     test('keeps a request-tier server the registry cannot resolve', async () => {
-      const result = await loadEphemeral({ mcpConfig: {} }, ['body-scoped']);
+      const result = await loadEphemeral(
+        { mcpConfig: {} },
+        {
+          ephemeralAgent: { mcp: ['body-scoped'] },
+        },
+      );
 
       expect(selectedServerNames()).toEqual(['body-scoped']);
       expect(result?.tools).toContain('tool_mcp_body-scoped');
     });
 
-    test('keeps a server whose config lookup fails', async () => {
-      mockGetServerConfig.mockRejectedValue(new Error('registry unavailable'));
+    test('keeps the selection when the catalog lookup fails', async () => {
+      mockGetAccessibleMCPServers.mockRejectedValue(new Error('registry unavailable'));
 
-      const result = await loadEphemeral({ mcpConfig: {} }, ['flaky']);
+      const result = await loadEphemeral(
+        { mcpConfig: {} },
+        {
+          ephemeralAgent: { mcp: ['flaky'] },
+        },
+      );
 
       expect(selectedServerNames()).toEqual(['flaky']);
       expect(result?.tools).toContain('tool_mcp_flaky');
+    });
+
+    test('publishes the servers actually in play back onto the request body', async () => {
+      const body = { ephemeralAgent: { mcp: ['visible', 'hidden'] } };
+
+      await loadEphemeral(
+        {
+          mcpConfig: {},
+          modelSpecs: {
+            list: [
+              {
+                name: 'pins-hidden',
+                label: 'Pins Hidden',
+                preset: { endpoint: 'openai', model: 'gpt-4' },
+                mcpServers: ['hidden'],
+              },
+            ],
+          },
+        },
+        body,
+        'pins-hidden',
+      );
+
+      /** `applyContextToAgent` reads this straight off the body and prefers it
+       *  over the agent's tools when loading `serverInstructions`: the hidden
+       *  pick is gone, the spec's pin stays. */
+      expect(body.ephemeralAgent.mcp).toEqual(['visible', 'hidden']);
     });
   });
 

--- a/packages/api/src/agents/__tests__/load.spec.ts
+++ b/packages/api/src/agents/__tests__/load.spec.ts
@@ -257,6 +257,34 @@ describe('loadAgent', () => {
       expect(result?.tools).toContain('tool_mcp_hidden');
     });
 
+    test('narrows the request body, so the instruction path cannot see a hidden server', async () => {
+      const config = {
+        mcpConfig: {
+          visible: { type: 'streamable-http', url: 'https://mcp.example.com/visible/mcp' },
+          hidden: {
+            type: 'streamable-http',
+            url: 'https://mcp.example.com/hidden/mcp',
+            chatMenu: false,
+          },
+        },
+      };
+      const body = { ephemeralAgent: { mcp: ['visible', 'hidden'] } };
+
+      await loadAgent(
+        {
+          req: { user: { id: 'user123' }, config: config as unknown as AppConfig, body },
+          agent_id: EPHEMERAL_AGENT_ID as string,
+          endpoint: 'openai',
+          model_parameters: { model: 'gpt-4' } as unknown as AgentModelParameters,
+        },
+        deps,
+      );
+
+      /** `applyContextToAgent` reads this straight off the body and prefers it
+       *  over the agent's tools when loading `serverInstructions`. */
+      expect(body.ephemeralAgent.mcp).toEqual(['visible']);
+    });
+
     test('keeps a request-tier server the registry cannot resolve', async () => {
       const result = await loadEphemeral({ mcpConfig: {} }, ['body-scoped']);
 

--- a/packages/api/src/agents/added.ts
+++ b/packages/api/src/agents/added.ts
@@ -61,14 +61,17 @@ export interface LoadAddedAgentDeps {
     serverName: string,
     serverConfig?: ParsedServerConfig,
   ) => Promise<Record<string, unknown> | null>;
-  /** Resolves a server's effective config for one user, so a chat selection can
-   *  be narrowed to what the chat menu offers. Omitted, the selection is used
-   *  as sent. */
-  getServerConfig?: (userId: string, serverName: string) => Promise<ParsedServerConfig | undefined>;
+  /** The MCP servers this user can reach, with the registry's tier precedence
+   *  already applied — the resolution behind the client's catalog. Omitted, the
+   *  chat selection is used as sent. */
+  getAccessibleMCPServers?: (
+    userId: string,
+    role?: string,
+  ) => Promise<Record<string, ParsedServerConfig>>;
 }
 
 interface LoadAddedAgentParams {
-  req: { user?: { id?: string }; config?: Record<string, unknown> };
+  req: { user?: { id?: string; role?: string }; config?: Record<string, unknown> };
   conversation: TConversation | null;
   primaryAgent?: Agent | null;
 }
@@ -196,8 +199,8 @@ export async function loadAddedAgent(
   const mcpServers = new Set<string>(
     await filterChatSelectableMCPServers(ephemeralAgent?.mcp, {
       userId,
-      mcpConfig: appConfig?.mcpConfig,
-      getServerConfig: deps.getServerConfig,
+      role: req.user?.role,
+      getAccessibleMCPServers: deps.getAccessibleMCPServers,
     }),
   );
 

--- a/packages/api/src/agents/added.ts
+++ b/packages/api/src/agents/added.ts
@@ -11,7 +11,11 @@ import {
 import type { Agent, AgentToolOptions, TConversation, TModelSpec } from 'librechat-data-provider';
 import type { AppConfig } from '@librechat/data-schemas';
 import type { ParsedServerConfig } from '~/mcp/types';
-import { requiresEphemeralUserConnection, validateMCPServerConfig } from '~/mcp/utils';
+import {
+  requiresEphemeralUserConnection,
+  filterChatSelectableMCPServers,
+  validateMCPServerConfig,
+} from '~/mcp/utils';
 import { ASK_USER_QUESTION_TOOL_NAME } from '~/agents/hitl/askUserQuestionTool';
 import { synthesizeBackgroundToolOptions } from '~/agents/background';
 import { mergeSynthesizedToolOptions } from '~/agents/selection';
@@ -57,6 +61,10 @@ export interface LoadAddedAgentDeps {
     serverName: string,
     serverConfig?: ParsedServerConfig,
   ) => Promise<Record<string, unknown> | null>;
+  /** Resolves a server's effective config for one user, so a chat selection can
+   *  be narrowed to what the chat menu offers. Omitted, the selection is used
+   *  as sent. */
+  getServerConfig?: (userId: string, serverName: string) => Promise<ParsedServerConfig | undefined>;
 }
 
 interface LoadAddedAgentParams {
@@ -182,8 +190,16 @@ export async function loadAddedAgent(
     return result as unknown as Agent;
   }
 
-  const mcpServers = new Set<string>(ephemeralAgent?.mcp);
   const userId = req.user?.id ?? '';
+  /** Narrowed like the primary ephemeral loader: picker selection only, spec
+   *  servers added below. */
+  const mcpServers = new Set<string>(
+    await filterChatSelectableMCPServers(ephemeralAgent?.mcp, {
+      userId,
+      mcpConfig: appConfig?.mcpConfig,
+      getServerConfig: deps.getServerConfig,
+    }),
+  );
 
   const modelSpecs = (appConfig?.modelSpecs as { list?: TModelSpec[] })?.list;
   let modelSpec: (typeof modelSpecs extends Array<infer T> | undefined ? T : never) | null = null;

--- a/packages/api/src/agents/load.ts
+++ b/packages/api/src/agents/load.ts
@@ -76,13 +76,19 @@ export async function loadEphemeralAgent(
   /** The picker's own selection is narrowed to what the picker may offer; a
    *  spec's servers are the operator's choice and are added after, so pinning a
    *  chat-hidden server to a spec keeps working. */
-  const mcpServers = new Set<string>(
-    await filterChatSelectableMCPServers(ephemeralAgent?.mcp, {
-      userId,
-      mcpConfig: req.config?.mcpConfig,
-      getServerConfig: deps.getServerConfig,
-    }),
-  );
+  const selectedMCPServers = await filterChatSelectableMCPServers(ephemeralAgent?.mcp, {
+    userId,
+    mcpConfig: req.config?.mcpConfig,
+    getServerConfig: deps.getServerConfig,
+  });
+  /** Narrow the request's own selection, not just this loader's copy. The
+   *  instruction path reads `req.body.ephemeralAgent.mcp` straight from the body
+   *  and prefers it over the agent's tools, so a hidden server would still have
+   *  its `serverInstructions` injected after its tools were dropped. */
+  if (ephemeralAgent != null && Array.isArray(ephemeralAgent.mcp)) {
+    ephemeralAgent.mcp = selectedMCPServers;
+  }
+  const mcpServers = new Set<string>(selectedMCPServers);
   if (modelSpec?.mcpServers) {
     for (const mcpServer of modelSpec.mcpServers) {
       mcpServers.add(mcpServer);

--- a/packages/api/src/agents/load.ts
+++ b/packages/api/src/agents/load.ts
@@ -37,15 +37,18 @@ export interface LoadAgentDeps {
     serverName: string,
     serverConfig?: ParsedServerConfig,
   ) => Promise<Record<string, unknown> | null>;
-  /** Resolves a server's effective config for one user, so a chat selection can
-   *  be narrowed to what the chat menu offers. Omitted, the selection is used
-   *  as sent. */
-  getServerConfig?: (userId: string, serverName: string) => Promise<ParsedServerConfig | undefined>;
+  /** The MCP servers this user can reach, with the registry's tier precedence
+   *  already applied — the resolution behind the client's catalog. Omitted, the
+   *  chat selection is used as sent. */
+  getAccessibleMCPServers?: (
+    userId: string,
+    role?: string,
+  ) => Promise<Record<string, ParsedServerConfig>>;
 }
 
 export interface LoadAgentParams {
   req: {
-    user?: { id?: string };
+    user?: { id?: string; role?: string };
     config?: AppConfig;
     body?: {
       promptPrefix?: string;
@@ -76,23 +79,24 @@ export async function loadEphemeralAgent(
   /** The picker's own selection is narrowed to what the picker may offer; a
    *  spec's servers are the operator's choice and are added after, so pinning a
    *  chat-hidden server to a spec keeps working. */
-  const selectedMCPServers = await filterChatSelectableMCPServers(ephemeralAgent?.mcp, {
-    userId,
-    mcpConfig: req.config?.mcpConfig,
-    getServerConfig: deps.getServerConfig,
-  });
-  /** Narrow the request's own selection, not just this loader's copy. The
-   *  instruction path reads `req.body.ephemeralAgent.mcp` straight from the body
-   *  and prefers it over the agent's tools, so a hidden server would still have
-   *  its `serverInstructions` injected after its tools were dropped. */
-  if (ephemeralAgent != null && Array.isArray(ephemeralAgent.mcp)) {
-    ephemeralAgent.mcp = selectedMCPServers;
-  }
-  const mcpServers = new Set<string>(selectedMCPServers);
+  const mcpServers = new Set<string>(
+    await filterChatSelectableMCPServers(ephemeralAgent?.mcp, {
+      userId,
+      role: req.user?.role,
+      getAccessibleMCPServers: deps.getAccessibleMCPServers,
+    }),
+  );
   if (modelSpec?.mcpServers) {
     for (const mcpServer of modelSpec.mcpServers) {
       mcpServers.add(mcpServer);
     }
+  }
+  /** Publish the servers this request will actually use back onto the body. The
+   *  instruction path reads `req.body.ephemeralAgent.mcp` directly and prefers
+   *  it over the agent's tools, so it would otherwise both inject a hidden
+   *  server's `serverInstructions` and omit a spec-pinned server's. */
+  if (ephemeralAgent != null && Array.isArray(ephemeralAgent.mcp)) {
+    ephemeralAgent.mcp = [...mcpServers];
   }
   const tools: string[] = [];
   if (ephemeralAgent?.execute_code === true || modelSpec?.executeCode === true) {

--- a/packages/api/src/agents/load.ts
+++ b/packages/api/src/agents/load.ts
@@ -16,7 +16,11 @@ import type {
 } from 'librechat-data-provider';
 import type { AppConfig } from '@librechat/data-schemas';
 import type { ParsedServerConfig } from '~/mcp/types';
-import { requiresEphemeralUserConnection, validateMCPServerConfig } from '~/mcp/utils';
+import {
+  requiresEphemeralUserConnection,
+  filterChatSelectableMCPServers,
+  validateMCPServerConfig,
+} from '~/mcp/utils';
 import { ASK_USER_QUESTION_TOOL_NAME } from '~/agents/hitl/askUserQuestionTool';
 import { synthesizeBackgroundToolOptions } from '~/agents/background';
 import { mergeSynthesizedToolOptions } from '~/agents/selection';
@@ -33,6 +37,10 @@ export interface LoadAgentDeps {
     serverName: string,
     serverConfig?: ParsedServerConfig,
   ) => Promise<Record<string, unknown> | null>;
+  /** Resolves a server's effective config for one user, so a chat selection can
+   *  be narrowed to what the chat menu offers. Omitted, the selection is used
+   *  as sent. */
+  getServerConfig?: (userId: string, serverName: string) => Promise<ParsedServerConfig | undefined>;
 }
 
 export interface LoadAgentParams {
@@ -64,8 +72,17 @@ export async function loadEphemeralAgent(
     modelSpec = modelSpecs?.list?.find((s) => s.name === spec) ?? null;
   }
   const ephemeralAgent: TEphemeralAgent | undefined = req.body?.ephemeralAgent;
-  const mcpServers = new Set<string>(ephemeralAgent?.mcp);
   const userId = req.user?.id ?? '';
+  /** The picker's own selection is narrowed to what the picker may offer; a
+   *  spec's servers are the operator's choice and are added after, so pinning a
+   *  chat-hidden server to a spec keeps working. */
+  const mcpServers = new Set<string>(
+    await filterChatSelectableMCPServers(ephemeralAgent?.mcp, {
+      userId,
+      mcpConfig: req.config?.mcpConfig,
+      getServerConfig: deps.getServerConfig,
+    }),
+  );
   if (modelSpec?.mcpServers) {
     for (const mcpServer of modelSpec.mcpServers) {
       mcpServers.add(mcpServer);

--- a/packages/api/src/mcp/__tests__/utils.test.ts
+++ b/packages/api/src/mcp/__tests__/utils.test.ts
@@ -20,6 +20,8 @@ import {
   isUserSourced,
   validateMCPServerConfig,
   requiresEphemeralUserConnection,
+  isChatSelectableMCPServer,
+  filterChatSelectableMCPServers,
 } from '~/mcp/utils';
 
 describe('normalizeServerName', () => {
@@ -1090,5 +1092,94 @@ describe('getMissingCustomUserVars', () => {
     expect(
       getMissingCustomUserVars(config, { THINGY_TOKEN: 'abc123', UNRELATED: 'value' }),
     ).toEqual([]);
+  });
+});
+
+describe('isChatSelectableMCPServer', () => {
+  it('rejects a server hidden from the chat menu', () => {
+    expect(isChatSelectableMCPServer({ chatMenu: false })).toBe(false);
+  });
+
+  it('rejects a server reachable only through an agent', () => {
+    expect(isChatSelectableMCPServer({ consumeOnly: true })).toBe(false);
+  });
+
+  it('accepts a server with the flags unset or explicitly on', () => {
+    expect(isChatSelectableMCPServer({})).toBe(true);
+    expect(isChatSelectableMCPServer({ chatMenu: true, consumeOnly: false })).toBe(true);
+  });
+
+  it('accepts an unresolved config so request-tier servers are not dropped', () => {
+    expect(isChatSelectableMCPServer(undefined)).toBe(true);
+    expect(isChatSelectableMCPServer(null)).toBe(true);
+  });
+});
+
+describe('filterChatSelectableMCPServers', () => {
+  const mcpConfig = {
+    visible: { chatMenu: true },
+    hidden: { chatMenu: false },
+    unset: {},
+  };
+
+  it('drops servers the config tier hides, without a registry lookup', async () => {
+    const getServerConfig = jest.fn();
+    await expect(
+      filterChatSelectableMCPServers(['visible', 'hidden'], {
+        userId: 'user123',
+        mcpConfig,
+        getServerConfig,
+      }),
+    ).resolves.toEqual(['visible']);
+    expect(getServerConfig).not.toHaveBeenCalledWith('user123', 'hidden');
+  });
+
+  it('drops servers the user only reaches through an agent', async () => {
+    const getServerConfig = jest.fn(async (_userId: string, serverName: string) =>
+      serverName === 'agent-only' ? { consumeOnly: true } : {},
+    );
+    await expect(
+      filterChatSelectableMCPServers(['direct', 'agent-only'], {
+        userId: 'user123',
+        mcpConfig: {},
+        getServerConfig,
+      }),
+    ).resolves.toEqual(['direct']);
+  });
+
+  it('keeps a server the registry cannot resolve', async () => {
+    const getServerConfig = jest.fn(async () => undefined);
+    await expect(
+      filterChatSelectableMCPServers(['body-scoped'], {
+        userId: 'user123',
+        mcpConfig: {},
+        getServerConfig,
+      }),
+    ).resolves.toEqual(['body-scoped']);
+  });
+
+  it('keeps a server whose lookup fails rather than dropping it', async () => {
+    const getServerConfig = jest.fn(async () => {
+      throw new Error('registry unavailable');
+    });
+    await expect(
+      filterChatSelectableMCPServers(['a', 'b'], {
+        userId: 'user123',
+        mcpConfig: {},
+        getServerConfig,
+      }),
+    ).resolves.toEqual(['a', 'b']);
+  });
+
+  it('uses the selection as sent when no resolver is supplied', async () => {
+    await expect(
+      filterChatSelectableMCPServers(['a', 'b'], { userId: 'user123' }),
+    ).resolves.toEqual(['a', 'b']);
+  });
+
+  it('returns an empty array for an empty or missing selection', async () => {
+    await expect(filterChatSelectableMCPServers([], { userId: 'u' })).resolves.toEqual([]);
+    await expect(filterChatSelectableMCPServers(undefined, { userId: 'u' })).resolves.toEqual([]);
+    await expect(filterChatSelectableMCPServers(null, { userId: 'u' })).resolves.toEqual([]);
   });
 });

--- a/packages/api/src/mcp/__tests__/utils.test.ts
+++ b/packages/api/src/mcp/__tests__/utils.test.ts
@@ -1147,6 +1147,62 @@ describe('filterChatSelectableMCPServers', () => {
     ).resolves.toEqual(['direct']);
   });
 
+  it('resolves one config lookup per distinct name, however often it repeats', async () => {
+    const getServerConfig = jest.fn(async () => ({}));
+    await expect(
+      filterChatSelectableMCPServers(['a', 'a', 'b', 'a', 'b'], {
+        userId: 'user123',
+        mcpConfig: {},
+        getServerConfig,
+      }),
+    ).resolves.toEqual(['a', 'b']);
+    expect(getServerConfig).toHaveBeenCalledTimes(2);
+  });
+
+  it('drops a hidden server named by its normalized spelling', async () => {
+    const getServerConfig = jest.fn(async () => undefined);
+    await expect(
+      filterChatSelectableMCPServers(['private_server'], {
+        userId: 'user123',
+        mcpConfig: { 'private server': { chatMenu: false } },
+        getServerConfig,
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it('keeps a visible server named by its normalized spelling, as sent', async () => {
+    const getServerConfig = jest.fn(async () => ({}));
+    await expect(
+      filterChatSelectableMCPServers(['private_server'], {
+        userId: 'user123',
+        mcpConfig: { 'private server': { chatMenu: true } },
+        getServerConfig,
+      }),
+    ).resolves.toEqual(['private_server']);
+  });
+
+  it('lets a request overlay re-enable a server the registry still hides', async () => {
+    const getServerConfig = jest.fn(async () => ({ chatMenu: false }));
+    await expect(
+      filterChatSelectableMCPServers(['revived'], {
+        userId: 'user123',
+        mcpConfig: { revived: { chatMenu: true } },
+        getServerConfig,
+      }),
+    ).resolves.toEqual(['revived']);
+  });
+
+  it('still drops an overlay-enabled server the user only reaches via an agent', async () => {
+    const getServerConfig = jest.fn(async () => ({ consumeOnly: true }));
+    await expect(
+      filterChatSelectableMCPServers(['revived'], {
+        userId: 'user123',
+        mcpConfig: { revived: { chatMenu: true } },
+        getServerConfig,
+      }),
+    ).resolves.toEqual([]);
+  });
+
   it('keeps a server the registry cannot resolve', async () => {
     const getServerConfig = jest.fn(async () => undefined);
     await expect(

--- a/packages/api/src/mcp/__tests__/utils.test.ts
+++ b/packages/api/src/mcp/__tests__/utils.test.ts
@@ -1116,126 +1116,116 @@ describe('isChatSelectableMCPServer', () => {
 });
 
 describe('filterChatSelectableMCPServers', () => {
-  const mcpConfig = {
+  const catalog = {
     visible: { chatMenu: true },
     hidden: { chatMenu: false },
     unset: {},
+    'agent-only': { consumeOnly: true },
+    'private server': { chatMenu: false },
   };
+  const accessible = jest.fn(async () => catalog);
 
-  it('drops servers the config tier hides, without a registry lookup', async () => {
-    const getServerConfig = jest.fn();
+  beforeEach(() => accessible.mockClear());
+
+  it('drops servers hidden from the chat menu', async () => {
     await expect(
       filterChatSelectableMCPServers(['visible', 'hidden'], {
         userId: 'user123',
-        mcpConfig,
-        getServerConfig,
+        getAccessibleMCPServers: accessible,
       }),
     ).resolves.toEqual(['visible']);
-    expect(getServerConfig).not.toHaveBeenCalledWith('user123', 'hidden');
   });
 
   it('drops servers the user only reaches through an agent', async () => {
-    const getServerConfig = jest.fn(async (_userId: string, serverName: string) =>
-      serverName === 'agent-only' ? { consumeOnly: true } : {},
-    );
     await expect(
-      filterChatSelectableMCPServers(['direct', 'agent-only'], {
+      filterChatSelectableMCPServers(['visible', 'agent-only'], {
         userId: 'user123',
-        mcpConfig: {},
-        getServerConfig,
+        getAccessibleMCPServers: accessible,
       }),
-    ).resolves.toEqual(['direct']);
+    ).resolves.toEqual(['visible']);
   });
 
-  it('resolves one config lookup per distinct name, however often it repeats', async () => {
-    const getServerConfig = jest.fn(async () => ({}));
+  it('keeps servers with the flags unset', async () => {
     await expect(
-      filterChatSelectableMCPServers(['a', 'a', 'b', 'a', 'b'], {
+      filterChatSelectableMCPServers(['unset'], {
         userId: 'user123',
-        mcpConfig: {},
-        getServerConfig,
+        getAccessibleMCPServers: accessible,
       }),
-    ).resolves.toEqual(['a', 'b']);
-    expect(getServerConfig).toHaveBeenCalledTimes(2);
+    ).resolves.toEqual(['unset']);
+  });
+
+  it('resolves the catalog once, however long the selection', async () => {
+    await expect(
+      filterChatSelectableMCPServers(['visible', 'visible', 'unset', 'visible'], {
+        userId: 'user123',
+        getAccessibleMCPServers: accessible,
+      }),
+    ).resolves.toEqual(['visible', 'unset']);
+    expect(accessible).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the role through, since it scopes what the user can reach', async () => {
+    await filterChatSelectableMCPServers(['visible'], {
+      userId: 'user123',
+      role: 'ADMIN',
+      getAccessibleMCPServers: accessible,
+    });
+    expect(accessible).toHaveBeenCalledWith('user123', 'ADMIN');
   });
 
   it('drops a hidden server named by its normalized spelling', async () => {
-    const getServerConfig = jest.fn(async () => undefined);
     await expect(
       filterChatSelectableMCPServers(['private_server'], {
         userId: 'user123',
-        mcpConfig: { 'private server': { chatMenu: false } },
-        getServerConfig,
+        getAccessibleMCPServers: accessible,
       }),
     ).resolves.toEqual([]);
   });
 
-  it('keeps a visible server named by its normalized spelling, as sent', async () => {
-    const getServerConfig = jest.fn(async () => ({}));
+  it('lets an exact accessible name win over another server normalizing onto it', async () => {
+    const crossTier = jest.fn(async () => ({
+      'private server': { chatMenu: false },
+      private_server: { chatMenu: true },
+    }));
     await expect(
       filterChatSelectableMCPServers(['private_server'], {
         userId: 'user123',
-        mcpConfig: { 'private server': { chatMenu: true } },
-        getServerConfig,
+        getAccessibleMCPServers: crossTier,
       }),
     ).resolves.toEqual(['private_server']);
   });
 
-  it('lets a request overlay re-enable a server the registry still hides', async () => {
-    const getServerConfig = jest.fn(async () => ({ chatMenu: false }));
-    await expect(
-      filterChatSelectableMCPServers(['revived'], {
-        userId: 'user123',
-        mcpConfig: { revived: { chatMenu: true } },
-        getServerConfig,
-      }),
-    ).resolves.toEqual(['revived']);
-  });
-
-  it('still drops an overlay-enabled server the user only reaches via an agent', async () => {
-    const getServerConfig = jest.fn(async () => ({ consumeOnly: true }));
-    await expect(
-      filterChatSelectableMCPServers(['revived'], {
-        userId: 'user123',
-        mcpConfig: { revived: { chatMenu: true } },
-        getServerConfig,
-      }),
-    ).resolves.toEqual([]);
-  });
-
-  it('keeps a server the registry cannot resolve', async () => {
-    const getServerConfig = jest.fn(async () => undefined);
+  it('keeps a request-tier server the registry does not know', async () => {
     await expect(
       filterChatSelectableMCPServers(['body-scoped'], {
         userId: 'user123',
-        mcpConfig: {},
-        getServerConfig,
+        getAccessibleMCPServers: accessible,
       }),
     ).resolves.toEqual(['body-scoped']);
   });
 
-  it('keeps a server whose lookup fails rather than dropping it', async () => {
-    const getServerConfig = jest.fn(async () => {
+  it('keeps the selection when the catalog lookup fails', async () => {
+    const failing = jest.fn(async () => {
       throw new Error('registry unavailable');
     });
     await expect(
       filterChatSelectableMCPServers(['a', 'b'], {
         userId: 'user123',
-        mcpConfig: {},
-        getServerConfig,
+        getAccessibleMCPServers: failing,
       }),
     ).resolves.toEqual(['a', 'b']);
   });
 
   it('uses the selection as sent when no resolver is supplied', async () => {
     await expect(
-      filterChatSelectableMCPServers(['a', 'b'], { userId: 'user123' }),
+      filterChatSelectableMCPServers(['a', 'a', 'b'], { userId: 'user123' }),
     ).resolves.toEqual(['a', 'b']);
   });
 
   it('returns an empty array for an empty or missing selection', async () => {
-    await expect(filterChatSelectableMCPServers([], { userId: 'u' })).resolves.toEqual([]);
-    await expect(filterChatSelectableMCPServers(undefined, { userId: 'u' })).resolves.toEqual([]);
-    await expect(filterChatSelectableMCPServers(null, { userId: 'u' })).resolves.toEqual([]);
+    const opts = { userId: 'u', getAccessibleMCPServers: accessible };
+    await expect(filterChatSelectableMCPServers([], opts)).resolves.toEqual([]);
+    await expect(filterChatSelectableMCPServers(undefined, opts)).resolves.toEqual([]);
+    await expect(filterChatSelectableMCPServers(null, opts)).resolves.toEqual([]);
   });
 });

--- a/packages/api/src/mcp/utils.ts
+++ b/packages/api/src/mcp/utils.ts
@@ -1,3 +1,4 @@
+import { logger } from '@librechat/data-schemas';
 import {
   Constants,
   MCPOptionsSchema,
@@ -401,6 +402,83 @@ export function getMissingRuntimeBodyPlaceholderFields(
  */
 export function requiresEphemeralUserConnection(config: UserScopedConnectionConfig): boolean {
   return getMCPRequestScope(config).requestScoped;
+}
+
+/**
+ * Whether a resolved server config may be reached from the chat MCP picker.
+ *
+ * Mirrors `selectableServers` in the client's `useMCPServerManager`, which is
+ * the list the dropdown offers: `chatMenu: false` is the operator hiding a
+ * server from chat, and `consumeOnly` marks a server the user reaches only
+ * through an agent that references it, never on its own.
+ *
+ * An unresolved config is selectable. A name the registry cannot resolve is
+ * either request-tier (declared on the request body and never registered) or
+ * genuinely unknown, and both already have their own handling downstream —
+ * failing closed here would silently drop request-scoped servers instead.
+ */
+export function isChatSelectableMCPServer(
+  config?: Pick<ParsedServerConfig, 'chatMenu' | 'consumeOnly'> | null,
+): boolean {
+  if (config == null) {
+    return true;
+  }
+  return config.chatMenu !== false && config.consumeOnly !== true;
+}
+
+/**
+ * Narrows a chat picker selection to the servers that picker is allowed to
+ * offer, so a stale client, a replayed body, or a hand-written request cannot
+ * reach a server the menu hides.
+ *
+ * Pass only the picker's own selection. Servers a model spec pins
+ * (`modelSpec.mcpServers`) are the operator's choice and stay attached even
+ * when hidden, so they must be added after this call, not through it.
+ *
+ * `chatMenu` only ever comes from the config tier, so the overlay settles it
+ * without a lookup; `consumeOnly` is derived per user and needs the registry.
+ * Lookups run concurrently and a failing one keeps its server: this narrows an
+ * already-authenticated selection and is not the authorization boundary.
+ */
+export async function filterChatSelectableMCPServers(
+  selectedServers: string[] | null | undefined,
+  {
+    userId,
+    mcpConfig,
+    getServerConfig,
+  }: {
+    userId: string;
+    mcpConfig?: Record<string, Pick<ParsedServerConfig, 'chatMenu'> | undefined> | null;
+    getServerConfig?: (
+      userId: string,
+      serverName: string,
+    ) => Promise<Pick<ParsedServerConfig, 'chatMenu' | 'consumeOnly'> | undefined>;
+  },
+): Promise<string[]> {
+  if (!Array.isArray(selectedServers) || selectedServers.length === 0) {
+    return [];
+  }
+  const selectable = await Promise.all(
+    selectedServers.map(async (serverName) => {
+      if (mcpConfig?.[serverName]?.chatMenu === false) {
+        return null;
+      }
+      if (getServerConfig == null) {
+        return serverName;
+      }
+      try {
+        const resolved = await getServerConfig(userId, serverName);
+        return isChatSelectableMCPServer(resolved) ? serverName : null;
+      } catch (error) {
+        logger.warn(
+          `[MCP] Could not resolve "${serverName}" while narrowing a chat selection; keeping it`,
+          error,
+        );
+        return serverName;
+      }
+    }),
+  );
+  return selectable.filter((serverName): serverName is string => serverName != null);
 }
 
 /**

--- a/packages/api/src/mcp/utils.ts
+++ b/packages/api/src/mcp/utils.ts
@@ -435,10 +435,19 @@ export function isChatSelectableMCPServer(
  * (`modelSpec.mcpServers`) are the operator's choice and stay attached even
  * when hidden, so they must be added after this call, not through it.
  *
- * `chatMenu` only ever comes from the config tier, so the overlay settles it
- * without a lookup; `consumeOnly` is derived per user and needs the registry.
- * Lookups run concurrently and a failing one keeps its server: this narrows an
- * already-authenticated selection and is not the authorization boundary.
+ * Names are deduplicated before any lookup — the selection is request-supplied,
+ * and a body repeating one name must not launch a resolver per occurrence — and
+ * resolved through the same normalized-name aliasing that tool loading uses, so
+ * a hidden server cannot be reached under its normalized spelling.
+ *
+ * `chatMenu` lives on the config tier, so the request's own overlay settles it
+ * and outranks whatever the registry holds; the registry supplies `consumeOnly`,
+ * which it derives per user. Lookups run concurrently, and a failing one keeps
+ * its server: this narrows an already-authenticated selection and is not the
+ * authorization boundary.
+ *
+ * Returns the names as they were sent, so callers keep addressing servers the
+ * way the rest of the request does.
  */
 export async function filterChatSelectableMCPServers(
   selectedServers: string[] | null | undefined,
@@ -458,26 +467,43 @@ export async function filterChatSelectableMCPServers(
   if (!Array.isArray(selectedServers) || selectedServers.length === 0) {
     return [];
   }
-  const selectable = await Promise.all(
-    selectedServers.map(async (serverName) => {
-      if (mcpConfig?.[serverName]?.chatMenu === false) {
-        return null;
-      }
-      if (getServerConfig == null) {
-        return serverName;
-      }
-      try {
-        const resolved = await getServerConfig(userId, serverName);
-        return isChatSelectableMCPServer(resolved) ? serverName : null;
-      } catch (error) {
-        logger.warn(
-          `[MCP] Could not resolve "${serverName}" while narrowing a chat selection; keeping it`,
-          error,
-        );
-        return serverName;
-      }
-    }),
-  );
+  const uniqueServers = [...new Set(selectedServers)];
+  const configNames = mcpConfig ? Object.keys(mcpConfig) : [];
+  const aliases = configNames.length > 0 ? buildServerNameAliases(configNames) : undefined;
+  /** A selection may spell a server the normalized way; the config keys the raw
+   *  name and tool loading maps the two together, so the flags must be read
+   *  through the same mapping. */
+  const canonicalName = (serverName: string): string => {
+    if (mcpConfig?.[serverName] != null) {
+      return serverName;
+    }
+    return aliases?.get(normalizeServerName(serverName)) ?? serverName;
+  };
+
+  const decide = async (serverName: string): Promise<string | null> => {
+    const canonical = canonicalName(serverName);
+    const overlay = mcpConfig?.[canonical];
+    if (overlay?.chatMenu === false) {
+      return null;
+    }
+    if (getServerConfig == null) {
+      return serverName;
+    }
+    let resolved: Pick<ParsedServerConfig, 'chatMenu' | 'consumeOnly'> | undefined;
+    try {
+      resolved = await getServerConfig(userId, canonical);
+    } catch (error) {
+      logger.warn(
+        `[MCP] Could not resolve "${canonical}" while narrowing a chat selection; keeping it`,
+        error,
+      );
+      return serverName;
+    }
+    const effective = overlay?.chatMenu === true ? { ...resolved, chatMenu: true } : resolved;
+    return isChatSelectableMCPServer(effective) ? serverName : null;
+  };
+
+  const selectable = await Promise.all(uniqueServers.map(decide));
   return selectable.filter((serverName): serverName is string => serverName != null);
 }
 

--- a/packages/api/src/mcp/utils.ts
+++ b/packages/api/src/mcp/utils.ts
@@ -435,16 +435,19 @@ export function isChatSelectableMCPServer(
  * (`modelSpec.mcpServers`) are the operator's choice and stay attached even
  * when hidden, so they must be added after this call, not through it.
  *
- * Names are deduplicated before any lookup — the selection is request-supplied,
- * and a body repeating one name must not launch a resolver per occurrence — and
- * resolved through the same normalized-name aliasing that tool loading uses, so
- * a hidden server cannot be reached under its normalized spelling.
+ * The accessible set comes from the registry — the same resolution that feeds
+ * the client's catalog, with its own tier precedence already applied — rather
+ * than being re-derived from the request's config overlay. A user-tier or
+ * process-backed server outranks a config entry of the same name, and this must
+ * agree with whatever the picker was actually offered.
  *
- * `chatMenu` lives on the config tier, so the request's own overlay settles it
- * and outranks whatever the registry holds; the registry supplies `consumeOnly`,
- * which it derives per user. Lookups run concurrently, and a failing one keeps
- * its server: this narrows an already-authenticated selection and is not the
- * authorization boundary.
+ * Names are deduplicated before the lookup, since the selection is
+ * request-supplied, and are matched through the same normalized-name aliasing
+ * that tool loading uses, built over the whole accessible set so an exact name
+ * always wins over another server's normalized form. A name the registry does
+ * not know is request-tier — declared on the body, never registered — and is
+ * kept, as is every name if the lookup fails: this narrows an
+ * already-authenticated selection and is not the authorization boundary.
  *
  * Returns the names as they were sent, so callers keep addressing servers the
  * way the rest of the request does.
@@ -453,58 +456,44 @@ export async function filterChatSelectableMCPServers(
   selectedServers: string[] | null | undefined,
   {
     userId,
-    mcpConfig,
-    getServerConfig,
+    role,
+    getAccessibleMCPServers,
   }: {
     userId: string;
-    mcpConfig?: Record<string, Pick<ParsedServerConfig, 'chatMenu'> | undefined> | null;
-    getServerConfig?: (
+    role?: string;
+    getAccessibleMCPServers?: (
       userId: string,
-      serverName: string,
-    ) => Promise<Pick<ParsedServerConfig, 'chatMenu' | 'consumeOnly'> | undefined>;
+      role?: string,
+    ) => Promise<Record<string, Pick<ParsedServerConfig, 'chatMenu' | 'consumeOnly'>>>;
   },
 ): Promise<string[]> {
   if (!Array.isArray(selectedServers) || selectedServers.length === 0) {
     return [];
   }
   const uniqueServers = [...new Set(selectedServers)];
-  const configNames = mcpConfig ? Object.keys(mcpConfig) : [];
-  const aliases = configNames.length > 0 ? buildServerNameAliases(configNames) : undefined;
-  /** A selection may spell a server the normalized way; the config keys the raw
-   *  name and tool loading maps the two together, so the flags must be read
-   *  through the same mapping. */
-  const canonicalName = (serverName: string): string => {
-    if (mcpConfig?.[serverName] != null) {
-      return serverName;
-    }
-    return aliases?.get(normalizeServerName(serverName)) ?? serverName;
-  };
+  if (getAccessibleMCPServers == null) {
+    return uniqueServers;
+  }
 
-  const decide = async (serverName: string): Promise<string | null> => {
-    const canonical = canonicalName(serverName);
-    const overlay = mcpConfig?.[canonical];
-    if (overlay?.chatMenu === false) {
-      return null;
-    }
-    if (getServerConfig == null) {
-      return serverName;
-    }
-    let resolved: Pick<ParsedServerConfig, 'chatMenu' | 'consumeOnly'> | undefined;
-    try {
-      resolved = await getServerConfig(userId, canonical);
-    } catch (error) {
-      logger.warn(
-        `[MCP] Could not resolve "${canonical}" while narrowing a chat selection; keeping it`,
-        error,
-      );
-      return serverName;
-    }
-    const effective = overlay?.chatMenu === true ? { ...resolved, chatMenu: true } : resolved;
-    return isChatSelectableMCPServer(effective) ? serverName : null;
-  };
+  let accessible: Record<string, Pick<ParsedServerConfig, 'chatMenu' | 'consumeOnly'>>;
+  try {
+    accessible = await getAccessibleMCPServers(userId, role);
+  } catch (error) {
+    logger.warn('[MCP] Could not resolve accessible servers; keeping the chat selection', error);
+    return uniqueServers;
+  }
 
-  const selectable = await Promise.all(uniqueServers.map(decide));
-  return selectable.filter((serverName): serverName is string => serverName != null);
+  const accessibleNames = Object.keys(accessible ?? {});
+  if (accessibleNames.length === 0) {
+    return uniqueServers;
+  }
+  const aliases = buildServerNameAliases(accessibleNames);
+
+  return uniqueServers.filter((serverName) => {
+    const resolved =
+      accessible[serverName] ?? accessible[aliases.get(normalizeServerName(serverName)) ?? ''];
+    return isChatSelectableMCPServer(resolved);
+  });
 }
 
 /**

--- a/packages/data-provider/src/mcp.ts
+++ b/packages/data-provider/src/mcp.ts
@@ -178,7 +178,14 @@ const BaseOptionsSchema = z.object({
   /** Timeout (ms) for the long-lived SSE GET stream body before undici aborts it. Default: 300_000 (5 min). */
   sseReadTimeout: z.number().int().positive().optional(),
   initTimeout: z.number().int().nonnegative().optional(),
-  /** Controls visibility in chat dropdown menu (MCPSelect) */
+  /**
+   * Whether the server is offered in chat.
+   *
+   * `false` hides it from the chat dropdown (MCPSelect) AND bars it from the
+   * chat selection a request carries, so a stale or hand-written request cannot
+   * reach it either. It does not restrict agents, nor a server a model spec
+   * pins through `mcpServers` — both are the operator's own choice.
+   */
   chatMenu: z.boolean().optional(),
   /**
    * Controls server instruction behavior:


### PR DESCRIPTION
## Summary

Stacked on #14159 — review that first; this PR's diff is only the backend commit.

#14159 stops the client from *sending* a chat-hidden MCP server. Nothing stops a request that names one anyway. The chat MCP picker offers a server only when the operator has not hidden it (`chatMenu: false`) and the user reaches it directly rather than through an agent (`consumeOnly`), and neither condition was enforced on the request. A stale client, a replayed body, or a hand-written one could name any server and get its tools.

`consumeOnly` is the sharper half: the registry derives it per user when a server is reachable only through an agent that references it. Ignoring it let a user reach in plain chat a server they had only ever been granted through an agent.

- New `isChatSelectableMCPServer` predicate, mirroring `selectableServers` in the client's `useMCPServerManager` so the two cannot drift.
- `filterChatSelectableMCPServers` narrows the picker's selection in both ephemeral loaders. The per-user config resolver is injected, so `packages/api` stays free of the registry and the loaders keep their existing `deps` shape.

**This is a deliberate semantics change**, not a bug fix riding along with one — that is why it is a separate PR. `chatMenu` is documented as "controls visibility in chat dropdown menu"; after this it also bounds what a chat request may use. Operators already treat it that way (see #14146), and for YAML servers it is the only lever they have, but it is a call worth making explicitly.

### Why the loaders and not the tool-resolution chokepoint

`ToolService` already resolves the same per-user config and would be cheaper. It cannot be used: it serves persisted agents too, and an agent legitimately uses both hidden and `consumeOnly` servers. Only the loaders know a server name came from the picker. Servers a model spec pins are the operator's own choice and are added *after* the narrowing, so pinning a chat-hidden server to a spec keeps working.

### What is deliberately kept

`chatMenu` only ever comes from the config tier — it is in `omitServerManagedFields`, so a DB server cannot carry it — and the overlay settles it with no lookup at all. Lookups for the rest run concurrently and are cached per server and user. A name the registry cannot resolve (request-tier, declared on the body and never registered) is kept, as is one whose lookup fails: this narrows an already-authenticated selection and is not the authorization boundary.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update — `chatMenu` now bounds request use, not just menu visibility.

## Testing

- `cd packages/api && npx jest src/agents/__tests__/load.spec.ts src/mcp/__tests__/utils.test.ts` — 145 passing.
- `cd api && npx jest server/services/Endpoints/agents server/services/Config` — 14 suites, 170 passing.
- `cd packages/api && npx jest src/agents src/mcp` — 186 suites passing; 4 fail for want of a live Redis and a stale local dist, and fail identically on `dev`.
- Five new integration tests. Verified against `origin/dev` that the two enforcement cases fail there; the three "keeps" cases pass on `dev` and here, pinning that the change does not over-reach.
- `npx tsc --noEmit` clean in `packages/api`; eslint and prettier clean on the touched files.

### Test Configuration

- Node.js v24.16.0
- npm 11.13.0

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
