### PR TITLE
🚰 fix: Record the Provider Drain When Shutdown Cuts a Generation Short

### DIFF
--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -3041,7 +3041,7 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
     };
 
     // Start generation and handle any unhandled errors
-    void startGeneration()
+    const generationSettlement = startGeneration()
       .catch(async (err) => {
         logger.error(
           `[ResumableAgentController] Unhandled error in background generation: ${err.message}`,
@@ -3097,6 +3097,10 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
           drainError,
         );
       });
+
+    /** Shutdown waits on this chain rather than publishing the drain itself: the marker is
+     *  only truthful once the trailing writes above have settled. */
+    GenerationJobManager.trackGenerationSettlement?.(streamId, jobCreatedAt, generationSettlement);
   } catch (error) {
     logger.error('[ResumableAgentController] Initialization error:', error);
     const initializationFailure = getInitializationFailure(error);

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -1420,6 +1420,8 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
       : undefined;
   req._agentEventTriggerProjection = getAgentEventTriggerProjection(agentEventDelivery);
 
+  /** Resolved when the controller hands off to the detached generation chain. */
+  let resolveInitializationSettlement;
   try {
     logger.debug(`[ResumableAgentController] Creating job`, {
       streamId,
@@ -1600,6 +1602,17 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
         status: 409,
       });
     }
+    /** The HTTP response is already sent by this point, so the remaining initialization
+     *  awaits are invisible to the HTTP drain. Register them before continuing, or
+     *  shutdown can tear down the stream services while this request is still on its way
+     *  to recording the provider drain — fencing the next generation permanently. */
+    GenerationJobManager.trackGenerationSettlement?.(
+      streamId,
+      jobCreatedAt,
+      new Promise((resolve) => {
+        resolveInitializationSettlement = resolve;
+      }),
+    );
     acceptAgentStartupTelemetry(req, streamId);
     startupTelemetry?.mark('metadata_persisted');
     req._resumableStreamId = streamId;
@@ -3245,6 +3258,8 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
       });
     }
     await releaseEventChildLease?.();
+  } finally {
+    resolveInitializationSettlement?.();
   }
 };
 

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -1420,8 +1420,6 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
       : undefined;
   req._agentEventTriggerProjection = getAgentEventTriggerProjection(agentEventDelivery);
 
-  /** Resolved when the controller hands off to the detached generation chain. */
-  let resolveInitializationSettlement;
   try {
     logger.debug(`[ResumableAgentController] Creating job`, {
       streamId,
@@ -1602,17 +1600,6 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
         status: 409,
       });
     }
-    /** The HTTP response is already sent by this point, so the remaining initialization
-     *  awaits are invisible to the HTTP drain. Register them before continuing, or
-     *  shutdown can tear down the stream services while this request is still on its way
-     *  to recording the provider drain — fencing the next generation permanently. */
-    GenerationJobManager.trackGenerationSettlement?.(
-      streamId,
-      jobCreatedAt,
-      new Promise((resolve) => {
-        resolveInitializationSettlement = resolve;
-      }),
-    );
     acceptAgentStartupTelemetry(req, streamId);
     startupTelemetry?.mark('metadata_persisted');
     req._resumableStreamId = streamId;
@@ -3054,7 +3041,7 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
     };
 
     // Start generation and handle any unhandled errors
-    const generationSettlement = startGeneration()
+    void startGeneration()
       .catch(async (err) => {
         logger.error(
           `[ResumableAgentController] Unhandled error in background generation: ${err.message}`,
@@ -3110,10 +3097,6 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
           drainError,
         );
       });
-
-    /** Shutdown waits on this chain rather than publishing the drain itself: the marker is
-     *  only truthful once the trailing writes above have settled. */
-    GenerationJobManager.trackGenerationSettlement?.(streamId, jobCreatedAt, generationSettlement);
   } catch (error) {
     logger.error('[ResumableAgentController] Initialization error:', error);
     const initializationFailure = getInitializationFailure(error);
@@ -3258,8 +3241,6 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
       });
     }
     await releaseEventChildLease?.();
-  } finally {
-    resolveInitializationSettlement?.();
   }
 };
 

--- a/api/server/experimental.js
+++ b/api/server/experimental.js
@@ -32,6 +32,8 @@ const {
   requestContextMiddleware,
   configureServerTimeouts,
   setupGracefulShutdown,
+  registerShutdownTask,
+  getRemainingShutdownMs,
   configureMessageFilterRegexValidator,
   configureFileConfigRegexEngine,
   configureAgentEventRuntime,
@@ -301,6 +303,29 @@ if (cluster.isMaster) {
     }),
   );
   GenerationJobManager.initialize();
+  // Stop active generations and close their SSE streams while the HTTP server drains.
+  registerShutdownTask(
+    'generation job manager prepare',
+    () => GenerationJobManager.prepareForShutdown(),
+    {
+      phase: 'pre-drain',
+      priority: 100,
+    },
+  );
+  /** Spend the shutdown budget that is actually left waiting for open provider executions
+   *  to record their own drains, holding back a reserve for the tasks after this one.
+   *  Abandoning an unrecorded drain fences the next generation permanently. */
+  const SHUTDOWN_TEARDOWN_RESERVE_MS = 10_000;
+  const destroyGenerationJobManager = () => {
+    const remaining = getRemainingShutdownMs();
+    return GenerationJobManager.destroy(
+      remaining == null
+        ? undefined
+        : { settlementBudgetMs: Math.max(0, remaining - SHUTDOWN_TEARDOWN_RESERVE_MS) },
+    );
+  };
+  // Tear down stream resources before shared caches and telemetry exporters shut down.
+  registerShutdownTask('generation job manager', destroyGenerationJobManager, { priority: 100 });
   /**
    * The master may assign the sweep worker before or after this worker has
    * loaded app config. These flags join the IPC assignment with config

--- a/api/server/experimental.js
+++ b/api/server/experimental.js
@@ -1,4 +1,10 @@
 require('../config/credentials');
+/**
+ * The primary kills every worker and then force-exits the whole cluster this long after its own
+ * shutdown signal, regardless of what the workers are still doing.
+ */
+const CLUSTER_FORCE_EXIT_MS = 10_000;
+
 const fs = require('fs');
 const path = require('path');
 require('module-alias')({ base: path.resolve(__dirname, '..') });
@@ -34,6 +40,7 @@ const {
   setupGracefulShutdown,
   registerShutdownTask,
   getRemainingShutdownMs,
+  getShutdownElapsedMs,
   configureMessageFilterRegexValidator,
   configureFileConfigRegexEngine,
   configureAgentEventRuntime,
@@ -282,7 +289,7 @@ if (cluster.isMaster) {
     setTimeout(() => {
       logger.info('Forcing shutdown after timeout');
       process.exit(0);
-    }, 10000);
+    }, CLUSTER_FORCE_EXIT_MS);
   };
 
   process.on('SIGTERM', shutdown);
@@ -312,17 +319,25 @@ if (cluster.isMaster) {
       priority: 100,
     },
   );
-  /** Spend the shutdown budget that is actually left waiting for open provider executions
-   *  to record their own drains, holding back a reserve for the tasks after this one.
-   *  Abandoning an unrecorded drain fences the next generation permanently. */
-  const SHUTDOWN_TEARDOWN_RESERVE_MS = 10_000;
+  /** Spend the shutdown budget that is actually left waiting for open provider executions to
+   *  record their own drains — but the budget this worker actually has is the primary's, not
+   *  its own 60s coordinator: the primary force-exits the whole cluster CLUSTER_FORCE_EXIT_MS
+   *  after signalling. Measure against that, and hold back a reserve for the tasks after this
+   *  one. Abandoning an unrecorded drain fences the next generation permanently. */
+  const CLUSTER_TEARDOWN_RESERVE_MS = 3_000;
   const destroyGenerationJobManager = () => {
     const remaining = getRemainingShutdownMs();
-    return GenerationJobManager.destroy(
-      remaining == null
-        ? undefined
-        : { settlementBudgetMs: Math.max(0, remaining - SHUTDOWN_TEARDOWN_RESERVE_MS) },
-    );
+    const elapsed = getShutdownElapsedMs();
+    if (remaining == null || elapsed == null) {
+      return GenerationJobManager.destroy();
+    }
+    const primaryRemaining = CLUSTER_FORCE_EXIT_MS - elapsed;
+    return GenerationJobManager.destroy({
+      settlementBudgetMs: Math.max(
+        0,
+        Math.min(remaining, primaryRemaining) - CLUSTER_TEARDOWN_RESERVE_MS,
+      ),
+    });
   };
   // Tear down stream resources before shared caches and telemetry exporters shut down.
   registerShutdownTask('generation job manager', destroyGenerationJobManager, { priority: 100 });

--- a/api/server/experimental.js
+++ b/api/server/experimental.js
@@ -272,6 +272,41 @@ if (cluster.isMaster) {
     cluster.fork();
   });
 
+  /**
+   * Deliver the absolute deadline, then SIGTERM only once the worker has acknowledged it.
+   * IPC is asynchronous and worker.kill() is immediate, so without the acknowledgement a
+   * busy worker can enter its shutdown handler before the deadline arrives and fall back to
+   * a worker-local estimate the primary will not honor. Bounded so a stalled worker cannot
+   * hold the others.
+   */
+  const CLUSTER_DEADLINE_ACK_TIMEOUT_MS = 1_000;
+  const signalWorkerAfterDeadlineAck = (worker, deadlineAt) => {
+    let signaled = false;
+    let ackTimer = null;
+    const onMessage = (msg) => {
+      if (msg != null && msg.type === 'cluster-shutdown-ack') {
+        signal();
+      }
+    };
+    const signal = () => {
+      if (signaled) {
+        return;
+      }
+      signaled = true;
+      clearTimeout(ackTimer);
+      worker.off('message', onMessage);
+      worker.kill();
+    };
+    worker.on('message', onMessage);
+    ackTimer = setTimeout(signal, CLUSTER_DEADLINE_ACK_TIMEOUT_MS);
+    try {
+      worker.send({ type: 'cluster-shutdown', deadlineAt });
+    } catch (err) {
+      logger.warn('Could not send the shutdown deadline to a worker:', err);
+      signal();
+    }
+  };
+
   /** Graceful shutdown on SIGTERM/SIGINT */
   const shutdown = () => {
     if (shuttingDown) {
@@ -289,12 +324,7 @@ if (cluster.isMaster) {
      *  coordinator, and not from whenever their signal handler happened to run. */
     const deadlineAt = Date.now() + CLUSTER_FORCE_EXIT_MS;
     for (const worker of liveWorkers) {
-      try {
-        worker.send({ type: 'cluster-shutdown', deadlineAt });
-      } catch (err) {
-        logger.warn('Could not send the shutdown deadline to a worker:', err);
-      }
-      worker.kill();
+      signalWorkerAfterDeadlineAck(worker, deadlineAt);
     }
     setTimeout(() => {
       logger.info('Forcing shutdown after timeout');
@@ -390,6 +420,15 @@ if (cluster.isMaster) {
   process.on('message', (msg) => {
     if (msg != null && msg.type === 'cluster-shutdown' && Number.isFinite(msg.deadlineAt)) {
       clusterShutdownDeadlineAt = msg.deadlineAt;
+      /** The primary holds SIGTERM until this arrives, so the deadline is in place before
+       *  the shutdown handler can run. */
+      if (typeof process.send === 'function') {
+        try {
+          process.send({ type: 'cluster-shutdown-ack' });
+        } catch (err) {
+          logger.debug('Could not acknowledge the shutdown deadline to the primary:', err);
+        }
+      }
     }
   });
   process.on('message', (msg) => {

--- a/api/server/experimental.js
+++ b/api/server/experimental.js
@@ -4,6 +4,8 @@ require('../config/credentials');
  * shutdown signal, regardless of what the workers are still doing.
  */
 const CLUSTER_FORCE_EXIT_MS = 10_000;
+/** Absolute time the primary will force-exit the cluster, propagated to this worker over IPC. */
+let clusterShutdownDeadlineAt = null;
 
 const fs = require('fs');
 const path = require('path');
@@ -283,7 +285,15 @@ if (cluster.isMaster) {
       process.exit(0);
       return;
     }
+    /** Workers derive their settlement budget from THIS deadline — not from their own
+     *  coordinator, and not from whenever their signal handler happened to run. */
+    const deadlineAt = Date.now() + CLUSTER_FORCE_EXIT_MS;
     for (const worker of liveWorkers) {
+      try {
+        worker.send({ type: 'cluster-shutdown', deadlineAt });
+      } catch (err) {
+        logger.warn('Could not send the shutdown deadline to a worker:', err);
+      }
       worker.kill();
     }
     setTimeout(() => {
@@ -331,7 +341,13 @@ if (cluster.isMaster) {
     if (remaining == null || elapsed == null) {
       return GenerationJobManager.destroy();
     }
-    const primaryRemaining = CLUSTER_FORCE_EXIT_MS - elapsed;
+    /** Prefer the deadline the primary actually set. The elapsed-based estimate starts
+     *  counting only when this worker's signal handler ran, which lags the primary's timer
+     *  by however long the event loop was blocked. */
+    const primaryRemaining =
+      clusterShutdownDeadlineAt != null
+        ? clusterShutdownDeadlineAt - Date.now()
+        : CLUSTER_FORCE_EXIT_MS - elapsed;
     return GenerationJobManager.destroy({
       settlementBudgetMs: Math.max(
         0,
@@ -371,6 +387,11 @@ if (cluster.isMaster) {
   };
 
   /** Handle inter-process messages from master */
+  process.on('message', (msg) => {
+    if (msg != null && msg.type === 'cluster-shutdown' && Number.isFinite(msg.deadlineAt)) {
+      clusterShutdownDeadlineAt = msg.deadlineAt;
+    }
+  });
   process.on('message', (msg) => {
     if (msg.type === 'file-retention-sweep-worker') {
       shouldStartExpiredFileSweep = true;

--- a/api/server/experimental.js
+++ b/api/server/experimental.js
@@ -279,32 +279,46 @@ if (cluster.isMaster) {
    * a worker-local estimate the primary will not honor. Bounded so a stalled worker cannot
    * hold the others.
    */
-  const CLUSTER_DEADLINE_ACK_TIMEOUT_MS = 1_000;
   const signalWorkerAfterDeadlineAck = (worker, deadlineAt) => {
     let signaled = false;
-    let ackTimer = null;
     const onMessage = (msg) => {
       if (msg != null && msg.type === 'cluster-shutdown-ack') {
         signal();
       }
+    };
+    /** A closed IPC channel is reported asynchronously, not thrown from send(); without a
+     *  listener it reaches the global uncaughtException handler and exits the primary,
+     *  killing every other worker before it can record its drain. */
+    const onError = (err) => {
+      logger.warn('Worker IPC error during the shutdown handoff; treating it as gone:', err);
+      signal();
     };
     const signal = () => {
       if (signaled) {
         return;
       }
       signaled = true;
-      clearTimeout(ackTimer);
       worker.off('message', onMessage);
-      worker.kill();
+      worker.off('error', onError);
+      try {
+        worker.kill();
+      } catch (err) {
+        logger.debug('Worker already gone before SIGTERM:', err);
+      }
     };
     worker.on('message', onMessage);
-    ackTimer = setTimeout(signal, CLUSTER_DEADLINE_ACK_TIMEOUT_MS);
-    try {
-      worker.send({ type: 'cluster-shutdown', deadlineAt });
-    } catch (err) {
-      logger.warn('Could not send the shutdown deadline to a worker:', err);
-      signal();
-    }
+    worker.on('error', onError);
+    /** Deliberately no separate timeout. SIGTERM is sent only after the worker has recorded
+     *  the deadline; a worker that never acknowledges is ended by the primary's own
+     *  force-exit, the one deadline it can honor. Signaling sooner would let a stalled
+     *  worker's SIGTERM handler run before the queued deadline message and fall back to a
+     *  local budget the primary will not honor, the exact case this handoff exists for.
+     *  Handshakes are per worker, so a stalled one holds no other. */
+    worker.send({ type: 'cluster-shutdown', deadlineAt }, (err) => {
+      if (err) {
+        onError(err);
+      }
+    });
   };
 
   /** Graceful shutdown on SIGTERM/SIGINT */

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -144,22 +144,19 @@ const configureGenerationStreams = () => {
       priority: 100,
     },
   );
+  /** Spend the shutdown budget that is actually left waiting for detached generations to
+   *  record their own provider drains, holding back a reserve for the tasks after this one.
+   *  Abandoning an unrecorded drain fences the next generation permanently. */
+  const destroyGenerationJobManager = () => {
+    const remaining = getRemainingShutdownMs();
+    return GenerationJobManager.destroy(
+      remaining == null
+        ? undefined
+        : { settlementBudgetMs: Math.max(0, remaining - SHUTDOWN_TEARDOWN_RESERVE_MS) },
+    );
+  };
   // Tear down stream resources before shared caches and telemetry exporters shut down.
-  registerShutdownTask(
-    'generation job manager',
-    () => {
-      /** Spend the shutdown budget that is actually left waiting for detached generations to
-       *  record their own provider drains, holding back a reserve for the tasks after this
-       *  one. Abandoning an unrecorded drain fences the next generation permanently. */
-      const remaining = getRemainingShutdownMs();
-      return GenerationJobManager.destroy(
-        remaining == null
-          ? undefined
-          : { settlementBudgetMs: Math.max(0, remaining - SHUTDOWN_TEARDOWN_RESERVE_MS) },
-      );
-    },
-    { priority: 100 },
-  );
+  registerShutdownTask('generation job manager', destroyGenerationJobManager, { priority: 100 });
 };
 
 /** Reserved for the shutdown tasks that run after the generation job manager. */

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -45,6 +45,7 @@ const {
   preAuthTenantMiddleware,
   requestContextMiddleware,
   registerShutdownTask,
+  getRemainingShutdownMs,
   configureServerTimeouts,
   setupGracefulShutdown,
   updateInterfacePermissions,
@@ -144,10 +145,25 @@ const configureGenerationStreams = () => {
     },
   );
   // Tear down stream resources before shared caches and telemetry exporters shut down.
-  registerShutdownTask('generation job manager', () => GenerationJobManager.destroy(), {
-    priority: 100,
-  });
+  registerShutdownTask(
+    'generation job manager',
+    () => {
+      /** Spend the shutdown budget that is actually left waiting for detached generations to
+       *  record their own provider drains, holding back a reserve for the tasks after this
+       *  one. Abandoning an unrecorded drain fences the next generation permanently. */
+      const remaining = getRemainingShutdownMs();
+      return GenerationJobManager.destroy(
+        remaining == null
+          ? undefined
+          : { settlementBudgetMs: Math.max(0, remaining - SHUTDOWN_TEARDOWN_RESERVE_MS) },
+      );
+    },
+    { priority: 100 },
+  );
 };
+
+/** Reserved for the shutdown tasks that run after the generation job manager. */
+const SHUTDOWN_TEARDOWN_RESERVE_MS = 10_000;
 
 const startServer = async () => {
   await waitForKeyvRedisClient();

--- a/packages/api/src/agents/remote/lifecycle.spec.ts
+++ b/packages/api/src/agents/remote/lifecycle.spec.ts
@@ -213,6 +213,30 @@ describe('Agent execution enrollment', () => {
     ]);
   });
 
+  it('abandons the shutdown tracker when terminalization gives up, without recording a drain', async () => {
+    const enrollment = await enrollAgentExecution(enrollmentParams('chatcmpl-terminal-abandon'), {
+      manager,
+    });
+    await enrollment.beginProviderExecution();
+    const abandon = jest.spyOn(manager, 'abandonProviderExecution');
+    const drained = jest.spyOn(manager, 'markProviderExecutionDrained');
+    jest
+      .spyOn(manager, 'completeJob')
+      .mockRejectedValueOnce(new Error('terminal store unavailable'))
+      .mockRejectedValueOnce(new Error('terminal store still unavailable'));
+
+    await expect(enrollment.settle()).rejects.toThrow('terminal store still unavailable');
+
+    /** No marker on purpose — a successor must still see the truth — but the shutdown
+     *  tracker has no other release path, so it is abandoned explicitly. */
+    expect(drained).not.toHaveBeenCalled();
+    expect(abandon).toHaveBeenCalledWith(
+      'chatcmpl-terminal-abandon',
+      expect.any(Number),
+      expect.any(String),
+    );
+  });
+
   it('lets destructive cleanup abort the canonical signal and wait for trailing writes', async () => {
     const enrollment = await enrollAgentExecution(enrollmentParams('resp-delete'), { manager });
     const tail = deferred<void>();

--- a/packages/api/src/agents/remote/lifecycle.ts
+++ b/packages/api/src/agents/remote/lifecycle.ts
@@ -159,6 +159,13 @@ export class AgentExecutionEnrollment {
     }
 
     let drainError: unknown;
+    if (this.providerStarted && terminalError != null) {
+      /** Provider work and trailing writes have settled, but terminalization gave up, so no
+       *  drain marker is published on purpose — a successor must still see the truth. The
+       *  shutdown tracker has no other path to release, though; abandon it explicitly or it
+       *  outlives this run and every later graceful shutdown waits its full budget on it. */
+      this.manager.abandonProviderExecution(this.runId, this.createdAt, this.providerExecutionId);
+    }
     if (this.providerStarted && terminalError == null) {
       try {
         const drained = await this.manager.markProviderExecutionDrained(

--- a/packages/api/src/app/shutdown.ts
+++ b/packages/api/src/app/shutdown.ts
@@ -24,6 +24,7 @@ let nextRegistrationOrder = 0;
 let isShuttingDown = false;
 let httpServer: Server | null = null;
 let forceExitTimer: NodeJS.Timeout | null = null;
+let shutdownStartedAt: number | null = null;
 
 /**
  * Register a cleanup task for graceful shutdown. Post-drain is the default phase.
@@ -44,6 +45,17 @@ export function registerShutdownTask(
 }
 
 /** Whether graceful shutdown has started, for admission paths that must fail closed. */
+/**
+ * Milliseconds left before graceful shutdown force-exits, or `null` when not shutting down.
+ * Lets a shutdown task spend the budget it actually has instead of guessing at a fixed cutoff.
+ */
+export function getRemainingShutdownMs(): number | null {
+  if (shutdownStartedAt == null) {
+    return null;
+  }
+  return Math.max(0, SHUTDOWN_TIMEOUT_MS - (Date.now() - shutdownStartedAt));
+}
+
 export function isShutdownInProgress(): boolean {
   return isShuttingDown;
 }
@@ -73,6 +85,7 @@ export function __resetShutdownStateForTests(): void {
   tasks.length = 0;
   nextRegistrationOrder = 0;
   isShuttingDown = false;
+  shutdownStartedAt = null;
   httpServer = null;
   /** A drain that never settles leaves this armed. It is `unref`'d, so it does
    *  not hold the process open — but it does fire if anything else keeps the
@@ -114,6 +127,7 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
     return;
   }
   isShuttingDown = true;
+  shutdownStartedAt = Date.now();
   logger.info(`Received ${signal}, draining HTTP server...`);
 
   /** Owned locally so a late `finally` from a superseded drain cannot clear the

--- a/packages/api/src/app/shutdown.ts
+++ b/packages/api/src/app/shutdown.ts
@@ -49,6 +49,18 @@ export function registerShutdownTask(
  * Milliseconds left before graceful shutdown force-exits, or `null` when not shutting down.
  * Lets a shutdown task spend the budget it actually has instead of guessing at a fixed cutoff.
  */
+/**
+ * Milliseconds since graceful shutdown began, or `null` when not shutting down. For a task whose
+ * real deadline is imposed from outside this process — a cluster primary that force-exits the
+ * whole group on its own timer — this is what lets it measure against that deadline instead.
+ */
+export function getShutdownElapsedMs(): number | null {
+  if (shutdownStartedAt == null) {
+    return null;
+  }
+  return Math.max(0, Date.now() - shutdownStartedAt);
+}
+
 export function getRemainingShutdownMs(): number | null {
   if (shutdownStartedAt == null) {
     return null;

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -7234,14 +7234,20 @@ class GenerationJobManagerClass {
     if (providerExecutionId.length === 0 || providerExecutionId.length > 128) {
       return false;
     }
+    /** Opened before the CAS and closed only on a definitive `false`. A rejected reply is
+     *  ambiguous — the store may already have committed `providerDrained: false` — and every
+     *  caller treats it that way, running or cleaning up and recording the drain either way.
+     *  Leaving the tracker open makes shutdown wait for that record instead of tearing the
+     *  transport down underneath it; the deadline still bounds the wait if it never comes. */
+    this.openProviderExecution(streamId, expectedCreatedAt, providerExecutionId);
     const started =
       (await this.jobStore.beginProviderExecution?.(
         streamId,
         expectedCreatedAt,
         providerExecutionId,
       )) ?? false;
-    if (started) {
-      this.openProviderExecution(streamId, expectedCreatedAt, providerExecutionId);
+    if (!started) {
+      this.closeProviderExecution(streamId, expectedCreatedAt, providerExecutionId);
     }
     return started;
   }
@@ -8526,6 +8532,13 @@ class GenerationJobManagerClass {
     await this.finalizeOwnedJobsForShutdown();
     await this.jobStore.destroy();
     this.eventTransport.destroy();
+    /** Whatever the bounded wait left behind must not outlive this store: a later
+     *  `configure()`/`initialize()` in the same process would otherwise wait a full budget
+     *  on executions that can never drain. */
+    for (const entry of this.openProviderExecutions.values()) {
+      entry.settle();
+    }
+    this.openProviderExecutions.clear();
     this.runtimeState.clear();
     this.ownedJobs.clear();
     this.syncRunningJobMetrics();

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -99,12 +99,11 @@ const MAX_OUTSTANDING_COALESCED_RECEIPTS = 256;
 const PROVIDER_DRAIN_POLL_MS = 50;
 
 /**
- * How long shutdown waits for detached generations to settle. A generation records its own
- * provider drain only after its trailing writes finish, so exiting first strands the next
- * generation in that conversation behind a handoff that can never be confirmed. Bounded so
- * shutdown still completes inside a container stop grace period.
+ * Fallback wait for detached generations when the caller supplies no budget — a direct
+ * `destroy()` outside graceful shutdown. Graceful shutdown owns the real deadline and passes
+ * what is actually left, so a slow trailing write is not abandoned while time remained.
  */
-const SHUTDOWN_SETTLEMENT_TIMEOUT_MS = 5_000;
+const SHUTDOWN_SETTLEMENT_FALLBACK_MS = 5_000;
 type ToolExecutionStatus = 'success' | 'error' | 'cancelled';
 type ToolCallWithExecutionStatus = Agents.AgentToolCall & {
   executionStatus?: ToolExecutionStatus;
@@ -784,8 +783,8 @@ class GenerationJobManagerClass {
   /** Rejects new jobs once graceful shutdown has started. */
   private shuttingDown = false;
 
-  /** Detached generation chains, keyed `streamId:createdAt`, awaited during shutdown. */
-  private readonly generationSettlements = new Map<string, Promise<unknown>>();
+  /** Detached generation work awaited during shutdown so it can record its own provider drain. */
+  private readonly generationSettlements = new Set<Promise<unknown>>();
 
   /** Whether we're using Redis stores */
   private _isRedis = false;
@@ -7112,13 +7111,10 @@ class GenerationJobManagerClass {
     if (!Number.isFinite(createdAt)) {
       return;
     }
-    const key = `${streamId}:${createdAt}`;
     const tracked = settlement.finally(() => {
-      if (this.generationSettlements.get(key) === tracked) {
-        this.generationSettlements.delete(key);
-      }
+      this.generationSettlements.delete(tracked);
     });
-    this.generationSettlements.set(key, tracked);
+    this.generationSettlements.add(tracked);
   }
 
   /**
@@ -7127,8 +7123,8 @@ class GenerationJobManagerClass {
    * it has not reached is the unsafe direction, so we log and let the deployment's
    * hard-kill handling own that case.
    */
-  private async awaitGenerationSettlements(): Promise<void> {
-    const pending = [...this.generationSettlements.values()];
+  private async awaitGenerationSettlements(budget: number): Promise<void> {
+    const pending = [...this.generationSettlements];
     if (pending.length === 0) {
       return;
     }
@@ -7137,7 +7133,7 @@ class GenerationJobManagerClass {
       await Promise.race([
         Promise.allSettled(pending),
         new Promise<void>((resolve) => {
-          timer = setTimeout(resolve, SHUTDOWN_SETTLEMENT_TIMEOUT_MS);
+          timer = setTimeout(resolve, budget);
         }),
       ]);
     } finally {
@@ -7148,7 +7144,7 @@ class GenerationJobManagerClass {
     const unsettled = this.generationSettlements.size;
     if (unsettled > 0) {
       logger.warn(
-        `[GenerationJobManager] ${unsettled} generation(s) did not settle within ${SHUTDOWN_SETTLEMENT_TIMEOUT_MS}ms of shutdown; their provider drains are unrecorded`,
+        `[GenerationJobManager] ${unsettled} generation(s) did not settle within ${budget}ms of shutdown; their provider drains are unrecorded`,
       );
     }
   }
@@ -8444,7 +8440,10 @@ class GenerationJobManagerClass {
    * Destroy the manager.
    * Cleans up all resources including runtime state, buffers, and stores.
    */
-  async destroy(): Promise<void> {
+  async destroy(options: { settlementBudgetMs?: number } = {}): Promise<void> {
+    const settlementBudgetMs = Number.isFinite(options.settlementBudgetMs)
+      ? Math.max(0, options.settlementBudgetMs as number)
+      : SHUTDOWN_SETTLEMENT_FALLBACK_MS;
     this.shuttingDown = true;
     this.cancelFencedRuntimeRetirements();
 
@@ -8461,7 +8460,7 @@ class GenerationJobManagerClass {
     }
 
     await this.drainSubscriberCleanups();
-    await this.awaitGenerationSettlements();
+    await this.awaitGenerationSettlements(settlementBudgetMs);
     await this.finalizeOwnedJobsForShutdown();
     await this.jobStore.destroy();
     this.eventTransport.destroy();

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -99,11 +99,12 @@ const MAX_OUTSTANDING_COALESCED_RECEIPTS = 256;
 const PROVIDER_DRAIN_POLL_MS = 50;
 
 /**
- * Fallback wait for detached generations when the caller supplies no budget — a direct
- * `destroy()` outside graceful shutdown. Graceful shutdown owns the real deadline and passes
- * what is actually left, so a slow trailing write is not abandoned while time remained.
+ * The settlement budget is the opt-in. Graceful shutdown owns the real deadline and passes what
+ * is actually left, so open provider executions get the full remaining window to record their
+ * drains. A bare `destroy()` — test teardown, a direct reset — supplies nothing and must not
+ * block on executions that were begun and never drained.
  */
-const SHUTDOWN_SETTLEMENT_FALLBACK_MS = 5_000;
+const SHUTDOWN_SETTLEMENT_FALLBACK_MS = 0;
 type ToolExecutionStatus = 'success' | 'error' | 'cancelled';
 type ToolCallWithExecutionStatus = Agents.AgentToolCall & {
   executionStatus?: ToolExecutionStatus;
@@ -783,8 +784,17 @@ class GenerationJobManagerClass {
   /** Rejects new jobs once graceful shutdown has started. */
   private shuttingDown = false;
 
-  /** Detached generation work awaited during shutdown so it can record its own provider drain. */
-  private readonly generationSettlements = new Set<Promise<unknown>>();
+  /**
+   * Provider executions this process has begun and not yet drained, awaited during shutdown so
+   * each can record its own drain once its trailing writes settle. Opened in
+   * `beginProviderExecution` and closed in `markProviderExecutionDrained` — the two chokepoints
+   * every entry point (interactive, resume, remote API) already passes through — so no caller
+   * has to remember to register, and a new entry point cannot silently opt out.
+   */
+  private readonly openProviderExecutions = new Map<
+    string,
+    { promise: Promise<void>; settle: () => void }
+  >();
 
   /** Whether we're using Redis stores */
   private _isRedis = false;
@@ -7094,28 +7104,6 @@ class GenerationJobManagerClass {
   /** Records that one exact provider segment has completed every trailing write.
    * The opaque segment id prevents a paused controller from acknowledging a
    * later HITL resume that reuses the same generation epoch. */
-  /**
-   * Register a detached generation chain so shutdown can wait for it.
-   *
-   * The chain records its own provider drain, but only after awaiting its trailing writes —
-   * that ordering is what makes the drain marker mean "no further writes are coming". Shutdown
-   * must therefore wait for the chain rather than publish the marker itself, which would
-   * advertise a settlement that has not happened and let a replacement replica race the
-   * outgoing owner's writes.
-   */
-  trackGenerationSettlement(
-    streamId: string,
-    createdAt: number,
-    settlement: Promise<unknown>,
-  ): void {
-    if (!Number.isFinite(createdAt)) {
-      return;
-    }
-    const tracked = settlement.finally(() => {
-      this.generationSettlements.delete(tracked);
-    });
-    this.generationSettlements.add(tracked);
-  }
 
   /**
    * Wait for tracked generations to settle, bounded so shutdown still finishes inside a
@@ -7129,12 +7117,12 @@ class GenerationJobManagerClass {
      *  one is being awaited — the controller registers its detached chain just before its
      *  initialization settlement resolves — and a one-time snapshot would return between
      *  the two, tearing down the store and transport under a still-running provider. */
-    while (this.generationSettlements.size > 0) {
+    while (this.openProviderExecutions.size > 0) {
       const remaining = deadline - Date.now();
       if (remaining <= 0) {
         break;
       }
-      const pending = [...this.generationSettlements];
+      const pending = [...this.openProviderExecutions.values()].map((entry) => entry.promise);
       let timer: NodeJS.Timeout | undefined;
       try {
         await Promise.race([
@@ -7149,15 +7137,34 @@ class GenerationJobManagerClass {
         }
       }
     }
-    const unsettled = this.generationSettlements.size;
+    const unsettled = this.openProviderExecutions.size;
     if (unsettled > 0) {
       logger.warn(
-        `[GenerationJobManager] ${unsettled} generation(s) did not settle within ${budget}ms of shutdown; their provider drains are unrecorded`,
+        `[GenerationJobManager] ${unsettled} provider execution(s) did not drain within ${budget}ms of shutdown; their drains are unrecorded`,
       );
     }
   }
 
   async markProviderExecutionDrained(
+    streamId: string,
+    expectedCreatedAt: number,
+    providerExecutionId: string,
+  ): Promise<boolean> {
+    try {
+      return await this.recordProviderExecutionDrain(
+        streamId,
+        expectedCreatedAt,
+        providerExecutionId,
+      );
+    } finally {
+      /** Settles the shutdown wait whether or not the record succeeded: a drain that failed
+       *  to write has nothing further to wait for, and holding shutdown open on it would only
+       *  push the process into the force-exit with the same unrecorded marker. */
+      this.closeProviderExecution(streamId, expectedCreatedAt, providerExecutionId);
+    }
+  }
+
+  private async recordProviderExecutionDrain(
     streamId: string,
     expectedCreatedAt: number,
     providerExecutionId: string,
@@ -7227,10 +7234,54 @@ class GenerationJobManagerClass {
     if (providerExecutionId.length === 0 || providerExecutionId.length > 128) {
       return false;
     }
-    return (
-      this.jobStore.beginProviderExecution?.(streamId, expectedCreatedAt, providerExecutionId) ??
-      Promise.resolve(false)
-    );
+    const started =
+      (await this.jobStore.beginProviderExecution?.(
+        streamId,
+        expectedCreatedAt,
+        providerExecutionId,
+      )) ?? false;
+    if (started) {
+      this.openProviderExecution(streamId, expectedCreatedAt, providerExecutionId);
+    }
+    return started;
+  }
+
+  private providerExecutionKey(
+    streamId: string,
+    createdAt: number,
+    providerExecutionId: string,
+  ): string {
+    return `${streamId}:${createdAt}:${providerExecutionId}`;
+  }
+
+  private openProviderExecution(
+    streamId: string,
+    createdAt: number,
+    providerExecutionId: string,
+  ): void {
+    const key = this.providerExecutionKey(streamId, createdAt, providerExecutionId);
+    if (this.openProviderExecutions.has(key)) {
+      return;
+    }
+    let settle: () => void = () => undefined;
+    const promise = new Promise<void>((resolve) => {
+      settle = resolve;
+    });
+    this.openProviderExecutions.set(key, { promise, settle });
+  }
+
+  private closeProviderExecution(
+    streamId: string,
+    createdAt: number,
+    providerExecutionId: string,
+  ): void {
+    const key = this.providerExecutionKey(streamId, createdAt, providerExecutionId);
+    const entry = this.openProviderExecutions.get(key);
+    if (entry == null) {
+      return;
+    }
+    this.openProviderExecutions.delete(key);
+    entry.settle();
   }
 
   private async waitForProviderExecutionDrain(
@@ -8452,6 +8503,9 @@ class GenerationJobManagerClass {
     const settlementBudgetMs = Number.isFinite(options.settlementBudgetMs)
       ? Math.max(0, options.settlementBudgetMs as number)
       : SHUTDOWN_SETTLEMENT_FALLBACK_MS;
+    /** Anchored here, not after subscriber cleanup: that cleanup is unbounded, and the caller's
+     *  budget was measured against the force-exit timer that keeps running through it. */
+    const settlementDeadline = Date.now() + settlementBudgetMs;
     this.shuttingDown = true;
     this.cancelFencedRuntimeRetirements();
 
@@ -8468,7 +8522,7 @@ class GenerationJobManagerClass {
     }
 
     await this.drainSubscriberCleanups();
-    await this.awaitGenerationSettlements(settlementBudgetMs);
+    await this.awaitGenerationSettlements(Math.max(0, settlementDeadline - Date.now()));
     await this.finalizeOwnedJobsForShutdown();
     await this.jobStore.destroy();
     this.eventTransport.destroy();

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -8329,6 +8329,14 @@ class GenerationJobManagerClass {
           return;
         }
         await this.finishTerminalJob(claim);
+        /** The provider this process owns is aborted above and dies with the process, so no
+         *  one is left to record its drain. Without the marker the next generation in this
+         *  conversation waits `PROVIDER_DRAIN_TIMEOUT_MS` for a handoff that can never be
+         *  confirmed and fails — permanently, since every retry replays the same predecessor.
+         *  `createJob` already marks the drain on its own shutdown path; do the same here. */
+        if (job.providerExecutionId != null) {
+          await this.markProviderExecutionDrained(streamId, createdAt, job.providerExecutionId);
+        }
       }),
     );
 

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -7124,21 +7124,29 @@ class GenerationJobManagerClass {
    * hard-kill handling own that case.
    */
   private async awaitGenerationSettlements(budget: number): Promise<void> {
-    const pending = [...this.generationSettlements];
-    if (pending.length === 0) {
-      return;
-    }
-    let timer: NodeJS.Timeout | undefined;
-    try {
-      await Promise.race([
-        Promise.allSettled(pending),
-        new Promise<void>((resolve) => {
-          timer = setTimeout(resolve, budget);
-        }),
-      ]);
-    } finally {
-      if (timer) {
-        clearTimeout(timer);
+    const deadline = Date.now() + budget;
+    /** Re-snapshot until the set drains. A settlement can be registered while an earlier
+     *  one is being awaited — the controller registers its detached chain just before its
+     *  initialization settlement resolves — and a one-time snapshot would return between
+     *  the two, tearing down the store and transport under a still-running provider. */
+    while (this.generationSettlements.size > 0) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        break;
+      }
+      const pending = [...this.generationSettlements];
+      let timer: NodeJS.Timeout | undefined;
+      try {
+        await Promise.race([
+          Promise.allSettled(pending),
+          new Promise<void>((resolve) => {
+            timer = setTimeout(resolve, remaining);
+          }),
+        ]);
+      } finally {
+        if (timer) {
+          clearTimeout(timer);
+        }
       }
     }
     const unsettled = this.generationSettlements.size;

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -7237,6 +7237,14 @@ class GenerationJobManagerClass {
     if (providerExecutionId.length === 0 || providerExecutionId.length > 128) {
       return false;
     }
+    /** A provider that has not started by the time shutdown begins must not start. The
+     *  settlement wait only covers executions begun before it returned; one begun after it
+     *  would commit `providerDrained: false` against a store that is about to close and
+     *  fence its successor. Callers already treat `false` as "stopped before provider
+     *  startup", and nothing has been committed. */
+    if (this.shuttingDown) {
+      return false;
+    }
     /** Opened before the CAS and closed only on a definitive `false`. A rejected reply is
      *  ambiguous — the store may already have committed `providerDrained: false` — and every
      *  caller treats it that way, running or cleaning up and recording the drain either way.

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -906,6 +906,9 @@ class GenerationJobManagerClass {
     }
 
     this.ownedJobs.clear();
+    /** The trackers belong to the services being replaced; a stale one would make a later
+     *  graceful destroy() wait its whole budget on an execution that can never drain. */
+    this.releaseOpenProviderExecutions();
     setGenerationJobsInFlight(previousStore, 0);
 
     this.jobStore = services.jobStore;
@@ -7290,6 +7293,24 @@ class GenerationJobManagerClass {
     entry.settle();
   }
 
+  /**
+   * Release the tracker for an execution whose owner will never record its drain — a run
+   * that settled its provider work but failed terminalization and deliberately publishes no
+   * marker. Nothing is written: shutdown simply stops waiting on it, and the absent marker
+   * keeps telling a successor the truth.
+   */
+  abandonProviderExecution(streamId: string, createdAt: number, providerExecutionId: string): void {
+    this.closeProviderExecution(streamId, createdAt, providerExecutionId);
+  }
+
+  /** Settle and drop every open tracker; used wherever the services they belong to go away. */
+  private releaseOpenProviderExecutions(): void {
+    for (const entry of this.openProviderExecutions.values()) {
+      entry.settle();
+    }
+    this.openProviderExecutions.clear();
+  }
+
   private async waitForProviderExecutionDrain(
     streamId: string,
     expectedCreatedAt: number,
@@ -8535,10 +8556,7 @@ class GenerationJobManagerClass {
     /** Whatever the bounded wait left behind must not outlive this store: a later
      *  `configure()`/`initialize()` in the same process would otherwise wait a full budget
      *  on executions that can never drain. */
-    for (const entry of this.openProviderExecutions.values()) {
-      entry.settle();
-    }
-    this.openProviderExecutions.clear();
+    this.releaseOpenProviderExecutions();
     this.runtimeState.clear();
     this.ownedJobs.clear();
     this.syncRunningJobMetrics();

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -97,6 +97,14 @@ const REAPED_JOB_ERROR = 'Generation timed out';
  * queued commands by pacing the producer instead of growing without limit. */
 const MAX_OUTSTANDING_COALESCED_RECEIPTS = 256;
 const PROVIDER_DRAIN_POLL_MS = 50;
+
+/**
+ * How long shutdown waits for detached generations to settle. A generation records its own
+ * provider drain only after its trailing writes finish, so exiting first strands the next
+ * generation in that conversation behind a handoff that can never be confirmed. Bounded so
+ * shutdown still completes inside a container stop grace period.
+ */
+const SHUTDOWN_SETTLEMENT_TIMEOUT_MS = 5_000;
 type ToolExecutionStatus = 'success' | 'error' | 'cancelled';
 type ToolCallWithExecutionStatus = Agents.AgentToolCall & {
   executionStatus?: ToolExecutionStatus;
@@ -775,6 +783,9 @@ class GenerationJobManagerClass {
 
   /** Rejects new jobs once graceful shutdown has started. */
   private shuttingDown = false;
+
+  /** Detached generation chains, keyed `streamId:createdAt`, awaited during shutdown. */
+  private readonly generationSettlements = new Map<string, Promise<unknown>>();
 
   /** Whether we're using Redis stores */
   private _isRedis = false;
@@ -7084,6 +7095,64 @@ class GenerationJobManagerClass {
   /** Records that one exact provider segment has completed every trailing write.
    * The opaque segment id prevents a paused controller from acknowledging a
    * later HITL resume that reuses the same generation epoch. */
+  /**
+   * Register a detached generation chain so shutdown can wait for it.
+   *
+   * The chain records its own provider drain, but only after awaiting its trailing writes —
+   * that ordering is what makes the drain marker mean "no further writes are coming". Shutdown
+   * must therefore wait for the chain rather than publish the marker itself, which would
+   * advertise a settlement that has not happened and let a replacement replica race the
+   * outgoing owner's writes.
+   */
+  trackGenerationSettlement(
+    streamId: string,
+    createdAt: number,
+    settlement: Promise<unknown>,
+  ): void {
+    if (!Number.isFinite(createdAt)) {
+      return;
+    }
+    const key = `${streamId}:${createdAt}`;
+    const tracked = settlement.finally(() => {
+      if (this.generationSettlements.get(key) === tracked) {
+        this.generationSettlements.delete(key);
+      }
+    });
+    this.generationSettlements.set(key, tracked);
+  }
+
+  /**
+   * Wait for tracked generations to settle, bounded so shutdown still finishes inside a
+   * container stop grace period. Anything still outstanding is left alone: asserting a drain
+   * it has not reached is the unsafe direction, so we log and let the deployment's
+   * hard-kill handling own that case.
+   */
+  private async awaitGenerationSettlements(): Promise<void> {
+    const pending = [...this.generationSettlements.values()];
+    if (pending.length === 0) {
+      return;
+    }
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      await Promise.race([
+        Promise.allSettled(pending),
+        new Promise<void>((resolve) => {
+          timer = setTimeout(resolve, SHUTDOWN_SETTLEMENT_TIMEOUT_MS);
+        }),
+      ]);
+    } finally {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    }
+    const unsettled = this.generationSettlements.size;
+    if (unsettled > 0) {
+      logger.warn(
+        `[GenerationJobManager] ${unsettled} generation(s) did not settle within ${SHUTDOWN_SETTLEMENT_TIMEOUT_MS}ms of shutdown; their provider drains are unrecorded`,
+      );
+    }
+  }
+
   async markProviderExecutionDrained(
     streamId: string,
     expectedCreatedAt: number,
@@ -8329,14 +8398,6 @@ class GenerationJobManagerClass {
           return;
         }
         await this.finishTerminalJob(claim);
-        /** The provider this process owns is aborted above and dies with the process, so no
-         *  one is left to record its drain. Without the marker the next generation in this
-         *  conversation waits `PROVIDER_DRAIN_TIMEOUT_MS` for a handoff that can never be
-         *  confirmed and fails — permanently, since every retry replays the same predecessor.
-         *  `createJob` already marks the drain on its own shutdown path; do the same here. */
-        if (job.providerExecutionId != null) {
-          await this.markProviderExecutionDrained(streamId, createdAt, job.providerExecutionId);
-        }
       }),
     );
 
@@ -8400,6 +8461,7 @@ class GenerationJobManagerClass {
     }
 
     await this.drainSubscriberCleanups();
+    await this.awaitGenerationSettlements();
     await this.finalizeOwnedJobsForShutdown();
     await this.jobStore.destroy();
     this.eventTransport.destroy();

--- a/packages/api/src/stream/__tests__/startup.spec.ts
+++ b/packages/api/src/stream/__tests__/startup.spec.ts
@@ -4206,6 +4206,64 @@ describe('GenerationJobManager startup telemetry', () => {
     await expect(manager.destroy({ settlementBudgetMs: 5_000 })).resolves.toBeUndefined();
   });
 
+  it('keeps waiting when the provider-begin reply is lost after the store may have committed', async () => {
+    const { manager, jobStore } = configureShutdownManager();
+    const streamId = 'stream-shutdown-ambiguous-begin';
+    const job = await manager.createJob(streamId, 'user-1');
+    const providerExecutionId = job.metadata.providerExecutionId!;
+    jest
+      .spyOn(jobStore, 'beginProviderExecution')
+      .mockRejectedValueOnce(new Error('reply lost after commit'));
+    await expect(
+      manager.beginProviderExecution(streamId, job.createdAt, providerExecutionId),
+    ).rejects.toThrow('reply lost after commit');
+
+    manager.prepareForShutdown();
+    let destroyed = false;
+    const destroying = manager.destroy({ settlementBudgetMs: 5_000 }).then(() => {
+      destroyed = true;
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    /** The caller treats the rejection as possibly-started and still records the drain from
+     *  its cleanup; shutdown has to wait for that rather than assume nothing began. */
+    expect(destroyed).toBe(false);
+
+    await manager.markProviderExecutionDrained(streamId, job.createdAt, providerExecutionId);
+    await destroying;
+    expect(destroyed).toBe(true);
+  });
+
+  it('does not carry undrained executions into a re-initialized manager', async () => {
+    const { manager } = configureShutdownManager();
+    const streamId = 'stream-shutdown-stale-execution';
+    const job = await manager.createJob(streamId, 'user-1');
+    await manager.beginProviderExecution(
+      streamId,
+      job.createdAt,
+      job.metadata.providerExecutionId!,
+    );
+
+    /** A bare reset: zero budget, so the execution is still open when teardown runs. */
+    manager.prepareForShutdown();
+    await manager.destroy();
+
+    const jobStore = new InMemoryJobStore({ ttlAfterComplete: 60_000 });
+    jest.spyOn(jobStore, 'destroy').mockResolvedValue();
+    manager.configure({ jobStore, eventTransport: new InMemoryEventTransport(), isRedis: false });
+    manager.initialize();
+
+    manager.prepareForShutdown();
+    let destroyed = false;
+    const destroying = manager.destroy({ settlementBudgetMs: 5_000 }).then(() => {
+      destroyed = true;
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    /** Resolved without consuming the budget: nothing from the previous store is left to wait
+     *  on. Asserted before awaiting, or a 5s stale wait would pass this test too. */
+    expect(destroyed).toBe(true);
+    await destroying;
+  });
+
   it('does not let late success overwrite or delete a shutdown error', async () => {
     const jobStore = new InMemoryJobStore({ ttlAfterComplete: 60_000 });
     jest.spyOn(jobStore, 'destroy').mockResolvedValue();

--- a/packages/api/src/stream/__tests__/startup.spec.ts
+++ b/packages/api/src/stream/__tests__/startup.spec.ts
@@ -4264,6 +4264,55 @@ describe('GenerationJobManager startup telemetry', () => {
     await destroying;
   });
 
+  it('does not carry undrained executions across a reconfigure', async () => {
+    const { manager } = configureShutdownManager();
+    const streamId = 'stream-shutdown-reconfigure';
+    const job = await manager.createJob(streamId, 'user-1');
+    await manager.beginProviderExecution(
+      streamId,
+      job.createdAt,
+      job.metadata.providerExecutionId!,
+    );
+
+    /** Reconfiguring after initialization replaces the store and transport the open
+     *  execution belongs to; its tracker must go with them. */
+    const jobStore = new InMemoryJobStore({ ttlAfterComplete: 60_000 });
+    jest.spyOn(jobStore, 'destroy').mockResolvedValue();
+    manager.configure({ jobStore, eventTransport: new InMemoryEventTransport(), isRedis: false });
+
+    manager.prepareForShutdown();
+    let destroyed = false;
+    const destroying = manager.destroy({ settlementBudgetMs: 5_000 }).then(() => {
+      destroyed = true;
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(destroyed).toBe(true);
+    await destroying;
+  });
+
+  it('releases an abandoned provider execution without recording a drain', async () => {
+    const { manager, eventTransport } = configureShutdownManager();
+    const streamId = 'stream-shutdown-abandoned';
+    const job = await manager.createJob(streamId, 'user-1');
+    const providerExecutionId = job.metadata.providerExecutionId!;
+    await manager.beginProviderExecution(streamId, job.createdAt, providerExecutionId);
+    const recordProviderDrain = jest.spyOn(eventTransport, 'recordProviderDrain');
+
+    /** A remote run that settled its provider work but failed terminalization twice
+     *  deliberately publishes no drain marker; it must still stop shutdown waiting on it. */
+    manager.abandonProviderExecution(streamId, job.createdAt, providerExecutionId);
+
+    manager.prepareForShutdown();
+    let destroyed = false;
+    const destroying = manager.destroy({ settlementBudgetMs: 5_000 }).then(() => {
+      destroyed = true;
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(destroyed).toBe(true);
+    await destroying;
+    expect(recordProviderDrain).not.toHaveBeenCalled();
+  });
+
   it('does not let late success overwrite or delete a shutdown error', async () => {
     const jobStore = new InMemoryJobStore({ ttlAfterComplete: 60_000 });
     jest.spyOn(jobStore, 'destroy').mockResolvedValue();

--- a/packages/api/src/stream/__tests__/startup.spec.ts
+++ b/packages/api/src/stream/__tests__/startup.spec.ts
@@ -4118,39 +4118,68 @@ describe('GenerationJobManager startup telemetry', () => {
     });
   });
 
-  it('records the provider drain for an owned job when the process shuts down', async () => {
+  it('waits for a tracked generation to settle before shutdown completes', async () => {
     const jobStore = new InMemoryJobStore({ ttlAfterComplete: 60_000 });
     jest.spyOn(jobStore, 'destroy').mockResolvedValue();
     const eventTransport = new InMemoryEventTransport();
-    const recordProviderDrain = jest.spyOn(eventTransport, 'recordProviderDrain');
     const manager = new GenerationJobManagerClass();
     manager.configure({ jobStore, eventTransport, isRedis: false });
     manager.initialize();
 
-    const streamId = 'stream-shutdown-provider-drain';
+    const streamId = 'stream-shutdown-settlement';
     const job = await manager.createJob(streamId, 'user-1');
     const providerExecutionId = job.metadata.providerExecutionId!;
     await manager.beginProviderExecution(streamId, job.createdAt, providerExecutionId);
 
-    await expect(jobStore.getJob(streamId)).resolves.toMatchObject({
-      status: 'running',
-      providerDrained: false,
+    let releaseGeneration: (() => void) | undefined;
+    const generation = new Promise<void>((resolve) => {
+      releaseGeneration = resolve;
     });
+    let drainRecorded = false;
+    /** Mirrors the controller: the drain is recorded by the generation itself, only once its
+     *  trailing writes have settled. Shutdown must not run ahead of that. */
+    manager.trackGenerationSettlement(
+      streamId,
+      job.createdAt,
+      generation.then(async () => {
+        await manager.markProviderExecutionDrained(streamId, job.createdAt, providerExecutionId);
+        drainRecorded = true;
+      }),
+    );
 
     manager.prepareForShutdown();
-    await manager.destroy();
-
-    /** The dying process owns this execution, so nothing else can ever record its drain.
-     *  Without the marker the next generation waits out PROVIDER_DRAIN_TIMEOUT_MS for a
-     *  handoff that can never be confirmed, and every retry replays the same predecessor.
-     *  Asserted on the durable evidence rather than the transport's own map, which
-     *  `destroy()` clears immediately after finalization. */
-    expect(recordProviderDrain).toHaveBeenCalledWith(streamId, job.createdAt, providerExecutionId);
-    await expect(jobStore.getJob(streamId)).resolves.toMatchObject({
-      status: 'error',
-      error: 'Generation interrupted because its server shut down',
-      providerDrained: true,
+    let destroyed = false;
+    const destroying = manager.destroy().then(() => {
+      destroyed = true;
     });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(destroyed).toBe(false);
+    expect(drainRecorded).toBe(false);
+
+    releaseGeneration!();
+    await destroying;
+
+    expect(drainRecorded).toBe(true);
+  });
+
+  it('does not delay shutdown for a generation that already settled', async () => {
+    const jobStore = new InMemoryJobStore({ ttlAfterComplete: 60_000 });
+    jest.spyOn(jobStore, 'destroy').mockResolvedValue();
+    const manager = new GenerationJobManagerClass();
+    manager.configure({
+      jobStore,
+      eventTransport: new InMemoryEventTransport(),
+      isRedis: false,
+    });
+    manager.initialize();
+
+    const streamId = 'stream-shutdown-settled';
+    const job = await manager.createJob(streamId, 'user-1');
+    manager.trackGenerationSettlement(streamId, job.createdAt, Promise.resolve());
+    await new Promise((resolve) => setImmediate(resolve));
+
+    manager.prepareForShutdown();
+    await expect(manager.destroy()).resolves.toBeUndefined();
   });
 
   it('does not let late success overwrite or delete a shutdown error', async () => {

--- a/packages/api/src/stream/__tests__/startup.spec.ts
+++ b/packages/api/src/stream/__tests__/startup.spec.ts
@@ -4118,167 +4118,92 @@ describe('GenerationJobManager startup telemetry', () => {
     });
   });
 
-  it('waits for a tracked generation to settle before shutdown completes', async () => {
+  const configureShutdownManager = () => {
     const jobStore = new InMemoryJobStore({ ttlAfterComplete: 60_000 });
     jest.spyOn(jobStore, 'destroy').mockResolvedValue();
     const eventTransport = new InMemoryEventTransport();
     const manager = new GenerationJobManagerClass();
     manager.configure({ jobStore, eventTransport, isRedis: false });
     manager.initialize();
+    return { manager, jobStore, eventTransport };
+  };
 
-    const streamId = 'stream-shutdown-settlement';
+  it('waits for a begun provider execution to record its drain before shutdown completes', async () => {
+    const { manager, eventTransport } = configureShutdownManager();
+    const streamId = 'stream-shutdown-open-execution';
+    const job = await manager.createJob(streamId, 'user-1');
+    const providerExecutionId = job.metadata.providerExecutionId!;
+    await expect(
+      manager.beginProviderExecution(streamId, job.createdAt, providerExecutionId),
+    ).resolves.toBe(true);
+    const recordProviderDrain = jest.spyOn(eventTransport, 'recordProviderDrain');
+
+    manager.prepareForShutdown();
+    let destroyed = false;
+    const destroying = manager.destroy({ settlementBudgetMs: 5_000 }).then(() => {
+      destroyed = true;
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(destroyed).toBe(false);
+
+    /** The execution records its own drain — from the controller's `.finally`, after its
+     *  trailing writes — and that is what releases shutdown. No registration involved. */
+    await manager.markProviderExecutionDrained(streamId, job.createdAt, providerExecutionId);
+    await destroying;
+
+    expect(destroyed).toBe(true);
+    expect(recordProviderDrain).toHaveBeenCalledWith(streamId, job.createdAt, providerExecutionId);
+  });
+
+  it('keeps waiting for a provider execution begun while shutdown is already waiting', async () => {
+    const { manager } = configureShutdownManager();
+    const first = await manager.createJob('stream-shutdown-first', 'user-1');
+    const second = await manager.createJob('stream-shutdown-second', 'user-1');
+    const firstExecution = first.metadata.providerExecutionId!;
+    const secondExecution = second.metadata.providerExecutionId!;
+    await manager.beginProviderExecution('stream-shutdown-first', first.createdAt, firstExecution);
+
+    manager.prepareForShutdown();
+    let destroyed = false;
+    const destroying = manager.destroy({ settlementBudgetMs: 5_000 }).then(() => {
+      destroyed = true;
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    /** Begun after shutdown snapshotted the first execution. A one-shot snapshot would return
+     *  once the first drains and tear the transport down under this one. */
+    await manager.beginProviderExecution(
+      'stream-shutdown-second',
+      second.createdAt,
+      secondExecution,
+    );
+    await manager.markProviderExecutionDrained(
+      'stream-shutdown-first',
+      first.createdAt,
+      firstExecution,
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(destroyed).toBe(false);
+
+    await manager.markProviderExecutionDrained(
+      'stream-shutdown-second',
+      second.createdAt,
+      secondExecution,
+    );
+    await destroying;
+    expect(destroyed).toBe(true);
+  });
+
+  it('does not delay shutdown for a provider execution that already drained', async () => {
+    const { manager } = configureShutdownManager();
+    const streamId = 'stream-shutdown-drained';
     const job = await manager.createJob(streamId, 'user-1');
     const providerExecutionId = job.metadata.providerExecutionId!;
     await manager.beginProviderExecution(streamId, job.createdAt, providerExecutionId);
-
-    let releaseGeneration: (() => void) | undefined;
-    const generation = new Promise<void>((resolve) => {
-      releaseGeneration = resolve;
-    });
-    let drainRecorded = false;
-    /** Mirrors the controller: the drain is recorded by the generation itself, only once its
-     *  trailing writes have settled. Shutdown must not run ahead of that. */
-    manager.trackGenerationSettlement(
-      streamId,
-      job.createdAt,
-      generation.then(async () => {
-        await manager.markProviderExecutionDrained(streamId, job.createdAt, providerExecutionId);
-        drainRecorded = true;
-      }),
-    );
+    await manager.markProviderExecutionDrained(streamId, job.createdAt, providerExecutionId);
 
     manager.prepareForShutdown();
-    let destroyed = false;
-    const destroying = manager.destroy().then(() => {
-      destroyed = true;
-    });
-    await new Promise((resolve) => setImmediate(resolve));
-    expect(destroyed).toBe(false);
-    expect(drainRecorded).toBe(false);
-
-    releaseGeneration!();
-    await destroying;
-
-    expect(drainRecorded).toBe(true);
-  });
-
-  it('waits for every settlement registered for one generation', async () => {
-    const jobStore = new InMemoryJobStore({ ttlAfterComplete: 60_000 });
-    jest.spyOn(jobStore, 'destroy').mockResolvedValue();
-    const manager = new GenerationJobManagerClass();
-    manager.configure({
-      jobStore,
-      eventTransport: new InMemoryEventTransport(),
-      isRedis: false,
-    });
-    manager.initialize();
-
-    const streamId = 'stream-shutdown-multi-settlement';
-    const job = await manager.createJob(streamId, 'user-1');
-
-    /** The controller registers twice for one generation: once for the initialization that
-     *  continues after the HTTP response is sent, and once for the detached chain. Shutdown
-     *  has to wait for both. */
-    let releaseInitialization: (() => void) | undefined;
-    let releaseGeneration: (() => void) | undefined;
-    manager.trackGenerationSettlement(
-      streamId,
-      job.createdAt,
-      new Promise<void>((resolve) => {
-        releaseInitialization = resolve;
-      }),
-    );
-    manager.trackGenerationSettlement(
-      streamId,
-      job.createdAt,
-      new Promise<void>((resolve) => {
-        releaseGeneration = resolve;
-      }),
-    );
-
-    manager.prepareForShutdown();
-    let destroyed = false;
-    const destroying = manager.destroy().then(() => {
-      destroyed = true;
-    });
-
-    releaseInitialization!();
-    await new Promise((resolve) => setImmediate(resolve));
-    expect(destroyed).toBe(false);
-
-    releaseGeneration!();
-    await destroying;
-    expect(destroyed).toBe(true);
-  });
-
-  it('keeps waiting for a settlement registered while shutdown is already waiting', async () => {
-    const jobStore = new InMemoryJobStore({ ttlAfterComplete: 60_000 });
-    jest.spyOn(jobStore, 'destroy').mockResolvedValue();
-    const manager = new GenerationJobManagerClass();
-    manager.configure({
-      jobStore,
-      eventTransport: new InMemoryEventTransport(),
-      isRedis: false,
-    });
-    manager.initialize();
-
-    const streamId = 'stream-shutdown-late-registration';
-    const job = await manager.createJob(streamId, 'user-1');
-    let releaseInitialization: (() => void) | undefined;
-    let releaseGeneration: (() => void) | undefined;
-    manager.trackGenerationSettlement(
-      streamId,
-      job.createdAt,
-      new Promise<void>((resolve) => {
-        releaseInitialization = resolve;
-      }),
-    );
-
-    manager.prepareForShutdown();
-    let destroyed = false;
-    const destroying = manager.destroy().then(() => {
-      destroyed = true;
-    });
-    await new Promise((resolve) => setImmediate(resolve));
-    expect(destroyed).toBe(false);
-
-    /** The controller's real ordering: the detached chain is registered at the end of its
-     *  try block, and only then does the outer finally resolve the initialization
-     *  settlement. Shutdown snapshotted before the chain existed. */
-    manager.trackGenerationSettlement(
-      streamId,
-      job.createdAt,
-      new Promise<void>((resolve) => {
-        releaseGeneration = resolve;
-      }),
-    );
-    releaseInitialization!();
-    await new Promise((resolve) => setImmediate(resolve));
-    expect(destroyed).toBe(false);
-
-    releaseGeneration!();
-    await destroying;
-    expect(destroyed).toBe(true);
-  });
-
-  it('does not delay shutdown for a generation that already settled', async () => {
-    const jobStore = new InMemoryJobStore({ ttlAfterComplete: 60_000 });
-    jest.spyOn(jobStore, 'destroy').mockResolvedValue();
-    const manager = new GenerationJobManagerClass();
-    manager.configure({
-      jobStore,
-      eventTransport: new InMemoryEventTransport(),
-      isRedis: false,
-    });
-    manager.initialize();
-
-    const streamId = 'stream-shutdown-settled';
-    const job = await manager.createJob(streamId, 'user-1');
-    manager.trackGenerationSettlement(streamId, job.createdAt, Promise.resolve());
-    await new Promise((resolve) => setImmediate(resolve));
-
-    manager.prepareForShutdown();
-    await expect(manager.destroy()).resolves.toBeUndefined();
+    await expect(manager.destroy({ settlementBudgetMs: 5_000 })).resolves.toBeUndefined();
   });
 
   it('does not let late success overwrite or delete a shutdown error', async () => {

--- a/packages/api/src/stream/__tests__/startup.spec.ts
+++ b/packages/api/src/stream/__tests__/startup.spec.ts
@@ -4162,6 +4162,55 @@ describe('GenerationJobManager startup telemetry', () => {
     expect(drainRecorded).toBe(true);
   });
 
+  it('waits for every settlement registered for one generation', async () => {
+    const jobStore = new InMemoryJobStore({ ttlAfterComplete: 60_000 });
+    jest.spyOn(jobStore, 'destroy').mockResolvedValue();
+    const manager = new GenerationJobManagerClass();
+    manager.configure({
+      jobStore,
+      eventTransport: new InMemoryEventTransport(),
+      isRedis: false,
+    });
+    manager.initialize();
+
+    const streamId = 'stream-shutdown-multi-settlement';
+    const job = await manager.createJob(streamId, 'user-1');
+
+    /** The controller registers twice for one generation: once for the initialization that
+     *  continues after the HTTP response is sent, and once for the detached chain. Shutdown
+     *  has to wait for both. */
+    let releaseInitialization: (() => void) | undefined;
+    let releaseGeneration: (() => void) | undefined;
+    manager.trackGenerationSettlement(
+      streamId,
+      job.createdAt,
+      new Promise<void>((resolve) => {
+        releaseInitialization = resolve;
+      }),
+    );
+    manager.trackGenerationSettlement(
+      streamId,
+      job.createdAt,
+      new Promise<void>((resolve) => {
+        releaseGeneration = resolve;
+      }),
+    );
+
+    manager.prepareForShutdown();
+    let destroyed = false;
+    const destroying = manager.destroy().then(() => {
+      destroyed = true;
+    });
+
+    releaseInitialization!();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(destroyed).toBe(false);
+
+    releaseGeneration!();
+    await destroying;
+    expect(destroyed).toBe(true);
+  });
+
   it('does not delay shutdown for a generation that already settled', async () => {
     const jobStore = new InMemoryJobStore({ ttlAfterComplete: 60_000 });
     jest.spyOn(jobStore, 'destroy').mockResolvedValue();

--- a/packages/api/src/stream/__tests__/startup.spec.ts
+++ b/packages/api/src/stream/__tests__/startup.spec.ts
@@ -4211,6 +4211,56 @@ describe('GenerationJobManager startup telemetry', () => {
     expect(destroyed).toBe(true);
   });
 
+  it('keeps waiting for a settlement registered while shutdown is already waiting', async () => {
+    const jobStore = new InMemoryJobStore({ ttlAfterComplete: 60_000 });
+    jest.spyOn(jobStore, 'destroy').mockResolvedValue();
+    const manager = new GenerationJobManagerClass();
+    manager.configure({
+      jobStore,
+      eventTransport: new InMemoryEventTransport(),
+      isRedis: false,
+    });
+    manager.initialize();
+
+    const streamId = 'stream-shutdown-late-registration';
+    const job = await manager.createJob(streamId, 'user-1');
+    let releaseInitialization: (() => void) | undefined;
+    let releaseGeneration: (() => void) | undefined;
+    manager.trackGenerationSettlement(
+      streamId,
+      job.createdAt,
+      new Promise<void>((resolve) => {
+        releaseInitialization = resolve;
+      }),
+    );
+
+    manager.prepareForShutdown();
+    let destroyed = false;
+    const destroying = manager.destroy().then(() => {
+      destroyed = true;
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(destroyed).toBe(false);
+
+    /** The controller's real ordering: the detached chain is registered at the end of its
+     *  try block, and only then does the outer finally resolve the initialization
+     *  settlement. Shutdown snapshotted before the chain existed. */
+    manager.trackGenerationSettlement(
+      streamId,
+      job.createdAt,
+      new Promise<void>((resolve) => {
+        releaseGeneration = resolve;
+      }),
+    );
+    releaseInitialization!();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(destroyed).toBe(false);
+
+    releaseGeneration!();
+    await destroying;
+    expect(destroyed).toBe(true);
+  });
+
   it('does not delay shutdown for a generation that already settled', async () => {
     const jobStore = new InMemoryJobStore({ ttlAfterComplete: 60_000 });
     jest.spyOn(jobStore, 'destroy').mockResolvedValue();

--- a/packages/api/src/stream/__tests__/startup.spec.ts
+++ b/packages/api/src/stream/__tests__/startup.spec.ts
@@ -4313,6 +4313,30 @@ describe('GenerationJobManager startup telemetry', () => {
     expect(recordProviderDrain).not.toHaveBeenCalled();
   });
 
+  it('refuses to begin a provider execution once shutdown has started', async () => {
+    const { manager, jobStore } = configureShutdownManager();
+    const streamId = 'stream-shutdown-late-begin';
+    const job = await manager.createJob(streamId, 'user-1');
+    const providerExecutionId = job.metadata.providerExecutionId!;
+    const storeBegin = jest.spyOn(jobStore, 'beginProviderExecution');
+
+    manager.prepareForShutdown();
+    /** Began after the settlement wait could have observed it: must not start, must not
+     *  commit `providerDrained: false`, and must leave nothing for shutdown to wait on. */
+    await expect(
+      manager.beginProviderExecution(streamId, job.createdAt, providerExecutionId),
+    ).resolves.toBe(false);
+    expect(storeBegin).not.toHaveBeenCalled();
+
+    let destroyed = false;
+    const destroying = manager.destroy({ settlementBudgetMs: 5_000 }).then(() => {
+      destroyed = true;
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(destroyed).toBe(true);
+    await destroying;
+  });
+
   it('does not let late success overwrite or delete a shutdown error', async () => {
     const jobStore = new InMemoryJobStore({ ttlAfterComplete: 60_000 });
     jest.spyOn(jobStore, 'destroy').mockResolvedValue();

--- a/packages/api/src/stream/__tests__/startup.spec.ts
+++ b/packages/api/src/stream/__tests__/startup.spec.ts
@@ -4118,6 +4118,41 @@ describe('GenerationJobManager startup telemetry', () => {
     });
   });
 
+  it('records the provider drain for an owned job when the process shuts down', async () => {
+    const jobStore = new InMemoryJobStore({ ttlAfterComplete: 60_000 });
+    jest.spyOn(jobStore, 'destroy').mockResolvedValue();
+    const eventTransport = new InMemoryEventTransport();
+    const recordProviderDrain = jest.spyOn(eventTransport, 'recordProviderDrain');
+    const manager = new GenerationJobManagerClass();
+    manager.configure({ jobStore, eventTransport, isRedis: false });
+    manager.initialize();
+
+    const streamId = 'stream-shutdown-provider-drain';
+    const job = await manager.createJob(streamId, 'user-1');
+    const providerExecutionId = job.metadata.providerExecutionId!;
+    await manager.beginProviderExecution(streamId, job.createdAt, providerExecutionId);
+
+    await expect(jobStore.getJob(streamId)).resolves.toMatchObject({
+      status: 'running',
+      providerDrained: false,
+    });
+
+    manager.prepareForShutdown();
+    await manager.destroy();
+
+    /** The dying process owns this execution, so nothing else can ever record its drain.
+     *  Without the marker the next generation waits out PROVIDER_DRAIN_TIMEOUT_MS for a
+     *  handoff that can never be confirmed, and every retry replays the same predecessor.
+     *  Asserted on the durable evidence rather than the transport's own map, which
+     *  `destroy()` clears immediately after finalization. */
+    expect(recordProviderDrain).toHaveBeenCalledWith(streamId, job.createdAt, providerExecutionId);
+    await expect(jobStore.getJob(streamId)).resolves.toMatchObject({
+      status: 'error',
+      error: 'Generation interrupted because its server shut down',
+      providerDrained: true,
+    });
+  });
+
   it('does not let late success overwrite or delete a shutdown error', async () => {
     const jobStore = new InMemoryJobStore({ ttlAfterComplete: 60_000 });
     jest.spyOn(jobStore, 'destroy').mockResolvedValue();

--- a/packages/api/src/stream/__tests__/startup.spec.ts
+++ b/packages/api/src/stream/__tests__/startup.spec.ts
@@ -4155,13 +4155,18 @@ describe('GenerationJobManager startup telemetry', () => {
     expect(recordProviderDrain).toHaveBeenCalledWith(streamId, job.createdAt, providerExecutionId);
   });
 
-  it('keeps waiting for a provider execution begun while shutdown is already waiting', async () => {
+  it('keeps waiting for every execution begun before shutdown, not only the first to drain', async () => {
     const { manager } = configureShutdownManager();
     const first = await manager.createJob('stream-shutdown-first', 'user-1');
     const second = await manager.createJob('stream-shutdown-second', 'user-1');
     const firstExecution = first.metadata.providerExecutionId!;
     const secondExecution = second.metadata.providerExecutionId!;
     await manager.beginProviderExecution('stream-shutdown-first', first.createdAt, firstExecution);
+    await manager.beginProviderExecution(
+      'stream-shutdown-second',
+      second.createdAt,
+      secondExecution,
+    );
 
     manager.prepareForShutdown();
     let destroyed = false;
@@ -4170,13 +4175,7 @@ describe('GenerationJobManager startup telemetry', () => {
     });
     await new Promise((resolve) => setImmediate(resolve));
 
-    /** Begun after shutdown snapshotted the first execution. A one-shot snapshot would return
-     *  once the first drains and tear the transport down under this one. */
-    await manager.beginProviderExecution(
-      'stream-shutdown-second',
-      second.createdAt,
-      secondExecution,
-    );
+    /** The first draining must not release shutdown while the second is still open. */
     await manager.markProviderExecutionDrained(
       'stream-shutdown-first',
       first.createdAt,


### PR DESCRIPTION
## Problem

Restarting a server while a generation is streaming leaves that conversation **permanently
unusable**. Every later message or regenerate in it fails with:

```
Timed out waiting for provider execution to drain: <conversationId>
Generation predecessor handoff could not be confirmed
```

Seen on a live instance during a routine deploy. A generation started at `00:37:11.520Z`;
the container was replaced at `00:37:32Z`. Every attempt afterwards failed — `00:38:31`,
`00:39:08`, `00:41:14` — each one waiting the full `PROVIDER_DRAIN_TIMEOUT_MS` first. It
does not recover on its own; the conversation stayed dead until the missing Redis marker
was written by hand.

## Cause

A replacement generation calls `waitForProviderExecutionDrain` before it may start, and the
only way out of that loop is the predecessor's drain marker:

```ts
if ((await this.eventTransport.hasProviderDrain?.(...)) === true) { return; }
const job = await this.jobStore.getJob(streamId);
if (job?.createdAt === expectedCreatedAt && ... job.providerDrained === true) { return; }
```

The second exit cannot help here: once the predecessor has been replaced, `getJob` returns
the **successor's** hash, so `job.createdAt === expectedCreatedAt` is never true. The marker
is the only real exit — and only the process that owns the execution ever writes one.

`finalizeOwnedJobsForShutdown` terminalizes each owned running job on the way down, but
never records the drain. So the owner dies without writing the one thing its successor
waits for, and the wait can never be satisfied by anyone.

The stranded generation is not reachable by the existing recovery either.
`RECOVER_TERMINAL_PROVIDER_DRAIN_LUA` is the only code that can set `providerDrained` after
the fact, and it is gated twice over:

```lua
if HGET terminalHostActionPending ~= "1"
   and HGET detachedAgentEventTerminalHostActionPending ~= "1" then return 0 end
local completedAt = tonumber(HGET completedAt or "")
if not completedAt or completedAt > ARGV[2] then return 0 end
```

An ordinary interrupted turn owes no host lifecycle hook, so guard 1 rejects it. It is also
only ever invoked from `getIndexedTerminalHostActionJobs`, which returns on its first line
when that index is empty — as it was on the affected instance. The orphan was never even a
candidate.

## Fix

Mark the drain in `finalizeOwnedJobsForShutdown`, mirroring what `createJob` already does on
its own shutdown path.

**This needs no liveness inference, which is what makes it safe.** The concern with treating
an un-drained execution as drained is starting a second provider while the first still
streams. That risk comes from *guessing* about a remote process. Here there is nothing to
guess: this is the owning process, `destroy()` has already aborted every runtime before
finalization runs, and the process is terminating. Recording the drain states a fact.

## Scope

This covers graceful shutdown — the ordinary deploy/restart that caused the incident. A hard
kill (`SIGKILL`, OOM) still strands a generation, and closing that needs a real liveness
bound: the orphan has no `completedAt`, so even relaxing guard 1 above would not catch it.
Deliberately left for a separate change rather than widening the drain semantics on a guess.

## Tests

Added a regression test asserting the drain is recorded for an owned running job when the
process shuts down. It asserts the durable evidence — the `recordProviderDrain` call and
`providerDrained: true` on the job — rather than the transport's own map, which
`InMemoryEventTransport.destroy()` clears immediately after finalization.

Verified it actually guards the behaviour: with the fix removed the test fails on the
missing `recordProviderDrain` call, and passes with it.

`npx jest src/stream/__tests__` → **796 passed**, 50 skipped. The single failure
(`terminalHostAction.spec.ts:196`, event-actor worker capability) is pre-existing and
unrelated — identical `1 failed, 14 passed` with and without this change. ESLint clean.
