### PR TITLE
⚡ feat: Add Gemini 3.8 Flash Support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -519,10 +519,10 @@ GOOGLE_KEY=user_provided
 # GOOGLE_AUTH_HEADER=true
 
 # Gemini API (AI Studio)
-# GOOGLE_MODELS=gemini-3.7-flash,gemini-3.6-flash,gemini-3.5-flash,gemini-3.5-flash-lite,gemini-3.1-pro-preview,gemini-3.1-pro-preview-customtools,gemini-3.1-flash-lite-preview,gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash,gemini-2.0-flash-lite
+# GOOGLE_MODELS=gemini-3.8-flash,gemini-3.7-flash,gemini-3.6-flash,gemini-3.5-flash,gemini-3.5-flash-lite,gemini-3.1-pro-preview,gemini-3.1-pro-preview-customtools,gemini-3.1-flash-lite-preview,gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash,gemini-2.0-flash-lite
 
 # Vertex AI
-# GOOGLE_MODELS=gemini-3.7-flash,gemini-3.6-flash,gemini-3.5-flash,gemini-3.5-flash-lite,gemini-3.1-pro-preview,gemini-3.1-pro-preview-customtools,gemini-3.1-flash-lite-preview,gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash-001,gemini-2.0-flash-lite-001
+# GOOGLE_MODELS=gemini-3.8-flash,gemini-3.7-flash,gemini-3.6-flash,gemini-3.5-flash,gemini-3.5-flash-lite,gemini-3.1-pro-preview,gemini-3.1-pro-preview-customtools,gemini-3.1-flash-lite-preview,gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash-001,gemini-2.0-flash-lite-001
 
 # GOOGLE_TITLE_MODEL=gemini-2.0-flash-lite-001
 

--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "5.1.6",
-    "@librechat/agents": "^3.7.14",
+    "@librechat/agents": "^3.7.15",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/api/utils/tokens.spec.js
+++ b/api/utils/tokens.spec.js
@@ -359,6 +359,9 @@ describe('getModelMaxTokens', () => {
     expect(getModelMaxTokens('gemini-3.7-flash', EModelEndpoint.google)).toBe(
       maxTokensMap[EModelEndpoint.google]['gemini-3.7-flash'],
     );
+    expect(getModelMaxTokens('gemini-3.8-flash', EModelEndpoint.google)).toBe(
+      maxTokensMap[EModelEndpoint.google]['gemini-3.8-flash'],
+    );
     expect(getModelMaxTokens('gemini-2.5-pro', EModelEndpoint.google)).toBe(
       maxTokensMap[EModelEndpoint.google]['gemini-2.5-pro'],
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "5.1.6",
-        "@librechat/agents": "^3.7.14",
+        "@librechat/agents": "^3.7.15",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -10633,9 +10633,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.7.14",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.7.14.tgz",
-      "integrity": "sha512-aKWy0sJgR84eRUOujZAwL15nEfclDZ48ULlSGlazw5ozN/Ixiqr+bc+eY/cvDEBWPXpvoZKb/G+XjQJVUP3xVg==",
+      "version": "3.7.15",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.7.15.tgz",
+      "integrity": "sha512-4huKqYzZ7mOav0NdtzId0adT4YE00bRfx+FaPtfzAeZxUryKXwRPmq8/La77tH7Ljf+AnC00pdJHUcPezuBoHQ==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
@@ -42639,7 +42639,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "5.1.6",
-        "@librechat/agents": "^3.7.14",
+        "@librechat/agents": "^3.7.15",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/api": "^1.9.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -113,7 +113,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "5.1.6",
-    "@librechat/agents": "^3.7.14",
+    "@librechat/agents": "^3.7.15",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@opentelemetry/api": "^1.9.0",

--- a/packages/api/src/endpoints/google/llm.spec.ts
+++ b/packages/api/src/endpoints/google/llm.spec.ts
@@ -1069,6 +1069,111 @@ describe('getGoogleConfig', () => {
       });
     });
 
+    it('should default Gemini 3.8 Flash to medium thinkingLevel', () => {
+      const credentials = {
+        [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',
+      };
+
+      const result = getGoogleConfig(credentials, {
+        modelOptions: {
+          model: 'gemini-3.8-flash',
+        },
+      });
+
+      expect((result.llmConfig as Record<string, unknown>).thinkingConfig).toMatchObject({
+        includeThoughts: true,
+        thinkingLevel: 'MEDIUM',
+      });
+    });
+
+    it('should remove legacy sampling params for Gemini 3.8 Flash', () => {
+      const credentials = {
+        [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',
+      };
+
+      const modelOptions = {
+        model: 'gemini-3.8-flash',
+        temperature: 0.7,
+        topP: 0.9,
+        topK: 40,
+        top_p: 0.9,
+        top_k: 40,
+        presencePenalty: 0.5,
+        frequencyPenalty: 0.5,
+        thinking_budget: 5000,
+      } as unknown as t.GoogleParameters;
+
+      const result = getGoogleConfig(credentials, { modelOptions });
+
+      expect(result.llmConfig).not.toHaveProperty('temperature');
+      expect(result.llmConfig).not.toHaveProperty('topP');
+      expect(result.llmConfig).not.toHaveProperty('topK');
+      expect(result.llmConfig).not.toHaveProperty('top_p');
+      expect(result.llmConfig).not.toHaveProperty('top_k');
+      expect(result.llmConfig).not.toHaveProperty('presencePenalty');
+      expect(result.llmConfig).not.toHaveProperty('frequencyPenalty');
+      expect(result.llmConfig).not.toHaveProperty('thinking_budget');
+    });
+
+    it.each([
+      [ThinkingLevel.low, 'LOW'],
+      [ThinkingLevel.medium, 'MEDIUM'],
+      [ThinkingLevel.high, 'HIGH'],
+    ])('should preserve explicit Gemini 3.8 Flash thinkingLevel "%s"', (level, expected) => {
+      const credentials = {
+        [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',
+      };
+
+      const result = getGoogleConfig(credentials, {
+        modelOptions: {
+          model: 'gemini-3.8-flash',
+          thinkingLevel: level,
+        },
+      });
+
+      expect((result.llmConfig as Record<string, unknown>).thinkingConfig).toMatchObject({
+        includeThoughts: true,
+        thinkingLevel: expected,
+      });
+    });
+
+    it('should substitute minimal thinkingLevel with low for Gemini 3.8 Flash', () => {
+      const credentials = {
+        [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',
+      };
+
+      const result = getGoogleConfig(credentials, {
+        modelOptions: {
+          model: 'gemini-3.8-flash',
+          thinkingLevel: ThinkingLevel.minimal,
+        },
+      });
+
+      expect((result.llmConfig as Record<string, unknown>).thinkingConfig).toMatchObject({
+        includeThoughts: true,
+        thinkingLevel: 'LOW',
+      });
+    });
+
+    it('should apply Gemini 3.8 Flash handling to versioned aliases', () => {
+      const credentials = {
+        [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',
+      };
+
+      const result = getGoogleConfig(credentials, {
+        modelOptions: {
+          model: 'models/gemini-3.8-flash-latest',
+          temperature: 0.7,
+        },
+      });
+
+      expect(result.llmConfig).not.toHaveProperty('temperature');
+      expect((result.llmConfig as Record<string, unknown>).thinkingConfig).toMatchObject({
+        includeThoughts: true,
+        thinkingLevel: 'MEDIUM',
+      });
+    });
+
     it('should remove unsupported penalty params for Gemini 3.5 Flash-Lite', () => {
       const credentials = {
         [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',

--- a/packages/api/src/endpoints/google/llm.ts
+++ b/packages/api/src/endpoints/google/llm.ts
@@ -32,12 +32,15 @@ type GeminiFlashThinkingRule = {
  * most-specific-first so `gemini-3.5-flash-lite` resolves before the
  * `gemini-3.5-flash` prefix.
  *
- * Gemini 3.7 Flash supports only `low`/`medium`/`high` and errors on `minimal`,
- * so an explicit `minimal` is substituted with the nearest supported level.
+ * Gemini 3.7 and 3.8 Flash support only `low`/`medium`/`high` and error on
+ * `minimal`, so an explicit `minimal` is substituted with the nearest supported
+ * level.
  * @see https://ai.google.dev/gemini-api/docs/latest-model#api-changes-and-parameter-updates
  * @see https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash
+ * @see https://ai.google.dev/gemini-api/docs/models/gemini-3.8-flash
  */
 const geminiFlashThinkingRules: ReadonlyArray<GeminiFlashThinkingRule> = [
+  { id: 'gemini-3.8-flash', default: 'MEDIUM', substitutions: { MINIMAL: 'LOW' } },
   { id: 'gemini-3.7-flash', default: 'MEDIUM', substitutions: { MINIMAL: 'LOW' } },
   { id: 'gemini-3.6-flash', default: 'MEDIUM' },
   { id: 'gemini-3.5-flash-lite', default: 'MINIMAL' },

--- a/packages/api/src/endpoints/openai/config.google.spec.ts
+++ b/packages/api/src/endpoints/openai/config.google.spec.ts
@@ -153,7 +153,7 @@ describe('getOpenAIConfig - Google Compatibility', () => {
         expect(result.tools).toEqual([]);
       });
 
-      it.each(['gemini-3.6-flash', 'gemini-3.7-flash'])(
+      it.each(['gemini-3.6-flash', 'gemini-3.7-flash', 'gemini-3.8-flash'])(
         'should strip Flash-blocked addParams so the transform cannot re-add them (%s)',
         (model) => {
           const apiKey = JSON.stringify({ GOOGLE_API_KEY: 'test-google-key' });

--- a/packages/api/src/utils/tokens.spec.ts
+++ b/packages/api/src/utils/tokens.spec.ts
@@ -79,6 +79,18 @@ describe('Gemini 3.7 Flash', () => {
   });
 });
 
+describe('Gemini 3.8 Flash', () => {
+  it('resolves the 1,048,576-token context window', () => {
+    expect(getModelMaxTokens('gemini-3.8-flash', EModelEndpoint.google)).toBe(1048576);
+  });
+
+  it('matches the longest key over the shorter gemini-3 pattern for aliases', () => {
+    expect(getModelMaxTokens('models/gemini-3.8-flash-latest', EModelEndpoint.google)).toBe(
+      1048576,
+    );
+  });
+});
+
 describe('Qwen3.5 and later generations', () => {
   it('resolves 262K for the vLLM model id that regressed to the qwen3 window', () => {
     expect(getModelMaxTokens('Qwen/Qwen3.5-397B-A17B-FP8', EModelEndpoint.openAI)).toBe(262144);

--- a/packages/api/src/utils/tokens.ts
+++ b/packages/api/src/utils/tokens.ts
@@ -143,6 +143,7 @@ const googleModels = {
   'gemini-3.5-flash-lite': 1048576,
   'gemini-3.6-flash': 1048576,
   'gemini-3.7-flash': 1048576,
+  'gemini-3.8-flash': 1048576,
 };
 
 const anthropicModels = {

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2739,6 +2739,8 @@ export const defaultModels = {
   [EModelEndpoint.assistants]: [...sharedOpenAIModels, 'chatgpt-4o-latest'],
   [EModelEndpoint.agents]: sharedOpenAIModels, // TODO: Add agent models (agentsModels)
   [EModelEndpoint.google]: [
+    // Gemini 3.8 Models
+    'gemini-3.8-flash',
     // Gemini 3.7 Models
     'gemini-3.7-flash',
     // Gemini 3.6 Models

--- a/packages/data-schemas/src/methods/tx.spec.ts
+++ b/packages/data-schemas/src/methods/tx.spec.ts
@@ -1556,6 +1556,7 @@ describe('Google Model Tests', () => {
     'gemini-3.1-pro-preview',
     'gemini-3.1-pro-preview-customtools',
     'gemini-3.1-flash-lite-preview',
+    'gemini-3.8-flash',
     'gemini-3.7-flash',
     'gemini-3.6-flash',
     'gemini-3.5-flash',
@@ -1607,6 +1608,7 @@ describe('Google Model Tests', () => {
       'gemini-3.1-pro-preview': 'gemini-3.1',
       'gemini-3.1-pro-preview-customtools': 'gemini-3.1',
       'gemini-3.1-flash-lite-preview': 'gemini-3.1-flash-lite',
+      'gemini-3.8-flash': 'gemini-3.8-flash',
       'gemini-3.7-flash': 'gemini-3.7-flash',
       'gemini-3.6-flash': 'gemini-3.6-flash',
       'gemini-3.5-flash': 'gemini-3.5-flash',
@@ -1761,8 +1763,24 @@ describe('Google Model Tests', () => {
     );
   });
 
-  it('should apply the introductory Flash rates to Gemini 3.6 and 3.7 Flash', () => {
-    for (const model of ['gemini-3.6-flash', 'gemini-3.7-flash']) {
+  it('should return correct rates for Gemini 3.8 Flash', () => {
+    const model = 'gemini-3.8-flash';
+    expect(getMultiplier({ model, tokenType: 'prompt', endpoint: EModelEndpoint.google })).toBe(
+      tokenValues['gemini-3.8-flash'].prompt,
+    );
+    expect(getMultiplier({ model, tokenType: 'completion', endpoint: EModelEndpoint.google })).toBe(
+      tokenValues['gemini-3.8-flash'].completion,
+    );
+    expect(getCacheMultiplier({ model, cacheType: 'write' })).toBe(
+      cacheTokenValues['gemini-3.8-flash'].write,
+    );
+    expect(getCacheMultiplier({ model, cacheType: 'read' })).toBe(
+      cacheTokenValues['gemini-3.8-flash'].read,
+    );
+  });
+
+  it('should apply the introductory Flash rates to Gemini 3.6, 3.7 and 3.8 Flash', () => {
+    for (const model of ['gemini-3.6-flash', 'gemini-3.7-flash', 'gemini-3.8-flash']) {
       expect(getMultiplier({ model, tokenType: 'prompt', endpoint: EModelEndpoint.google })).toBe(
         0.75,
       );

--- a/packages/data-schemas/src/methods/tx.ts
+++ b/packages/data-schemas/src/methods/tx.ts
@@ -223,9 +223,10 @@ export const tokenValues: Record<string, { prompt: number; completion: number }>
     'gemini-3.1-flash-lite': { prompt: 0.25, completion: 1.5 },
     'gemini-3.5-flash': { prompt: 1.5, completion: 9 },
     'gemini-3.5-flash-lite': { prompt: 0.3, completion: 2.5 },
-    // Gemini 3.6/3.7 Flash introductory pricing through 2026-12-31; revert to { prompt: 1.5, completion: 7.5 } after.
+    // Gemini 3.6/3.7/3.8 Flash introductory pricing through 2026-12-31; revert to { prompt: 1.5, completion: 7.5 } after.
     'gemini-3.6-flash': { prompt: 0.75, completion: 3.75 },
     'gemini-3.7-flash': { prompt: 0.75, completion: 3.75 },
+    'gemini-3.8-flash': { prompt: 0.75, completion: 3.75 },
     'gemini-pro-vision': { prompt: 0.5, completion: 1.5 },
     grok: { prompt: 2.0, completion: 10.0 },
     'grok-beta': { prompt: 5.0, completion: 15.0 },
@@ -423,9 +424,10 @@ export const cacheTokenValues: Record<string, { write: number; read: number }> =
   'gemini-3.5-flash': { write: 1.5, read: 0.15 },
   // Gemini 3.5 Flash-Lite - cache write: $0.30/1M, cache read: $0.03/1M
   'gemini-3.5-flash-lite': { write: 0.3, read: 0.03 },
-  // Gemini 3.6/3.7 Flash introductory pricing through 2026-12-31; revert to { write: 1.5, read: 0.15 } after.
+  // Gemini 3.6/3.7/3.8 Flash introductory pricing through 2026-12-31; revert to { write: 1.5, read: 0.15 } after.
   'gemini-3.6-flash': { write: 0.75, read: 0.075 },
   'gemini-3.7-flash': { write: 0.75, read: 0.075 },
+  'gemini-3.8-flash': { write: 0.75, read: 0.075 },
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds first-class support for Google's Gemini 3.8 Flash (`gemini-3.8-flash`, GA 2026-09-02) for both the Gemini API (AI Studio) and Google Cloud Gemini Enterprise Agent Platform, following the Gemini 3.7 Flash integration ([#14818](https://github.com/danny-avila/LibreChat/pull/14818)).

As the issue predicted, this is registration rather than new behavior. The Flash-family handler #14818 generalized from an `[id, level]` tuple to a rule object already carries exactly the shape 3.8 needs, so the model is a one-line entry:

```ts
{ id: 'gemini-3.8-flash', default: 'MEDIUM', substitutions: { MINIMAL: 'LOW' } },
```

It inherits the strip of deprecated sampling params (`temperature`/`topP`/`topK`), the rejected penalty params, and `thinkingBudget`; defaults to `medium` thinking; and — like 3.7 — errors on `minimal` (which the Google endpoint still offers in its thinkingLevel slider), so an explicit `minimal` is substituted with the nearest supported level, `low`. Explicit `low`/`medium`/`high` pass through unchanged.

## Verified against Google's docs

| | Value |
|---|---|
| Model ID | `gemini-3.8-flash` |
| Context window | 1,048,576 |
| Max output | 65,536 |
| Thinking levels | `low` / `medium` / `high` — `minimal` returns an error |
| Input → output | Text, image, video, audio, PDF → text |
| Pricing (through 2026-12-31) | $0.75 in / $3.75 out / $0.075 cached, per 1M |
| Pricing (from 2027-01-01) | $1.50 / $7.50 / $0.15 |

Identical to 3.7 Flash, including the promotional structure — so this reuses the existing dated-pricing comments rather than introducing new pricing behavior.

## Changes

- **`packages/api/src/endpoints/google/llm.ts`** — register the model in the Flash-family thinking-rule table
- **`packages/api/src/utils/tokens.ts`** — 1,048,576-token context window
- **`packages/data-provider/src/config.ts`** — default Google model list
- **`packages/data-schemas/src/methods/tx.ts`** — API and cache pricing, with the existing 3.6/3.7 introductory-rate comments extended to name 3.8
- **`.env.example`** — `GOOGLE_MODELS` examples for both integrations
- **Tests** — mirroring the 3.7 Flash coverage: thinking default, legacy-param strip, explicit level pass-through, `minimal` substitution, versioned aliases (`models/gemini-3.8-flash-latest`), context window, model-key mapping, rates, and the shared Flash-blocked `addParams` case

## Prefill handling — fixed upstream and shipped

Both Codex and Copilot flagged that `NO_PREFILL_GEMINI_MODELS` in `@librechat/agents` didn't know 3.8 Flash, so LibreChat's continue flow (`useChatHelpers.ts` → `isContinued`) could reach Google with a trailing `model` turn and get an HTTP 400. That was real — the list was hardcoded and exported only as a read-only predicate, so nothing here could inject into it.

Rather than enumerate 3.8 (the third such edit, after 3.6 and 3.7), [danny-avila/agents#499](https://github.com/danny-avila/agents/pull/499) derives the rule from the model version — Flash from 3.6 onward — matching how `modelDisallowsAssistantPrefill` already works for Claude in the same SDK. Gemini 3.5 Flash-Lite stays an explicit entry, since it rejects prefill while its sibling Gemini 3.5 Flash accepts it. Future Flash models need no SDK change.

That shipped as **3.7.15**, and this PR now pins it. `^3.7.13` already permitted 3.7.15, but the lockfile pinned 3.7.13 and `npm ci` honors the pin — the lock is what actually delivers the fix. The declared floor is raised in both workspaces alongside it because the fix is required rather than merely compatible.

Verified against the published tarball rather than the source, exercising `dropUnsupportedModelTurnPrefill` from `dist/cjs`:

| Model | Trailing turn dropped |
|---|---|
| `gemini-3.8-flash`, `models/gemini-3.8-flash-latest` | yes |
| `gemini-3.7-flash`, `gemini-3.6-flash`, `gemini-3.5-flash-lite` | yes |
| `gemini-4-flash` (future) | yes |
| `gemini-3.5-flash`, `gemini-3-flash-preview` | no |
| `gemini-3.8-pro`, `gemini-2.5-flash` | no |

## Testing

- `packages/api` google + openai/config.google + utils — 1142 passed (42 suites)
- `packages/data-schemas` `tx.spec.ts` — 262 passed
- `packages/data-provider` — 1727 passed / 1 skipped (37 suites)
- `api` `utils/tokens.spec.js` — 203 passed
- `npm run static-checks -- --against origin/dev` — all affected checks pass
- `tsc --noEmit` clean in `data-provider` and `data-schemas`

The 10 new assertions were confirmed to fail with the source changes stashed (7 in `packages/api`, 3 in `tx.spec.ts`), so they guard the registration rather than restate it.

Refs #15516
