### PR TITLE
🫱 fix: Keep Polling Through Queued Run Handoffs

### DIFF
--- a/client/src/data-provider/SSE/__tests__/queries.test.ts
+++ b/client/src/data-provider/SSE/__tests__/queries.test.ts
@@ -42,6 +42,10 @@ import {
   genTitleQueryKey,
   queueTitleGeneration,
   useActiveJobs,
+  resetActiveJobsGrace,
+  getActiveJobsRefetchInterval,
+  ACTIVE_JOBS_POLL_MS,
+  ACTIVE_JOBS_SUCCESSOR_GRACE_MS,
 } from '../queries';
 
 describe('fetchStreamStatus generation protocol advertisement', () => {
@@ -84,14 +88,65 @@ describe('useActiveJobs focus behaviour', () => {
     expect(options.staleTime).toBe(5_000);
   });
 
-  it('polls only while something is listed', () => {
+  it('polls while something is listed', () => {
     (useQuery as jest.Mock).mockClear();
+    resetActiveJobsGrace();
 
     useActiveJobs();
 
     const options = (useQuery as jest.Mock).mock.calls[0][0];
-    expect(options.refetchInterval({ activeJobIds: ['convo-1'] })).toBe(5_000);
-    expect(options.refetchInterval({ activeJobIds: [] })).toBe(false);
+    expect(options.refetchInterval({ activeJobIds: ['convo-1'] })).toBe(ACTIVE_JOBS_POLL_MS);
+  });
+});
+
+describe('useActiveJobs successor grace', () => {
+  let now = 1_000_000;
+
+  beforeEach(() => {
+    now = 1_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+    resetActiveJobsGrace();
+  });
+
+  afterEach(() => {
+    (Date.now as jest.Mock).mockRestore?.();
+    resetActiveJobsGrace();
+  });
+
+  it('does not poll for an empty list it has never seen fill', () => {
+    expect(getActiveJobsRefetchInterval({ activeJobIds: [] })).toBe(false);
+  });
+
+  it('keeps asking across the handover to a server-started successor', () => {
+    /**
+     * The run ends, the client removes its own job optimistically, and the
+     * backend admits the queued turn (or a background-tool continuation) it
+     * owns. Going quiet on the empty list is what leaves the pane on the
+     * previous turn until a reload.
+     */
+    expect(getActiveJobsRefetchInterval({ activeJobIds: ['convo-1'] })).toBe(ACTIVE_JOBS_POLL_MS);
+
+    now += 1_000;
+    expect(getActiveJobsRefetchInterval({ activeJobIds: [] })).toBe(ACTIVE_JOBS_POLL_MS);
+  });
+
+  it('stops once the handover window has passed without a successor', () => {
+    expect(getActiveJobsRefetchInterval({ activeJobIds: ['convo-1'] })).toBe(ACTIVE_JOBS_POLL_MS);
+
+    now += ACTIVE_JOBS_SUCCESSOR_GRACE_MS + 1;
+    expect(getActiveJobsRefetchInterval({ activeJobIds: [] })).toBe(false);
+  });
+
+  it('renews the window when the successor turns up', () => {
+    getActiveJobsRefetchInterval({ activeJobIds: ['convo-1'] });
+    now += 1_000;
+    getActiveJobsRefetchInterval({ activeJobIds: [] });
+
+    now += 1_000;
+    expect(getActiveJobsRefetchInterval({ activeJobIds: ['convo-1'] })).toBe(ACTIVE_JOBS_POLL_MS);
+
+    now += ACTIVE_JOBS_SUCCESSOR_GRACE_MS - 1;
+    expect(getActiveJobsRefetchInterval({ activeJobIds: [] })).toBe(ACTIVE_JOBS_POLL_MS);
   });
 });
 

--- a/client/src/data-provider/SSE/queries.ts
+++ b/client/src/data-provider/SSE/queries.ts
@@ -219,6 +219,40 @@ export function useTitleGeneration(enabled = true) {
  * - Polls while jobs are active
  * - Shows generation indicators in conversation list
  */
+export const ACTIVE_JOBS_POLL_MS = 5_000;
+/**
+ * How long to keep asking after the last job this client knew about ended.
+ *
+ * A successor the server admits for itself — a queued turn handed to the
+ * backend, a background-tool continuation — starts as part of terminalizing
+ * the run before it. But finishing a run also empties this list, partly
+ * because the client removes its own job optimistically the moment `FINAL`
+ * lands. Stopping the poll on an empty list therefore goes quiet at exactly
+ * the moment a successor appears, and with the tab already focused there is no
+ * focus refetch to recover: the pane waits for a reload. Keep asking across
+ * that handover instead.
+ */
+export const ACTIVE_JOBS_SUCCESSOR_GRACE_MS = 30_000;
+
+/** Module-scoped rather than per-observer: this is one shared query, and a
+ *  component mounting mid-handover should inherit the grace, not restart it. */
+let lastListedActiveJobsAt = 0;
+
+/** @internal Test seam — the grace window is wall-clock state. */
+export function resetActiveJobsGrace(): void {
+  lastListedActiveJobsAt = 0;
+}
+
+export function getActiveJobsRefetchInterval(data?: ActiveJobsResponse): number | false {
+  if ((data?.activeJobIds?.length ?? 0) > 0) {
+    lastListedActiveJobsAt = Date.now();
+    return ACTIVE_JOBS_POLL_MS;
+  }
+  return Date.now() - lastListedActiveJobsAt < ACTIVE_JOBS_SUCCESSOR_GRACE_MS
+    ? ACTIVE_JOBS_POLL_MS
+    : false;
+}
+
 export function useActiveJobs(enabled = true) {
   return useQuery({
     queryKey: [QueryKeys.activeJobs],
@@ -231,7 +265,7 @@ export function useActiveJobs(enabled = true) {
      *  invisible until some unrelated refetch, and returning to the tab is
      *  exactly when a pane needs to know whether its history has moved. */
     refetchOnWindowFocus: 'always',
-    refetchInterval: (data) => ((data?.activeJobIds?.length ?? 0) > 0 ? 5_000 : false),
+    refetchInterval: getActiveJobsRefetchInterval,
     retry: false,
   });
 }


### PR DESCRIPTION
Follow-up to #15414, from a new and much easier reproduction:

> Send a message. Before it finishes, **queue** a follow-up (queue, not steer). The queued turn is admitted and a new run starts — and nothing on screen ever changes.

Reproduces on desktop as well as mobile, which is the tell that it is not a transport problem.

## Why

Queued turns are server-owned. `useQueueDrain` deliberately declines the boundary — `serverOwnsBoundary` returns `null` — because the backend admits the successor itself. So the client never creates a submission for that run; it has to learn about it from the active-job list, exactly like a background-tool continuation.

It cannot, because finishing a run silences that list:

- `removeActiveJob` drops this client's own job optimistically the moment `FINAL` lands, so the list is empty immediately.
- `refetchInterval` is disabled on an empty list.
- `refetchOnWindowFocus: 'always'` only helps if a focus event happens, and on desktop the tab is already focused.

So the poll stops at precisely the moment the successor is admitted, and nothing asks again until a reload.

## The fix

Keep asking for a bounded window after the last job this client knew about ended. That is the handover: a successor the server admits for itself starts as part of terminalizing the run before it.

The window is module-scoped rather than per-observer, because this is one shared query and a component mounting mid-handover should inherit the grace rather than restart it.

## Relationship to #15414

Two halves of one symptom, and neither is observable alone:

- Without #15414's re-arm, the announcement lands on a pane that still reads its finished submission as an attachment.
- Without this, the announcement never lands at all.

#15414 merged while this was being written, so it ships separately.

## Testing

Four cases, and the grace branch is mutation-checked — removing it fails two of them:

- an empty list never seen to fill does not poll
- the poll continues across the handover
- it stops once the window passes with no successor
- the window renews when a successor turns up

Full client suite: 491 suites / 6174 tests green. eslint and tsc clean.

## Known limit

A successor admitted *after* the window — a background task that runs for minutes before its continuation — still waits for a focus refetch. Covering that needs a signal that a successor is pending rather than a time bound; worth doing only if it shows up in practice.
