### PR TITLE
🪛 chore: Align Vite Build Config With Native ESM

### DIFF
--- a/client/src/components/Chat/Input/TokenUsage/Breakdown.tsx
+++ b/client/src/components/Chat/Input/TokenUsage/Breakdown.tsx
@@ -204,7 +204,7 @@ export default function Breakdown({
               : formatTokens(usedTokens)}
             <ChevronDown
               aria-hidden="true"
-              className="ease-out size-3.5 shrink-0 text-text-tertiary transition-transform duration-300 group-data-[state=open]:rotate-180 motion-reduce:transition-none"
+              className="size-3.5 shrink-0 text-text-tertiary transition-transform duration-300 ease-out group-data-[state=open]:rotate-180 motion-reduce:transition-none"
             />
           </span>
         </CollapsibleTrigger>

--- a/client/src/components/Chat/Input/TokenUsage/Breakdown.tsx
+++ b/client/src/components/Chat/Input/TokenUsage/Breakdown.tsx
@@ -204,7 +204,7 @@ export default function Breakdown({
               : formatTokens(usedTokens)}
             <ChevronDown
               aria-hidden="true"
-              className="ease-[cubic-bezier(0,0,0.2,1)] size-3.5 shrink-0 text-text-tertiary transition-transform duration-300 group-data-[state=open]:rotate-180 motion-reduce:transition-none"
+              className="ease-out size-3.5 shrink-0 text-text-tertiary transition-transform duration-300 group-data-[state=open]:rotate-180 motion-reduce:transition-none"
             />
           </span>
         </CollapsibleTrigger>

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -85,7 +85,7 @@ export default defineConfig(({ command }) => ({
         this.emitFile({
           type: 'asset',
           fileName: 'sw-heal.js',
-          source: fs.readFileSync(path.resolve(__dirname, 'sw/heal.js'), 'utf8'),
+          source: fs.readFileSync(path.resolve(import.meta.dirname, 'sw/heal.js'), 'utf8'),
         });
       },
     },
@@ -422,8 +422,8 @@ export default defineConfig(({ command }) => ({
   },
   resolve: {
     alias: {
-      '~': path.join(__dirname, 'src/'),
-      $fonts: path.resolve(__dirname, 'public/fonts'),
+      '~': path.join(import.meta.dirname, 'src/'),
+      $fonts: path.resolve(import.meta.dirname, 'public/fonts'),
       'micromark-extension-math': 'micromark-extension-llm-math',
     },
   },


### PR DESCRIPTION
## Summary

I resolved the Vite native config-loader compatibility warning and the ambiguous Tailwind easing utility emitted during production builds.

- Replaced all `__dirname` references in the Vite config with ESM-native `import.meta.dirname` paths.
- Replaced the ambiguous arbitrary easing class with the equivalent built-in `ease-out` utility.
- Preserved the existing service-worker asset path, aliases, and chevron transition behavior.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `git diff --check`.
- Verified that `client/vite.config.ts` contains no remaining `__dirname` references.
- Verified that all expected `import.meta.dirname` and `ease-out` replacements are present.
- Deferred the production build and TypeScript checks to CI because dependencies are not installed in this dedicated worktree.

### **Test Configuration**:

- Node.js: v24.16.0
- Base branch: `dev`

## Checklist

- [x] My code adheres to this project style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
