### PR TITLE
🔒 fix: Scope MeiliSearch Conversation and Message Search to the Active Tenant

### DIFF
--- a/api/db/indexSync.js
+++ b/api/db/indexSync.js
@@ -16,6 +16,15 @@ const syncThreshold = process.env.MEILI_SYNC_THRESHOLD
   : defaultSyncThreshold;
 const requiredFilterableAttributes = ['user', 'tenantId'];
 
+function mergeFilterableAttributes(configuredAttributes) {
+  const current = Array.isArray(configuredAttributes) ? configuredAttributes : [];
+  const merged = [...new Set([...current, ...requiredFilterableAttributes])];
+  const unchanged =
+    merged.length === current.length &&
+    merged.every((attribute, index) => attribute === current[index]);
+  return unchanged ? null : merged;
+}
+
 class MeiliSearchClient {
   static instance = null;
 
@@ -97,15 +106,11 @@ async function ensureFilterableAttributes(client) {
       const messagesIndex = client.index('messages');
       const settings = await messagesIndex.getSettings();
 
-      if (
-        !settings.filterableAttributes ||
-        !requiredFilterableAttributes.every((attribute) =>
-          settings.filterableAttributes.includes(attribute),
-        )
-      ) {
+      const filterableAttributes = mergeFilterableAttributes(settings.filterableAttributes);
+      if (filterableAttributes) {
         logger.info('[indexSync] Configuring messages index to filter by user and tenant...');
         await messagesIndex.updateSettings({
-          filterableAttributes: requiredFilterableAttributes,
+          filterableAttributes,
         });
         logger.info('[indexSync] Messages index configured for user and tenant filtering');
         settingsUpdated = true;
@@ -134,15 +139,11 @@ async function ensureFilterableAttributes(client) {
       const convosIndex = client.index('convos');
       const settings = await convosIndex.getSettings();
 
-      if (
-        !settings.filterableAttributes ||
-        !requiredFilterableAttributes.every((attribute) =>
-          settings.filterableAttributes.includes(attribute),
-        )
-      ) {
+      const filterableAttributes = mergeFilterableAttributes(settings.filterableAttributes);
+      if (filterableAttributes) {
         logger.info('[indexSync] Configuring convos index to filter by user and tenant...');
         await convosIndex.updateSettings({
-          filterableAttributes: requiredFilterableAttributes,
+          filterableAttributes,
         });
         logger.info('[indexSync] Convos index configured for user and tenant filtering');
         settingsUpdated = true;

--- a/api/db/indexSync.js
+++ b/api/db/indexSync.js
@@ -14,6 +14,7 @@ const defaultSyncThreshold = 1000;
 const syncThreshold = process.env.MEILI_SYNC_THRESHOLD
   ? parseInt(process.env.MEILI_SYNC_THRESHOLD, 10)
   : defaultSyncThreshold;
+const requiredFilterableAttributes = ['user', 'tenantId'];
 
 class MeiliSearchClient {
   static instance = null;
@@ -96,12 +97,17 @@ async function ensureFilterableAttributes(client) {
       const messagesIndex = client.index('messages');
       const settings = await messagesIndex.getSettings();
 
-      if (!settings.filterableAttributes || !settings.filterableAttributes.includes('user')) {
-        logger.info('[indexSync] Configuring messages index to filter by user...');
+      if (
+        !settings.filterableAttributes ||
+        !requiredFilterableAttributes.every((attribute) =>
+          settings.filterableAttributes.includes(attribute),
+        )
+      ) {
+        logger.info('[indexSync] Configuring messages index to filter by user and tenant...');
         await messagesIndex.updateSettings({
-          filterableAttributes: ['user'],
+          filterableAttributes: requiredFilterableAttributes,
         });
-        logger.info('[indexSync] Messages index configured for user filtering');
+        logger.info('[indexSync] Messages index configured for user and tenant filtering');
         settingsUpdated = true;
       }
 
@@ -128,12 +134,17 @@ async function ensureFilterableAttributes(client) {
       const convosIndex = client.index('convos');
       const settings = await convosIndex.getSettings();
 
-      if (!settings.filterableAttributes || !settings.filterableAttributes.includes('user')) {
-        logger.info('[indexSync] Configuring convos index to filter by user...');
+      if (
+        !settings.filterableAttributes ||
+        !requiredFilterableAttributes.every((attribute) =>
+          settings.filterableAttributes.includes(attribute),
+        )
+      ) {
+        logger.info('[indexSync] Configuring convos index to filter by user and tenant...');
         await convosIndex.updateSettings({
-          filterableAttributes: ['user'],
+          filterableAttributes: requiredFilterableAttributes,
         });
-        logger.info('[indexSync] Convos index configured for user filtering');
+        logger.info('[indexSync] Convos index configured for user and tenant filtering');
         settingsUpdated = true;
       }
 

--- a/api/db/indexSync.js
+++ b/api/db/indexSync.js
@@ -15,6 +15,7 @@ const syncThreshold = process.env.MEILI_SYNC_THRESHOLD
   ? parseInt(process.env.MEILI_SYNC_THRESHOLD, 10)
   : defaultSyncThreshold;
 const requiredFilterableAttributes = ['user', 'tenantId'];
+const settingsTimeoutMs = 10 * 60 * 1000;
 
 function mergeFilterableAttributes(configuredAttributes) {
   const current = Array.isArray(configuredAttributes) ? configuredAttributes : [];
@@ -23,6 +24,17 @@ function mergeFilterableAttributes(configuredAttributes) {
     merged.length === current.length &&
     merged.every((attribute, index) => attribute === current[index]);
   return unchanged ? null : merged;
+}
+
+async function updateFilterableAttributes(client, index, filterableAttributes) {
+  const enqueued = await index.updateSettings({ filterableAttributes });
+  const task = await client.waitForTask(enqueued.taskUid, {
+    timeOutMs: settingsTimeoutMs,
+    intervalMs: 100,
+  });
+  if (task.status !== 'succeeded') {
+    throw new Error(`[indexSync] Meili settings task ${enqueued.taskUid} ended with ${task.status}`);
+  }
 }
 
 class MeiliSearchClient {
@@ -109,9 +121,7 @@ async function ensureFilterableAttributes(client) {
       const filterableAttributes = mergeFilterableAttributes(settings.filterableAttributes);
       if (filterableAttributes) {
         logger.info('[indexSync] Configuring messages index to filter by user and tenant...');
-        await messagesIndex.updateSettings({
-          filterableAttributes,
-        });
+        await updateFilterableAttributes(client, messagesIndex, filterableAttributes);
         logger.info('[indexSync] Messages index configured for user and tenant filtering');
         settingsUpdated = true;
       }
@@ -142,9 +152,7 @@ async function ensureFilterableAttributes(client) {
       const filterableAttributes = mergeFilterableAttributes(settings.filterableAttributes);
       if (filterableAttributes) {
         logger.info('[indexSync] Configuring convos index to filter by user and tenant...');
-        await convosIndex.updateSettings({
-          filterableAttributes,
-        });
+        await updateFilterableAttributes(client, convosIndex, filterableAttributes);
         logger.info('[indexSync] Convos index configured for user and tenant filtering');
         settingsUpdated = true;
       }

--- a/api/db/indexSync.spec.js
+++ b/api/db/indexSync.spec.js
@@ -101,7 +101,7 @@ describe('performSync() - syncThreshold logic', () => {
     // Mock MeiliSearch client responses
     mockMeiliHealth.mockResolvedValue({ status: 'available' });
     mockMeiliIndex.mockReturnValue({
-      getSettings: jest.fn().mockResolvedValue({ filterableAttributes: ['user'] }),
+      getSettings: jest.fn().mockResolvedValue({ filterableAttributes: ['user', 'tenantId'] }),
       updateSettings: jest.fn().mockResolvedValue({}),
       search: jest.fn().mockResolvedValue({ hits: [] }),
     });

--- a/api/db/indexSync.spec.js
+++ b/api/db/indexSync.spec.js
@@ -16,6 +16,7 @@ const mockLogger = {
 
 const mockMeiliHealth = jest.fn();
 const mockMeiliIndex = jest.fn();
+const mockMeiliWaitForTask = jest.fn();
 const mockBatchResetMeiliFlags = jest.fn();
 const mockIsEnabled = jest.fn();
 const mockGetLogStores = jest.fn();
@@ -41,6 +42,7 @@ jest.mock('meilisearch', () => ({
   MeiliSearch: jest.fn(() => ({
     health: mockMeiliHealth,
     index: mockMeiliIndex,
+    waitForTask: mockMeiliWaitForTask,
   })),
 }));
 
@@ -100,9 +102,10 @@ describe('performSync() - syncThreshold logic', () => {
 
     // Mock MeiliSearch client responses
     mockMeiliHealth.mockResolvedValue({ status: 'available' });
+    mockMeiliWaitForTask.mockResolvedValue({ status: 'succeeded' });
     mockMeiliIndex.mockReturnValue({
       getSettings: jest.fn().mockResolvedValue({ filterableAttributes: ['user', 'tenantId'] }),
-      updateSettings: jest.fn().mockResolvedValue({}),
+      updateSettings: jest.fn().mockResolvedValue({ taskUid: 1 }),
       search: jest.fn().mockResolvedValue({ hits: [] }),
     });
 
@@ -341,7 +344,7 @@ describe('performSync() - syncThreshold logic', () => {
       isComplete: true,
     });
 
-    const updateSettings = jest.fn().mockResolvedValue({});
+    const updateSettings = jest.fn().mockResolvedValue({ taskUid: 1 });
     mockMeiliIndex.mockReturnValue({
       getSettings: jest.fn().mockResolvedValue({
         filterableAttributes: ['user', 'tenantId', 'customAttribute'],
@@ -390,7 +393,7 @@ describe('performSync() - syncThreshold logic', () => {
     // Mock settings update scenario
     mockMeiliIndex.mockReturnValue({
       getSettings: jest.fn().mockResolvedValue({ filterableAttributes: [] }), // No user field
-      updateSettings: jest.fn().mockResolvedValue({}),
+      updateSettings: jest.fn().mockResolvedValue({ taskUid: 1 }),
       search: jest.fn().mockResolvedValue({ hits: [] }),
     });
 
@@ -431,7 +434,7 @@ describe('performSync() - syncThreshold logic', () => {
     Conversation.syncWithMeili.mockResolvedValue(undefined);
 
     // Mock settings update scenario
-    const updateSettings = jest.fn().mockResolvedValue({});
+    const updateSettings = jest.fn().mockResolvedValue({ taskUid: 1 });
     mockMeiliIndex.mockReturnValue({
       getSettings: jest.fn().mockResolvedValue({
         filterableAttributes: ['user', 'customAttribute'],
@@ -452,6 +455,11 @@ describe('performSync() - syncThreshold logic', () => {
     expect(updateSettings).toHaveBeenCalledTimes(2);
     expect(updateSettings).toHaveBeenCalledWith({
       filterableAttributes: ['user', 'customAttribute', 'tenantId'],
+    });
+    expect(mockMeiliWaitForTask).toHaveBeenCalledTimes(2);
+    expect(mockMeiliWaitForTask).toHaveBeenCalledWith(1, {
+      timeOutMs: 600_000,
+      intervalMs: 100,
     });
 
     // Assert: Conversation sync triggered despite being below threshold (50 < 1000)
@@ -485,7 +493,7 @@ describe('performSync() - syncThreshold logic', () => {
     // Mock settings update scenario
     mockMeiliIndex.mockReturnValue({
       getSettings: jest.fn().mockResolvedValue({ filterableAttributes: [] }), // No user field
-      updateSettings: jest.fn().mockResolvedValue({}),
+      updateSettings: jest.fn().mockResolvedValue({ taskUid: 1 }),
       search: jest.fn().mockResolvedValue({ hits: [] }),
     });
 

--- a/api/db/indexSync.spec.js
+++ b/api/db/indexSync.spec.js
@@ -431,9 +431,12 @@ describe('performSync() - syncThreshold logic', () => {
     Conversation.syncWithMeili.mockResolvedValue(undefined);
 
     // Mock settings update scenario
+    const updateSettings = jest.fn().mockResolvedValue({});
     mockMeiliIndex.mockReturnValue({
-      getSettings: jest.fn().mockResolvedValue({ filterableAttributes: [] }), // No user field
-      updateSettings: jest.fn().mockResolvedValue({}),
+      getSettings: jest.fn().mockResolvedValue({
+        filterableAttributes: ['user', 'customAttribute'],
+      }),
+      updateSettings,
       search: jest.fn().mockResolvedValue({ hits: [] }),
     });
 
@@ -446,6 +449,10 @@ describe('performSync() - syncThreshold logic', () => {
     // Assert: Flags were reset due to settings update
     expect(mockBatchResetMeiliFlags).toHaveBeenCalledWith(Message.collection);
     expect(mockBatchResetMeiliFlags).toHaveBeenCalledWith(Conversation.collection);
+    expect(updateSettings).toHaveBeenCalledTimes(2);
+    expect(updateSettings).toHaveBeenCalledWith({
+      filterableAttributes: ['user', 'customAttribute', 'tenantId'],
+    });
 
     // Assert: Conversation sync triggered despite being below threshold (50 < 1000)
     expect(Conversation.syncWithMeili).toHaveBeenCalledTimes(1);

--- a/api/db/indexSync.spec.js
+++ b/api/db/indexSync.spec.js
@@ -341,9 +341,20 @@ describe('performSync() - syncThreshold logic', () => {
       isComplete: true,
     });
 
+    const updateSettings = jest.fn().mockResolvedValue({});
+    mockMeiliIndex.mockReturnValue({
+      getSettings: jest.fn().mockResolvedValue({
+        filterableAttributes: ['user', 'tenantId', 'customAttribute'],
+      }),
+      updateSettings,
+      search: jest.fn().mockResolvedValue({ hits: [] }),
+    });
+
     // Act
     const indexSync = require('./indexSync');
     await indexSync();
+
+    expect(updateSettings).not.toHaveBeenCalled();
 
     // Assert: No countDocuments calls
     expect(Message.countDocuments).not.toHaveBeenCalled();

--- a/api/server/routes/__tests__/messages-get.spec.js
+++ b/api/server/routes/__tests__/messages-get.spec.js
@@ -1,7 +1,7 @@
+const mockGetTenantId = jest.fn();
 const { CLIENT_MESSAGE_SELECT, MEILI_SEARCH_LIMIT } = require('@librechat/data-schemas');
 const express = require('express');
 const request = require('supertest');
-const mockGetTenantId = jest.fn();
 
 jest.mock('@librechat/agents', () => ({
   sleep: jest.fn(),
@@ -677,11 +677,7 @@ describe('message route conversation ownership filters', () => {
     const response = await request(app).get('/api/messages?search=needle');
 
     expect(response.status).toBe(200);
-    expect(searchMessages).toHaveBeenCalledWith(
-      'needle',
-      { filter, limit: 25 },
-      true,
-    );
+    expect(searchMessages).toHaveBeenCalledWith('needle', { filter, limit: 25 }, true);
   });
 
   it('returns indistinguishable not-found responses for child and missing query reads', async () => {

--- a/api/server/routes/__tests__/messages-get.spec.js
+++ b/api/server/routes/__tests__/messages-get.spec.js
@@ -1,6 +1,7 @@
 const { CLIENT_MESSAGE_SELECT, MEILI_SEARCH_LIMIT } = require('@librechat/data-schemas');
 const express = require('express');
 const request = require('supertest');
+const mockGetTenantId = jest.fn();
 
 jest.mock('@librechat/agents', () => ({
   sleep: jest.fn(),
@@ -122,6 +123,7 @@ jest.mock('~/server/services/Endpoints/agents/subagentThreadStore', () => ({}));
 
 jest.mock('@librechat/data-schemas', () => ({
   ...jest.requireActual('@librechat/data-schemas'),
+  getTenantId: mockGetTenantId,
   logger: {
     debug: jest.fn(),
     info: jest.fn(),
@@ -258,6 +260,7 @@ describe('message route conversation ownership filters', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetTenantId.mockReturnValue(undefined);
     canReadActiveJobConversation.mockResolvedValue(false);
     prepareMessageRequestValidation.mockImplementation((req, res, next) => {
       req.messageRequestValidation = {
@@ -652,6 +655,33 @@ describe('message route conversation ownership filters', () => {
     expect(response.body.messages).toHaveLength(1);
     expect(response.body.messages[0]).toMatchObject({ messageId: 'hit-1', title: 'Found' });
     expect(response.body.messages[0]).not.toHaveProperty('contextMeta');
+  });
+
+  it.each([
+    {
+      name: 'active tenant with escaped characters',
+      tenantId: 'tenant"\\id',
+      filter: `user = "${authenticatedUserId}" AND tenantId = "tenant\\"\\\\id"`,
+    },
+    {
+      name: 'system context',
+      tenantId: '__SYSTEM__',
+      filter: `user = "${authenticatedUserId}"`,
+    },
+  ])('uses the tenant-aware message search filter in $name', async ({ tenantId, filter }) => {
+    mockGetTenantId.mockReturnValue(tenantId);
+    searchMessages.mockResolvedValue({ hits: [] });
+    getConvosQueried.mockResolvedValue({ convoMap: {} });
+    getMessages.mockResolvedValue([]);
+
+    const response = await request(app).get('/api/messages?search=needle');
+
+    expect(response.status).toBe(200);
+    expect(searchMessages).toHaveBeenCalledWith(
+      'needle',
+      { filter, limit: 25 },
+      true,
+    );
   });
 
   it('returns indistinguishable not-found responses for child and missing query reads', async () => {

--- a/api/server/routes/messages.js
+++ b/api/server/routes/messages.js
@@ -1,6 +1,13 @@
 const express = require('express');
 const { v4: uuidv4 } = require('uuid');
-const { logger, CLIENT_MESSAGE_SELECT, MEILI_SEARCH_LIMIT } = require('@librechat/data-schemas');
+const {
+  logger,
+  getTenantId,
+  SYSTEM_TENANT_ID,
+  CLIENT_MESSAGE_SELECT,
+  MEILI_SEARCH_LIMIT,
+  escapeMeiliFilterValue,
+} = require('@librechat/data-schemas');
 const {
   ContentTypes,
   feedbackSchema,
@@ -146,10 +153,15 @@ router.get('/', async (req, res) => {
       }
       response = messageResult.value;
     } else if (search) {
+      const tenantId = getTenantId();
+      const tenantFilter =
+        tenantId && tenantId !== SYSTEM_TENANT_ID
+          ? ` AND tenantId = "${escapeMeiliFilterValue(tenantId)}"`
+          : '';
       const searchResults = await db.searchMessages(
         search,
         {
-          filter: `user = "${user}"`,
+          filter: `user = "${escapeMeiliFilterValue(user)}"${tenantFilter}`,
           limit: Math.min(pageSize, MEILI_SEARCH_LIMIT),
         },
         true,

--- a/packages/data-schemas/src/methods/conversation.spec.ts
+++ b/packages/data-schemas/src/methods/conversation.spec.ts
@@ -7042,5 +7042,61 @@ describe('Conversation Operations', () => {
         titleMatch.conversationId,
       ]);
     });
+
+    it('scopes both search indexes to the active tenant', async () => {
+      const tenantId = 'tenant-a';
+      const conversationId = uuidv4();
+      await tenantStorage.run({ tenantId }, async () => {
+        await Conversation.create({
+          conversationId,
+          user: 'user123',
+          title: 'Tenant conversation',
+          endpoint: EModelEndpoint.openAI,
+        });
+      });
+
+      const meiliSearch = jest.fn().mockResolvedValue({ hits: [] });
+      Object.assign(Conversation, { meiliSearch });
+      searchMessages.mockResolvedValue({ hits: [{ conversationId }] });
+
+      const result = await tenantStorage.run({ tenantId }, () =>
+        getConvosByCursor('user123', { search: 'keyword' }),
+      );
+
+      const searchParams = {
+        filter: 'user = "user123" AND tenantId = "tenant-a"',
+        limit: MEILI_SEARCH_LIMIT,
+        attributesToRetrieve: ['conversationId'],
+      };
+      expect(meiliSearch).toHaveBeenCalledWith('keyword', searchParams);
+      expect(searchMessages).toHaveBeenCalledWith('keyword', searchParams);
+      expect(result?.conversations.map((c) => c.conversationId)).toEqual([conversationId]);
+    });
+
+    it('keeps search unscoped in system and tenantless contexts', async () => {
+      const conversationId = uuidv4();
+      await Conversation.create({
+        conversationId,
+        user: 'user123',
+        title: 'System conversation',
+        endpoint: EModelEndpoint.openAI,
+      });
+
+      const meiliSearch = jest.fn().mockResolvedValue({ hits: [{ conversationId }] });
+      Object.assign(Conversation, { meiliSearch });
+      searchMessages.mockResolvedValue({ hits: [] });
+
+      await runAsSystem(async () => {
+        const result = await getConvosByCursor('user123', { search: 'keyword' });
+        const searchParams = {
+          filter: 'user = "user123"',
+          limit: MEILI_SEARCH_LIMIT,
+          attributesToRetrieve: ['conversationId'],
+        };
+        expect(meiliSearch).toHaveBeenCalledWith('keyword', searchParams);
+        expect(searchMessages).toHaveBeenCalledWith('keyword', searchParams);
+        expect(result?.conversations.map((c) => c.conversationId)).toEqual([conversationId]);
+      });
+    });
   });
 });

--- a/packages/data-schemas/src/methods/conversation.spec.ts
+++ b/packages/data-schemas/src/methods/conversation.spec.ts
@@ -7066,7 +7066,7 @@ describe('Conversation Operations', () => {
       const searchParams = {
         filter: 'user = "user123" AND tenantId = "tenant-a"',
         limit: MEILI_SEARCH_LIMIT,
-        attributesToRetrieve: ['conversationId'],
+        attributesToRetrieve: ['conversationId', 'originalConversationId'],
       };
       expect(meiliSearch).toHaveBeenCalledWith('keyword', searchParams);
       expect(searchMessages).toHaveBeenCalledWith('keyword', searchParams);
@@ -7091,12 +7091,42 @@ describe('Conversation Operations', () => {
         const searchParams = {
           filter: 'user = "user123"',
           limit: MEILI_SEARCH_LIMIT,
-          attributesToRetrieve: ['conversationId'],
+          attributesToRetrieve: ['conversationId', 'originalConversationId'],
         };
         expect(meiliSearch).toHaveBeenCalledWith('keyword', searchParams);
         expect(searchMessages).toHaveBeenCalledWith('keyword', searchParams);
         expect(result?.conversations.map((c) => c.conversationId)).toEqual([conversationId]);
       });
+
+      jest.clearAllMocks();
+      searchMessages.mockResolvedValue({ hits: [] });
+      const result = await getConvosByCursor('user123', { search: 'keyword' });
+      const searchParams = {
+        filter: 'user = "user123"',
+        limit: MEILI_SEARCH_LIMIT,
+        attributesToRetrieve: ['conversationId', 'originalConversationId'],
+      };
+      expect(meiliSearch).toHaveBeenCalledWith('keyword', searchParams);
+      expect(searchMessages).toHaveBeenCalledWith('keyword', searchParams);
+      expect(result?.conversations.map((c) => c.conversationId)).toEqual([conversationId]);
+    });
+
+    it('escapes user and tenant values in scoped search filters', async () => {
+      const meiliSearch = jest.fn().mockResolvedValue({ hits: [] });
+      Object.assign(Conversation, { meiliSearch });
+      searchMessages.mockResolvedValue({ hits: [] });
+
+      await tenantStorage.run({ tenantId: 'tenant"\\id' }, () =>
+        getConvosByCursor('user"\\id', { search: 'keyword' }),
+      );
+
+      const searchParams = {
+        filter: 'user = "user\\"\\\\id" AND tenantId = "tenant\\"\\\\id"',
+        limit: MEILI_SEARCH_LIMIT,
+        attributesToRetrieve: ['conversationId', 'originalConversationId'],
+      };
+      expect(meiliSearch).toHaveBeenCalledWith('keyword', searchParams);
+      expect(searchMessages).toHaveBeenCalledWith('keyword', searchParams);
     });
   });
 });

--- a/packages/data-schemas/src/methods/conversation.spec.ts
+++ b/packages/data-schemas/src/methods/conversation.spec.ts
@@ -7128,5 +7128,47 @@ describe('Conversation Operations', () => {
       expect(meiliSearch).toHaveBeenCalledWith('keyword', searchParams);
       expect(searchMessages).toHaveBeenCalledWith('keyword', searchParams);
     });
+
+    /* The tenant filter matches on an exact `tenantId`, so documents indexed before
+       tenancy existed - and documents still awaiting the v2 reindex - are excluded
+       while a tenant is active. That mirrors the Mongo side, which scopes the same
+       conversations out of the unsearched sidebar listing. */
+    it('excludes conversations without a tenantId, as the unsearched listing does', async () => {
+      const tenantId = 'tenant-a';
+      const untenantedId = uuidv4();
+      const tenantedId = uuidv4();
+      await Conversation.create({
+        conversationId: untenantedId,
+        user: 'user123',
+        title: 'Pre-tenancy keyword',
+        endpoint: EModelEndpoint.openAI,
+      });
+      await tenantStorage.run({ tenantId }, () =>
+        Conversation.create({
+          conversationId: tenantedId,
+          user: 'user123',
+          title: 'Tenant keyword',
+          endpoint: EModelEndpoint.openAI,
+        }),
+      );
+
+      const indexed = [{ conversationId: untenantedId }, { conversationId: tenantedId, tenantId }];
+      const searchIndex = (_query: string, { filter }: { filter: string }) => {
+        const scopedTenantId = /tenantId = "([^"]*)"/.exec(filter)?.[1];
+        return Promise.resolve({
+          hits: indexed.filter((doc) => !scopedTenantId || doc.tenantId === scopedTenantId),
+        });
+      };
+      Object.assign(Conversation, { meiliSearch: jest.fn(searchIndex) });
+      searchMessages.mockImplementation(searchIndex);
+
+      const searched = await tenantStorage.run({ tenantId }, () =>
+        getConvosByCursor('user123', { search: 'keyword' }),
+      );
+      const listed = await tenantStorage.run({ tenantId }, () => getConvosByCursor('user123'));
+
+      expect(searched?.conversations.map((c) => c.conversationId)).toEqual([tenantedId]);
+      expect(listed?.conversations.map((c) => c.conversationId)).toEqual([tenantedId]);
+    });
   });
 });

--- a/packages/data-schemas/src/methods/conversation.ts
+++ b/packages/data-schemas/src/methods/conversation.ts
@@ -539,8 +539,7 @@ export function createConversationMethods(
     fieldsToSelect: string | null = 'conversationId user',
   ) {
     try {
-      const Conversation = mongoose.models.Conversation as Model<IConversation> &
-        Pick<SchemaWithMeiliMethods, 'meiliSearch'>;
+      const Conversation = mongoose.models.Conversation as Model<IConversation>;
       return await Conversation.findOne({ conversationId }, fieldsToSelect).lean<IConversation>();
     } catch (error) {
       logger.error('[searchConversation] Error searching conversation', error);

--- a/packages/data-schemas/src/methods/conversation.ts
+++ b/packages/data-schemas/src/methods/conversation.ts
@@ -539,7 +539,8 @@ export function createConversationMethods(
     fieldsToSelect: string | null = 'conversationId user',
   ) {
     try {
-      const Conversation = mongoose.models.Conversation as Model<IConversation>;
+      const Conversation = mongoose.models.Conversation as Model<IConversation> &
+        Pick<SchemaWithMeiliMethods, 'meiliSearch'>;
       return await Conversation.findOne({ conversationId }, fieldsToSelect).lean<IConversation>();
     } catch (error) {
       logger.error('[searchConversation] Error searching conversation', error);

--- a/packages/data-schemas/src/methods/conversation.ts
+++ b/packages/data-schemas/src/methods/conversation.ts
@@ -45,8 +45,10 @@ import {
 import { createChatExpirationDate, createTempChatExpirationDate } from '~/utils/tempChatRetention';
 import { isAgentFadingTier, isAgentFadingTierEntries } from '~/utils/fading';
 import { isCompactionSemanticIndexProjection } from '~/types/compaction';
+import { getTenantId, SYSTEM_TENANT_ID } from '~/config/tenantContext';
 import { tenantSafeBulkWrite } from '~/utils/tenantBulkWrite';
 import { isValidObjectIdString } from '~/utils/objectId';
+import { escapeMeiliFilterValue } from '~/utils/search';
 import { decrementTagCounts } from './conversationTag';
 import logger from '~/config/winston';
 
@@ -72,8 +74,6 @@ const MEILI_SEARCH_LIMIT = 1000;
 /** Ceiling for a single conversation page; the sidebar's largest request is 100. */
 const MAX_CONVO_PAGE_SIZE = 100;
 const DEFAULT_CONVO_PAGE_SIZE = 25;
-const escapeMeiliFilterValue = (value: string): string =>
-  value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 
 function validateAgentEventActorSuspension(
   conversationId: string,
@@ -2756,8 +2756,13 @@ export function createConversationMethods(
 
     if (search) {
       try {
+        const tenantId = getTenantId();
+        const tenantFilter =
+          tenantId && tenantId !== SYSTEM_TENANT_ID
+            ? ` AND tenantId = "${escapeMeiliFilterValue(tenantId)}"`
+            : '';
         const searchParams: SearchParams = {
-          filter: `user = "${escapeMeiliFilterValue(user)}"`,
+          filter: `user = "${escapeMeiliFilterValue(user)}"${tenantFilter}`,
           limit: MEILI_SEARCH_LIMIT,
           attributesToRetrieve: ['conversationId', 'originalConversationId'],
         };

--- a/packages/data-schemas/src/methods/share.test.ts
+++ b/packages/data-schemas/src/methods/share.test.ts
@@ -4,6 +4,7 @@ import { MongoMemoryServer } from 'mongodb-memory-server';
 import { Constants, ContentTypes, Tools } from 'librechat-data-provider';
 import type { SchemaWithMeiliMethods } from '~/models/plugins/mongoMeili';
 import type * as t from '~/types';
+import { tenantStorage, runAsSystem } from '~/config/tenantContext';
 import {
   createShareMethods,
   anonymizeSharedContent,
@@ -1252,6 +1253,52 @@ describe('Share Methods', () => {
       expect(result.links[0].title).toBe('Matching Share');
 
       // Verify that meiliSearch was called with the correct user filter
+      expect(meiliSearchMock).toHaveBeenCalledWith('search term', {
+        filter: `user = "${userId}"`,
+        limit: MEILI_SEARCH_LIMIT,
+        attributesToRetrieve: ['conversationId'],
+      });
+    });
+
+    test('scopes search to the active tenant and escapes filter values', async () => {
+      const userId = 'user"\\id';
+      const meiliSearchMock = jest.fn().mockResolvedValue({ hits: [] });
+      Conversation.meiliSearch = meiliSearchMock;
+
+      await tenantStorage.run({ tenantId: 'tenant"\\id' }, () =>
+        shareMethods.getSharedLinks(
+          userId,
+          undefined,
+          10,
+          'createdAt',
+          'desc',
+          'search term',
+        ),
+      );
+
+      expect(meiliSearchMock).toHaveBeenCalledWith('search term', {
+        filter: 'user = "user\\"\\\\id" AND tenantId = "tenant\\"\\\\id"',
+        limit: MEILI_SEARCH_LIMIT,
+        attributesToRetrieve: ['conversationId'],
+      });
+    });
+
+    test('keeps search unscoped in system context', async () => {
+      const userId = new mongoose.Types.ObjectId().toString();
+      const meiliSearchMock = jest.fn().mockResolvedValue({ hits: [] });
+      Conversation.meiliSearch = meiliSearchMock;
+
+      await runAsSystem(() =>
+        shareMethods.getSharedLinks(
+          userId,
+          undefined,
+          10,
+          'createdAt',
+          'desc',
+          'search term',
+        ),
+      );
+
       expect(meiliSearchMock).toHaveBeenCalledWith('search term', {
         filter: `user = "${userId}"`,
         limit: MEILI_SEARCH_LIMIT,

--- a/packages/data-schemas/src/methods/share.ts
+++ b/packages/data-schemas/src/methods/share.ts
@@ -9,8 +9,10 @@ import {
   stripMessageUIResourceMarkers,
 } from '~/utils/stripUIResourceMarkers';
 import { activeExpirationFilter } from '~/utils/retention';
+import { getTenantId, SYSTEM_TENANT_ID } from '~/config/tenantContext';
 import { isValidObjectIdString } from '~/utils/objectId';
 import { MEILI_SEARCH_LIMIT } from '~/common/search';
+import { escapeMeiliFilterValue } from '~/utils/search';
 import { CLIENT_MESSAGE_SELECT } from './message';
 import logger from '~/config/winston';
 
@@ -969,8 +971,13 @@ export function createShareMethods(mongoose: typeof import('mongoose')): {
 
       if (search && search.trim()) {
         try {
+          const tenantId = getTenantId();
+          const tenantFilter =
+            tenantId && tenantId !== SYSTEM_TENANT_ID
+              ? ` AND tenantId = "${escapeMeiliFilterValue(tenantId)}"`
+              : '';
           const searchResults = await Conversation.meiliSearch(search, {
-            filter: `user = "${user}"`,
+            filter: `user = "${escapeMeiliFilterValue(user)}"${tenantFilter}`,
             limit: MEILI_SEARCH_LIMIT,
             attributesToRetrieve: ['conversationId'],
           });

--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -84,6 +84,7 @@ const mockGetDocuments = jest.fn().mockResolvedValue({ results: [] });
 const mockWaitForTask = jest.fn().mockResolvedValue({ status: 'succeeded' });
 const mockIndex = jest.fn().mockReturnValue({
   getRawInfo: jest.fn(),
+  getSettings: jest.fn().mockResolvedValue({ filterableAttributes: [] }),
   updateSettings: jest.fn(),
   addDocuments: mockAddDocuments,
   addDocumentsInBatches: mockAddDocumentsInBatches,

--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -210,6 +210,21 @@ describe('Meilisearch Mongoose plugin', () => {
     mongoose.deleteModel(modelName);
   });
 
+  test('retries filterable-attribute setup after a transient failure', async () => {
+    const modelName = `SettingsRetry${Date.now()}`;
+    mockWaitForTask
+      .mockRejectedValueOnce(new Error('temporary settings failure'))
+      .mockResolvedValue({ status: 'succeeded' });
+    const Model = createDynamicMeiliModel(modelName);
+    await waitForMock(mockWaitForTask);
+    await wait(0);
+
+    await expect(Model.meiliSearch('query')).resolves.toEqual({ hits: [] });
+    expect(mockUpdateSettings).toHaveBeenCalledTimes(2);
+    expect(mockSearch).toHaveBeenCalledWith('query', undefined);
+    mongoose.deleteModel(modelName);
+  });
+
   test('settles query updates and deletes when no document hook is available', async () => {
     const modelName = `QueryMiddlewareResult${Date.now()}`;
     const Model = createDynamicMeiliModel(modelName);

--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -2330,6 +2330,57 @@ describe('Meilisearch Mongoose plugin', () => {
       expect(docsWithMissingIndex).toBe(1);
     });
 
+    test('syncWithMeili reindexes older projections but never downgrades newer ones', async () => {
+      const conversationModel = createConversationModel(
+        mongoose,
+      ) as unknown as SchemaWithMeiliMethods;
+      await conversationModel.deleteMany({});
+      mockAddDocumentsInBatches.mockClear();
+
+      const futureId = new mongoose.Types.ObjectId();
+      const staleId = new mongoose.Types.ObjectId();
+      await conversationModel.collection.insertMany([
+        {
+          conversationId: futureId,
+          user: new mongoose.Types.ObjectId(),
+          title: 'Newer projection',
+          endpoint: EModelEndpoint.openAI,
+          expiredAt: null,
+          _meiliIndex: true,
+          _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION + 1,
+        },
+        {
+          conversationId: staleId,
+          user: new mongoose.Types.ObjectId(),
+          title: 'Stale projection',
+          endpoint: EModelEndpoint.openAI,
+          expiredAt: null,
+          _meiliIndex: true,
+          _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION - 1,
+        },
+      ]);
+
+      await conversationModel.syncWithMeili();
+
+      expect(mockAddDocumentsInBatches).toHaveBeenCalled();
+
+      const [futureDoc, staleDoc] = await Promise.all([
+        conversationModel.collection.findOne({ conversationId: futureId }),
+        conversationModel.collection.findOne({ conversationId: staleId }),
+      ]);
+
+      // Newer-stamped projection is left alone, not re-indexed nor downgraded.
+      expect(futureDoc?._meiliIndexSchemaVersion).toBe(MEILI_INDEX_SCHEMA_VERSION + 1);
+      expect(futureDoc?._meiliIndex).toBe(true);
+      expect(mockAddDocumentsInBatches).not.toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ conversationId: futureId })]),
+      );
+
+      // Strictly older projection is re-indexed and stamped forward to the local version.
+      expect(staleDoc?._meiliIndexSchemaVersion).toBe(MEILI_INDEX_SCHEMA_VERSION);
+      expect(staleDoc?._meiliIndex).toBe(true);
+    });
+
     test('getSyncProgress counts documents with missing _meiliIndex as not indexed', async () => {
       const messageModel = createMessageModel(mongoose) as unknown as SchemaWithMeiliMethods;
       await messageModel.deleteMany({});

--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -1696,6 +1696,7 @@ describe('Meilisearch Mongoose plugin', () => {
       mockDeleteDocuments.mockClear();
       mockIndex.mockReturnValue({
         getRawInfo: jest.fn(),
+        getSettings: jest.fn().mockResolvedValue({ filterableAttributes: [] }),
         updateSettings: jest.fn(),
         addDocuments: mockAddDocuments,
         addDocumentsInBatches: mockAddDocumentsInBatches,

--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -2372,9 +2372,10 @@ describe('Meilisearch Mongoose plugin', () => {
       // Newer-stamped projection is left alone, not re-indexed nor downgraded.
       expect(futureDoc?._meiliIndexSchemaVersion).toBe(MEILI_INDEX_SCHEMA_VERSION + 1);
       expect(futureDoc?._meiliIndex).toBe(true);
-      expect(mockAddDocumentsInBatches).not.toHaveBeenCalledWith(
-        expect.arrayContaining([expect.objectContaining({ conversationId: futureId })]),
+      const reindexedIds = mockAddDocumentsInBatches.mock.calls.flatMap((call) =>
+        (call[0] as Array<Record<string, unknown>>).map((doc) => String(doc.conversationId)),
       );
+      expect(reindexedIds).not.toContain(String(futureId));
 
       // Strictly older projection is re-indexed and stamped forward to the local version.
       expect(staleDoc?._meiliIndexSchemaVersion).toBe(MEILI_INDEX_SCHEMA_VERSION);

--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -11,6 +11,7 @@ interface DynamicMeiliDocument extends mongoose.Document {
   docId: string;
   user: string;
   title: string;
+  tenantId?: string;
   isTemporary?: boolean;
   expiredAt?: Date | null;
   _meiliIndex?: boolean;
@@ -33,6 +34,10 @@ const createDynamicMeiliModel = (modelName: string): DynamicMeiliModel => {
       meiliIndex: true,
     },
     user: {
+      type: String,
+      meiliIndex: true,
+    },
+    tenantId: {
       type: String,
       meiliIndex: true,
     },
@@ -81,11 +86,14 @@ const mockDeleteDocument = jest.fn();
 const mockDeleteDocuments = jest.fn();
 const mockGetDocument = jest.fn();
 const mockGetDocuments = jest.fn().mockResolvedValue({ results: [] });
+const mockGetSettings = jest.fn().mockResolvedValue({ filterableAttributes: [] });
+const mockUpdateSettings = jest.fn().mockResolvedValue({ taskUid: 3 });
+const mockSearch = jest.fn().mockResolvedValue({ hits: [] });
 const mockWaitForTask = jest.fn().mockResolvedValue({ status: 'succeeded' });
 const mockIndex = jest.fn().mockReturnValue({
   getRawInfo: jest.fn(),
-  getSettings: jest.fn().mockResolvedValue({ filterableAttributes: [] }),
-  updateSettings: jest.fn(),
+  getSettings: mockGetSettings,
+  updateSettings: mockUpdateSettings,
   addDocuments: mockAddDocuments,
   addDocumentsInBatches: mockAddDocumentsInBatches,
   updateDocuments: mockUpdateDocuments,
@@ -93,6 +101,7 @@ const mockIndex = jest.fn().mockReturnValue({
   deleteDocuments: mockDeleteDocuments,
   getDocument: mockGetDocument,
   getDocuments: mockGetDocuments,
+  search: mockSearch,
 });
 jest.mock('meilisearch', () => {
   return {
@@ -131,6 +140,9 @@ describe('Meilisearch Mongoose plugin', () => {
     mockDeleteDocuments.mockReset().mockResolvedValue({ taskUid: 1 });
     mockGetDocument.mockClear();
     mockGetDocuments.mockReset().mockResolvedValue({ results: [] });
+    mockGetSettings.mockReset().mockResolvedValue({ filterableAttributes: [] });
+    mockUpdateSettings.mockReset().mockResolvedValue({ taskUid: 3 });
+    mockSearch.mockReset().mockResolvedValue({ hits: [] });
     mockWaitForTask.mockReset().mockResolvedValue({ status: 'succeeded' });
   });
 
@@ -143,6 +155,59 @@ describe('Meilisearch Mongoose plugin', () => {
     await mongoServer.stop();
 
     process.env = OLD_ENV;
+  });
+
+  test('preserves custom filterable attributes while adding required attributes', async () => {
+    const modelName = `FilterableAttributes${Date.now()}`;
+    mockGetSettings.mockResolvedValueOnce({ filterableAttributes: ['customAttribute'] });
+
+    createDynamicMeiliModel(modelName);
+    await waitForMock(mockUpdateSettings);
+
+    expect(mockUpdateSettings).toHaveBeenCalledWith({
+      filterableAttributes: ['customAttribute', 'user', 'tenantId'],
+    });
+    expect(mockWaitForTask).toHaveBeenCalledWith(3, {
+      timeOutMs: 600_000,
+      intervalMs: 100,
+    });
+    mongoose.deleteModel(modelName);
+  });
+
+  test('does not update filterable attributes when required attributes are configured', async () => {
+    const modelName = `ConfiguredAttributes${Date.now()}`;
+    mockGetSettings.mockResolvedValueOnce({
+      filterableAttributes: ['user', 'tenantId', 'customAttribute'],
+    });
+
+    createDynamicMeiliModel(modelName);
+    await waitForMock(mockGetSettings);
+
+    expect(mockUpdateSettings).not.toHaveBeenCalled();
+    mongoose.deleteModel(modelName);
+  });
+
+  test('waits for filterable attributes before searching', async () => {
+    const modelName = `SettingsReady${Date.now()}`;
+    let completeSettings: (task: { status: string }) => void = () => undefined;
+    const settingsTask = new Promise<{ status: string }>((resolve) => {
+      completeSettings = resolve;
+    });
+    mockUpdateSettings.mockResolvedValueOnce({ taskUid: 99 });
+    mockWaitForTask.mockImplementation((taskUid: number) =>
+      taskUid === 99 ? settingsTask : Promise.resolve({ status: 'succeeded' }),
+    );
+    const Model = createDynamicMeiliModel(modelName);
+    await waitForMock(mockUpdateSettings);
+
+    const search = Model.meiliSearch('query');
+    await wait(0);
+    expect(mockSearch).not.toHaveBeenCalled();
+
+    completeSettings({ status: 'succeeded' });
+    await search;
+    expect(mockSearch).toHaveBeenCalledWith('query', undefined);
+    mongoose.deleteModel(modelName);
   });
 
   test('settles query updates and deletes when no document hook is available', async () => {
@@ -1696,8 +1761,8 @@ describe('Meilisearch Mongoose plugin', () => {
       mockDeleteDocuments.mockClear();
       mockIndex.mockReturnValue({
         getRawInfo: jest.fn(),
-        getSettings: jest.fn().mockResolvedValue({ filterableAttributes: [] }),
-        updateSettings: jest.fn(),
+        getSettings: mockGetSettings,
+        updateSettings: mockUpdateSettings,
         addDocuments: mockAddDocuments,
         addDocumentsInBatches: mockAddDocumentsInBatches,
         updateDocuments: mockUpdateDocuments,
@@ -1705,6 +1770,7 @@ describe('Meilisearch Mongoose plugin', () => {
         deleteDocuments: mockDeleteDocuments,
         getDocument: mockGetDocument,
         getDocuments: mockGetDocuments,
+        search: mockSearch,
       });
     });
 

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -287,8 +287,8 @@ const createMeiliMongooseModel = ({
   getExcludedIndexedQuery,
   excludeFromIndexPath,
   attributesToIndex,
+  ensureSettingsReady,
   primaryKey,
-  settingsReady,
   syncOptions,
 }: {
   client: MeiliSearch;
@@ -297,8 +297,8 @@ const createMeiliMongooseModel = ({
   getExcludedIndexedQuery: () => FilterQuery<unknown> | null;
   excludeFromIndexPath?: string;
   attributesToIndex: string[];
+  ensureSettingsReady: () => Promise<void>;
   primaryKey: string;
-  settingsReady: Promise<void>;
   syncOptions: { batchSize: number; delayMs: number };
 }) => {
   const syncConfig = { ...getSyncConfig(), ...syncOptions };
@@ -745,7 +745,7 @@ const createMeiliMongooseModel = ({
       params: SearchParams,
       populate: boolean,
     ): Promise<SearchResponse<MeiliIndexable, Record<string, unknown>>> {
-      await settingsReady;
+      await ensureSettingsReady();
       const data = await index.search(q, params);
 
       if (populate) {
@@ -1026,7 +1026,7 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
   /** Create index only if it doesn't exist */
   const index = client.index<MeiliIndexable>(indexName);
 
-  const settingsReady = (async () => {
+  const configureIndex = async (): Promise<void> => {
     try {
       await index.getRawInfo();
       logger.debug(`[mongoMeili] Index ${indexName} already exists`);
@@ -1102,8 +1102,22 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
       logger.error(`[mongoMeili] Error updating index settings for ${indexName}:`, settingsError);
       throw settingsError;
     }
-  })();
-  void settingsReady.catch(() => undefined);
+  };
+  let settingsReady: Promise<void> | undefined;
+  const ensureSettingsReady = (): Promise<void> => {
+    if (settingsReady) {
+      return settingsReady;
+    }
+    const pending = configureIndex();
+    settingsReady = pending;
+    void pending.catch(() => {
+      if (settingsReady === pending) {
+        settingsReady = undefined;
+      }
+    });
+    return pending;
+  };
+  void ensureSettingsReady().catch(() => undefined);
 
   // Collect attributes from the schema that should be indexed
   const attributesToIndex: string[] = [
@@ -1128,8 +1142,8 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
       getExcludedIndexedQuery: () => buildExcludedIndexedQuery(options.excludeFromIndexPath),
       excludeFromIndexPath: options.excludeFromIndexPath,
       attributesToIndex,
+      ensureSettingsReady,
       primaryKey,
-      settingsReady,
       syncOptions,
     }),
   );

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -110,7 +110,7 @@ const hasSchemaPath = (schema: Schema, path: string): boolean =>
   Object.prototype.hasOwnProperty.call(schema.obj, path);
 
 /** Bump when the indexed document shape or projection changes. */
-export const MEILI_INDEX_SCHEMA_VERSION = 1;
+export const MEILI_INDEX_SCHEMA_VERSION = 2;
 
 const explicitTemporaryFlagKey = 'meiliExplicitTemporaryFlag';
 const previouslyIndexedFlagKey = 'meiliPreviouslyIndexed';
@@ -1059,11 +1059,20 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
       }
     }
 
+    const filterableAttributes = ['user'];
+    if (hasSchemaPath(schema, 'tenantId')) {
+      filterableAttributes.push('tenantId');
+    }
+
     try {
       await index.updateSettings({
-        filterableAttributes: ['user'],
+        filterableAttributes,
       });
-      logger.debug(`[mongoMeili] Updated index ${indexName} settings to make 'user' filterable`);
+      logger.debug(
+        `[mongoMeili] Updated index ${indexName} settings to make ${filterableAttributes.join(
+          ' and ',
+        )} filterable`,
+      );
     } catch (settingsError) {
       logger.error(`[mongoMeili] Error updating index settings for ${indexName}:`, settingsError);
     }

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -116,6 +116,7 @@ const explicitTemporaryFlagKey = 'meiliExplicitTemporaryFlag';
 const previouslyIndexedFlagKey = 'meiliPreviouslyIndexed';
 const meiliCleanupVersion = 1;
 const meiliRequestTimeoutMs = 10_000;
+const meiliSettingsTimeoutMs = 10 * 60_000;
 const meiliWriteMaxAttempts = 3;
 const meiliRetryBaseDelayMs = 250;
 const meiliVersionReconcileMaxAttempts = 3;
@@ -287,6 +288,7 @@ const createMeiliMongooseModel = ({
   excludeFromIndexPath,
   attributesToIndex,
   primaryKey,
+  settingsReady,
   syncOptions,
 }: {
   client: MeiliSearch;
@@ -296,6 +298,7 @@ const createMeiliMongooseModel = ({
   excludeFromIndexPath?: string;
   attributesToIndex: string[];
   primaryKey: string;
+  settingsReady: Promise<void>;
   syncOptions: { batchSize: number; delayMs: number };
 }) => {
   const syncConfig = { ...getSyncConfig(), ...syncOptions };
@@ -742,6 +745,7 @@ const createMeiliMongooseModel = ({
       params: SearchParams,
       populate: boolean,
     ): Promise<SearchResponse<MeiliIndexable, Record<string, unknown>>> {
+      await settingsReady;
       const data = await index.search(q, params);
 
       if (populate) {
@@ -1022,7 +1026,7 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
   /** Create index only if it doesn't exist */
   const index = client.index<MeiliIndexable>(indexName);
 
-  (async () => {
+  const settingsReady = (async () => {
     try {
       await index.getRawInfo();
       logger.debug(`[mongoMeili] Index ${indexName} already exists`);
@@ -1079,9 +1083,16 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
         return;
       }
 
-      await index.updateSettings({
+      const enqueued = await index.updateSettings({
         filterableAttributes,
       });
+      const task = await client.waitForTask(enqueued.taskUid, {
+        timeOutMs: meiliSettingsTimeoutMs,
+        intervalMs: 100,
+      });
+      if (task.status !== 'succeeded') {
+        throw new Error(`Meili settings task ${enqueued.taskUid} ended with ${task.status}`);
+      }
       logger.debug(
         `[mongoMeili] Updated index ${indexName} settings to make ${filterableAttributes.join(
           ' and ',
@@ -1089,8 +1100,10 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
       );
     } catch (settingsError) {
       logger.error(`[mongoMeili] Error updating index settings for ${indexName}:`, settingsError);
+      throw settingsError;
     }
   })();
+  void settingsReady.catch(() => undefined);
 
   // Collect attributes from the schema that should be indexed
   const attributesToIndex: string[] = [
@@ -1116,6 +1129,7 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
       excludeFromIndexPath: options.excludeFromIndexPath,
       attributesToIndex,
       primaryKey,
+      settingsReady,
       syncOptions,
     }),
   );

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -391,8 +391,9 @@ const createMeiliMongooseModel = ({
             $set: {
               _meiliIndex: true,
               _meiliCleanupVersion: meiliCleanupVersion,
-              _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION,
             },
+            /** Monotonic: never stamp a document back to an older projection version. */
+            $max: { _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION },
           },
         );
         if (acknowledgement.matchedCount > 0) {
@@ -435,7 +436,8 @@ const createMeiliMongooseModel = ({
               { _meiliIndex: { $ne: true }, _meiliIndexAttempted: true },
               {
                 _meiliIndex: true,
-                _meiliIndexSchemaVersion: { $ne: MEILI_INDEX_SCHEMA_VERSION },
+                /** Monotonic: only strictly older projections are stale; newer ones are already current. */
+                _meiliIndexSchemaVersion: { $not: { $gte: MEILI_INDEX_SCHEMA_VERSION } },
               },
             ],
           },
@@ -448,7 +450,7 @@ const createMeiliMongooseModel = ({
             indexableQuery,
             {
               _meiliIndex: true,
-              _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION,
+              _meiliIndexSchemaVersion: { $gte: MEILI_INDEX_SCHEMA_VERSION },
             },
           ],
         }),
@@ -510,7 +512,8 @@ const createMeiliMongooseModel = ({
                 { _meiliIndex: { $ne: true } },
                 {
                   _meiliIndex: true,
-                  _meiliIndexSchemaVersion: { $ne: MEILI_INDEX_SCHEMA_VERSION },
+                  /** Monotonic: reindex only strictly older projections; never downgrade newer ones. */
+                  _meiliIndexSchemaVersion: { $not: { $gte: MEILI_INDEX_SCHEMA_VERSION } },
                 },
               ],
             },
@@ -591,8 +594,9 @@ const createMeiliMongooseModel = ({
             $set: {
               _meiliIndex: true,
               _meiliCleanupVersion: meiliCleanupVersion,
-              _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION,
             },
+            /** Monotonic: never stamp a document back to an older projection version. */
+            $max: { _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION },
           },
           { timestamps: false },
         );

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -1059,12 +1059,26 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
       }
     }
 
-    const filterableAttributes = ['user'];
+    const requiredFilterableAttributes = ['user'];
     if (hasSchemaPath(schema, 'tenantId')) {
-      filterableAttributes.push('tenantId');
+      requiredFilterableAttributes.push('tenantId');
     }
 
     try {
+      const settings = await index.getSettings();
+      const currentFilterableAttributes = settings.filterableAttributes ?? [];
+      const filterableAttributes = [
+        ...new Set([...currentFilterableAttributes, ...requiredFilterableAttributes]),
+      ];
+      const settingsUnchanged =
+        filterableAttributes.length === currentFilterableAttributes.length &&
+        filterableAttributes.every(
+          (attribute, index) => attribute === currentFilterableAttributes[index],
+        );
+      if (settingsUnchanged) {
+        return;
+      }
+
       await index.updateSettings({
         filterableAttributes,
       });

--- a/packages/data-schemas/src/schema/convo.ts
+++ b/packages/data-schemas/src/schema/convo.ts
@@ -373,6 +373,7 @@ const convoSchema: Schema<IConversation> = new Schema(
     tenantId: {
       type: String,
       index: true,
+      meiliIndex: true,
     },
     pinned: {
       type: Boolean,

--- a/packages/data-schemas/src/schema/message.ts
+++ b/packages/data-schemas/src/schema/message.ts
@@ -299,6 +299,7 @@ const messageSchema: Schema<IMessage> = new Schema(
     tenantId: {
       type: String,
       index: true,
+      meiliIndex: true,
     },
   },
   { timestamps: true },

--- a/packages/data-schemas/src/utils/index.ts
+++ b/packages/data-schemas/src/utils/index.ts
@@ -10,3 +10,4 @@ export * from './stripUIResourceMarkers';
 export * from './fading';
 export { buildIndexWithRetry, createIndexesWithRetry, isIndexBuildInProgress } from './retry';
 export type { IndexBuildOptions } from './retry';
+export * from './search';

--- a/packages/data-schemas/src/utils/search.spec.ts
+++ b/packages/data-schemas/src/utils/search.spec.ts
@@ -1,0 +1,10 @@
+import { escapeMeiliFilterValue } from './search';
+
+describe('escapeMeiliFilterValue', () => {
+  it('escapes quotes and backslashes in filter values', () => {
+    expect(escapeMeiliFilterValue('user123')).toBe('user123');
+    expect(escapeMeiliFilterValue('user"123')).toBe('user\\"123');
+    expect(escapeMeiliFilterValue('user\\123')).toBe('user\\\\123');
+    expect(escapeMeiliFilterValue('user\\"123')).toBe('user\\\\\\"123');
+  });
+});

--- a/packages/data-schemas/src/utils/search.ts
+++ b/packages/data-schemas/src/utils/search.ts
@@ -1,5 +1,5 @@
 /**
- * Escapes special characters in values used in MeiliSearch filter expressions.
+ * Escapes backslashes and double quotes in MeiliSearch string filter values.
  */
 export const escapeMeiliFilterValue = (value: string): string =>
   value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');

--- a/packages/data-schemas/src/utils/search.ts
+++ b/packages/data-schemas/src/utils/search.ts
@@ -1,0 +1,5 @@
+/**
+ * Escapes special characters in values used in MeiliSearch filter expressions.
+ */
+export const escapeMeiliFilterValue = (value: string): string =>
+  value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');


### PR DESCRIPTION
## Summary

This change scopes MeiliSearch conversation and message searches to the active tenant. Without this filter, equal `user` and `conversationId` values reused across tenants can allow a hit from one tenant to surface a conversation from another tenant, and cross-tenant hits can consume the search result budget before current-tenant hits are reached.

## Dependency

This PR depends on #15484, which introduced `_meiliIndexSchemaVersion` and the stale-projection reindex path. It is based on the merged `dev` branch and uses schema version `2` for the tenant-index projection change.

## Changes

- Index `tenantId` on conversation and message MeiliSearch documents.
- Preserve operator-configured filterable attributes while requiring `user` and `tenantId`.
- Reindex existing documents by bumping `MEILI_INDEX_SCHEMA_VERSION` to `2`.
- Add the active tenant filter to both sidebar search indexes, shared-link search, and the main messages search.
- Keep tenantless and system contexts unscoped, matching existing behavior.
- Escape user and tenant values before placing them in MeiliSearch filter expressions.
- Make schema-version reconciliation and stamping monotonic (`$not { $gte }` staleness checks, `$max` stamping) so a mixed-fleet rolling deployment cannot downgrade documents to an older projection; documents stamped by a newer projection version are left untouched.
- Gate searches on the index settings task: startup configuration is now awaited (with retry on transient failure) before any Meili search runs, so `tenantId` is filterable before tenant-filtered queries are issued.
- Add coverage for tenant scoping, tenantless/system behavior, filter escaping, preservation of custom index settings, monotonic version reconciliation, and settings-readiness retry.

An active tenant intentionally matches only documents with that exact `tenantId`; legacy tenantless documents remain excluded until they are migrated into a tenant context.

## Testing

Unit tests cover the tenant-scoped filters, tenantless and system contexts, escaping, index settings preservation, projection-version reindexing (including no-downgrade behavior verified against the actual batch documents), and settings-readiness retry. `packages/data-schemas` and `api` suites pass against the rebased `dev`; `tsc --noEmit` is clean.