### PR TITLE
🧶 fix: Untangle Parallel Subagent Descriptor Paths

### DIFF
--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -802,6 +802,25 @@ const initializeClient = async ({
   const resolveLazyMetadata = createConcurrencyLimiter(SUBAGENT_GRAPH_LOAD_CONCURRENCY);
   const subagentGraphIds = new Set();
   const expandedSubagentDescriptorState = { configCount: 0, rootAgentIds: [] };
+  /** Parallel paths may reach the same eager config with different cycle-pruned children.
+   *  The lexicographically earliest traversal owns its child assignment so shared object
+   *  identity is preserved without allowing promise settlement order to choose the result. */
+  const descriptorOwnerPaths = new Map();
+
+  const isEarlierDescriptorPath = (candidatePath, currentPath) => {
+    const sharedLength = Math.min(candidatePath.length, currentPath.length);
+    for (let index = 0; index < sharedLength; index++) {
+      if (candidatePath[index] === currentPath[index]) continue;
+      return candidatePath[index] < currentPath[index];
+    }
+    return candidatePath.length < currentPath.length;
+  };
+
+  const claimDescriptorPath = (agentId, candidatePath) => {
+    const currentPath = descriptorOwnerPaths.get(agentId);
+    if (currentPath && !isEarlierDescriptorPath(candidatePath, currentPath)) return;
+    descriptorOwnerPaths.set(agentId, candidatePath);
+  };
 
   const assertSubagentGraphRoom = (agentId) => {
     if (subagentGraphIds.has(agentId)) {
@@ -1167,7 +1186,12 @@ const initializeClient = async ({
     return initializeLoadedSubagent({ agent, agentId, configId, context, lazyChildren });
   };
 
-  const buildLazySubagentDescriptors = async (agent, depth = 0, ancestors = new Set()) => {
+  const buildLazySubagentDescriptors = async (
+    agent,
+    depth = 0,
+    ancestors = new Set(),
+    traversalPath = [],
+  ) => {
     if (!subagentsAvailableForRun || !agent.subagents?.enabled) {
       return [];
     }
@@ -1189,8 +1213,9 @@ const initializeClient = async ({
     const nextAncestors = new Set(ancestors);
     nextAncestors.add(agent.id);
     const descriptors = await Promise.all(
-      subagentIds.map(async (subagentId) => {
+      subagentIds.map(async (subagentId, childIndex) => {
         if (skippedAgentIds.has(subagentId) || nextAncestors.has(subagentId)) return null;
+        const childPath = [...traversalPath, childIndex];
         const existing =
           subagentId === primaryConfig.id ? primaryConfig : agentConfigs.get(subagentId);
         if (existing) {
@@ -1199,16 +1224,18 @@ const initializeClient = async ({
             subagentGraphIds.add(subagentId);
           }
           countExpandedSubagentDescriptor(subagentId);
+          claimDescriptorPath(subagentId, childPath);
           const existingChildren = await buildLazySubagentDescriptors(
             existing,
             depth + 1,
             nextAncestors,
+            childPath,
           );
-          return {
-            ...existing,
-            lazySubagentConfigs: existingChildren.filter((child) => child.configId),
-            subagentAgentConfigs: existingChildren.filter((child) => !child.configId),
-          };
+          if (descriptorOwnerPaths.get(subagentId) === childPath) {
+            existing.lazySubagentConfigs = existingChildren.filter((child) => child.configId);
+            existing.subagentAgentConfigs = existingChildren.filter((child) => !child.configId);
+          }
+          return existing;
         }
         const metadata = await loadSubagentMetadata(subagentId);
         if (!metadata) return null;
@@ -1221,6 +1248,7 @@ const initializeClient = async ({
           metadata,
           depth + 1,
           nextAncestors,
+          childPath,
         );
         const lazyChildren = childDescriptors.filter((child) => child.configId);
         const eagerChildren = childDescriptors.filter((child) => !child.configId);
@@ -1272,11 +1300,15 @@ const initializeClient = async ({
       .filter((config) => config?.id)
       .map((config) => config.id);
     await Promise.all(
-      rootConfigs.map(async (config) => {
+      rootConfigs.map(async (config, rootIndex) => {
         if (!config?.id) return;
-        const descriptors = await buildLazySubagentDescriptors(config);
-        config.lazySubagentConfigs = descriptors.filter((child) => child.configId);
-        config.subagentAgentConfigs = descriptors.filter((child) => !child.configId);
+        const rootPath = [rootIndex];
+        claimDescriptorPath(config.id, rootPath);
+        const descriptors = await buildLazySubagentDescriptors(config, 0, new Set(), rootPath);
+        if (descriptorOwnerPaths.get(config.id) === rootPath) {
+          config.lazySubagentConfigs = descriptors.filter((child) => child.configId);
+          config.subagentAgentConfigs = descriptors.filter((child) => !child.configId);
+        }
       }),
     );
   };

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -1204,9 +1204,11 @@ const initializeClient = async ({
             depth + 1,
             nextAncestors,
           );
-          existing.lazySubagentConfigs = existingChildren.filter((child) => child.configId);
-          existing.subagentAgentConfigs = existingChildren.filter((child) => !child.configId);
-          return existing;
+          return {
+            ...existing,
+            lazySubagentConfigs: existingChildren.filter((child) => child.configId),
+            subagentAgentConfigs: existingChildren.filter((child) => !child.configId),
+          };
         }
         const metadata = await loadSubagentMetadata(subagentId);
         if (!metadata) return null;

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -802,25 +802,6 @@ const initializeClient = async ({
   const resolveLazyMetadata = createConcurrencyLimiter(SUBAGENT_GRAPH_LOAD_CONCURRENCY);
   const subagentGraphIds = new Set();
   const expandedSubagentDescriptorState = { configCount: 0, rootAgentIds: [] };
-  /** Parallel paths may reach the same eager config with different cycle-pruned children.
-   *  The lexicographically earliest traversal owns its child assignment so shared object
-   *  identity is preserved without allowing promise settlement order to choose the result. */
-  const descriptorOwnerPaths = new Map();
-
-  const isEarlierDescriptorPath = (candidatePath, currentPath) => {
-    const sharedLength = Math.min(candidatePath.length, currentPath.length);
-    for (let index = 0; index < sharedLength; index++) {
-      if (candidatePath[index] === currentPath[index]) continue;
-      return candidatePath[index] < currentPath[index];
-    }
-    return candidatePath.length < currentPath.length;
-  };
-
-  const claimDescriptorPath = (agentId, candidatePath) => {
-    const currentPath = descriptorOwnerPaths.get(agentId);
-    if (currentPath && !isEarlierDescriptorPath(candidatePath, currentPath)) return;
-    descriptorOwnerPaths.set(agentId, candidatePath);
-  };
 
   const assertSubagentGraphRoom = (agentId) => {
     if (subagentGraphIds.has(agentId)) {
@@ -1186,12 +1167,7 @@ const initializeClient = async ({
     return initializeLoadedSubagent({ agent, agentId, configId, context, lazyChildren });
   };
 
-  const buildLazySubagentDescriptors = async (
-    agent,
-    depth = 0,
-    ancestors = new Set(),
-    traversalPath = [],
-  ) => {
+  const buildLazySubagentDescriptors = async (agent, depth = 0, ancestors = new Set()) => {
     if (!subagentsAvailableForRun || !agent.subagents?.enabled) {
       return [];
     }
@@ -1213,9 +1189,8 @@ const initializeClient = async ({
     const nextAncestors = new Set(ancestors);
     nextAncestors.add(agent.id);
     const descriptors = await Promise.all(
-      subagentIds.map(async (subagentId, childIndex) => {
+      subagentIds.map(async (subagentId) => {
         if (skippedAgentIds.has(subagentId) || nextAncestors.has(subagentId)) return null;
-        const childPath = [...traversalPath, childIndex];
         const existing =
           subagentId === primaryConfig.id ? primaryConfig : agentConfigs.get(subagentId);
         if (existing) {
@@ -1224,17 +1199,10 @@ const initializeClient = async ({
             subagentGraphIds.add(subagentId);
           }
           countExpandedSubagentDescriptor(subagentId);
-          claimDescriptorPath(subagentId, childPath);
-          const existingChildren = await buildLazySubagentDescriptors(
-            existing,
-            depth + 1,
-            nextAncestors,
-            childPath,
-          );
-          if (descriptorOwnerPaths.get(subagentId) === childPath) {
-            existing.lazySubagentConfigs = existingChildren.filter((child) => child.configId);
-            existing.subagentAgentConfigs = existingChildren.filter((child) => !child.configId);
-          }
+          /** Every initialized config is expanded independently in `rootSubagentConfigs`.
+           *  Descend here only to enforce path-sensitive depth and size limits; mutating the
+           *  shared object from this ancestor-specific walk would race its root expansion. */
+          await buildLazySubagentDescriptors(existing, depth + 1, nextAncestors);
           return existing;
         }
         const metadata = await loadSubagentMetadata(subagentId);
@@ -1248,7 +1216,6 @@ const initializeClient = async ({
           metadata,
           depth + 1,
           nextAncestors,
-          childPath,
         );
         const lazyChildren = childDescriptors.filter((child) => child.configId);
         const eagerChildren = childDescriptors.filter((child) => !child.configId);
@@ -1300,15 +1267,11 @@ const initializeClient = async ({
       .filter((config) => config?.id)
       .map((config) => config.id);
     await Promise.all(
-      rootConfigs.map(async (config, rootIndex) => {
+      rootConfigs.map(async (config) => {
         if (!config?.id) return;
-        const rootPath = [rootIndex];
-        claimDescriptorPath(config.id, rootPath);
-        const descriptors = await buildLazySubagentDescriptors(config, 0, new Set(), rootPath);
-        if (descriptorOwnerPaths.get(config.id) === rootPath) {
-          config.lazySubagentConfigs = descriptors.filter((child) => child.configId);
-          config.subagentAgentConfigs = descriptors.filter((child) => !child.configId);
-        }
+        const descriptors = await buildLazySubagentDescriptors(config);
+        config.lazySubagentConfigs = descriptors.filter((child) => child.configId);
+        config.subagentAgentConfigs = descriptors.filter((child) => !child.configId);
       }),
     );
   };

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -2479,6 +2479,40 @@ describe('initializeClient — subagent loading', () => {
     expect(agentClientArgs.agentConfigs.has(HANDOFF_AND_SUB_ID)).toBe(true);
   });
 
+  it('keeps path-specific children isolated when parallel walkers share initialized agents', async () => {
+    const leftId = 'agent_parallel_left';
+    const rightId = 'agent_parallel_right';
+    const sharedId = 'agent_parallel_shared';
+    const primaryConfig = makePrimaryConfig({
+      subagents: { enabled: true, allowSelf: false, agent_ids: [leftId, rightId] },
+    });
+    const leftConfig = makeNestedSubagentConfig(leftId, [sharedId]);
+    const rightConfig = makeNestedSubagentConfig(rightId, [sharedId]);
+    const sharedConfig = makeNestedSubagentConfig(sharedId, [leftId]);
+    mockInitializeAgent.mockResolvedValue(primaryConfig);
+    processAddedConvo.mockImplementationOnce(async ({ agentConfigs }) => {
+      agentConfigs.set(leftId, leftConfig);
+      agentConfigs.set(rightId, rightConfig);
+      agentConfigs.set(sharedId, sharedConfig);
+      return { userMCPAuthMap: undefined };
+    });
+
+    await initializeClient({
+      req: makeSubagentReq(),
+      res: {},
+      signal: new AbortController().signal,
+      endpointOption: makeEndpointOption(),
+    });
+
+    const [left, right] = agentClientArgs.agent.subagentAgentConfigs;
+    const leftShared = left.subagentAgentConfigs[0];
+    const rightShared = right.subagentAgentConfigs[0];
+    expect(leftShared).not.toBe(rightShared);
+    expect(leftShared.subagentAgentConfigs).toEqual([]);
+    expect(rightShared.subagentAgentConfigs.map((child) => child.id)).toEqual([leftId]);
+    expect(agentClientArgs.agentConfigs.get(sharedId)).toBe(sharedConfig);
+  });
+
   it('clears subagents config on primary when the capability is disabled', async () => {
     /** Admin can turn subagents off at the endpoint level even if an agent was
      *  configured for them. The primary's `subagents` field should be

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -2479,7 +2479,7 @@ describe('initializeClient — subagent loading', () => {
     expect(agentClientArgs.agentConfigs.has(HANDOFF_AND_SUB_ID)).toBe(true);
   });
 
-  it('keeps shared initialized agent children deterministic across parallel walkers', async () => {
+  it('preserves shared initialized agent children across parallel walkers', async () => {
     const leftId = 'agent_parallel_left';
     const rightId = 'agent_parallel_right';
     const sharedId = 'agent_parallel_shared';
@@ -2513,8 +2513,8 @@ describe('initializeClient — subagent loading', () => {
     const rightShared = right.subagentAgentConfigs[0];
     expect(leftShared).toBe(sharedConfig);
     expect(rightShared).toBe(sharedConfig);
-    expect(leftShared.subagentAgentConfigs).toEqual([]);
-    expect(rightShared.subagentAgentConfigs).toEqual([]);
+    expect(leftShared.subagentAgentConfigs.map((child) => child.id)).toEqual([leftId]);
+    expect(rightShared.subagentAgentConfigs.map((child) => child.id)).toEqual([leftId]);
     expect(agentClientArgs.agentConfigs.get(sharedId)).toBe(sharedConfig);
   });
 

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -2479,7 +2479,7 @@ describe('initializeClient — subagent loading', () => {
     expect(agentClientArgs.agentConfigs.has(HANDOFF_AND_SUB_ID)).toBe(true);
   });
 
-  it('keeps path-specific children isolated when parallel walkers share initialized agents', async () => {
+  it('keeps shared initialized agent children deterministic across parallel walkers', async () => {
     const leftId = 'agent_parallel_left';
     const rightId = 'agent_parallel_right';
     const sharedId = 'agent_parallel_shared';
@@ -2504,12 +2504,17 @@ describe('initializeClient — subagent loading', () => {
       endpointOption: makeEndpointOption(),
     });
 
-    const [left, right] = agentClientArgs.agent.subagentAgentConfigs;
+    const subagentsById = new Map(
+      agentClientArgs.agent.subagentAgentConfigs.map((config) => [config.id, config]),
+    );
+    const left = subagentsById.get(leftId);
+    const right = subagentsById.get(rightId);
     const leftShared = left.subagentAgentConfigs[0];
     const rightShared = right.subagentAgentConfigs[0];
-    expect(leftShared).not.toBe(rightShared);
+    expect(leftShared).toBe(sharedConfig);
+    expect(rightShared).toBe(sharedConfig);
     expect(leftShared.subagentAgentConfigs).toEqual([]);
-    expect(rightShared.subagentAgentConfigs.map((child) => child.id)).toEqual([leftId]);
+    expect(rightShared.subagentAgentConfigs).toEqual([]);
     expect(agentClientArgs.agentConfigs.get(sharedId)).toBe(sharedConfig);
   });
 

--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -2022,6 +2022,74 @@ describe('subagentConfigs', () => {
     });
   });
 
+  it('prunes shared-agent cycles per traversal path without dropping valid edges', async () => {
+    const left = makeAgent({
+      id: 'agent_left',
+      name: 'Left',
+      subagents: { enabled: true, allowSelf: false, agent_ids: ['agent_shared'] },
+    }) as TestRunAgent;
+    const right = makeAgent({
+      id: 'agent_right',
+      name: 'Right',
+      subagents: { enabled: true, allowSelf: false, agent_ids: ['agent_shared'] },
+    }) as TestRunAgent;
+    const shared = makeAgent({
+      id: 'agent_shared',
+      name: 'Shared',
+      subagents: { enabled: true, allowSelf: false, agent_ids: ['agent_left'] },
+    }) as TestRunAgent;
+    left.subagentAgentConfigs = [shared];
+    right.subagentAgentConfigs = [shared];
+    shared.subagentAgentConfigs = [left];
+
+    const agents = await callAndCapture({
+      agents: [
+        makeAgent({
+          subagents: {
+            enabled: true,
+            allowSelf: false,
+            agent_ids: ['agent_left', 'agent_right'],
+          },
+          subagentAgentConfigs: [left, right],
+        }),
+      ],
+    });
+
+    const rootConfigs = agents[0].subagentConfigs as Parameters<typeof buildChildInputs>[0][];
+    const rootConfigsByType = new Map(rootConfigs.map((config) => [config.type, config]));
+    const leftConfig = rootConfigsByType.get('agent_left');
+    const rightConfig = rootConfigsByType.get('agent_right');
+    if (!leftConfig || !rightConfig) {
+      throw new Error('Expected both root subagent configs');
+    }
+    const leftInputs = buildChildInputs(leftConfig, 'agent_left', MAX_SUBAGENT_DEPTH);
+    const rightInputs = buildChildInputs(rightConfig, 'agent_right', MAX_SUBAGENT_DEPTH);
+    const leftShared = leftInputs.subagentConfigs?.[0];
+    const rightShared = rightInputs.subagentConfigs?.[0];
+    if (
+      !leftShared ||
+      !rightShared ||
+      leftInputs.maxSubagentDepth == null ||
+      rightInputs.maxSubagentDepth == null
+    ) {
+      throw new Error('Expected both shared subagent configs');
+    }
+    const leftSharedInputs = buildChildInputs(
+      leftShared,
+      'agent_shared',
+      leftInputs.maxSubagentDepth,
+    );
+    const rightSharedInputs = buildChildInputs(
+      rightShared,
+      'agent_shared',
+      rightInputs.maxSubagentDepth,
+    );
+
+    expect(leftSharedInputs.subagentConfigs).toBeUndefined();
+    expect(rightSharedInputs.subagentConfigs).toHaveLength(1);
+    expect(rightSharedInputs.subagentConfigs?.[0]).toMatchObject({ type: 'agent_left' });
+  });
+
   it('combines self-spawn and explicit subagents when both enabled', async () => {
     const child = makeAgent({ id: 'agent_child', name: 'Helper' });
     const agents = await callAndCapture({


### PR DESCRIPTION
## Summary

I separated shared subagent graph assembly from path-local validation so parallel descriptor walks cannot race on initialized configs or discard edges that are valid through another path. This addresses #15488 while preserving the expanded-entry safety limit enforced again by the runtime builder.

- Preserve one initialized config object per agent ID for runtime context, graph resolution, and handoff use.
- Assign each eager config's complete direct adjacency only from its own root expansion.
- Keep nested walks read-only while retaining path-sensitive depth, cycle, and expanded-entry validation.
- Add initialization and runtime regressions for a cyclic diamond, proving the runtime prunes the ancestor cycle without dropping the alternate valid edge.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Passed `NODE_PATH=/Users/danny/Projects/LibreChat/node_modules:/Users/danny/Projects/LibreChat-ts-fixes/packages/data-schemas/node_modules /Users/danny/Projects/LibreChat/node_modules/.bin/jest src/agents/__tests__/run-summarization.test.ts --runInBand -t "prunes shared-agent cycles per traversal path"`.
- Ran `node --check api/server/services/Endpoints/agents/initialize.js`.
- Ran `node --check api/server/services/Endpoints/agents/initialize.spec.js`.
- Ran `git diff --check`.
- Attempted the focused API initialization Jest test; the current worktree has no dependency install, and the reusable install from another checkout is incompatible with current `origin/dev` (`createAgentQueuedTurnLifecycle is not a function`). CI runs the suite with a clean matching install.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
