### PR TITLE
🔎 fix: Respect Search Page Limits in MeiliSearch Queries

### DIFF
--- a/api/server/routes/__tests__/messages-get.spec.js
+++ b/api/server/routes/__tests__/messages-get.spec.js
@@ -1,4 +1,4 @@
-const { CLIENT_MESSAGE_SELECT } = require('@librechat/data-schemas');
+const { CLIENT_MESSAGE_SELECT, MEILI_SEARCH_LIMIT } = require('@librechat/data-schemas');
 const express = require('express');
 const request = require('supertest');
 
@@ -212,6 +212,8 @@ describe('message route conversation ownership filters', () => {
     getMessage,
     getMessages,
     getMessagesByCursor,
+    getConvosQueried,
+    searchMessages,
     saveConvo,
     saveMessage,
     updateMessage,
@@ -461,6 +463,55 @@ describe('message route conversation ownership filters', () => {
       CLIENT_MESSAGE_SELECT,
     );
   });
+
+  it.each([
+    {
+      name: 'default',
+      query: 'search=needle',
+      searchLimit: 25,
+      conversationLimit: 25,
+    },
+    {
+      name: 'custom',
+      query: 'search=needle&pageSize=40',
+      searchLimit: 40,
+      conversationLimit: 40,
+    },
+    {
+      name: 'capped',
+      query: `search=needle&pageSize=${MEILI_SEARCH_LIMIT + 1}`,
+      searchLimit: MEILI_SEARCH_LIMIT,
+      conversationLimit: MEILI_SEARCH_LIMIT + 1,
+    },
+    {
+      name: 'invalid',
+      query: 'search=needle&pageSize=-1',
+      searchLimit: 25,
+      conversationLimit: 25,
+    },
+  ])(
+    'uses the $name page size for message search limits',
+    async ({ query, searchLimit, conversationLimit }) => {
+      searchMessages.mockResolvedValue({ hits: [] });
+      getConvosQueried.mockResolvedValue({ convoMap: {} });
+      getMessages.mockResolvedValue([]);
+
+      const response = await request(app).get(`/api/messages?${query}`);
+
+      expect(response.status).toBe(200);
+      expect(searchMessages).toHaveBeenCalledWith(
+        'needle',
+        { filter: `user = "${authenticatedUserId}"`, limit: searchLimit },
+        true,
+      );
+      expect(getConvosQueried).toHaveBeenCalledWith(
+        authenticatedUserId,
+        [],
+        null,
+        conversationLimit,
+      );
+    },
+  );
 
   it('returns indistinguishable not-found responses for child and missing query reads', async () => {
     getConvoOwnership.mockResolvedValueOnce({

--- a/api/server/routes/messages.js
+++ b/api/server/routes/messages.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const { v4: uuidv4 } = require('uuid');
-const { logger, CLIENT_MESSAGE_SELECT } = require('@librechat/data-schemas');
+const { logger, CLIENT_MESSAGE_SELECT, MEILI_SEARCH_LIMIT } = require('@librechat/data-schemas');
 const {
   ContentTypes,
   feedbackSchema,
@@ -89,7 +89,8 @@ router.get('/', async (req, res) => {
       messageId,
       search,
     } = req.query;
-    const pageSize = parseInt(pageSizeRaw, 10) || 25;
+    const parsedPageSize = parseInt(pageSizeRaw, 10);
+    const pageSize = Number.isFinite(parsedPageSize) && parsedPageSize > 0 ? parsedPageSize : 25;
 
     let response;
     const sortField = ['endpoint', 'createdAt', 'updatedAt'].includes(sortBy)
@@ -137,11 +138,18 @@ router.get('/', async (req, res) => {
       }
       response = messageResult.value;
     } else if (search) {
-      const searchResults = await db.searchMessages(search, { filter: `user = "${user}"` }, true);
+      const searchResults = await db.searchMessages(
+        search,
+        {
+          filter: `user = "${user}"`,
+          limit: Math.min(pageSize, MEILI_SEARCH_LIMIT),
+        },
+        true,
+      );
 
       const messages = searchResults.hits || [];
 
-      const result = await db.getConvosQueried(req.user.id, messages, cursor);
+      const result = await db.getConvosQueried(req.user.id, messages, cursor, pageSize);
 
       const messageIds = [];
       const cleanedMessages = [];

--- a/packages/data-schemas/src/common/index.ts
+++ b/packages/data-schemas/src/common/index.ts
@@ -1,3 +1,4 @@
 export * from './enum';
+export * from './search';
 export * from './pagination';
 export * from './permissions';

--- a/packages/data-schemas/src/common/search.ts
+++ b/packages/data-schemas/src/common/search.ts
@@ -1,0 +1,2 @@
+/** MeiliSearch's default `pagination.maxTotalHits` ceiling. */
+export const MEILI_SEARCH_LIMIT = 1000;

--- a/packages/data-schemas/src/methods/share.test.ts
+++ b/packages/data-schemas/src/methods/share.test.ts
@@ -10,6 +10,7 @@ import {
   type ShareMethods,
   type SharedLinkContentSnapshot,
 } from './share';
+import { MEILI_SEARCH_LIMIT } from '~/common/search';
 import logger from '~/config/winston';
 
 describe('Share Methods', () => {
@@ -1251,7 +1252,11 @@ describe('Share Methods', () => {
       expect(result.links[0].title).toBe('Matching Share');
 
       // Verify that meiliSearch was called with the correct user filter
-      expect(meiliSearchMock).toHaveBeenCalledWith('search term', { filter: `user = "${userId}"` });
+      expect(meiliSearchMock).toHaveBeenCalledWith('search term', {
+        filter: `user = "${userId}"`,
+        limit: MEILI_SEARCH_LIMIT,
+        attributesToRetrieve: ['conversationId'],
+      });
     });
 
     test('should handle empty results', async () => {
@@ -1328,6 +1333,8 @@ describe('Share Methods', () => {
       // Verify correct filter was used
       expect(meiliSearchMock).toHaveBeenCalledWith('search term', {
         filter: `user = "${userId1}"`,
+        limit: MEILI_SEARCH_LIMIT,
+        attributesToRetrieve: ['conversationId'],
       });
 
       // Search as userId2
@@ -1347,6 +1354,8 @@ describe('Share Methods', () => {
       // Verify correct filter was used for second user
       expect(meiliSearchMock).toHaveBeenCalledWith('search term', {
         filter: `user = "${userId2}"`,
+        limit: MEILI_SEARCH_LIMIT,
+        attributesToRetrieve: ['conversationId'],
       });
     });
 

--- a/packages/data-schemas/src/methods/share.ts
+++ b/packages/data-schemas/src/methods/share.ts
@@ -10,6 +10,7 @@ import {
 } from '~/utils/stripUIResourceMarkers';
 import { activeExpirationFilter } from '~/utils/retention';
 import { isValidObjectIdString } from '~/utils/objectId';
+import { MEILI_SEARCH_LIMIT } from '~/common/search';
 import { CLIENT_MESSAGE_SELECT } from './message';
 import logger from '~/config/winston';
 
@@ -970,6 +971,8 @@ export function createShareMethods(mongoose: typeof import('mongoose')): {
         try {
           const searchResults = await Conversation.meiliSearch(search, {
             filter: `user = "${user}"`,
+            limit: MEILI_SEARCH_LIMIT,
+            attributesToRetrieve: ['conversationId'],
           });
 
           if (!searchResults?.hits?.length) {


### PR DESCRIPTION
## Summary

Two search paths relied on MeiliSearch's default 20-hit response regardless of their application-level pagination:

- `/api/messages?search=` accepts a configurable `pageSize` but could return at most 20 MeiliSearch hits, and `getConvosQueried` independently fell back to its own 25-conversation limit.
- Shared-link search applies MongoDB cursor pagination after resolving matching conversation IDs, but only the first 20 MeiliSearch matches were available to paginate.

## Fix

- Add a shared `MEILI_SEARCH_LIMIT` matching MeiliSearch's default `pagination.maxTotalHits` ceiling of 1000.
- Validate a positive message `pageSize`, request `Math.min(pageSize, MEILI_SEARCH_LIMIT)` message hits, and pass the requested page size through to `getConvosQueried`.
- Request up to `MEILI_SEARCH_LIMIT` shared-link conversation matches while retrieving only `conversationId`, avoiding unused title, tag, and user fields.

## Known limits

This does not add cursor pagination to the main message search response; it still returns `nextCursor: null`. Both paths remain bounded by the MeiliSearch index's configured `pagination.maxTotalHits` value.

## Coverage

Route coverage checks default, custom, capped, and invalid message page sizes. Shared-link tests assert the user filter, explicit limit, and ID-only projection.
