### PR TITLE
🔑 fix: Use Consistent MeiliSearch Keys for Conversation Documents

### DIFF
--- a/api/db/indexSync.js
+++ b/api/db/indexSync.js
@@ -16,6 +16,15 @@ const syncThreshold = process.env.MEILI_SYNC_THRESHOLD
   : defaultSyncThreshold;
 const requiredFilterableAttributes = ['user', 'tenantId'];
 
+function mergeFilterableAttributes(configuredAttributes) {
+  const current = Array.isArray(configuredAttributes) ? configuredAttributes : [];
+  const merged = [...new Set([...current, ...requiredFilterableAttributes])];
+  const unchanged =
+    merged.length === current.length &&
+    merged.every((attribute, index) => attribute === current[index]);
+  return unchanged ? null : merged;
+}
+
 class MeiliSearchClient {
   static instance = null;
 
@@ -97,15 +106,11 @@ async function ensureFilterableAttributes(client) {
       const messagesIndex = client.index('messages');
       const settings = await messagesIndex.getSettings();
 
-      if (
-        !settings.filterableAttributes ||
-        !requiredFilterableAttributes.every((attribute) =>
-          settings.filterableAttributes.includes(attribute),
-        )
-      ) {
+      const filterableAttributes = mergeFilterableAttributes(settings.filterableAttributes);
+      if (filterableAttributes) {
         logger.info('[indexSync] Configuring messages index to filter by user and tenant...');
         await messagesIndex.updateSettings({
-          filterableAttributes: requiredFilterableAttributes,
+          filterableAttributes,
         });
         logger.info('[indexSync] Messages index configured for user and tenant filtering');
         settingsUpdated = true;
@@ -134,15 +139,11 @@ async function ensureFilterableAttributes(client) {
       const convosIndex = client.index('convos');
       const settings = await convosIndex.getSettings();
 
-      if (
-        !settings.filterableAttributes ||
-        !requiredFilterableAttributes.every((attribute) =>
-          settings.filterableAttributes.includes(attribute),
-        )
-      ) {
+      const filterableAttributes = mergeFilterableAttributes(settings.filterableAttributes);
+      if (filterableAttributes) {
         logger.info('[indexSync] Configuring convos index to filter by user and tenant...');
         await convosIndex.updateSettings({
-          filterableAttributes: requiredFilterableAttributes,
+          filterableAttributes,
         });
         logger.info('[indexSync] Convos index configured for user and tenant filtering');
         settingsUpdated = true;

--- a/api/db/indexSync.js
+++ b/api/db/indexSync.js
@@ -14,6 +14,7 @@ const defaultSyncThreshold = 1000;
 const syncThreshold = process.env.MEILI_SYNC_THRESHOLD
   ? parseInt(process.env.MEILI_SYNC_THRESHOLD, 10)
   : defaultSyncThreshold;
+const requiredFilterableAttributes = ['user', 'tenantId'];
 
 class MeiliSearchClient {
   static instance = null;
@@ -96,12 +97,17 @@ async function ensureFilterableAttributes(client) {
       const messagesIndex = client.index('messages');
       const settings = await messagesIndex.getSettings();
 
-      if (!settings.filterableAttributes || !settings.filterableAttributes.includes('user')) {
-        logger.info('[indexSync] Configuring messages index to filter by user...');
+      if (
+        !settings.filterableAttributes ||
+        !requiredFilterableAttributes.every((attribute) =>
+          settings.filterableAttributes.includes(attribute),
+        )
+      ) {
+        logger.info('[indexSync] Configuring messages index to filter by user and tenant...');
         await messagesIndex.updateSettings({
-          filterableAttributes: ['user'],
+          filterableAttributes: requiredFilterableAttributes,
         });
-        logger.info('[indexSync] Messages index configured for user filtering');
+        logger.info('[indexSync] Messages index configured for user and tenant filtering');
         settingsUpdated = true;
       }
 
@@ -128,12 +134,17 @@ async function ensureFilterableAttributes(client) {
       const convosIndex = client.index('convos');
       const settings = await convosIndex.getSettings();
 
-      if (!settings.filterableAttributes || !settings.filterableAttributes.includes('user')) {
-        logger.info('[indexSync] Configuring convos index to filter by user...');
+      if (
+        !settings.filterableAttributes ||
+        !requiredFilterableAttributes.every((attribute) =>
+          settings.filterableAttributes.includes(attribute),
+        )
+      ) {
+        logger.info('[indexSync] Configuring convos index to filter by user and tenant...');
         await convosIndex.updateSettings({
-          filterableAttributes: ['user'],
+          filterableAttributes: requiredFilterableAttributes,
         });
-        logger.info('[indexSync] Convos index configured for user filtering');
+        logger.info('[indexSync] Convos index configured for user and tenant filtering');
         settingsUpdated = true;
       }
 

--- a/api/db/indexSync.js
+++ b/api/db/indexSync.js
@@ -15,6 +15,7 @@ const syncThreshold = process.env.MEILI_SYNC_THRESHOLD
   ? parseInt(process.env.MEILI_SYNC_THRESHOLD, 10)
   : defaultSyncThreshold;
 const requiredFilterableAttributes = ['user', 'tenantId'];
+const settingsTimeoutMs = 10 * 60 * 1000;
 
 function mergeFilterableAttributes(configuredAttributes) {
   const current = Array.isArray(configuredAttributes) ? configuredAttributes : [];
@@ -23,6 +24,17 @@ function mergeFilterableAttributes(configuredAttributes) {
     merged.length === current.length &&
     merged.every((attribute, index) => attribute === current[index]);
   return unchanged ? null : merged;
+}
+
+async function updateFilterableAttributes(client, index, filterableAttributes) {
+  const enqueued = await index.updateSettings({ filterableAttributes });
+  const task = await client.waitForTask(enqueued.taskUid, {
+    timeOutMs: settingsTimeoutMs,
+    intervalMs: 100,
+  });
+  if (task.status !== 'succeeded') {
+    throw new Error(`[indexSync] Meili settings task ${enqueued.taskUid} ended with ${task.status}`);
+  }
 }
 
 class MeiliSearchClient {
@@ -109,9 +121,7 @@ async function ensureFilterableAttributes(client) {
       const filterableAttributes = mergeFilterableAttributes(settings.filterableAttributes);
       if (filterableAttributes) {
         logger.info('[indexSync] Configuring messages index to filter by user and tenant...');
-        await messagesIndex.updateSettings({
-          filterableAttributes,
-        });
+        await updateFilterableAttributes(client, messagesIndex, filterableAttributes);
         logger.info('[indexSync] Messages index configured for user and tenant filtering');
         settingsUpdated = true;
       }
@@ -142,9 +152,7 @@ async function ensureFilterableAttributes(client) {
       const filterableAttributes = mergeFilterableAttributes(settings.filterableAttributes);
       if (filterableAttributes) {
         logger.info('[indexSync] Configuring convos index to filter by user and tenant...');
-        await convosIndex.updateSettings({
-          filterableAttributes,
-        });
+        await updateFilterableAttributes(client, convosIndex, filterableAttributes);
         logger.info('[indexSync] Convos index configured for user and tenant filtering');
         settingsUpdated = true;
       }

--- a/api/db/indexSync.spec.js
+++ b/api/db/indexSync.spec.js
@@ -101,7 +101,7 @@ describe('performSync() - syncThreshold logic', () => {
     // Mock MeiliSearch client responses
     mockMeiliHealth.mockResolvedValue({ status: 'available' });
     mockMeiliIndex.mockReturnValue({
-      getSettings: jest.fn().mockResolvedValue({ filterableAttributes: ['user'] }),
+      getSettings: jest.fn().mockResolvedValue({ filterableAttributes: ['user', 'tenantId'] }),
       updateSettings: jest.fn().mockResolvedValue({}),
       search: jest.fn().mockResolvedValue({ hits: [] }),
     });

--- a/api/db/indexSync.spec.js
+++ b/api/db/indexSync.spec.js
@@ -16,6 +16,7 @@ const mockLogger = {
 
 const mockMeiliHealth = jest.fn();
 const mockMeiliIndex = jest.fn();
+const mockMeiliWaitForTask = jest.fn();
 const mockBatchResetMeiliFlags = jest.fn();
 const mockIsEnabled = jest.fn();
 const mockGetLogStores = jest.fn();
@@ -41,6 +42,7 @@ jest.mock('meilisearch', () => ({
   MeiliSearch: jest.fn(() => ({
     health: mockMeiliHealth,
     index: mockMeiliIndex,
+    waitForTask: mockMeiliWaitForTask,
   })),
 }));
 
@@ -100,9 +102,10 @@ describe('performSync() - syncThreshold logic', () => {
 
     // Mock MeiliSearch client responses
     mockMeiliHealth.mockResolvedValue({ status: 'available' });
+    mockMeiliWaitForTask.mockResolvedValue({ status: 'succeeded' });
     mockMeiliIndex.mockReturnValue({
       getSettings: jest.fn().mockResolvedValue({ filterableAttributes: ['user', 'tenantId'] }),
-      updateSettings: jest.fn().mockResolvedValue({}),
+      updateSettings: jest.fn().mockResolvedValue({ taskUid: 1 }),
       search: jest.fn().mockResolvedValue({ hits: [] }),
     });
 
@@ -341,7 +344,7 @@ describe('performSync() - syncThreshold logic', () => {
       isComplete: true,
     });
 
-    const updateSettings = jest.fn().mockResolvedValue({});
+    const updateSettings = jest.fn().mockResolvedValue({ taskUid: 1 });
     mockMeiliIndex.mockReturnValue({
       getSettings: jest.fn().mockResolvedValue({
         filterableAttributes: ['user', 'tenantId', 'customAttribute'],
@@ -390,7 +393,7 @@ describe('performSync() - syncThreshold logic', () => {
     // Mock settings update scenario
     mockMeiliIndex.mockReturnValue({
       getSettings: jest.fn().mockResolvedValue({ filterableAttributes: [] }), // No user field
-      updateSettings: jest.fn().mockResolvedValue({}),
+      updateSettings: jest.fn().mockResolvedValue({ taskUid: 1 }),
       search: jest.fn().mockResolvedValue({ hits: [] }),
     });
 
@@ -431,7 +434,7 @@ describe('performSync() - syncThreshold logic', () => {
     Conversation.syncWithMeili.mockResolvedValue(undefined);
 
     // Mock settings update scenario
-    const updateSettings = jest.fn().mockResolvedValue({});
+    const updateSettings = jest.fn().mockResolvedValue({ taskUid: 1 });
     mockMeiliIndex.mockReturnValue({
       getSettings: jest.fn().mockResolvedValue({
         filterableAttributes: ['user', 'customAttribute'],
@@ -452,6 +455,11 @@ describe('performSync() - syncThreshold logic', () => {
     expect(updateSettings).toHaveBeenCalledTimes(2);
     expect(updateSettings).toHaveBeenCalledWith({
       filterableAttributes: ['user', 'customAttribute', 'tenantId'],
+    });
+    expect(mockMeiliWaitForTask).toHaveBeenCalledTimes(2);
+    expect(mockMeiliWaitForTask).toHaveBeenCalledWith(1, {
+      timeOutMs: 600_000,
+      intervalMs: 100,
     });
 
     // Assert: Conversation sync triggered despite being below threshold (50 < 1000)
@@ -485,7 +493,7 @@ describe('performSync() - syncThreshold logic', () => {
     // Mock settings update scenario
     mockMeiliIndex.mockReturnValue({
       getSettings: jest.fn().mockResolvedValue({ filterableAttributes: [] }), // No user field
-      updateSettings: jest.fn().mockResolvedValue({}),
+      updateSettings: jest.fn().mockResolvedValue({ taskUid: 1 }),
       search: jest.fn().mockResolvedValue({ hits: [] }),
     });
 

--- a/api/db/indexSync.spec.js
+++ b/api/db/indexSync.spec.js
@@ -431,9 +431,12 @@ describe('performSync() - syncThreshold logic', () => {
     Conversation.syncWithMeili.mockResolvedValue(undefined);
 
     // Mock settings update scenario
+    const updateSettings = jest.fn().mockResolvedValue({});
     mockMeiliIndex.mockReturnValue({
-      getSettings: jest.fn().mockResolvedValue({ filterableAttributes: [] }), // No user field
-      updateSettings: jest.fn().mockResolvedValue({}),
+      getSettings: jest.fn().mockResolvedValue({
+        filterableAttributes: ['user', 'customAttribute'],
+      }),
+      updateSettings,
       search: jest.fn().mockResolvedValue({ hits: [] }),
     });
 
@@ -446,6 +449,10 @@ describe('performSync() - syncThreshold logic', () => {
     // Assert: Flags were reset due to settings update
     expect(mockBatchResetMeiliFlags).toHaveBeenCalledWith(Message.collection);
     expect(mockBatchResetMeiliFlags).toHaveBeenCalledWith(Conversation.collection);
+    expect(updateSettings).toHaveBeenCalledTimes(2);
+    expect(updateSettings).toHaveBeenCalledWith({
+      filterableAttributes: ['user', 'customAttribute', 'tenantId'],
+    });
 
     // Assert: Conversation sync triggered despite being below threshold (50 < 1000)
     expect(Conversation.syncWithMeili).toHaveBeenCalledTimes(1);

--- a/api/db/indexSync.spec.js
+++ b/api/db/indexSync.spec.js
@@ -341,9 +341,20 @@ describe('performSync() - syncThreshold logic', () => {
       isComplete: true,
     });
 
+    const updateSettings = jest.fn().mockResolvedValue({});
+    mockMeiliIndex.mockReturnValue({
+      getSettings: jest.fn().mockResolvedValue({
+        filterableAttributes: ['user', 'tenantId', 'customAttribute'],
+      }),
+      updateSettings,
+      search: jest.fn().mockResolvedValue({ hits: [] }),
+    });
+
     // Act
     const indexSync = require('./indexSync');
     await indexSync();
+
+    expect(updateSettings).not.toHaveBeenCalled();
 
     // Assert: No countDocuments calls
     expect(Message.countDocuments).not.toHaveBeenCalled();

--- a/api/server/routes/__tests__/messages-get.spec.js
+++ b/api/server/routes/__tests__/messages-get.spec.js
@@ -1,6 +1,7 @@
 const { CLIENT_MESSAGE_SELECT, MEILI_SEARCH_LIMIT } = require('@librechat/data-schemas');
 const express = require('express');
 const request = require('supertest');
+const mockGetTenantId = jest.fn();
 
 jest.mock('@librechat/agents', () => ({
   sleep: jest.fn(),
@@ -122,6 +123,7 @@ jest.mock('~/server/services/Endpoints/agents/subagentThreadStore', () => ({}));
 
 jest.mock('@librechat/data-schemas', () => ({
   ...jest.requireActual('@librechat/data-schemas'),
+  getTenantId: mockGetTenantId,
   logger: {
     debug: jest.fn(),
     info: jest.fn(),
@@ -257,6 +259,7 @@ describe('message route conversation ownership filters', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetTenantId.mockReturnValue(undefined);
     canReadActiveJobConversation.mockResolvedValue(false);
     prepareMessageRequestValidation.mockImplementation((req, res, next) => {
       req.messageRequestValidation = {
@@ -512,6 +515,33 @@ describe('message route conversation ownership filters', () => {
       );
     },
   );
+
+  it.each([
+    {
+      name: 'active tenant with escaped characters',
+      tenantId: 'tenant"\\id',
+      filter: `user = "${authenticatedUserId}" AND tenantId = "tenant\\"\\\\id"`,
+    },
+    {
+      name: 'system context',
+      tenantId: '__SYSTEM__',
+      filter: `user = "${authenticatedUserId}"`,
+    },
+  ])('uses the tenant-aware message search filter in $name', async ({ tenantId, filter }) => {
+    mockGetTenantId.mockReturnValue(tenantId);
+    searchMessages.mockResolvedValue({ hits: [] });
+    getConvosQueried.mockResolvedValue({ convoMap: {} });
+    getMessages.mockResolvedValue([]);
+
+    const response = await request(app).get('/api/messages?search=needle');
+
+    expect(response.status).toBe(200);
+    expect(searchMessages).toHaveBeenCalledWith(
+      'needle',
+      { filter, limit: 25 },
+      true,
+    );
+  });
 
   it('returns indistinguishable not-found responses for child and missing query reads', async () => {
     getConvoOwnership.mockResolvedValueOnce({

--- a/api/server/routes/__tests__/messages-get.spec.js
+++ b/api/server/routes/__tests__/messages-get.spec.js
@@ -1,7 +1,7 @@
+const mockGetTenantId = jest.fn();
 const { CLIENT_MESSAGE_SELECT, MEILI_SEARCH_LIMIT } = require('@librechat/data-schemas');
 const express = require('express');
 const request = require('supertest');
-const mockGetTenantId = jest.fn();
 
 jest.mock('@librechat/agents', () => ({
   sleep: jest.fn(),
@@ -536,11 +536,7 @@ describe('message route conversation ownership filters', () => {
     const response = await request(app).get('/api/messages?search=needle');
 
     expect(response.status).toBe(200);
-    expect(searchMessages).toHaveBeenCalledWith(
-      'needle',
-      { filter, limit: 25 },
-      true,
-    );
+    expect(searchMessages).toHaveBeenCalledWith('needle', { filter, limit: 25 }, true);
   });
 
   it('returns indistinguishable not-found responses for child and missing query reads', async () => {

--- a/api/server/routes/messages.js
+++ b/api/server/routes/messages.js
@@ -1,6 +1,13 @@
 const express = require('express');
 const { v4: uuidv4 } = require('uuid');
-const { logger, CLIENT_MESSAGE_SELECT, MEILI_SEARCH_LIMIT } = require('@librechat/data-schemas');
+const {
+  logger,
+  getTenantId,
+  SYSTEM_TENANT_ID,
+  CLIENT_MESSAGE_SELECT,
+  MEILI_SEARCH_LIMIT,
+  escapeMeiliFilterValue,
+} = require('@librechat/data-schemas');
 const {
   ContentTypes,
   feedbackSchema,
@@ -138,10 +145,15 @@ router.get('/', async (req, res) => {
       }
       response = messageResult.value;
     } else if (search) {
+      const tenantId = getTenantId();
+      const tenantFilter =
+        tenantId && tenantId !== SYSTEM_TENANT_ID
+          ? ` AND tenantId = "${escapeMeiliFilterValue(tenantId)}"`
+          : '';
       const searchResults = await db.searchMessages(
         search,
         {
-          filter: `user = "${user}"`,
+          filter: `user = "${escapeMeiliFilterValue(user)}"${tenantFilter}`,
           limit: Math.min(pageSize, MEILI_SEARCH_LIMIT),
         },
         true,

--- a/packages/data-schemas/src/methods/conversation.spec.ts
+++ b/packages/data-schemas/src/methods/conversation.spec.ts
@@ -6740,7 +6740,7 @@ describe('Conversation Operations', () => {
       const searchParams = {
         filter: 'user = "user123" AND tenantId = "tenant-a"',
         limit: MEILI_SEARCH_LIMIT,
-        attributesToRetrieve: ['conversationId'],
+        attributesToRetrieve: ['conversationId', 'originalConversationId'],
       };
       expect(meiliSearch).toHaveBeenCalledWith('keyword', searchParams);
       expect(searchMessages).toHaveBeenCalledWith('keyword', searchParams);
@@ -6765,12 +6765,42 @@ describe('Conversation Operations', () => {
         const searchParams = {
           filter: 'user = "user123"',
           limit: MEILI_SEARCH_LIMIT,
-          attributesToRetrieve: ['conversationId'],
+          attributesToRetrieve: ['conversationId', 'originalConversationId'],
         };
         expect(meiliSearch).toHaveBeenCalledWith('keyword', searchParams);
         expect(searchMessages).toHaveBeenCalledWith('keyword', searchParams);
         expect(result?.conversations.map((c) => c.conversationId)).toEqual([conversationId]);
       });
+
+      jest.clearAllMocks();
+      searchMessages.mockResolvedValue({ hits: [] });
+      const result = await getConvosByCursor('user123', { search: 'keyword' });
+      const searchParams = {
+        filter: 'user = "user123"',
+        limit: MEILI_SEARCH_LIMIT,
+        attributesToRetrieve: ['conversationId', 'originalConversationId'],
+      };
+      expect(meiliSearch).toHaveBeenCalledWith('keyword', searchParams);
+      expect(searchMessages).toHaveBeenCalledWith('keyword', searchParams);
+      expect(result?.conversations.map((c) => c.conversationId)).toEqual([conversationId]);
+    });
+
+    it('escapes user and tenant values in scoped search filters', async () => {
+      const meiliSearch = jest.fn().mockResolvedValue({ hits: [] });
+      Object.assign(Conversation, { meiliSearch });
+      searchMessages.mockResolvedValue({ hits: [] });
+
+      await tenantStorage.run({ tenantId: 'tenant"\\id' }, () =>
+        getConvosByCursor('user"\\id', { search: 'keyword' }),
+      );
+
+      const searchParams = {
+        filter: 'user = "user\\"\\\\id" AND tenantId = "tenant\\"\\\\id"',
+        limit: MEILI_SEARCH_LIMIT,
+        attributesToRetrieve: ['conversationId', 'originalConversationId'],
+      };
+      expect(meiliSearch).toHaveBeenCalledWith('keyword', searchParams);
+      expect(searchMessages).toHaveBeenCalledWith('keyword', searchParams);
     });
   });
 });

--- a/packages/data-schemas/src/methods/conversation.spec.ts
+++ b/packages/data-schemas/src/methods/conversation.spec.ts
@@ -6716,5 +6716,61 @@ describe('Conversation Operations', () => {
         titleMatch.conversationId,
       ]);
     });
+
+    it('scopes both search indexes to the active tenant', async () => {
+      const tenantId = 'tenant-a';
+      const conversationId = uuidv4();
+      await tenantStorage.run({ tenantId }, async () => {
+        await Conversation.create({
+          conversationId,
+          user: 'user123',
+          title: 'Tenant conversation',
+          endpoint: EModelEndpoint.openAI,
+        });
+      });
+
+      const meiliSearch = jest.fn().mockResolvedValue({ hits: [] });
+      Object.assign(Conversation, { meiliSearch });
+      searchMessages.mockResolvedValue({ hits: [{ conversationId }] });
+
+      const result = await tenantStorage.run({ tenantId }, () =>
+        getConvosByCursor('user123', { search: 'keyword' }),
+      );
+
+      const searchParams = {
+        filter: 'user = "user123" AND tenantId = "tenant-a"',
+        limit: MEILI_SEARCH_LIMIT,
+        attributesToRetrieve: ['conversationId'],
+      };
+      expect(meiliSearch).toHaveBeenCalledWith('keyword', searchParams);
+      expect(searchMessages).toHaveBeenCalledWith('keyword', searchParams);
+      expect(result?.conversations.map((c) => c.conversationId)).toEqual([conversationId]);
+    });
+
+    it('keeps search unscoped in system and tenantless contexts', async () => {
+      const conversationId = uuidv4();
+      await Conversation.create({
+        conversationId,
+        user: 'user123',
+        title: 'System conversation',
+        endpoint: EModelEndpoint.openAI,
+      });
+
+      const meiliSearch = jest.fn().mockResolvedValue({ hits: [{ conversationId }] });
+      Object.assign(Conversation, { meiliSearch });
+      searchMessages.mockResolvedValue({ hits: [] });
+
+      await runAsSystem(async () => {
+        const result = await getConvosByCursor('user123', { search: 'keyword' });
+        const searchParams = {
+          filter: 'user = "user123"',
+          limit: MEILI_SEARCH_LIMIT,
+          attributesToRetrieve: ['conversationId'],
+        };
+        expect(meiliSearch).toHaveBeenCalledWith('keyword', searchParams);
+        expect(searchMessages).toHaveBeenCalledWith('keyword', searchParams);
+        expect(result?.conversations.map((c) => c.conversationId)).toEqual([conversationId]);
+      });
+    });
   });
 });

--- a/packages/data-schemas/src/methods/conversation.spec.ts
+++ b/packages/data-schemas/src/methods/conversation.spec.ts
@@ -6802,5 +6802,47 @@ describe('Conversation Operations', () => {
       expect(meiliSearch).toHaveBeenCalledWith('keyword', searchParams);
       expect(searchMessages).toHaveBeenCalledWith('keyword', searchParams);
     });
+
+    /* The tenant filter matches on an exact `tenantId`, so documents indexed before
+       tenancy existed - and documents still awaiting the v2 reindex - are excluded
+       while a tenant is active. That mirrors the Mongo side, which scopes the same
+       conversations out of the unsearched sidebar listing. */
+    it('excludes conversations without a tenantId, as the unsearched listing does', async () => {
+      const tenantId = 'tenant-a';
+      const untenantedId = uuidv4();
+      const tenantedId = uuidv4();
+      await Conversation.create({
+        conversationId: untenantedId,
+        user: 'user123',
+        title: 'Pre-tenancy keyword',
+        endpoint: EModelEndpoint.openAI,
+      });
+      await tenantStorage.run({ tenantId }, () =>
+        Conversation.create({
+          conversationId: tenantedId,
+          user: 'user123',
+          title: 'Tenant keyword',
+          endpoint: EModelEndpoint.openAI,
+        }),
+      );
+
+      const indexed = [{ conversationId: untenantedId }, { conversationId: tenantedId, tenantId }];
+      const searchIndex = (_query: string, { filter }: { filter: string }) => {
+        const scopedTenantId = /tenantId = "([^"]*)"/.exec(filter)?.[1];
+        return Promise.resolve({
+          hits: indexed.filter((doc) => !scopedTenantId || doc.tenantId === scopedTenantId),
+        });
+      };
+      Object.assign(Conversation, { meiliSearch: jest.fn(searchIndex) });
+      searchMessages.mockImplementation(searchIndex);
+
+      const searched = await tenantStorage.run({ tenantId }, () =>
+        getConvosByCursor('user123', { search: 'keyword' }),
+      );
+      const listed = await tenantStorage.run({ tenantId }, () => getConvosByCursor('user123'));
+
+      expect(searched?.conversations.map((c) => c.conversationId)).toEqual([tenantedId]);
+      expect(listed?.conversations.map((c) => c.conversationId)).toEqual([tenantedId]);
+    });
   });
 });

--- a/packages/data-schemas/src/methods/conversation.ts
+++ b/packages/data-schemas/src/methods/conversation.ts
@@ -518,8 +518,7 @@ export function createConversationMethods(
     fieldsToSelect: string | null = 'conversationId user',
   ) {
     try {
-      const Conversation = mongoose.models.Conversation as Model<IConversation> &
-        Pick<SchemaWithMeiliMethods, 'meiliSearch'>;
+      const Conversation = mongoose.models.Conversation as Model<IConversation>;
       return await Conversation.findOne({ conversationId }, fieldsToSelect).lean<IConversation>();
     } catch (error) {
       logger.error('[searchConversation] Error searching conversation', error);

--- a/packages/data-schemas/src/methods/conversation.ts
+++ b/packages/data-schemas/src/methods/conversation.ts
@@ -518,7 +518,8 @@ export function createConversationMethods(
     fieldsToSelect: string | null = 'conversationId user',
   ) {
     try {
-      const Conversation = mongoose.models.Conversation as Model<IConversation>;
+      const Conversation = mongoose.models.Conversation as Model<IConversation> &
+        Pick<SchemaWithMeiliMethods, 'meiliSearch'>;
       return await Conversation.findOne({ conversationId }, fieldsToSelect).lean<IConversation>();
     } catch (error) {
       logger.error('[searchConversation] Error searching conversation', error);

--- a/packages/data-schemas/src/methods/conversation.ts
+++ b/packages/data-schemas/src/methods/conversation.ts
@@ -44,8 +44,10 @@ import {
 } from './chatProject';
 import { isCompactionSemanticIndexProjection } from '~/types/compaction';
 import { createTempChatExpirationDate } from '~/utils/tempChatRetention';
+import { getTenantId, SYSTEM_TENANT_ID } from '~/config/tenantContext';
 import { tenantSafeBulkWrite } from '~/utils/tenantBulkWrite';
 import { isValidObjectIdString } from '~/utils/objectId';
+import { escapeMeiliFilterValue } from '~/utils/search';
 import { decrementTagCounts } from './conversationTag';
 import logger from '~/config/winston';
 
@@ -53,8 +55,6 @@ const AGENT_EVENT_ACTOR_RECEIPT_RETENTION_MS = 90 * 24 * 60 * 60_000;
 const MAX_AGENT_EVENT_ACTOR_SUSPENSION_BYTES = 64 * 1_024;
 /** MeiliSearch's default `pagination.maxTotalHits` ceiling. */
 const MEILI_SEARCH_LIMIT = 1000;
-const escapeMeiliFilterValue = (value: string): string =>
-  value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 
 function validateAgentEventActorSuspension(
   conversationId: string,
@@ -2638,8 +2638,13 @@ export function createConversationMethods(
 
     if (search) {
       try {
+        const tenantId = getTenantId();
+        const tenantFilter =
+          tenantId && tenantId !== SYSTEM_TENANT_ID
+            ? ` AND tenantId = "${escapeMeiliFilterValue(tenantId)}"`
+            : '';
         const searchParams: SearchParams = {
-          filter: `user = "${escapeMeiliFilterValue(user)}"`,
+          filter: `user = "${escapeMeiliFilterValue(user)}"${tenantFilter}`,
           limit: MEILI_SEARCH_LIMIT,
           attributesToRetrieve: ['conversationId', 'originalConversationId'],
         };

--- a/packages/data-schemas/src/methods/share.test.ts
+++ b/packages/data-schemas/src/methods/share.test.ts
@@ -4,6 +4,7 @@ import { MongoMemoryServer } from 'mongodb-memory-server';
 import { Constants, ContentTypes, Tools } from 'librechat-data-provider';
 import type { SchemaWithMeiliMethods } from '~/models/plugins/mongoMeili';
 import type * as t from '~/types';
+import { tenantStorage, runAsSystem } from '~/config/tenantContext';
 import {
   createShareMethods,
   anonymizeSharedContent,
@@ -1252,6 +1253,52 @@ describe('Share Methods', () => {
       expect(result.links[0].title).toBe('Matching Share');
 
       // Verify that meiliSearch was called with the correct user filter
+      expect(meiliSearchMock).toHaveBeenCalledWith('search term', {
+        filter: `user = "${userId}"`,
+        limit: MEILI_SEARCH_LIMIT,
+        attributesToRetrieve: ['conversationId'],
+      });
+    });
+
+    test('scopes search to the active tenant and escapes filter values', async () => {
+      const userId = 'user"\\id';
+      const meiliSearchMock = jest.fn().mockResolvedValue({ hits: [] });
+      Conversation.meiliSearch = meiliSearchMock;
+
+      await tenantStorage.run({ tenantId: 'tenant"\\id' }, () =>
+        shareMethods.getSharedLinks(
+          userId,
+          undefined,
+          10,
+          'createdAt',
+          'desc',
+          'search term',
+        ),
+      );
+
+      expect(meiliSearchMock).toHaveBeenCalledWith('search term', {
+        filter: 'user = "user\\"\\\\id" AND tenantId = "tenant\\"\\\\id"',
+        limit: MEILI_SEARCH_LIMIT,
+        attributesToRetrieve: ['conversationId'],
+      });
+    });
+
+    test('keeps search unscoped in system context', async () => {
+      const userId = new mongoose.Types.ObjectId().toString();
+      const meiliSearchMock = jest.fn().mockResolvedValue({ hits: [] });
+      Conversation.meiliSearch = meiliSearchMock;
+
+      await runAsSystem(() =>
+        shareMethods.getSharedLinks(
+          userId,
+          undefined,
+          10,
+          'createdAt',
+          'desc',
+          'search term',
+        ),
+      );
+
       expect(meiliSearchMock).toHaveBeenCalledWith('search term', {
         filter: `user = "${userId}"`,
         limit: MEILI_SEARCH_LIMIT,

--- a/packages/data-schemas/src/methods/share.test.ts
+++ b/packages/data-schemas/src/methods/share.test.ts
@@ -1221,14 +1221,14 @@ describe('Share Methods', () => {
 
       // Mock meiliSearch method
       const meiliSearchMock = jest.fn().mockResolvedValue({
-        hits: [{ conversationId: 'conv1' }],
+        hits: [{ conversationId: 'conv|1', originalConversationId: 'conv|1' }],
       });
       Conversation.meiliSearch = meiliSearchMock;
 
       await SharedLink.create([
         {
           shareId: 'share1',
-          conversationId: 'conv1',
+          conversationId: 'conv|1',
           user: userId,
           title: 'Matching Share',
         },
@@ -1256,7 +1256,7 @@ describe('Share Methods', () => {
       expect(meiliSearchMock).toHaveBeenCalledWith('search term', {
         filter: `user = "${userId}"`,
         limit: MEILI_SEARCH_LIMIT,
-        attributesToRetrieve: ['conversationId'],
+        attributesToRetrieve: ['conversationId', 'originalConversationId'],
       });
     });
 
@@ -1381,7 +1381,7 @@ describe('Share Methods', () => {
       expect(meiliSearchMock).toHaveBeenCalledWith('search term', {
         filter: `user = "${userId1}"`,
         limit: MEILI_SEARCH_LIMIT,
-        attributesToRetrieve: ['conversationId'],
+        attributesToRetrieve: ['conversationId', 'originalConversationId'],
       });
 
       // Search as userId2
@@ -1402,7 +1402,7 @@ describe('Share Methods', () => {
       expect(meiliSearchMock).toHaveBeenCalledWith('search term', {
         filter: `user = "${userId2}"`,
         limit: MEILI_SEARCH_LIMIT,
-        attributesToRetrieve: ['conversationId'],
+        attributesToRetrieve: ['conversationId', 'originalConversationId'],
       });
     });
 

--- a/packages/data-schemas/src/methods/share.test.ts
+++ b/packages/data-schemas/src/methods/share.test.ts
@@ -4,13 +4,13 @@ import { MongoMemoryServer } from 'mongodb-memory-server';
 import { Constants, ContentTypes, Tools } from 'librechat-data-provider';
 import type { SchemaWithMeiliMethods } from '~/models/plugins/mongoMeili';
 import type * as t from '~/types';
-import { tenantStorage, runAsSystem } from '~/config/tenantContext';
 import {
   createShareMethods,
   anonymizeSharedContent,
   type ShareMethods,
   type SharedLinkContentSnapshot,
 } from './share';
+import { tenantStorage, runAsSystem } from '~/config/tenantContext';
 import { MEILI_SEARCH_LIMIT } from '~/common/search';
 import logger from '~/config/winston';
 
@@ -1266,20 +1266,13 @@ describe('Share Methods', () => {
       Conversation.meiliSearch = meiliSearchMock;
 
       await tenantStorage.run({ tenantId: 'tenant"\\id' }, () =>
-        shareMethods.getSharedLinks(
-          userId,
-          undefined,
-          10,
-          'createdAt',
-          'desc',
-          'search term',
-        ),
+        shareMethods.getSharedLinks(userId, undefined, 10, 'createdAt', 'desc', 'search term'),
       );
 
       expect(meiliSearchMock).toHaveBeenCalledWith('search term', {
         filter: 'user = "user\\"\\\\id" AND tenantId = "tenant\\"\\\\id"',
         limit: MEILI_SEARCH_LIMIT,
-        attributesToRetrieve: ['conversationId'],
+        attributesToRetrieve: ['conversationId', 'originalConversationId'],
       });
     });
 
@@ -1289,20 +1282,13 @@ describe('Share Methods', () => {
       Conversation.meiliSearch = meiliSearchMock;
 
       await runAsSystem(() =>
-        shareMethods.getSharedLinks(
-          userId,
-          undefined,
-          10,
-          'createdAt',
-          'desc',
-          'search term',
-        ),
+        shareMethods.getSharedLinks(userId, undefined, 10, 'createdAt', 'desc', 'search term'),
       );
 
       expect(meiliSearchMock).toHaveBeenCalledWith('search term', {
         filter: `user = "${userId}"`,
         limit: MEILI_SEARCH_LIMIT,
-        attributesToRetrieve: ['conversationId'],
+        attributesToRetrieve: ['conversationId', 'originalConversationId'],
       });
     });
 

--- a/packages/data-schemas/src/methods/share.ts
+++ b/packages/data-schemas/src/methods/share.ts
@@ -979,7 +979,7 @@ export function createShareMethods(mongoose: typeof import('mongoose')): {
           const searchResults = await Conversation.meiliSearch(search, {
             filter: `user = "${escapeMeiliFilterValue(user)}"${tenantFilter}`,
             limit: MEILI_SEARCH_LIMIT,
-            attributesToRetrieve: ['conversationId'],
+            attributesToRetrieve: ['conversationId', 'originalConversationId'],
           });
 
           if (!searchResults?.hits?.length) {

--- a/packages/data-schemas/src/methods/share.ts
+++ b/packages/data-schemas/src/methods/share.ts
@@ -9,8 +9,10 @@ import {
   stripMessageUIResourceMarkers,
 } from '~/utils/stripUIResourceMarkers';
 import { activeExpirationFilter } from '~/utils/retention';
+import { getTenantId, SYSTEM_TENANT_ID } from '~/config/tenantContext';
 import { isValidObjectIdString } from '~/utils/objectId';
 import { MEILI_SEARCH_LIMIT } from '~/common/search';
+import { escapeMeiliFilterValue } from '~/utils/search';
 import { CLIENT_MESSAGE_SELECT } from './message';
 import logger from '~/config/winston';
 
@@ -969,8 +971,13 @@ export function createShareMethods(mongoose: typeof import('mongoose')): {
 
       if (search && search.trim()) {
         try {
+          const tenantId = getTenantId();
+          const tenantFilter =
+            tenantId && tenantId !== SYSTEM_TENANT_ID
+              ? ` AND tenantId = "${escapeMeiliFilterValue(tenantId)}"`
+              : '';
           const searchResults = await Conversation.meiliSearch(search, {
-            filter: `user = "${user}"`,
+            filter: `user = "${escapeMeiliFilterValue(user)}"${tenantFilter}`,
             limit: MEILI_SEARCH_LIMIT,
             attributesToRetrieve: ['conversationId'],
           });

--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -1669,6 +1669,7 @@ describe('Meilisearch Mongoose plugin', () => {
       mockDeleteDocuments.mockClear();
       mockIndex.mockReturnValue({
         getRawInfo: jest.fn(),
+        getSettings: jest.fn().mockResolvedValue({ filterableAttributes: [] }),
         updateSettings: jest.fn(),
         addDocuments: mockAddDocuments,
         addDocumentsInBatches: mockAddDocumentsInBatches,

--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -83,6 +83,7 @@ const mockGetDocuments = jest.fn().mockResolvedValue({ results: [] });
 const mockWaitForTask = jest.fn().mockResolvedValue({ status: 'succeeded' });
 const mockIndex = jest.fn().mockReturnValue({
   getRawInfo: jest.fn(),
+  getSettings: jest.fn().mockResolvedValue({ filterableAttributes: [] }),
   updateSettings: jest.fn(),
   addDocuments: mockAddDocuments,
   addDocumentsInBatches: mockAddDocumentsInBatches,

--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -2303,6 +2303,57 @@ describe('Meilisearch Mongoose plugin', () => {
       expect(docsWithMissingIndex).toBe(1);
     });
 
+    test('syncWithMeili reindexes older projections but never downgrades newer ones', async () => {
+      const conversationModel = createConversationModel(
+        mongoose,
+      ) as unknown as SchemaWithMeiliMethods;
+      await conversationModel.deleteMany({});
+      mockAddDocumentsInBatches.mockClear();
+
+      const futureId = new mongoose.Types.ObjectId();
+      const staleId = new mongoose.Types.ObjectId();
+      await conversationModel.collection.insertMany([
+        {
+          conversationId: futureId,
+          user: new mongoose.Types.ObjectId(),
+          title: 'Newer projection',
+          endpoint: EModelEndpoint.openAI,
+          expiredAt: null,
+          _meiliIndex: true,
+          _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION + 1,
+        },
+        {
+          conversationId: staleId,
+          user: new mongoose.Types.ObjectId(),
+          title: 'Stale projection',
+          endpoint: EModelEndpoint.openAI,
+          expiredAt: null,
+          _meiliIndex: true,
+          _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION - 1,
+        },
+      ]);
+
+      await conversationModel.syncWithMeili();
+
+      expect(mockAddDocumentsInBatches).toHaveBeenCalled();
+
+      const [futureDoc, staleDoc] = await Promise.all([
+        conversationModel.collection.findOne({ conversationId: futureId }),
+        conversationModel.collection.findOne({ conversationId: staleId }),
+      ]);
+
+      // Newer-stamped projection is left alone, not re-indexed nor downgraded.
+      expect(futureDoc?._meiliIndexSchemaVersion).toBe(MEILI_INDEX_SCHEMA_VERSION + 1);
+      expect(futureDoc?._meiliIndex).toBe(true);
+      expect(mockAddDocumentsInBatches).not.toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ conversationId: futureId })]),
+      );
+
+      // Strictly older projection is re-indexed and stamped forward to the local version.
+      expect(staleDoc?._meiliIndexSchemaVersion).toBe(MEILI_INDEX_SCHEMA_VERSION);
+      expect(staleDoc?._meiliIndex).toBe(true);
+    });
+
     test('getSyncProgress counts documents with missing _meiliIndex as not indexed', async () => {
       const messageModel = createMessageModel(mongoose) as unknown as SchemaWithMeiliMethods;
       await messageModel.deleteMany({});

--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -205,6 +205,21 @@ describe('Meilisearch Mongoose plugin', () => {
     mongoose.deleteModel(modelName);
   });
 
+  test('retries filterable-attribute setup after a transient failure', async () => {
+    const modelName = `SettingsRetry${Date.now()}`;
+    mockWaitForTask
+      .mockRejectedValueOnce(new Error('temporary settings failure'))
+      .mockResolvedValue({ status: 'succeeded' });
+    const Model = createDynamicMeiliModel(modelName);
+    await waitForMock(mockWaitForTask);
+    await wait(0);
+
+    await expect(Model.meiliSearch('query')).resolves.toEqual({ hits: [] });
+    expect(mockUpdateSettings).toHaveBeenCalledTimes(2);
+    expect(mockSearch).toHaveBeenCalledWith('query', undefined);
+    mongoose.deleteModel(modelName);
+  });
+
   test('settles query updates and deletes when no document hook is available', async () => {
     const modelName = `QueryMiddlewareResult${Date.now()}`;
     const Model = createDynamicMeiliModel(modelName);

--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -10,6 +10,7 @@ interface DynamicMeiliDocument extends mongoose.Document {
   docId: string;
   user: string;
   title: string;
+  tenantId?: string;
   isTemporary?: boolean;
   expiredAt?: Date | null;
   _meiliIndex?: boolean;
@@ -32,6 +33,10 @@ const createDynamicMeiliModel = (modelName: string): DynamicMeiliModel => {
       meiliIndex: true,
     },
     user: {
+      type: String,
+      meiliIndex: true,
+    },
+    tenantId: {
       type: String,
       meiliIndex: true,
     },
@@ -80,11 +85,14 @@ const mockDeleteDocument = jest.fn();
 const mockDeleteDocuments = jest.fn();
 const mockGetDocument = jest.fn();
 const mockGetDocuments = jest.fn().mockResolvedValue({ results: [] });
+const mockGetSettings = jest.fn().mockResolvedValue({ filterableAttributes: [] });
+const mockUpdateSettings = jest.fn().mockResolvedValue({ taskUid: 3 });
+const mockSearch = jest.fn().mockResolvedValue({ hits: [] });
 const mockWaitForTask = jest.fn().mockResolvedValue({ status: 'succeeded' });
 const mockIndex = jest.fn().mockReturnValue({
   getRawInfo: jest.fn(),
-  getSettings: jest.fn().mockResolvedValue({ filterableAttributes: [] }),
-  updateSettings: jest.fn(),
+  getSettings: mockGetSettings,
+  updateSettings: mockUpdateSettings,
   addDocuments: mockAddDocuments,
   addDocumentsInBatches: mockAddDocumentsInBatches,
   updateDocuments: mockUpdateDocuments,
@@ -92,6 +100,7 @@ const mockIndex = jest.fn().mockReturnValue({
   deleteDocuments: mockDeleteDocuments,
   getDocument: mockGetDocument,
   getDocuments: mockGetDocuments,
+  search: mockSearch,
 });
 jest.mock('meilisearch', () => {
   return {
@@ -130,6 +139,9 @@ describe('Meilisearch Mongoose plugin', () => {
     mockDeleteDocuments.mockReset().mockResolvedValue({ taskUid: 1 });
     mockGetDocument.mockClear();
     mockGetDocuments.mockReset().mockResolvedValue({ results: [] });
+    mockGetSettings.mockReset().mockResolvedValue({ filterableAttributes: [] });
+    mockUpdateSettings.mockReset().mockResolvedValue({ taskUid: 3 });
+    mockSearch.mockReset().mockResolvedValue({ hits: [] });
     mockWaitForTask.mockReset().mockResolvedValue({ status: 'succeeded' });
   });
 
@@ -138,6 +150,59 @@ describe('Meilisearch Mongoose plugin', () => {
     await mongoServer.stop();
 
     process.env = OLD_ENV;
+  });
+
+  test('preserves custom filterable attributes while adding required attributes', async () => {
+    const modelName = `FilterableAttributes${Date.now()}`;
+    mockGetSettings.mockResolvedValueOnce({ filterableAttributes: ['customAttribute'] });
+
+    createDynamicMeiliModel(modelName);
+    await waitForMock(mockUpdateSettings);
+
+    expect(mockUpdateSettings).toHaveBeenCalledWith({
+      filterableAttributes: ['customAttribute', 'user', 'tenantId'],
+    });
+    expect(mockWaitForTask).toHaveBeenCalledWith(3, {
+      timeOutMs: 600_000,
+      intervalMs: 100,
+    });
+    mongoose.deleteModel(modelName);
+  });
+
+  test('does not update filterable attributes when required attributes are configured', async () => {
+    const modelName = `ConfiguredAttributes${Date.now()}`;
+    mockGetSettings.mockResolvedValueOnce({
+      filterableAttributes: ['user', 'tenantId', 'customAttribute'],
+    });
+
+    createDynamicMeiliModel(modelName);
+    await waitForMock(mockGetSettings);
+
+    expect(mockUpdateSettings).not.toHaveBeenCalled();
+    mongoose.deleteModel(modelName);
+  });
+
+  test('waits for filterable attributes before searching', async () => {
+    const modelName = `SettingsReady${Date.now()}`;
+    let completeSettings: (task: { status: string }) => void = () => undefined;
+    const settingsTask = new Promise<{ status: string }>((resolve) => {
+      completeSettings = resolve;
+    });
+    mockUpdateSettings.mockResolvedValueOnce({ taskUid: 99 });
+    mockWaitForTask.mockImplementation((taskUid: number) =>
+      taskUid === 99 ? settingsTask : Promise.resolve({ status: 'succeeded' }),
+    );
+    const Model = createDynamicMeiliModel(modelName);
+    await waitForMock(mockUpdateSettings);
+
+    const search = Model.meiliSearch('query');
+    await wait(0);
+    expect(mockSearch).not.toHaveBeenCalled();
+
+    completeSettings({ status: 'succeeded' });
+    await search;
+    expect(mockSearch).toHaveBeenCalledWith('query', undefined);
+    mongoose.deleteModel(modelName);
   });
 
   test('settles query updates and deletes when no document hook is available', async () => {
@@ -1669,8 +1734,8 @@ describe('Meilisearch Mongoose plugin', () => {
       mockDeleteDocuments.mockClear();
       mockIndex.mockReturnValue({
         getRawInfo: jest.fn(),
-        getSettings: jest.fn().mockResolvedValue({ filterableAttributes: [] }),
-        updateSettings: jest.fn(),
+        getSettings: mockGetSettings,
+        updateSettings: mockUpdateSettings,
         addDocuments: mockAddDocuments,
         addDocumentsInBatches: mockAddDocumentsInBatches,
         updateDocuments: mockUpdateDocuments,
@@ -1678,6 +1743,7 @@ describe('Meilisearch Mongoose plugin', () => {
         deleteDocuments: mockDeleteDocuments,
         getDocument: mockGetDocument,
         getDocuments: mockGetDocuments,
+        search: mockSearch,
       });
     });
 

--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -2,7 +2,10 @@ import mongoose from 'mongoose';
 import { EModelEndpoint } from 'librechat-data-provider';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import type { SchemaWithMeiliMethods } from '~/models/plugins/mongoMeili';
-import mongoMeili, { MEILI_INDEX_SCHEMA_VERSION } from '~/models/plugins/mongoMeili';
+import mongoMeili, {
+  MEILI_INDEX_SCHEMA_VERSION,
+  toMeiliConversationKey,
+} from '~/models/plugins/mongoMeili';
 import { createConversationModel } from '~/models/convo';
 import { createMessageModel } from '~/models/message';
 
@@ -541,7 +544,12 @@ describe('Meilisearch Mongoose plugin', () => {
     expect(mockDeleteDocument).not.toHaveBeenCalledWith(String(msg._id));
   });
 
-  test('updateDocuments receives preprocessed data with primaryKey', async () => {
+  test('toMeiliConversationKey encodes pipes into double hyphens', () => {
+    expect(toMeiliConversationKey('abc|def|ghi')).toBe('abc--def--ghi');
+    expect(toMeiliConversationKey('normal-id')).toBe('normal-id');
+  });
+
+  test('updateDocuments receives preprocessed data with primaryKey and originalConversationId', async () => {
     const conversationModel = createConversationModel(
       mongoose,
     ) as unknown as SchemaWithMeiliMethods;
@@ -560,7 +568,12 @@ describe('Meilisearch Mongoose plugin', () => {
 
     await waitForMock(mockUpdateDocuments);
     expect(mockUpdateDocuments).toHaveBeenCalledWith(
-      [expect.objectContaining({ conversationId: 'abc--def--ghi' })],
+      [
+        expect.objectContaining({
+          conversationId: 'abc--def--ghi',
+          originalConversationId: 'abc|def|ghi',
+        }),
+      ],
       { primaryKey: 'conversationId' },
     );
   });
@@ -1798,6 +1811,45 @@ describe('Meilisearch Mongoose plugin', () => {
       expect(mockDeleteDocuments).toHaveBeenCalledWith([orphanedConvoId1, orphanedConvoId2]);
     });
 
+    test('cleanupMeiliIndex preserves pipe-containing conversation IDs with originalConversationId', async () => {
+      const conversationModel = createConversationModel(
+        mongoose,
+      ) as unknown as SchemaWithMeiliMethods;
+      await conversationModel.deleteMany({});
+
+      const existingPipeConvoId = 'convo|with|pipe';
+      const orphanedPipeConvoId = 'orphaned|with|pipe';
+
+      await conversationModel.collection.insertOne({
+        conversationId: existingPipeConvoId,
+        user: new mongoose.Types.ObjectId(),
+        title: 'Pipe Conversation',
+        endpoint: EModelEndpoint.openAI,
+        _meiliIndex: true,
+        expiredAt: null,
+      });
+
+      mockGetDocuments.mockResolvedValueOnce({
+        results: [
+          {
+            conversationId: toMeiliConversationKey(existingPipeConvoId),
+            originalConversationId: existingPipeConvoId,
+          },
+          {
+            conversationId: toMeiliConversationKey(orphanedPipeConvoId),
+            originalConversationId: orphanedPipeConvoId,
+          },
+        ],
+      });
+
+      const indexMock = mockIndex();
+      await conversationModel.cleanupMeiliIndex(indexMock, 'conversationId', 100, 0);
+
+      expect(mockDeleteDocuments).toHaveBeenCalledWith([
+        toMeiliConversationKey(orphanedPipeConvoId),
+      ]);
+    });
+
     test('cleanupMeiliIndex handles offset correctly when documents are deleted', async () => {
       const messageModel = createMessageModel(mongoose) as unknown as SchemaWithMeiliMethods;
       await messageModel.deleteMany({});
@@ -2535,6 +2587,61 @@ describe('Meilisearch Mongoose plugin', () => {
         _meiliIndex: true,
       });
       expect(afterSync.length).toBe(2);
+    });
+
+    test('deleteObjectFromMeili uses toMeiliConversationKey for conversationId', async () => {
+      const conversationModel = createConversationModel(
+        mongoose,
+      ) as unknown as SchemaWithMeiliMethods;
+      const convo = await conversationModel.create({
+        conversationId: 'delete|with|pipes',
+        user: new mongoose.Types.ObjectId(),
+        title: 'Delete Pipe Test',
+        endpoint: EModelEndpoint.openAI,
+      });
+      mockDeleteDocument.mockClear();
+
+      await new Promise<void>((resolve) => {
+        convo.deleteObjectFromMeili!(() => resolve());
+      });
+
+      expect(mockDeleteDocument).toHaveBeenCalledWith('delete--with--pipes');
+    });
+
+    test('deleteMany hook deletes documents using toMeiliConversationKey', async () => {
+      const conversationModel = createConversationModel(
+        mongoose,
+      ) as unknown as SchemaWithMeiliMethods;
+      await conversationModel.create({
+        conversationId: 'batch|del|pipe',
+        user: new mongoose.Types.ObjectId(),
+        title: 'Batch Delete Pipe Test',
+        endpoint: EModelEndpoint.openAI,
+      });
+      mockDeleteDocument.mockClear();
+
+      await conversationModel.deleteMany({ conversationId: 'batch|del|pipe' });
+
+      expect(mockDeleteDocument).toHaveBeenCalledWith('batch--del--pipe');
+    });
+
+    test('normalizes search hits back to originalConversationId', async () => {
+      const conversationModel = createConversationModel(
+        mongoose,
+      ) as unknown as SchemaWithMeiliMethods;
+      const conversationId = 'search|with|pipes';
+      mockSearch.mockResolvedValue({
+        hits: [
+          {
+            conversationId: toMeiliConversationKey(conversationId),
+            originalConversationId: conversationId,
+          },
+        ],
+      });
+
+      const result = await conversationModel.meiliSearch('keyword', undefined, false);
+
+      expect(result.hits[0].conversationId).toBe(conversationId);
     });
   });
 });

--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -1812,9 +1812,7 @@ describe('Meilisearch Mongoose plugin', () => {
     });
 
     test('cleanupMeiliIndex preserves pipe-containing conversation IDs with originalConversationId', async () => {
-      const conversationModel = createConversationModel(
-        mongoose,
-      ) as unknown as SchemaWithMeiliMethods;
+      const conversationModel = mongoose.models.Conversation as SchemaWithMeiliMethods;
       await conversationModel.deleteMany({});
 
       const existingPipeConvoId = 'convo|with|pipe';
@@ -2590,9 +2588,7 @@ describe('Meilisearch Mongoose plugin', () => {
     });
 
     test('deleteObjectFromMeili uses toMeiliConversationKey for conversationId', async () => {
-      const conversationModel = createConversationModel(
-        mongoose,
-      ) as unknown as SchemaWithMeiliMethods;
+      const conversationModel = mongoose.models.Conversation as SchemaWithMeiliMethods;
       const convo = await conversationModel.create({
         conversationId: 'delete|with|pipes',
         user: new mongoose.Types.ObjectId(),
@@ -2609,9 +2605,7 @@ describe('Meilisearch Mongoose plugin', () => {
     });
 
     test('deleteMany hook deletes documents using toMeiliConversationKey', async () => {
-      const conversationModel = createConversationModel(
-        mongoose,
-      ) as unknown as SchemaWithMeiliMethods;
+      const conversationModel = mongoose.models.Conversation as SchemaWithMeiliMethods;
       await conversationModel.create({
         conversationId: 'batch|del|pipe',
         user: new mongoose.Types.ObjectId(),
@@ -2626,9 +2620,7 @@ describe('Meilisearch Mongoose plugin', () => {
     });
 
     test('normalizes search hits back to originalConversationId', async () => {
-      const conversationModel = createConversationModel(
-        mongoose,
-      ) as unknown as SchemaWithMeiliMethods;
+      const conversationModel = mongoose.models.Conversation as SchemaWithMeiliMethods;
       const conversationId = 'search|with|pipes';
       mockSearch.mockResolvedValue({
         hits: [

--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -3,6 +3,7 @@ import { EModelEndpoint } from 'librechat-data-provider';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import type { SchemaWithMeiliMethods } from '~/models/plugins/mongoMeili';
 import mongoMeili, {
+  MEILI_CONVERSATION_INDEX_SCHEMA_VERSION,
   MEILI_INDEX_SCHEMA_VERSION,
   toMeiliConversationKey,
 } from '~/models/plugins/mongoMeili';
@@ -1258,9 +1259,10 @@ describe('Meilisearch Mongoose plugin', () => {
       await conversationModel.deleteMany({});
       mockAddDocumentsInBatches.mockClear();
       mockAddDocuments.mockClear();
+      const conversationId = 'batch|conversation';
 
       await conversationModel.collection.insertOne({
-        conversationId: new mongoose.Types.ObjectId(),
+        conversationId,
         user: new mongoose.Types.ObjectId(),
         title: 'Test Conversation',
         endpoint: EModelEndpoint.openAI,
@@ -1271,10 +1273,16 @@ describe('Meilisearch Mongoose plugin', () => {
       // Run sync which should call processSyncBatch internally
       await conversationModel.syncWithMeili();
 
-      // Verify addDocumentsInBatches was called with explicit primaryKey
-      expect(mockAddDocumentsInBatches).toHaveBeenCalledWith(expect.any(Array), undefined, {
-        primaryKey: 'conversationId',
-      });
+      expect(mockAddDocumentsInBatches).toHaveBeenCalledWith(
+        [
+          expect.objectContaining({
+            conversationId: 'batch--conversation',
+            originalConversationId: conversationId,
+          }),
+        ],
+        undefined,
+        { primaryKey: 'conversationId' },
+      );
     });
 
     test('a transient document-write failure retries without delaying MongoDB persistence', async () => {
@@ -1413,7 +1421,7 @@ describe('Meilisearch Mongoose plugin', () => {
         title: 'Indexed',
         endpoint: EModelEndpoint.openAI,
         _meiliIndex: true,
-        _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION,
+        _meiliIndexSchemaVersion: MEILI_CONVERSATION_INDEX_SCHEMA_VERSION,
         expiredAt: null,
       });
 
@@ -1443,7 +1451,7 @@ describe('Meilisearch Mongoose plugin', () => {
         title: 'Legacy Indexed Conversation',
         endpoint: EModelEndpoint.openAI,
         _meiliIndex: true,
-        _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION - 1,
+        _meiliIndexSchemaVersion: MEILI_CONVERSATION_INDEX_SCHEMA_VERSION - 1,
         expiredAt: null,
       });
 
@@ -1460,7 +1468,7 @@ describe('Meilisearch Mongoose plugin', () => {
             .findOne({ title: 'Legacy Indexed Conversation' })
             .select('+_meiliIndexSchemaVersion')
         )?._meiliIndexSchemaVersion,
-      ).toBe(MEILI_INDEX_SCHEMA_VERSION);
+      ).toBe(MEILI_CONVERSATION_INDEX_SCHEMA_VERSION);
     });
 
     test('getSyncProgress excludes TTL documents from counts', async () => {
@@ -1476,7 +1484,7 @@ describe('Meilisearch Mongoose plugin', () => {
         title: 'Syncable Indexed',
         endpoint: EModelEndpoint.openAI,
         _meiliIndex: true,
-        _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION,
+        _meiliIndexSchemaVersion: MEILI_CONVERSATION_INDEX_SCHEMA_VERSION,
         expiredAt: null,
       });
 
@@ -2327,7 +2335,7 @@ describe('Meilisearch Mongoose plugin', () => {
           endpoint: EModelEndpoint.openAI,
           expiredAt: null,
           _meiliIndex: true,
-          _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION,
+          _meiliIndexSchemaVersion: MEILI_CONVERSATION_INDEX_SCHEMA_VERSION,
         },
       ]);
 
@@ -2634,6 +2642,49 @@ describe('Meilisearch Mongoose plugin', () => {
       const result = await conversationModel.meiliSearch('keyword', undefined, false);
 
       expect(result.hits[0].conversationId).toBe(conversationId);
+    });
+
+    test('populates normalized and legacy conversation hits from MongoDB', async () => {
+      const conversationModel = mongoose.models.Conversation as SchemaWithMeiliMethods;
+      const conversationId = 'populate|with|pipes';
+      const legacyConversationId = 'legacy-conversation';
+      await conversationModel.deleteMany({});
+      await conversationModel.collection.insertMany([
+        {
+          conversationId,
+          user: new mongoose.Types.ObjectId(),
+          title: 'Normalized Conversation',
+          endpoint: EModelEndpoint.openAI,
+        },
+        {
+          conversationId: legacyConversationId,
+          user: new mongoose.Types.ObjectId(),
+          title: 'Legacy Conversation',
+          endpoint: EModelEndpoint.openAI,
+        },
+      ]);
+      mockSearch.mockResolvedValue({
+        hits: [
+          {
+            conversationId: toMeiliConversationKey(conversationId),
+            originalConversationId: conversationId,
+          },
+          { conversationId: legacyConversationId },
+        ],
+      });
+
+      const result = await conversationModel.meiliSearch('keyword', undefined, true);
+
+      expect(result.hits).toEqual([
+        expect.objectContaining({
+          conversationId,
+          title: 'Normalized Conversation',
+        }),
+        expect.objectContaining({
+          conversationId: legacyConversationId,
+          title: 'Legacy Conversation',
+        }),
+      ]);
     });
   });
 });

--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -1768,11 +1768,11 @@ describe('Meilisearch Mongoose plugin', () => {
     beforeEach(() => {
       mockGetDocuments = jest.fn();
       mockDeleteDocuments.mockClear();
-        mockIndex.mockReturnValue({
-          getRawInfo: jest.fn(),
-          getSettings: mockGetSettings,
-          updateSettings: mockUpdateSettings,
-          addDocuments: mockAddDocuments,
+      mockIndex.mockReturnValue({
+        getRawInfo: jest.fn(),
+        getSettings: mockGetSettings,
+        updateSettings: mockUpdateSettings,
+        addDocuments: mockAddDocuments,
         addDocumentsInBatches: mockAddDocumentsInBatches,
         updateDocuments: mockUpdateDocuments,
         deleteDocument: mockDeleteDocument,
@@ -2378,7 +2378,7 @@ describe('Meilisearch Mongoose plugin', () => {
           endpoint: EModelEndpoint.openAI,
           expiredAt: null,
           _meiliIndex: true,
-          _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION + 1,
+          _meiliIndexSchemaVersion: MEILI_CONVERSATION_INDEX_SCHEMA_VERSION + 1,
         },
         {
           conversationId: staleId,
@@ -2387,7 +2387,7 @@ describe('Meilisearch Mongoose plugin', () => {
           endpoint: EModelEndpoint.openAI,
           expiredAt: null,
           _meiliIndex: true,
-          _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION - 1,
+          _meiliIndexSchemaVersion: MEILI_CONVERSATION_INDEX_SCHEMA_VERSION - 1,
         },
       ]);
 
@@ -2401,14 +2401,14 @@ describe('Meilisearch Mongoose plugin', () => {
       ]);
 
       // Newer-stamped projection is left alone, not re-indexed nor downgraded.
-      expect(futureDoc?._meiliIndexSchemaVersion).toBe(MEILI_INDEX_SCHEMA_VERSION + 1);
+      expect(futureDoc?._meiliIndexSchemaVersion).toBe(MEILI_CONVERSATION_INDEX_SCHEMA_VERSION + 1);
       expect(futureDoc?._meiliIndex).toBe(true);
       expect(mockAddDocumentsInBatches).not.toHaveBeenCalledWith(
         expect.arrayContaining([expect.objectContaining({ conversationId: futureId })]),
       );
 
       // Strictly older projection is re-indexed and stamped forward to the local version.
-      expect(staleDoc?._meiliIndexSchemaVersion).toBe(MEILI_INDEX_SCHEMA_VERSION);
+      expect(staleDoc?._meiliIndexSchemaVersion).toBe(MEILI_CONVERSATION_INDEX_SCHEMA_VERSION);
       expect(staleDoc?._meiliIndex).toBe(true);
     });
 

--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -1760,11 +1760,11 @@ describe('Meilisearch Mongoose plugin', () => {
     beforeEach(() => {
       mockGetDocuments = jest.fn();
       mockDeleteDocuments.mockClear();
-      mockIndex.mockReturnValue({
-        getRawInfo: jest.fn(),
-        getSettings: mockGetSettings,
-        updateSettings: mockUpdateSettings,
-        addDocuments: mockAddDocuments,
+        mockIndex.mockReturnValue({
+          getRawInfo: jest.fn(),
+          getSettings: mockGetSettings,
+          updateSettings: mockUpdateSettings,
+          addDocuments: mockAddDocuments,
         addDocumentsInBatches: mockAddDocumentsInBatches,
         updateDocuments: mockUpdateDocuments,
         deleteDocument: mockDeleteDocument,

--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -2403,9 +2403,10 @@ describe('Meilisearch Mongoose plugin', () => {
       // Newer-stamped projection is left alone, not re-indexed nor downgraded.
       expect(futureDoc?._meiliIndexSchemaVersion).toBe(MEILI_CONVERSATION_INDEX_SCHEMA_VERSION + 1);
       expect(futureDoc?._meiliIndex).toBe(true);
-      expect(mockAddDocumentsInBatches).not.toHaveBeenCalledWith(
-        expect.arrayContaining([expect.objectContaining({ conversationId: futureId })]),
+      const reindexedIds = mockAddDocumentsInBatches.mock.calls.flatMap((call) =>
+        (call[0] as Array<Record<string, unknown>>).map((doc) => String(doc.conversationId)),
       );
+      expect(reindexedIds).not.toContain(String(futureId));
 
       // Strictly older projection is re-indexed and stamped forward to the local version.
       expect(staleDoc?._meiliIndexSchemaVersion).toBe(MEILI_CONVERSATION_INDEX_SCHEMA_VERSION);
@@ -2613,7 +2614,40 @@ describe('Meilisearch Mongoose plugin', () => {
     });
 
     test('deleteMany hook deletes documents using toMeiliConversationKey', async () => {
-      const conversationModel = mongoose.models.Conversation as SchemaWithMeiliMethods;
+      // The pre-deleteMany hook is gated on `meiliEnabled`, which this suite leaves
+      // false at plugin-module load. Re-require the plugin with SEARCH enabled so the
+      // hook actually runs, and attach it to a dedicated model.
+      const previousSearch = process.env.SEARCH;
+      process.env.SEARCH = 'true';
+      let isolatedPlugin: typeof import('~/models/plugins/mongoMeili').default | undefined;
+      jest.isolateModules(() => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        isolatedPlugin = require('~/models/plugins/mongoMeili').default;
+      });
+      process.env.SEARCH = previousSearch;
+
+      const hookSchema = new mongoose.Schema(
+        {
+          conversationId: { type: String, required: true },
+          user: { type: String },
+          title: { type: String },
+          endpoint: { type: String },
+          messages: [{ type: mongoose.Schema.Types.ObjectId }],
+        },
+        { timestamps: true },
+      );
+      hookSchema.plugin(isolatedPlugin!, {
+        mongoose,
+        host: 'foo',
+        apiKey: 'bar',
+        indexName: 'convos',
+        primaryKey: 'conversationId',
+      });
+      const hookModel = mongoose.model('ConversationHookTest', hookSchema);
+
+      const conversationModel = createConversationModel(
+        mongoose,
+      ) as unknown as SchemaWithMeiliMethods;
       await conversationModel.create({
         conversationId: 'batch|del|pipe',
         user: new mongoose.Types.ObjectId(),
@@ -2622,9 +2656,14 @@ describe('Meilisearch Mongoose plugin', () => {
       });
       mockDeleteDocument.mockClear();
 
-      await conversationModel.deleteMany({ conversationId: 'batch|del|pipe' });
+      // The hook looks the documents up through the shared Conversation model, so a
+      // deleteMany on the hook model surfaces the encoded-key deletion.
+      await hookModel.deleteMany({ conversationId: 'batch|del|pipe' });
 
       expect(mockDeleteDocument).toHaveBeenCalledWith('batch--del--pipe');
+
+      mongoose.deleteModel('ConversationHookTest');
+      await conversationModel.deleteMany({ conversationId: 'batch|del|pipe' });
     });
 
     test('normalizes search hits back to originalConversationId', async () => {

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -116,6 +116,7 @@ const explicitTemporaryFlagKey = 'meiliExplicitTemporaryFlag';
 const previouslyIndexedFlagKey = 'meiliPreviouslyIndexed';
 const meiliCleanupVersion = 1;
 const meiliRequestTimeoutMs = 10_000;
+const meiliSettingsTimeoutMs = 10 * 60_000;
 const meiliWriteMaxAttempts = 3;
 const meiliRetryBaseDelayMs = 250;
 const meiliVersionReconcileMaxAttempts = 3;
@@ -287,6 +288,7 @@ const createMeiliMongooseModel = ({
   excludeFromIndexPath,
   attributesToIndex,
   primaryKey,
+  settingsReady,
   syncOptions,
 }: {
   client: MeiliSearch;
@@ -296,6 +298,7 @@ const createMeiliMongooseModel = ({
   excludeFromIndexPath?: string;
   attributesToIndex: string[];
   primaryKey: string;
+  settingsReady: Promise<void>;
   syncOptions: { batchSize: number; delayMs: number };
 }) => {
   const syncConfig = { ...getSyncConfig(), ...syncOptions };
@@ -741,6 +744,7 @@ const createMeiliMongooseModel = ({
       params: SearchParams,
       populate: boolean,
     ): Promise<SearchResponse<MeiliIndexable, Record<string, unknown>>> {
+      await settingsReady;
       const data = await index.search(q, params);
 
       if (populate) {
@@ -1021,7 +1025,7 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
   /** Create index only if it doesn't exist */
   const index = client.index<MeiliIndexable>(indexName);
 
-  (async () => {
+  const settingsReady = (async () => {
     try {
       await index.getRawInfo();
       logger.debug(`[mongoMeili] Index ${indexName} already exists`);
@@ -1078,9 +1082,16 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
         return;
       }
 
-      await index.updateSettings({
+      const enqueued = await index.updateSettings({
         filterableAttributes,
       });
+      const task = await client.waitForTask(enqueued.taskUid, {
+        timeOutMs: meiliSettingsTimeoutMs,
+        intervalMs: 100,
+      });
+      if (task.status !== 'succeeded') {
+        throw new Error(`Meili settings task ${enqueued.taskUid} ended with ${task.status}`);
+      }
       logger.debug(
         `[mongoMeili] Updated index ${indexName} settings to make ${filterableAttributes.join(
           ' and ',
@@ -1088,8 +1099,10 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
       );
     } catch (settingsError) {
       logger.error(`[mongoMeili] Error updating index settings for ${indexName}:`, settingsError);
+      throw settingsError;
     }
   })();
+  void settingsReady.catch(() => undefined);
 
   // Collect attributes from the schema that should be indexed
   const attributesToIndex: string[] = [
@@ -1115,6 +1128,7 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
       excludeFromIndexPath: options.excludeFromIndexPath,
       attributesToIndex,
       primaryKey,
+      settingsReady,
       syncOptions,
     }),
   );

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -114,7 +114,7 @@ const hasSchemaPath = (schema: Schema, path: string): boolean =>
 /** Bump when the indexed document shape or projection changes for every index. */
 export const MEILI_INDEX_SCHEMA_VERSION = 2;
 /** Bump for conversation-only projection changes. */
-export const MEILI_CONVERSATION_INDEX_SCHEMA_VERSION = MEILI_INDEX_SCHEMA_VERSION + 1;
+export const MEILI_CONVERSATION_INDEX_SCHEMA_VERSION: number = MEILI_INDEX_SCHEMA_VERSION + 1;
 
 /**
  * Encodes a conversation ID for use as a MeiliSearch document primary key.
@@ -737,10 +737,7 @@ const createMeiliMongooseModel = ({
               : meiliIds;
 
           const existingDocs = await this.find({
-            $and: [
-              { [primaryKey]: { $in: candidateMongoIds } },
-              getIndexableQuery(),
-            ],
+            $and: [{ [primaryKey]: { $in: candidateMongoIds } }, getIndexableQuery()],
           })
             .select(primaryKey)
             .lean();

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -287,8 +287,8 @@ const createMeiliMongooseModel = ({
   getExcludedIndexedQuery,
   excludeFromIndexPath,
   attributesToIndex,
+  ensureSettingsReady,
   primaryKey,
-  settingsReady,
   syncOptions,
 }: {
   client: MeiliSearch;
@@ -297,8 +297,8 @@ const createMeiliMongooseModel = ({
   getExcludedIndexedQuery: () => FilterQuery<unknown> | null;
   excludeFromIndexPath?: string;
   attributesToIndex: string[];
+  ensureSettingsReady: () => Promise<void>;
   primaryKey: string;
-  settingsReady: Promise<void>;
   syncOptions: { batchSize: number; delayMs: number };
 }) => {
   const syncConfig = { ...getSyncConfig(), ...syncOptions };
@@ -744,7 +744,7 @@ const createMeiliMongooseModel = ({
       params: SearchParams,
       populate: boolean,
     ): Promise<SearchResponse<MeiliIndexable, Record<string, unknown>>> {
-      await settingsReady;
+      await ensureSettingsReady();
       const data = await index.search(q, params);
 
       if (populate) {
@@ -1025,7 +1025,7 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
   /** Create index only if it doesn't exist */
   const index = client.index<MeiliIndexable>(indexName);
 
-  const settingsReady = (async () => {
+  const configureIndex = async (): Promise<void> => {
     try {
       await index.getRawInfo();
       logger.debug(`[mongoMeili] Index ${indexName} already exists`);
@@ -1101,8 +1101,22 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
       logger.error(`[mongoMeili] Error updating index settings for ${indexName}:`, settingsError);
       throw settingsError;
     }
-  })();
-  void settingsReady.catch(() => undefined);
+  };
+  let settingsReady: Promise<void> | undefined;
+  const ensureSettingsReady = (): Promise<void> => {
+    if (settingsReady) {
+      return settingsReady;
+    }
+    const pending = configureIndex();
+    settingsReady = pending;
+    void pending.catch(() => {
+      if (settingsReady === pending) {
+        settingsReady = undefined;
+      }
+    });
+    return pending;
+  };
+  void ensureSettingsReady().catch(() => undefined);
 
   // Collect attributes from the schema that should be indexed
   const attributesToIndex: string[] = [
@@ -1127,8 +1141,8 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
       getExcludedIndexedQuery: () => buildExcludedIndexedQuery(options.excludeFromIndexPath),
       excludeFromIndexPath: options.excludeFromIndexPath,
       attributesToIndex,
+      ensureSettingsReady,
       primaryKey,
-      settingsReady,
       syncOptions,
     }),
   );

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -112,7 +112,7 @@ const hasSchemaPath = (schema: Schema, path: string): boolean =>
   Object.prototype.hasOwnProperty.call(schema.obj, path);
 
 /** Bump when the indexed document shape or projection changes. */
-export const MEILI_INDEX_SCHEMA_VERSION = 2;
+export const MEILI_INDEX_SCHEMA_VERSION = 3;
 
 /**
  * Encodes a conversation ID for use as a MeiliSearch document primary key.
@@ -137,17 +137,16 @@ const prepareObjectForIndex = (object: Record<string, unknown>, primaryKey: stri
   }
 };
 
-const normalizeSearchHit = (hit: MeiliIndexable, primaryKey: string): MeiliIndexable => {
+const normalizeSearchHit = (hit: MeiliIndexable, primaryKey: string): void => {
   if (primaryKey === 'conversationId') {
     const originalConversationId =
       typeof hit.originalConversationId === 'string'
         ? hit.originalConversationId
         : hit.conversationId;
     if (originalConversationId) {
-      return { ...hit, conversationId: originalConversationId };
+      hit.conversationId = originalConversationId;
     }
   }
-  return hit;
 };
 
 const explicitTemporaryFlagKey = 'meiliExplicitTemporaryFlag';
@@ -761,8 +760,11 @@ const createMeiliMongooseModel = ({
                 `Meili cleanup task ${deletion.taskUid} ended with ${deletionTask.status}`,
               );
             }
+            const documentsByMeiliId = new Map(
+              batch.results.map((doc) => [String(doc[primaryKey]), doc] as const),
+            );
             const toDeleteMongoIds = toDelete.map((id) => {
-              const matchingDoc = batch.results.find((d) => String(d[primaryKey]) === id);
+              const matchingDoc = documentsByMeiliId.get(id);
               return typeof matchingDoc?.originalConversationId === 'string'
                 ? matchingDoc.originalConversationId
                 : id;
@@ -821,7 +823,9 @@ const createMeiliMongooseModel = ({
             )
           : [];
 
-      data.hits = data.hits.map((hit) => normalizeSearchHit(hit, primaryKey));
+      for (const hit of data.hits) {
+        normalizeSearchHit(hit, primaryKey);
+      }
 
       if (populate) {
         const query: Record<string, unknown> = {};

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -110,7 +110,7 @@ const hasSchemaPath = (schema: Schema, path: string): boolean =>
   Object.prototype.hasOwnProperty.call(schema.obj, path);
 
 /** Bump when the indexed document shape or projection changes. */
-export const MEILI_INDEX_SCHEMA_VERSION = 1;
+export const MEILI_INDEX_SCHEMA_VERSION = 2;
 
 const explicitTemporaryFlagKey = 'meiliExplicitTemporaryFlag';
 const previouslyIndexedFlagKey = 'meiliPreviouslyIndexed';
@@ -1058,11 +1058,20 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
       }
     }
 
+    const filterableAttributes = ['user'];
+    if (hasSchemaPath(schema, 'tenantId')) {
+      filterableAttributes.push('tenantId');
+    }
+
     try {
       await index.updateSettings({
-        filterableAttributes: ['user'],
+        filterableAttributes,
       });
-      logger.debug(`[mongoMeili] Updated index ${indexName} settings to make 'user' filterable`);
+      logger.debug(
+        `[mongoMeili] Updated index ${indexName} settings to make ${filterableAttributes.join(
+          ' and ',
+        )} filterable`,
+      );
     } catch (settingsError) {
       logger.error(`[mongoMeili] Error updating index settings for ${indexName}:`, settingsError);
     }

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -391,8 +391,9 @@ const createMeiliMongooseModel = ({
             $set: {
               _meiliIndex: true,
               _meiliCleanupVersion: meiliCleanupVersion,
-              _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION,
             },
+            /** Monotonic: never stamp a document back to an older projection version. */
+            $max: { _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION },
           },
         );
         if (acknowledgement.matchedCount > 0) {
@@ -435,7 +436,8 @@ const createMeiliMongooseModel = ({
               { _meiliIndex: { $ne: true }, _meiliIndexAttempted: true },
               {
                 _meiliIndex: true,
-                _meiliIndexSchemaVersion: { $ne: MEILI_INDEX_SCHEMA_VERSION },
+                /** Monotonic: only strictly older projections are stale; newer ones are already current. */
+                _meiliIndexSchemaVersion: { $not: { $gte: MEILI_INDEX_SCHEMA_VERSION } },
               },
             ],
           },
@@ -448,7 +450,7 @@ const createMeiliMongooseModel = ({
             indexableQuery,
             {
               _meiliIndex: true,
-              _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION,
+              _meiliIndexSchemaVersion: { $gte: MEILI_INDEX_SCHEMA_VERSION },
             },
           ],
         }),
@@ -509,7 +511,8 @@ const createMeiliMongooseModel = ({
                 { _meiliIndex: { $ne: true } },
                 {
                   _meiliIndex: true,
-                  _meiliIndexSchemaVersion: { $ne: MEILI_INDEX_SCHEMA_VERSION },
+                  /** Monotonic: reindex only strictly older projections; never downgrade newer ones. */
+                  _meiliIndexSchemaVersion: { $not: { $gte: MEILI_INDEX_SCHEMA_VERSION } },
                 },
               ],
             },
@@ -590,8 +593,9 @@ const createMeiliMongooseModel = ({
             $set: {
               _meiliIndex: true,
               _meiliCleanupVersion: meiliCleanupVersion,
-              _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION,
             },
+            /** Monotonic: never stamp a document back to an older projection version. */
+            $max: { _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION },
           },
           { timestamps: false },
         );

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -529,38 +529,33 @@ const createMeiliMongooseModel = ({
         `[syncWithMeili] Approximate total number of all ${collectionName}: ${approxTotalCount}`,
       );
 
-      try {
-        // First, handle documents that need to be removed from Meili
-        logger.info(`[syncWithMeili] Starting cleanup of Meili index ${index.uid} before sync`);
-        await this.cleanupMeiliIndex(index, primaryKey, batchSize, delayMs);
-        logger.info(`[syncWithMeili] Completed cleanup of Meili index: ${index.uid}`);
-      } catch (error) {
-        logger.error('[syncWithMeili] Error during cleanup Meili before sync:', error);
-        throw error;
-      }
-
       let processedCount = 0;
-      let hasMore = true;
 
-      while (hasMore) {
-        const indexableQuery = getIndexableQuery();
-        const query: FilterQuery<unknown> = {
-          $and: [
-            indexableQuery,
-            {
-              $or: [
-                { _meiliIndex: { $ne: true } },
-                {
-                  _meiliIndex: true,
-                  /** Monotonic: reindex only strictly older projections; never downgrade newer ones. */
-                  _meiliIndexSchemaVersion: { $not: { $gte: indexSchemaVersion } },
-                },
-              ],
-            },
-          ],
-        };
+      try {
+        // Reindex stale-schema documents first: orphan cleanup resolves legacy
+        // documents through originalConversationId, so deleting orphans before
+        // this migration pass would drop live legacy pipe-ID conversations
+        // from search until their reindex batch restored them.
+        let hasMore = true;
 
-        try {
+        while (hasMore) {
+          const indexableQuery = getIndexableQuery();
+          const query: FilterQuery<unknown> = {
+            $and: [
+              indexableQuery,
+              {
+                $or: [
+                  { _meiliIndex: { $ne: true } },
+                  {
+                    _meiliIndex: true,
+                    /** Monotonic: reindex only strictly older projections; never downgrade newer ones. */
+                    _meiliIndexSchemaVersion: { $not: { $gte: indexSchemaVersion } },
+                  },
+                ],
+              },
+            ],
+          };
+
           const documents = await this.find(query)
             .select(attributesToIndex.join(' ') + ' _meiliIndex')
             .limit(batchSize)
@@ -585,10 +580,21 @@ const createMeiliMongooseModel = ({
           if (hasMore && delayMs > 0) {
             await new Promise((resolve) => setTimeout(resolve, delayMs));
           }
-        } catch (error) {
-          logger.error('[syncWithMeili] Error processing documents batch:', error);
-          throw error;
         }
+      } catch (error) {
+        logger.error('[syncWithMeili] Error processing documents batch:', error);
+        throw error;
+      }
+
+      try {
+        // Cleanup runs after reindexing so legacy documents carry
+        // originalConversationId before orphan detection runs.
+        logger.info(`[syncWithMeili] Starting cleanup of Meili index ${index.uid} after sync`);
+        await this.cleanupMeiliIndex(index, primaryKey, batchSize, delayMs);
+        logger.info(`[syncWithMeili] Completed cleanup of Meili index: ${index.uid}`);
+      } catch (error) {
+        logger.error('[syncWithMeili] Error during cleanup Meili after sync:', error);
+        throw error;
       }
 
       const duration = Date.now() - startTime;

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -1058,12 +1058,26 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
       }
     }
 
-    const filterableAttributes = ['user'];
+    const requiredFilterableAttributes = ['user'];
     if (hasSchemaPath(schema, 'tenantId')) {
-      filterableAttributes.push('tenantId');
+      requiredFilterableAttributes.push('tenantId');
     }
 
     try {
+      const settings = await index.getSettings();
+      const currentFilterableAttributes = settings.filterableAttributes ?? [];
+      const filterableAttributes = [
+        ...new Set([...currentFilterableAttributes, ...requiredFilterableAttributes]),
+      ];
+      const settingsUnchanged =
+        filterableAttributes.length === currentFilterableAttributes.length &&
+        filterableAttributes.every(
+          (attribute, index) => attribute === currentFilterableAttributes[index],
+        );
+      if (settingsUnchanged) {
+        return;
+      }
+
       await index.updateSettings({
         filterableAttributes,
       });

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -29,6 +29,8 @@ interface MongoMeiliOptions {
 
 interface MeiliIndexable {
   [key: string]: unknown;
+  conversationId?: string;
+  originalConversationId?: string;
   _meiliIndex?: boolean;
   _meiliIndexAttempted?: boolean;
   _meiliIndexVersion?: string;
@@ -111,6 +113,42 @@ const hasSchemaPath = (schema: Schema, path: string): boolean =>
 
 /** Bump when the indexed document shape or projection changes. */
 export const MEILI_INDEX_SCHEMA_VERSION = 2;
+
+/**
+ * Encodes a conversation ID for use as a MeiliSearch document primary key.
+ */
+export const toMeiliConversationKey = (id: unknown): string => {
+  const str = String(id);
+  return str.includes('|') ? str.replace(/\|/g, '--') : str;
+};
+
+const getMeiliPrimaryKey = (value: unknown, primaryKey: string): string => {
+  if (primaryKey === 'conversationId') {
+    return toMeiliConversationKey(value);
+  }
+  return String(value);
+};
+
+const prepareObjectForIndex = (object: Record<string, unknown>, primaryKey: string): void => {
+  if (primaryKey === 'conversationId' && object.conversationId != null) {
+    const rawId = String(object.conversationId);
+    object.originalConversationId = rawId;
+    object.conversationId = toMeiliConversationKey(rawId);
+  }
+};
+
+const normalizeSearchHit = (hit: MeiliIndexable, primaryKey: string): MeiliIndexable => {
+  if (primaryKey === 'conversationId') {
+    const originalConversationId =
+      typeof hit.originalConversationId === 'string'
+        ? hit.originalConversationId
+        : hit.conversationId;
+    if (originalConversationId) {
+      return { ...hit, conversationId: originalConversationId };
+    }
+  }
+  return hit;
+};
 
 const explicitTemporaryFlagKey = 'meiliExplicitTemporaryFlag';
 const previouslyIndexedFlagKey = 'meiliPreviouslyIndexed';
@@ -323,7 +361,7 @@ const createMeiliMongooseModel = ({
 
   const deleteDocumentAndWait = async (doc: DocumentWithMeiliIndex): Promise<void> => {
     const deletion = await index.deleteDocument(
-      String(doc[primaryKey as keyof DocumentWithMeiliIndex]),
+      getMeiliPrimaryKey(doc[primaryKey as keyof DocumentWithMeiliIndex], primaryKey),
     );
     const deletionTask = await client.waitForTask(deletion.taskUid, {
       timeOutMs: meiliRequestTimeoutMs,
@@ -569,9 +607,11 @@ const createMeiliMongooseModel = ({
       }
 
       // Format documents for MeiliSearch
-      const formattedDocs = documents.map((doc) =>
-        _.omitBy(_.pick(doc, attributesToIndex), (_v, k) => k.startsWith('$')),
-      );
+      const formattedDocs = documents.map((doc) => {
+        const object = _.omitBy(_.pick(doc, attributesToIndex), (_v, k) => k.startsWith('$'));
+        prepareObjectForIndex(object, primaryKey);
+        return object;
+      });
 
       try {
         const docsIds = documents.map((doc) => doc._id);
@@ -626,10 +666,10 @@ const createMeiliMongooseModel = ({
           break;
         }
 
-        const pendingIds = pendingExcludedDocuments.map(
-          (doc: Record<string, unknown>) => doc[primaryKey],
+        const pendingIds = pendingExcludedDocuments.map((doc: Record<string, unknown>) =>
+          getMeiliPrimaryKey(doc[primaryKey], primaryKey),
         );
-        const deletion = await index.deleteDocuments(pendingIds.map(String));
+        const deletion = await index.deleteDocuments(pendingIds);
         const deletionTask = await client.waitForTask(deletion.taskUid, {
           timeOutMs: 10000,
           intervalMs: 100,
@@ -639,8 +679,11 @@ const createMeiliMongooseModel = ({
             `Meili cleanup task ${deletion.taskUid} ended with ${deletionTask.status}`,
           );
         }
+        const pendingDocIds = pendingExcludedDocuments.map(
+          (doc: Record<string, unknown>) => doc._id,
+        );
         await this.updateMany(
-          { ...excludedIndexedQuery, [primaryKey]: { $in: pendingIds } },
+          { _id: { $in: pendingDocIds } },
           {
             $set: { _meiliCleanupVersion: meiliCleanupVersion },
             $unset: { _meiliIndex: '', _meiliIndexAttempted: '' },
@@ -680,22 +723,35 @@ const createMeiliMongooseModel = ({
             break;
           }
 
-          const meiliIds = batch.results.map((doc) => doc[primaryKey]);
-          const query: Record<string, unknown> = {};
-          query[primaryKey] = { $in: meiliIds };
+          const meiliIds = batch.results.map((doc) => String(doc[primaryKey]));
+          const candidateMongoIds =
+            primaryKey === 'conversationId'
+              ? batch.results.map((doc) =>
+                  typeof doc.originalConversationId === 'string'
+                    ? doc.originalConversationId
+                    : String(doc[primaryKey]),
+                )
+              : meiliIds;
 
-          const existingDocs = await this.find({ ...query, ...getIndexableQuery() })
+          const existingDocs = await this.find({
+            $and: [
+              { [primaryKey]: { $in: candidateMongoIds } },
+              getIndexableQuery(),
+            ],
+          })
             .select(primaryKey)
             .lean();
 
-          const existingIds = new Set(
-            existingDocs.map((doc: Record<string, unknown>) => doc[primaryKey]),
+          const existingMeiliKeys = new Set(
+            existingDocs.map((doc: Record<string, unknown>) =>
+              getMeiliPrimaryKey(doc[primaryKey], primaryKey),
+            ),
           );
 
           // Delete documents that don't exist in MongoDB
-          const toDelete = meiliIds.filter((id) => !existingIds.has(id));
+          const toDelete = meiliIds.filter((id) => !existingMeiliKeys.has(id));
           if (toDelete.length > 0) {
-            const deletion = await index.deleteDocuments(toDelete.map(String));
+            const deletion = await index.deleteDocuments(toDelete);
             const deletionTask = await client.waitForTask(deletion.taskUid, {
               timeOutMs: 10000,
               intervalMs: 100,
@@ -705,8 +761,14 @@ const createMeiliMongooseModel = ({
                 `Meili cleanup task ${deletion.taskUid} ended with ${deletionTask.status}`,
               );
             }
+            const toDeleteMongoIds = toDelete.map((id) => {
+              const matchingDoc = batch.results.find((d) => String(d[primaryKey]) === id);
+              return typeof matchingDoc?.originalConversationId === 'string'
+                ? matchingDoc.originalConversationId
+                : id;
+            });
             await this.updateMany(
-              { [primaryKey]: { $in: toDelete } },
+              { [primaryKey]: { $in: toDeleteMongoIds } },
               {
                 $set: { _meiliCleanupVersion: meiliCleanupVersion },
                 $unset: { _meiliIndex: '', _meiliIndexAttempted: '' },
@@ -750,10 +812,24 @@ const createMeiliMongooseModel = ({
     ): Promise<SearchResponse<MeiliIndexable, Record<string, unknown>>> {
       await ensureSettingsReady();
       const data = await index.search(q, params);
+      const originalConversationIds =
+        primaryKey === 'conversationId'
+          ? data.hits.map((hit) =>
+              typeof hit.originalConversationId === 'string'
+                ? hit.originalConversationId
+                : String(hit.conversationId),
+            )
+          : [];
+
+      data.hits = data.hits.map((hit) => normalizeSearchHit(hit, primaryKey));
 
       if (populate) {
         const query: Record<string, unknown> = {};
-        query[primaryKey] = _.map(data.hits, (hit) => hit[primaryKey]);
+        if (primaryKey === 'conversationId') {
+          query[primaryKey] = { $in: originalConversationIds };
+        } else {
+          query[primaryKey] = _.map(data.hits, (hit) => hit[primaryKey]);
+        }
 
         const projection = Object.keys(this.schema.obj).reduce<Record<string, number>>(
           (results, key) => {
@@ -794,13 +870,7 @@ const createMeiliMongooseModel = ({
         k.startsWith('$'),
       );
 
-      if (
-        object.conversationId &&
-        typeof object.conversationId === 'string' &&
-        object.conversationId.includes('|')
-      ) {
-        object.conversationId = object.conversationId.replace(/\|/g, '--');
-      }
+      prepareObjectForIndex(object, primaryKey);
 
       if (object.content && Array.isArray(object.content)) {
         /** Search indexes the full conversational record, steered words included. */
@@ -857,7 +927,9 @@ const createMeiliMongooseModel = ({
       next: CallbackWithoutResultAndOptionalError,
     ): Promise<void> {
       try {
-        await index.deleteDocument(String(this[primaryKey as keyof DocumentWithMeiliIndex]));
+        await index.deleteDocument(
+          getMeiliPrimaryKey(this[primaryKey as keyof DocumentWithMeiliIndex], primaryKey),
+        );
         next();
       } catch (error) {
         logger.error('[deleteObjectFromMeili] Error deleting document from Meili:', error);
@@ -1254,7 +1326,7 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
         // Process deletions in batches
         await processBatch(deletedConvos, batchSize, delayMs, async (batch) => {
           const promises = batch.map((convo: Record<string, unknown>) =>
-            convoIndex.deleteDocument(convo.conversationId as string),
+            convoIndex.deleteDocument(toMeiliConversationKey(convo.conversationId)),
           );
           await Promise.all(promises);
         });

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -129,7 +129,7 @@ const getMeiliPrimaryKey = (value: unknown, primaryKey: string): string => {
   return String(value);
 };
 
-const prepareObjectForIndex = (object: Record<string, unknown>, primaryKey: string): void => {
+const prepareObjectForIndex = (object: MeiliIndexable, primaryKey: string): void => {
   if (primaryKey === 'conversationId' && object.conversationId != null) {
     const rawId = String(object.conversationId);
     object.originalConversationId = rawId;

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -814,14 +814,14 @@ const createMeiliMongooseModel = ({
     ): Promise<SearchResponse<MeiliIndexable, Record<string, unknown>>> {
       await ensureSettingsReady();
       const data = await index.search(q, params);
-      const originalConversationIds =
-        primaryKey === 'conversationId'
-          ? data.hits.map((hit) =>
-              typeof hit.originalConversationId === 'string'
-                ? hit.originalConversationId
-                : String(hit.conversationId),
-            )
-          : [];
+      let originalConversationIds: string[] = [];
+      if (populate && primaryKey === 'conversationId') {
+        originalConversationIds = data.hits.map((hit) =>
+          typeof hit.originalConversationId === 'string'
+            ? hit.originalConversationId
+            : String(hit.conversationId),
+        );
+      }
 
       for (const hit of data.hits) {
         normalizeSearchHit(hit, primaryKey);

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -111,8 +111,10 @@ const getSyncConfig = () => ({
 const hasSchemaPath = (schema: Schema, path: string): boolean =>
   Object.prototype.hasOwnProperty.call(schema.obj, path);
 
-/** Bump when the indexed document shape or projection changes. */
-export const MEILI_INDEX_SCHEMA_VERSION = 3;
+/** Bump when the indexed document shape or projection changes for every index. */
+export const MEILI_INDEX_SCHEMA_VERSION = 2;
+/** Bump for conversation-only projection changes. */
+export const MEILI_CONVERSATION_INDEX_SCHEMA_VERSION = MEILI_INDEX_SCHEMA_VERSION + 1;
 
 /**
  * Encodes a conversation ID for use as a MeiliSearch document primary key.
@@ -325,6 +327,7 @@ const createMeiliMongooseModel = ({
   excludeFromIndexPath,
   attributesToIndex,
   ensureSettingsReady,
+  indexSchemaVersion,
   primaryKey,
   syncOptions,
 }: {
@@ -335,6 +338,7 @@ const createMeiliMongooseModel = ({
   excludeFromIndexPath?: string;
   attributesToIndex: string[];
   ensureSettingsReady: () => Promise<void>;
+  indexSchemaVersion: number;
   primaryKey: string;
   syncOptions: { batchSize: number; delayMs: number };
 }) => {
@@ -430,7 +434,7 @@ const createMeiliMongooseModel = ({
               _meiliCleanupVersion: meiliCleanupVersion,
             },
             /** Monotonic: never stamp a document back to an older projection version. */
-            $max: { _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION },
+            $max: { _meiliIndexSchemaVersion: indexSchemaVersion },
           },
         );
         if (acknowledgement.matchedCount > 0) {
@@ -474,7 +478,7 @@ const createMeiliMongooseModel = ({
               {
                 _meiliIndex: true,
                 /** Monotonic: only strictly older projections are stale; newer ones are already current. */
-                _meiliIndexSchemaVersion: { $not: { $gte: MEILI_INDEX_SCHEMA_VERSION } },
+                _meiliIndexSchemaVersion: { $not: { $gte: indexSchemaVersion } },
               },
             ],
           },
@@ -487,7 +491,7 @@ const createMeiliMongooseModel = ({
             indexableQuery,
             {
               _meiliIndex: true,
-              _meiliIndexSchemaVersion: { $gte: MEILI_INDEX_SCHEMA_VERSION },
+              _meiliIndexSchemaVersion: { $gte: indexSchemaVersion },
             },
           ],
         }),
@@ -549,7 +553,7 @@ const createMeiliMongooseModel = ({
                 {
                   _meiliIndex: true,
                   /** Monotonic: reindex only strictly older projections; never downgrade newer ones. */
-                  _meiliIndexSchemaVersion: { $not: { $gte: MEILI_INDEX_SCHEMA_VERSION } },
+                  _meiliIndexSchemaVersion: { $not: { $gte: indexSchemaVersion } },
                 },
               ],
             },
@@ -634,7 +638,7 @@ const createMeiliMongooseModel = ({
               _meiliCleanupVersion: meiliCleanupVersion,
             },
             /** Monotonic: never stamp a document back to an older projection version. */
-            $max: { _meiliIndexSchemaVersion: MEILI_INDEX_SCHEMA_VERSION },
+            $max: { _meiliIndexSchemaVersion: indexSchemaVersion },
           },
           { timestamps: false },
         );
@@ -1104,6 +1108,10 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
 
   /** Create index only if it doesn't exist */
   const index = client.index<MeiliIndexable>(indexName);
+  const indexSchemaVersion =
+    primaryKey === 'conversationId'
+      ? MEILI_CONVERSATION_INDEX_SCHEMA_VERSION
+      : MEILI_INDEX_SCHEMA_VERSION;
 
   const configureIndex = async (): Promise<void> => {
     try {
@@ -1222,6 +1230,7 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
       excludeFromIndexPath: options.excludeFromIndexPath,
       attributesToIndex,
       ensureSettingsReady,
+      indexSchemaVersion,
       primaryKey,
       syncOptions,
     }),

--- a/packages/data-schemas/src/schema/convo.ts
+++ b/packages/data-schemas/src/schema/convo.ts
@@ -350,6 +350,7 @@ const convoSchema: Schema<IConversation> = new Schema(
     tenantId: {
       type: String,
       index: true,
+      meiliIndex: true,
     },
     pinned: {
       type: Boolean,

--- a/packages/data-schemas/src/schema/message.ts
+++ b/packages/data-schemas/src/schema/message.ts
@@ -297,6 +297,7 @@ const messageSchema: Schema<IMessage> = new Schema(
     tenantId: {
       type: String,
       index: true,
+      meiliIndex: true,
     },
   },
   { timestamps: true },

--- a/packages/data-schemas/src/utils/index.ts
+++ b/packages/data-schemas/src/utils/index.ts
@@ -7,3 +7,4 @@ export * from './transactions';
 export * from './objectId';
 export * from './yaml';
 export * from './stripUIResourceMarkers';
+export * from './search';

--- a/packages/data-schemas/src/utils/search.spec.ts
+++ b/packages/data-schemas/src/utils/search.spec.ts
@@ -1,0 +1,10 @@
+import { escapeMeiliFilterValue } from './search';
+
+describe('escapeMeiliFilterValue', () => {
+  it('escapes quotes and backslashes in filter values', () => {
+    expect(escapeMeiliFilterValue('user123')).toBe('user123');
+    expect(escapeMeiliFilterValue('user"123')).toBe('user\\"123');
+    expect(escapeMeiliFilterValue('user\\123')).toBe('user\\\\123');
+    expect(escapeMeiliFilterValue('user\\"123')).toBe('user\\\\\\"123');
+  });
+});

--- a/packages/data-schemas/src/utils/search.ts
+++ b/packages/data-schemas/src/utils/search.ts
@@ -1,5 +1,5 @@
 /**
- * Escapes special characters in values used in MeiliSearch filter expressions.
+ * Escapes backslashes and double quotes in MeiliSearch string filter values.
  */
 export const escapeMeiliFilterValue = (value: string): string =>
   value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');

--- a/packages/data-schemas/src/utils/search.ts
+++ b/packages/data-schemas/src/utils/search.ts
@@ -1,0 +1,5 @@
+/**
+ * Escapes special characters in values used in MeiliSearch filter expressions.
+ */
+export const escapeMeiliFilterValue = (value: string): string =>
+  value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');


### PR DESCRIPTION
## Summary

Conversation IDs containing `|` are rewritten to `--` when indexed in MeiliSearch, but cleanup and deletion paths previously addressed the raw MongoDB ID. Batch sync also bypassed the preparation step, so the same conversation could be written under different keys depending on the sync path.

## Dependency and ordering

This PR depends on #15484, which introduced `_meiliIndexSchemaVersion` and the stale-projection reindex path. It is based on the merged `dev` branch and uses schema version `3`, following the tenant projection change in #15522; merge #15522 before this PR for monotonic schema-version progression. If this PR is merged first, #15522 must be rebased and increment its version accordingly.

## Changes

- Centralize the existing `|` to `--` conversation-key conversion.
- Apply the same key preparation to deletion, batch sync, cleanup, and search population paths.
- Retain `originalConversationId` on indexed conversation documents.
- Resolve MongoDB lookups and returned search hits through the original ID, with a legacy-document fallback.
- Bump `MEILI_INDEX_SCHEMA_VERSION` to `3` so existing indexed conversations receive the backfilled original ID.
- Add coverage for pipe-containing IDs, cleanup and deletion, search/populate normalization, and matching batch and hook sync keys.

This intentionally preserves the existing key format and does not introduce a new composite or base64url primary key format.

## Testing

Unit tests cover consistent key preparation across sync and deletion paths, cleanup retention, search-hit normalization, population, and legacy documents.