### PR TITLE
🫙 fix: Drop Blank Content Blocks From Promptless Sends

### DIFF
--- a/api/app/clients/prompts/formatAgentMessages.spec.js
+++ b/api/app/clients/prompts/formatAgentMessages.spec.js
@@ -622,4 +622,41 @@ describe('formatAgentMessages', () => {
       expect(result[0].content).toEqual(media);
     });
   });
+
+  describe('promptless sends', () => {
+    it('should drop a promptless user message that has no attachments to replay', () => {
+      const result = formatAgentMessages([
+        { role: 'user', content: '' },
+        { role: 'assistant', content: 'Hi' },
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].content).toEqual([{ type: 'text', text: 'Hi' }]);
+    });
+
+    it('should not emit a blank text block for a whitespace-only user message', () => {
+      const result = formatAgentMessages([{ role: 'user', content: '   ' }]);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should keep a promptless user message that still carries its images', () => {
+      const image_urls = [{ type: 'image_url', image_url: { url: 'data:image/png;base64,AAA' } }];
+      const result = formatAgentMessages([{ role: 'user', content: '', image_urls }]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].content).toEqual(image_urls);
+      expect(result[0].content).not.toContainEqual(
+        expect.objectContaining({ type: 'text', text: '' }),
+      );
+    });
+
+    it('should still format a user message that has text', () => {
+      const result = formatAgentMessages([{ role: 'user', content: 'hello' }]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBeInstanceOf(HumanMessage);
+      expect(result[0].content).toEqual([{ type: 'text', text: 'hello' }]);
+    });
+  });
 });

--- a/api/app/clients/prompts/formatAgentMessages.spec.js
+++ b/api/app/clients/prompts/formatAgentMessages.spec.js
@@ -624,20 +624,38 @@ describe('formatAgentMessages', () => {
   });
 
   describe('promptless sends', () => {
-    it('should drop a promptless user message that has no attachments to replay', () => {
+    const PLACEHOLDER = [{ type: 'text', text: '(no text)' }];
+
+    it('should stand in for a replayed promptless turn instead of a blank block', () => {
       const result = formatAgentMessages([
         { role: 'user', content: '' },
         { role: 'assistant', content: 'Hi' },
       ]);
 
-      expect(result).toHaveLength(1);
-      expect(result[0].content).toEqual([{ type: 'text', text: 'Hi' }]);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBeInstanceOf(HumanMessage);
+      expect(result[0].content).toEqual(PLACEHOLDER);
+      expect(result[0].content).not.toContainEqual(
+        expect.objectContaining({ type: 'text', text: '' }),
+      );
+    });
+
+    it('should keep the turn so assistant messages never become adjacent', () => {
+      const result = formatAgentMessages([
+        { role: 'assistant', content: 'first' },
+        { role: 'user', content: '' },
+        { role: 'assistant', content: 'second' },
+      ]);
+
+      expect(result).toHaveLength(3);
+      expect(result[1]).toBeInstanceOf(HumanMessage);
     });
 
     it('should not emit a blank text block for a whitespace-only user message', () => {
       const result = formatAgentMessages([{ role: 'user', content: '   ' }]);
 
-      expect(result).toHaveLength(0);
+      expect(result).toHaveLength(1);
+      expect(result[0].content).toEqual(PLACEHOLDER);
     });
 
     it('should keep a promptless user message that still carries its images', () => {

--- a/api/app/clients/prompts/formatMessages.js
+++ b/api/app/clients/prompts/formatMessages.js
@@ -163,10 +163,27 @@ const formatAgentMessages = (payload) => {
 
   for (const message of payload) {
     if (typeof message.content === 'string') {
-      message.content = [{ type: ContentTypes.TEXT, [ContentTypes.TEXT]: message.content }];
+      /** An empty string yields a blank text block, which strict providers (Bedrock,
+       *  Anthropic) reject outright for the whole request. `formatVisionMessage`
+       *  already guards this for image-bearing sends; history replay of a
+       *  promptless send reaches here with no `image_urls`, so guard it too. */
+      message.content = message.content.trim()
+        ? [{ type: ContentTypes.TEXT, [ContentTypes.TEXT]: message.content }]
+        : [];
     }
     if (message.role !== 'assistant') {
-      messages.push(formatMessage({ message, langChain: true }));
+      const formatted = formatMessage({ message, langChain: true });
+      /** A promptless send replayed from history can reduce to nothing once its
+       *  attachments are no longer resent. Providers reject both a blank text
+       *  block and an empty content array, and contentless assistant turns are
+       *  already skipped below, so drop it rather than emit an invalid message. */
+      const { content: formattedContent } = formatted;
+      const isEmpty = Array.isArray(formattedContent)
+        ? formattedContent.length === 0
+        : typeof formattedContent === 'string' && formattedContent.trim() === '';
+      if (!isEmpty) {
+        messages.push(formatted);
+      }
       continue;
     }
 

--- a/api/app/clients/prompts/formatMessages.js
+++ b/api/app/clients/prompts/formatMessages.js
@@ -8,6 +8,12 @@ const {
 } = require('@librechat/agents/langchain/messages');
 
 /**
+ * Stands in for a user turn that carries no text and whose attachments are no longer
+ * being resent, so the turn stays valid without inventing content it never had.
+ */
+const EMPTY_MESSAGE_PLACEHOLDER = '(no text)';
+
+/**
  * Formats a message to OpenAI Vision API payload format.
  *
  * @param {Object} params - The parameters for formatting.
@@ -174,16 +180,21 @@ const formatAgentMessages = (payload) => {
     if (message.role !== 'assistant') {
       const formatted = formatMessage({ message, langChain: true });
       /** A promptless send replayed from history can reduce to nothing once its
-       *  attachments are no longer resent. Providers reject both a blank text
-       *  block and an empty content array, and contentless assistant turns are
-       *  already skipped below, so drop it rather than emit an invalid message. */
+       *  attachments are no longer resent. Providers reject a blank text block and
+       *  an empty content array alike, but dropping the turn is not safe either:
+       *  nothing merges the assistant turns it would leave adjacent, and the same
+       *  providers reject consecutive assistant messages. Keep the turn, and give
+       *  it the smallest honest stand-in for the content that is no longer there. */
       const { content: formattedContent } = formatted;
       const isEmpty = Array.isArray(formattedContent)
         ? formattedContent.length === 0
         : typeof formattedContent === 'string' && formattedContent.trim() === '';
-      if (!isEmpty) {
-        messages.push(formatted);
+      if (isEmpty) {
+        formatted.content = [
+          { type: ContentTypes.TEXT, [ContentTypes.TEXT]: EMPTY_MESSAGE_PLACEHOLDER },
+        ];
       }
+      messages.push(formatted);
       continue;
     }
 


### PR DESCRIPTION
## Problem

A promptless send (attachment, no typed text) can replay from history as a **blank text
content block**, which strict providers reject for the entire request. On Bedrock:

```
ValidationException: The text field in the ContentBlock object at
messages.234.content.0 is blank. Add text to the text field, and try again.
```

The whole conversation becomes unusable — and it does not self-heal, because each retry
is persisted as a child of the offending turn, so the blank block stays in the replayed
history. Observed on a live instance: **10 consecutive failures** across 18 minutes, every
user retry ("try agian", "what do i do here?", "test") returning the identical error.

## Cause

`formatVisionMessage` was already guarded for this in #13717 ("Allow Promptless Sends When
Files Are Attached"), but only along the path where the message still carries `image_urls`.

`image_urls` is populated for the turn the file is *sent*. On every later turn that message
is plain history with no `image_urls`, so it never reaches the vision path — it falls
through to `formatAgentMessages`, where an empty string is unconditionally wrapped:

```js
if (typeof message.content === 'string') {
  message.content = [{ type: ContentTypes.TEXT, [ContentTypes.TEXT]: message.content }];
}
```

producing `[{ type: 'text', text: '' }]`. Reproduced directly against the real function:

| input | before | after |
|---|---|---|
| `content: ''`, no `image_urls` | `[{"type":"text","text":""}]` ← **blank** | dropped |
| `content: ''`, with `image_urls` | `[image_url]` | `[image_url]` (unchanged) |
| `content: 'hello'` | `[{"type":"text","text":"hello"}]` | unchanged |

This also explains why the error names a message deep in history rather than the newest
one, and why it presents as intermittent: it depends on whether that turn is inside the
replayed window with its attachments no longer resent.

Non-image attachments (`pasted-text.txt`, CSV) never populate `image_urls` at all, so they
take this path from the very first turn.

## Fix

Two guards in `formatAgentMessages`:

1. Don't wrap an empty/whitespace-only string into a text part — mirrors the existing
   `formatVisionMessage` guard.
2. Don't push a non-assistant message that formats to nothing. Emitting an empty `content`
   array is rejected by the same providers, so removing the blank block alone would only
   trade one `ValidationException` for another. Contentless *assistant* turns are already
   skipped further down, so this makes the two paths consistent.

Messages that still carry their images are untouched — the image remains the content, which
is the whole point of a promptless send.

## Tests

Four cases added under a `promptless sends` block: the dropped replay, whitespace-only
input, image-bearing sends keeping their content (and explicitly asserting no blank text
part), and a normal text message as control.

`npx jest formatMessages formatAgentMessages` → **46 passed, 1 skipped, 0 failed**
(42 before these tests). ESLint clean.
