### PR TITLE
🔄 fix: Reindex MeiliSearch Documents After Indexed-Projection Changes

### DIFF
--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -1,7 +1,8 @@
 import mongoose from 'mongoose';
 import { EModelEndpoint } from 'librechat-data-provider';
 import { MongoMemoryServer } from 'mongodb-memory-server';
-import mongoMeili, { type SchemaWithMeiliMethods } from '~/models/plugins/mongoMeili';
+import type { SchemaWithMeiliMethods } from '~/models/plugins/mongoMeili';
+import mongoMeili, { MEILI_INDEX_SCHEMA_VERSION } from '~/models/plugins/mongoMeili';
 import { createConversationModel } from '~/models/convo';
 import { createMessageModel } from '~/models/message';
 
@@ -13,6 +14,7 @@ interface DynamicMeiliDocument extends mongoose.Document {
   expiredAt?: Date | null;
   _meiliIndex?: boolean;
   _meiliIndexAttempted?: boolean;
+  _meiliIndexSchemaVersion?: number;
   _meiliCleanupVersion?: number;
 }
 
@@ -1317,6 +1319,7 @@ describe('Meilisearch Mongoose plugin', () => {
         title: 'Indexed',
         endpoint: EModelEndpoint.openAI,
         _meiliIndex: true,
+        _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION,
         expiredAt: null,
       });
 
@@ -1336,6 +1339,38 @@ describe('Meilisearch Mongoose plugin', () => {
       expect(progress.isComplete).toBe(false);
     });
 
+    test('reindexes documents from an older indexed schema version', async () => {
+      const conversationModel = createConversationModel(
+        mongoose,
+      ) as unknown as SchemaWithMeiliMethods;
+      await conversationModel.deleteMany({});
+
+      await conversationModel.collection.insertOne({
+        conversationId: new mongoose.Types.ObjectId().toString(),
+        user: new mongoose.Types.ObjectId(),
+        title: 'Legacy Indexed Conversation',
+        endpoint: EModelEndpoint.openAI,
+        _meiliIndex: true,
+        _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION - 1,
+        expiredAt: null,
+      });
+
+      const progress = await conversationModel.getSyncProgress();
+
+      expect(progress.totalProcessed).toBe(0);
+      expect(progress.pendingIndexing).toBe(1);
+
+      await conversationModel.syncWithMeili();
+
+      expect(
+        (
+          await conversationModel
+            .findOne({ title: 'Legacy Indexed Conversation' })
+            .select('+_meiliIndexSchemaVersion')
+        )?._meiliIndexSchemaVersion,
+      ).toBe(MEILI_INDEX_SCHEMA_VERSION);
+    });
+
     test('getSyncProgress excludes TTL documents from counts', async () => {
       const conversationModel = createConversationModel(
         mongoose,
@@ -1349,6 +1384,7 @@ describe('Meilisearch Mongoose plugin', () => {
         title: 'Syncable Indexed',
         endpoint: EModelEndpoint.openAI,
         _meiliIndex: true,
+        _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION,
         expiredAt: null,
       });
 
@@ -1399,6 +1435,7 @@ describe('Meilisearch Mongoose plugin', () => {
         user: new mongoose.Types.ObjectId(),
         isCreatedByUser: true,
         _meiliIndex: true,
+        _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION,
         expiredAt: null,
       });
 
@@ -1408,6 +1445,7 @@ describe('Meilisearch Mongoose plugin', () => {
         user: new mongoose.Types.ObjectId(),
         isCreatedByUser: false,
         _meiliIndex: true,
+        _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION,
         expiredAt: null,
       });
 
@@ -2158,6 +2196,7 @@ describe('Meilisearch Mongoose plugin', () => {
           endpoint: EModelEndpoint.openAI,
           expiredAt: null,
           _meiliIndex: true,
+          _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION,
         },
       ]);
 
@@ -2196,6 +2235,7 @@ describe('Meilisearch Mongoose plugin', () => {
           isCreatedByUser: true,
           expiredAt: null,
           _meiliIndex: true,
+          _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION,
         },
         {
           messageId: new mongoose.Types.ObjectId(),

--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -1340,9 +1340,7 @@ describe('Meilisearch Mongoose plugin', () => {
     });
 
     test('reindexes documents from an older indexed schema version', async () => {
-      const conversationModel = createConversationModel(
-        mongoose,
-      ) as unknown as SchemaWithMeiliMethods;
+      const conversationModel = mongoose.models.Conversation as SchemaWithMeiliMethods;
       await conversationModel.deleteMany({});
 
       await conversationModel.collection.insertOne({

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -32,6 +32,7 @@ interface MeiliIndexable {
   _meiliIndex?: boolean;
   _meiliIndexAttempted?: boolean;
   _meiliIndexVersion?: string;
+  _meiliIndexSchemaVersion?: number;
   _meiliCleanupVersion?: number;
 }
 
@@ -48,6 +49,7 @@ interface _DocumentWithMeiliIndex extends Document {
   _meiliIndex?: boolean;
   _meiliIndexAttempted?: boolean;
   _meiliIndexVersion?: string;
+  _meiliIndexSchemaVersion?: number;
   _meiliCleanupVersion?: number;
   isTemporary?: boolean;
   expiredAt?: Date | null;
@@ -106,6 +108,9 @@ const getSyncConfig = () => ({
 
 const hasSchemaPath = (schema: Schema, path: string): boolean =>
   Object.prototype.hasOwnProperty.call(schema.obj, path);
+
+/** Bump when the indexed document shape or projection changes. */
+export const MEILI_INDEX_SCHEMA_VERSION = 1;
 
 const explicitTemporaryFlagKey = 'meiliExplicitTemporaryFlag';
 const previouslyIndexedFlagKey = 'meiliPreviouslyIndexed';
@@ -304,6 +309,7 @@ const createMeiliMongooseModel = ({
       '+_meiliIndex',
       '+_meiliIndexAttempted',
       '+_meiliIndexVersion',
+      '+_meiliIndexSchemaVersion',
       'isTemporary',
       'expiredAt',
       'unfinished',
@@ -378,7 +384,13 @@ const createMeiliMongooseModel = ({
         // eslint-disable-next-line no-restricted-syntax -- versioned internal bookkeeping must not re-enter document middleware
         const acknowledgement = await doc.collection.updateOne(
           { _id: doc._id as Types.ObjectId, _meiliIndexVersion: version },
-          { $set: { _meiliIndex: true, _meiliCleanupVersion: meiliCleanupVersion } },
+          {
+            $set: {
+              _meiliIndex: true,
+              _meiliCleanupVersion: meiliCleanupVersion,
+              _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION,
+            },
+          },
         );
         if (acknowledgement.matchedCount > 0) {
           return;
@@ -412,23 +424,37 @@ const createMeiliMongooseModel = ({
     static async getSyncProgress(this: SchemaWithMeiliMethods): Promise<SyncProgress> {
       const indexableQuery = getIndexableQuery();
       const excludedIndexedQuery = getExcludedIndexedQuery();
-      const [totalDocuments, indexedDocuments, pendingIndexing, pendingCleanup] = await Promise.all(
-        [
+      const needsIndexingQuery: FilterQuery<unknown> = {
+        $and: [
+          indexableQuery,
+          {
+            $or: [
+              { _meiliIndex: { $ne: true }, _meiliIndexAttempted: true },
+              {
+                _meiliIndex: true,
+                _meiliIndexSchemaVersion: { $ne: MEILI_INDEX_SCHEMA_VERSION },
+              },
+            ],
+          },
+        ],
+      };
+      const [totalDocuments, indexedDocuments, pendingIndexing, pendingCleanup] =
+        await Promise.all([
           this.countDocuments(indexableQuery),
           this.countDocuments({
-            ...indexableQuery,
-            _meiliIndex: true,
+            $and: [
+              indexableQuery,
+              {
+                _meiliIndex: true,
+                _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION,
+              },
+            ],
           }),
-          this.countDocuments({
-            ...indexableQuery,
-            _meiliIndex: { $ne: true },
-            _meiliIndexAttempted: true,
-          }),
+          this.countDocuments(needsIndexingQuery),
           excludedIndexedQuery == null
             ? Promise.resolve(0)
             : this.countDocuments(excludedIndexedQuery),
-        ],
-      );
+        ]);
 
       return {
         totalProcessed: indexedDocuments,
@@ -441,7 +467,7 @@ const createMeiliMongooseModel = ({
 
     /**
      * Synchronizes data between the MongoDB collection and the MeiliSearch index by
-     * incrementally indexing only non-temporary documents where `_meiliIndex` is not `true`.
+     * incrementally indexing only non-temporary documents that are unindexed or stale.
      * */
     static async syncWithMeili(this: SchemaWithMeiliMethods): Promise<void> {
       const startTime = Date.now();
@@ -474,8 +500,18 @@ const createMeiliMongooseModel = ({
       while (hasMore) {
         const indexableQuery = getIndexableQuery();
         const query: FilterQuery<unknown> = {
-          ...indexableQuery,
-          _meiliIndex: { $ne: true },
+          $and: [
+            indexableQuery,
+            {
+              $or: [
+                { _meiliIndex: { $ne: true } },
+                {
+                  _meiliIndex: true,
+                  _meiliIndexSchemaVersion: { $ne: MEILI_INDEX_SCHEMA_VERSION },
+                },
+              ],
+            },
+          ],
         };
 
         try {
@@ -548,7 +584,13 @@ const createMeiliMongooseModel = ({
         // original conversation/message timestamps (fixes sidebar chronological sort).
         await this.updateMany(
           { _id: { $in: docsIds } },
-          { $set: { _meiliIndex: true, _meiliCleanupVersion: meiliCleanupVersion } },
+          {
+            $set: {
+              _meiliIndex: true,
+              _meiliCleanupVersion: meiliCleanupVersion,
+              _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION,
+            },
+          },
           { timestamps: false },
         );
       } catch (error) {
@@ -909,6 +951,11 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
     },
     _meiliIndexVersion: {
       type: String,
+      required: false,
+      select: false,
+    },
+    _meiliIndexSchemaVersion: {
+      type: Number,
       required: false,
       select: false,
     },

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -438,30 +438,29 @@ const createMeiliMongooseModel = ({
           },
         ],
       };
-      const [totalDocuments, indexedDocuments, pendingIndexing, pendingCleanup] =
-        await Promise.all([
-          this.countDocuments(indexableQuery),
-          this.countDocuments({
-            $and: [
-              indexableQuery,
-              {
-                _meiliIndex: true,
-                _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION,
-              },
-            ],
-          }),
-          this.countDocuments(needsIndexingQuery),
-          excludedIndexedQuery == null
-            ? Promise.resolve(0)
-            : this.countDocuments(excludedIndexedQuery),
-        ]);
+      const [totalDocuments, totalProcessed, pendingIndexing, pendingCleanup] = await Promise.all([
+        this.countDocuments(indexableQuery),
+        this.countDocuments({
+          $and: [
+            indexableQuery,
+            {
+              _meiliIndex: true,
+              _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION,
+            },
+          ],
+        }),
+        this.countDocuments(needsIndexingQuery),
+        excludedIndexedQuery == null
+          ? Promise.resolve(0)
+          : this.countDocuments(excludedIndexedQuery),
+      ]);
 
       return {
-        totalProcessed: indexedDocuments,
+        totalProcessed,
         totalDocuments,
         pendingIndexing,
         pendingCleanup,
-        isComplete: indexedDocuments === totalDocuments && pendingCleanup === 0,
+        isComplete: totalProcessed === totalDocuments && pendingCleanup === 0,
       };
     }
 


### PR DESCRIPTION
## Summary

`syncWithMeili` previously skipped every document with `_meiliIndex: true`, even when the indexed projection or document shape had changed. Existing MeiliSearch documents could therefore retain stale data and silently miss searches using newly indexed fields.

This PR adds `_meiliIndexSchemaVersion` and reindexes indexed documents whose marker does not match the current projection version.

## Changes

- Add a `select: false` `_meiliIndexSchemaVersion` marker to plugin schemas.
- Stamp the marker in both single-document acknowledgements and batch sync updates.
- Count and reindex stale documents in `getSyncProgress` and `syncWithMeili`.
- Avoid a schema default so unrelated document saves cannot falsely mark old projections current.
- Add coverage for stale-document reindexing, current-version skipping, and progress accounting.

## Migration

Existing documents from before this marker was introduced have no version and are intentionally treated as stale. The first startup after this PR is deployed triggers a full MeiliSearch reindex of existing conversation and message documents; this is expected and may temporarily increase indexing load.

Later projection changes must increment the marker after rebasing onto this PR. The tenant-scoping and conversation-key branches intentionally use subsequent versions and must not resolve their version conflicts by keeping the old value.

## Testing

Unit tests cover stale and current schema versions and sync progress.
