### PR TITLE
🗜 test: Clamp Recursive Child Inputs to Builder Types

### DIFF
--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -126,6 +126,8 @@ type TestRunAgent = ReturnType<typeof makeAgent> & {
   subagentAgentConfigs?: TestRunAgent[];
 };
 
+type BuildChildInput = Parameters<typeof buildChildInputs>[0];
+
 function makeSubagentChain(hops: number): TestRunAgent {
   const agents = Array.from({ length: hops + 1 }, (_, index) =>
     makeAgent({
@@ -2010,7 +2012,7 @@ describe('subagentConfigs', () => {
     });
 
     expect(agents[0].maxSubagentDepth).toBe(MAX_SUBAGENT_DEPTH);
-    const childConfig = (agents[0].subagentConfigs as Parameters<typeof buildChildInputs>[0][])[0];
+    const childConfig = (agents[0].subagentConfigs as BuildChildInput[])[0];
     expect(childConfig.allowNested).toBe(true);
 
     const childInputs = buildChildInputs(childConfig, 'agent_child', MAX_SUBAGENT_DEPTH);
@@ -2055,7 +2057,7 @@ describe('subagentConfigs', () => {
       ],
     });
 
-    const rootConfigs = agents[0].subagentConfigs as Parameters<typeof buildChildInputs>[0][];
+    const rootConfigs = agents[0].subagentConfigs as BuildChildInput[];
     const rootConfigsByType = new Map(rootConfigs.map((config) => [config.type, config]));
     const leftConfig = rootConfigsByType.get('agent_left');
     const rightConfig = rootConfigsByType.get('agent_right');
@@ -2064,8 +2066,8 @@ describe('subagentConfigs', () => {
     }
     const leftInputs = buildChildInputs(leftConfig, 'agent_left', MAX_SUBAGENT_DEPTH);
     const rightInputs = buildChildInputs(rightConfig, 'agent_right', MAX_SUBAGENT_DEPTH);
-    const leftShared = leftInputs.subagentConfigs?.[0];
-    const rightShared = rightInputs.subagentConfigs?.[0];
+    const leftShared = leftInputs.subagentConfigs?.[0] as BuildChildInput | undefined;
+    const rightShared = rightInputs.subagentConfigs?.[0] as BuildChildInput | undefined;
     if (
       !leftShared ||
       !rightShared ||


### PR DESCRIPTION
I fixed the recursive summarization regression test typing so known direct-agent configs are narrowed to the exact input accepted by `buildChildInputs`.

- Added a reusable `BuildChildInput` alias derived from the helper signature.
- Applied the alias to root and recursively returned shared-agent configs.
- Preserved the existing runtime cycle-pruning coverage and behavior.

Refs #15496

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Ran `npm run static-checks -- --staged`.
- [x] Ran `cd packages/api && jest src/agents/__tests__/run-summarization.test.ts --runInBand` (143 tests passed).
- [x] Confirmed `tsc --noEmit` reports no diagnostics for `run-summarization.test.ts`; unrelated stale generated workspace packages prevented treating the shared-install full-project output as authoritative.

### **Test Configuration**:

- Node.js 24.16.0
- macOS

## Checklist

- [x] My code adheres to this project style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes