### PR TITLE
Fix/api subagents dev

### DIFF
--- a/api/server/controllers/agents/__tests__/openai.spec.js
+++ b/api/server/controllers/agents/__tests__/openai.spec.js
@@ -304,6 +304,7 @@ jest.mock('@librechat/api', () => ({
     userMCPAuthMap: undefined,
   }),
   resolveSubagentGraphs: jest.fn().mockResolvedValue(undefined),
+  resolveSubagents: jest.fn().mockResolvedValue(undefined),
   executeAgentRun: async ({
     envelope,
     runId,
@@ -626,6 +627,59 @@ describe('OpenAIChatCompletionController', () => {
     const { createRun } = require('@librechat/api');
     expect(createRun).toHaveBeenCalledWith(
       expect.objectContaining({ initialSessions: mockInitialSessions }),
+    );
+    expect(createSubagentUsageSink).toHaveBeenCalledWith(expect.any(Array));
+  });
+
+  it('resolves explicit agent_ids subagents for remote chat-completion runs', async () => {
+    const { initializeAgent, resolveSubagents, createSubagentUsageSink } = require('@librechat/api');
+    const primaryConfig = {
+      id: 'agent-123',
+      model: 'gpt-4',
+      endpointTokenConfig: { 'gpt-4': { prompt: 1 } },
+      model_parameters: {},
+      toolRegistry: {},
+      edges: [],
+      subagents: {
+        enabled: true,
+        agent_ids: ['agent-child'],
+      },
+    };
+    initializeAgent.mockResolvedValueOnce(primaryConfig);
+    const childTokenConfig = { 'custom-model': { prompt: 7 } };
+    const childConfig = {
+      id: 'agent-child',
+      endpointTokenConfig: childTokenConfig,
+      agentContextAttachments: [{ file_id: 'child-file' }],
+    };
+    resolveSubagents.mockImplementationOnce(async ({ primaryConfig: config }, deps) => {
+      config.subagentAgentConfigs = [childConfig];
+      deps.onAgentInitialized(childConfig.id, { id: childConfig.id }, childConfig);
+    });
+    req.config.endpoints.agents.capabilities = ['subagents'];
+
+    await OpenAIChatCompletionController(req, res);
+
+    expect(resolveSubagents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        primaryConfig,
+        subagentsCapabilityEnabled: true,
+        resourceType: ResourceType.REMOTE_AGENT,
+        memoryAvailable: true,
+      }),
+      expect.objectContaining({ getAgent: expect.any(Function) }),
+    );
+    const usageParams = mockRecordCollectedUsage.mock.calls[0][1];
+    expect(usageParams.resolveEndpointTokenConfig({ agentId: 'agent-child' })).toBe(childTokenConfig);
+    expect(mockBuildAgentContextAttachmentsByAgentId).toHaveBeenCalledWith([
+      primaryConfig,
+      childConfig,
+    ]);
+    expect(mockBuildAgentScopedContext).toHaveBeenCalledWith(
+      expect.objectContaining({ agentIds: ['agent-123', 'agent-child'] }),
+    );
+    expect(mockApplyContextToAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ agent: childConfig, agentId: 'agent-child' }),
     );
     expect(createSubagentUsageSink).toHaveBeenCalledWith(expect.any(Array));
   });

--- a/api/server/controllers/agents/__tests__/responses.unit.spec.js
+++ b/api/server/controllers/agents/__tests__/responses.unit.spec.js
@@ -266,6 +266,7 @@ jest.mock('@librechat/api', () => ({
     };
   }),
   resolveSubagentGraphs: jest.fn().mockResolvedValue(undefined),
+  resolveSubagents: jest.fn().mockResolvedValue(undefined),
   getBalanceConfig: mockGetBalanceConfig,
   getTransactionsConfig: mockGetTransactionsConfig,
   recordCollectedUsage: mockRecordCollectedUsage,
@@ -707,6 +708,63 @@ describe('createResponse controller', () => {
     const { createRun } = require('@librechat/api');
     expect(createRun).toHaveBeenCalledWith(
       expect.objectContaining({ initialSessions: mockInitialSessions }),
+    );
+  });
+
+  it('resolves explicit agent_ids subagents for remote Responses API runs', async () => {
+    const { initializeAgent, resolveSubagents } = require('@librechat/api');
+    const primaryConfig = {
+      id: 'agent-123',
+      model: 'claude-3',
+      endpointTokenConfig: { 'claude-3': { prompt: 1 } },
+      model_parameters: {},
+      toolRegistry: {},
+      edges: [],
+      agentContextAttachments: [],
+      subagents: {
+        enabled: true,
+        agent_ids: ['agent-child'],
+      },
+    };
+    initializeAgent.mockResolvedValueOnce(primaryConfig);
+    const childConfig = {
+      id: 'agent-child',
+      endpointTokenConfig: { 'custom-model': { prompt: 7 } },
+      agentContextAttachments: [{ file_id: 'child-file' }],
+    };
+    resolveSubagents.mockImplementationOnce(async ({ primaryConfig: config }, deps) => {
+      config.subagentAgentConfigs = [childConfig];
+      deps.onAgentInitialized(childConfig.id, childConfig, childConfig);
+    });
+    req.config.endpoints.agents.capabilities = ['subagents'];
+
+    await createResponse(req, res);
+
+    expect(resolveSubagents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        primaryConfig,
+        subagentsCapabilityEnabled: true,
+        resourceType: ResourceType.REMOTE_AGENT,
+        memoryAvailable: true,
+      }),
+      expect.objectContaining({ getAgent: expect.any(Function) }),
+    );
+    expect(mockBuildAgentContextAttachmentsByAgentId).toHaveBeenCalledWith([
+      primaryConfig,
+      childConfig,
+    ]);
+    expect(mockBuildAgentScopedContext).toHaveBeenCalledWith(
+      expect.objectContaining({ agentIds: ['agent-123', 'agent-child'] }),
+    );
+    expect(mockApplyContextToAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ agent: childConfig, agentId: 'agent-child' }),
+    );
+    expect(mockBuildInlineMemoryContext).toHaveBeenCalledWith(
+      expect.objectContaining({ agent: childConfig, memoryAvailable: true }),
+    );
+    const usageParams = mockRecordCollectedUsage.mock.calls[0][1];
+    expect(usageParams.resolveEndpointTokenConfig({ agentId: childConfig.id })).toBe(
+      childConfig.endpointTokenConfig,
     );
   });
 

--- a/api/server/controllers/agents/openai.js
+++ b/api/server/controllers/agents/openai.js
@@ -44,6 +44,7 @@ const {
   contentFilterBlockResponse,
   contentFilterUninspectableResponse,
   discoverConnectedAgents,
+  resolveSubagents,
   resolveSubagentGraphs,
   getBlockedOpaqueFileField,
   getContentTraversalFragments,
@@ -595,94 +596,117 @@ const executeOpenAIChatCompletion = async (envelope, { req, res }) => {
       let handoffAgentConfigs = new Map();
       let discoveredEdges = [];
       let discoveredMCPAuthMap;
+      let discoveredSkippedIds;
       const subagentsCapabilityEnabled = enabledCapabilities.has(AgentCapabilities.subagents);
       const primaryHasGraphSubagents =
         subagentsCapabilityEnabled &&
         primaryConfig.subagents?.enabled === true &&
         (primaryConfig.subagents.graphs?.length ?? 0) > 0;
-      if (primaryConfig.edges?.length || primaryHasGraphSubagents) {
-        const modelsConfig = await getModelsConfig(req);
-        const discoveryParams = {
-          req,
-          res,
-          primaryConfig,
-          endpointOption,
-          allowedProviders,
-          modelsConfig,
-          loadTools,
-          requestFiles: [],
-          conversationId,
-          parentMessageId,
-          requestBody: mcpRequestBody,
-          resourceType: ResourceType.REMOTE_AGENT,
-          computeAccessibleSkillIds: (handoffAgent) =>
-            resolveAgentScopedSkillIds({
+      const primaryHasExplicitSubagents =
+        subagentsCapabilityEnabled &&
+        primaryConfig.subagents?.enabled === true &&
+        (primaryConfig.subagents.agent_ids?.length ?? 0) > 0;
+      const needsHandoffDiscovery = Boolean(primaryConfig.edges?.length);
+      const needsModelsConfig =
+        needsHandoffDiscovery || primaryHasGraphSubagents || primaryHasExplicitSubagents;
+      const modelsConfig = needsModelsConfig ? await getModelsConfig(req) : {};
+      const discoveryParams = {
+        req,
+        res,
+        primaryConfig,
+        endpointOption,
+        allowedProviders,
+        modelsConfig,
+        loadTools,
+        requestFiles: [],
+        conversationId,
+        parentMessageId,
+        requestBody: mcpRequestBody,
+        resourceType: ResourceType.REMOTE_AGENT,
+        computeAccessibleSkillIds: (handoffAgent) =>
+          resolveAgentScopedSkillIds({
+            agent: handoffAgent,
+            accessibleSkillIds,
+            skillsCapabilityEnabled,
+            ephemeralSkillsToggle,
+          }),
+        computeSkillAuthoringAvailable: (handoffAgent) =>
+          canAuthorSkillFiles({
+            agent: handoffAgent,
+            scopedEditableSkillIds: resolveAgentScopedSkillIds({
               agent: handoffAgent,
-              accessibleSkillIds,
+              accessibleSkillIds: editableSkillIds,
               skillsCapabilityEnabled,
               ephemeralSkillsToggle,
             }),
-          computeSkillAuthoringAvailable: (handoffAgent) =>
-            canAuthorSkillFiles({
-              agent: handoffAgent,
-              scopedEditableSkillIds: resolveAgentScopedSkillIds({
-                agent: handoffAgent,
-                accessibleSkillIds: editableSkillIds,
-                skillsCapabilityEnabled,
-                ephemeralSkillsToggle,
-              }),
-              skillCreateAllowed,
-              skillsCapabilityEnabled,
-              ephemeralSkillsToggle,
-            }),
-          skillStates,
-          defaultActiveOnShare,
-          codeEnvAvailable: enabledCapabilities.has(AgentCapabilities.execute_code),
-          backgroundToolsAvailable: enabledCapabilities.has(AgentCapabilities.run_in_background),
-          toolIntentsAvailable: enabledCapabilities.has(AgentCapabilities.tool_intents),
-          statefulSessionsAvailable: enabledCapabilities.has(
-            AgentCapabilities.stateful_code_sessions,
-          ),
-          allowedStatefulCodeEnvironments: agentsEConfig?.statefulCodeSessions?.allowedEnvironments,
-          memoryAvailable,
-        };
-        const discoveryDeps = {
-          getAgent: db.getAgent,
-          checkPermission: async ({ userId, role, resourceId, requiredPermission }) => {
-            const permissions = await getRemoteAgentPermissions(
-              { getEffectivePermissions },
-              userId,
-              role,
-              resourceId,
-            );
-            return hasPermissions(permissions, requiredPermission);
-          },
-          logViolation,
-          db: dbMethods,
-          onAgentInitialized: (loadedAgentId, loadedAgent, config) => {
-            agentToolContexts.set(
-              loadedAgentId,
-              buildAgentToolContext({ agent: loadedAgent, config }),
-            );
-          },
-          initializeAgent,
-        };
-        if (primaryConfig.edges?.length) {
-          ({
-            agentConfigs: handoffAgentConfigs,
-            edges: discoveredEdges,
-            userMCPAuthMap: discoveredMCPAuthMap,
-          } = await discoverConnectedAgents(discoveryParams, discoveryDeps));
-        }
-        if (subagentsCapabilityEnabled) {
-          discoveredMCPAuthMap = await resolveSubagentGraphs(
-            {
-              ...discoveryParams,
-              rootConfigs: [primaryConfig, ...handoffAgentConfigs.values()],
-            },
-            discoveryDeps,
+            skillCreateAllowed,
+            skillsCapabilityEnabled,
+            ephemeralSkillsToggle,
+          }),
+        skillStates,
+        defaultActiveOnShare,
+        codeEnvAvailable: enabledCapabilities.has(AgentCapabilities.execute_code),
+        backgroundToolsAvailable: enabledCapabilities.has(AgentCapabilities.run_in_background),
+        toolIntentsAvailable: enabledCapabilities.has(AgentCapabilities.tool_intents),
+        statefulSessionsAvailable: enabledCapabilities.has(
+          AgentCapabilities.stateful_code_sessions,
+        ),
+        allowedStatefulCodeEnvironments: agentsEConfig?.statefulCodeSessions?.allowedEnvironments,
+        memoryAvailable,
+      };
+      const discoveryDeps = {
+        getAgent: db.getAgent,
+        checkPermission: async ({ userId, role, resourceId, requiredPermission }) => {
+          const permissions = await getRemoteAgentPermissions(
+            { getEffectivePermissions },
+            userId,
+            role,
+            resourceId,
           );
-        }
+          return hasPermissions(permissions, requiredPermission);
+        },
+        logViolation,
+        db: dbMethods,
+        onAgentInitialized: (loadedAgentId, loadedAgent, config) => {
+          agentToolContexts.set(
+            loadedAgentId,
+            buildAgentToolContext({ agent: loadedAgent, config }),
+          );
+        },
+        initializeAgent,
+      };
+      if (needsHandoffDiscovery) {
+        ({
+          agentConfigs: handoffAgentConfigs,
+          edges: discoveredEdges,
+          userMCPAuthMap: discoveredMCPAuthMap,
+          skippedAgentIds: discoveredSkippedIds,
+        } = await discoverConnectedAgents(discoveryParams, discoveryDeps));
+      }
+      if (subagentsCapabilityEnabled && (needsHandoffDiscovery || primaryHasGraphSubagents)) {
+        discoveredMCPAuthMap = await resolveSubagentGraphs(
+          {
+            ...discoveryParams,
+            rootConfigs: [primaryConfig, ...handoffAgentConfigs.values()],
+          },
+          discoveryDeps,
+        );
+      }
+      const explicitSubagentMCPAuthMap = await resolveSubagents(
+        {
+          ...discoveryParams,
+          agentConfigs: handoffAgentConfigs,
+          edges: discoveredEdges,
+          subagentsCapabilityEnabled,
+          skippedAgentIds: discoveredSkippedIds,
+        },
+        discoveryDeps,
+      );
+      if (explicitSubagentMCPAuthMap) {
+        discoveredMCPAuthMap = {
+          ...discoveredMCPAuthMap,
+          ...explicitSubagentMCPAuthMap,
+        };
       }
 
       primaryConfig.edges = discoveredEdges;

--- a/api/server/controllers/agents/openai.js
+++ b/api/server/controllers/agents/openai.js
@@ -1044,14 +1044,7 @@ const executeOpenAIChatCompletion = async (envelope, { req, res }) => {
       // the primary and any discovered handoff sub-agents)
       const userMCPAuthMap = discoveredMCPAuthMap ?? primaryConfig.userMCPAuthMap;
 
-      const contextAgentsById = new Map(runAgents.map((runAgent) => [runAgent.id, runAgent]));
-      for (const runAgent of runAgents) {
-        for (const graph of runAgent.subagentGraphConfigs ?? []) {
-          for (const memberConfig of graph.memberConfigs) {
-            contextAgentsById.set(memberConfig.id, memberConfig);
-          }
-        }
-      }
+      const contextAgentsById = new Map(modelBoundAgentsById);
       const contextAgents = [...contextAgentsById.values()];
       const agentScopedContext = await buildAgentScopedContext({
         agentIds: contextAgents.map(({ id }) => id),

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -31,6 +31,7 @@ const {
   createSubagentUsageSink,
   getTransactionsConfig,
   resolveAgentTokenConfig,
+  resolveSubagents,
   resolveSubagentGraphs,
   inspectContent,
   extractAgentContent,
@@ -839,94 +840,117 @@ const executeResponse = async (envelope, { req, res }) => {
       let handoffAgentConfigs = new Map();
       let discoveredEdges = [];
       let discoveredMCPAuthMap;
+      let discoveredSkippedIds;
       const subagentsCapabilityEnabled = enabledCapabilities.has(AgentCapabilities.subagents);
       const primaryHasGraphSubagents =
         subagentsCapabilityEnabled &&
         primaryConfig.subagents?.enabled === true &&
         (primaryConfig.subagents.graphs?.length ?? 0) > 0;
-      if (primaryConfig.edges?.length || primaryHasGraphSubagents) {
-        const modelsConfig = await getModelsConfig(req);
-        const discoveryParams = {
-          req,
-          res,
-          primaryConfig,
-          endpointOption,
-          allowedProviders,
-          modelsConfig,
-          loadTools,
-          requestFiles: [],
-          conversationId,
-          parentMessageId,
-          requestBody: mcpRequestBody,
-          resourceType: ResourceType.REMOTE_AGENT,
-          computeAccessibleSkillIds: (handoffAgent) =>
-            resolveAgentScopedSkillIds({
+      const primaryHasExplicitSubagents =
+        subagentsCapabilityEnabled &&
+        primaryConfig.subagents?.enabled === true &&
+        (primaryConfig.subagents.agent_ids?.length ?? 0) > 0;
+      const needsHandoffDiscovery = Boolean(primaryConfig.edges?.length);
+      const needsModelsConfig =
+        needsHandoffDiscovery || primaryHasGraphSubagents || primaryHasExplicitSubagents;
+      const modelsConfig = needsModelsConfig ? await getModelsConfig(req) : {};
+      const discoveryParams = {
+        req,
+        res,
+        primaryConfig,
+        endpointOption,
+        allowedProviders,
+        modelsConfig,
+        loadTools,
+        requestFiles: [],
+        conversationId,
+        parentMessageId,
+        requestBody: mcpRequestBody,
+        resourceType: ResourceType.REMOTE_AGENT,
+        computeAccessibleSkillIds: (handoffAgent) =>
+          resolveAgentScopedSkillIds({
+            agent: handoffAgent,
+            accessibleSkillIds,
+            skillsCapabilityEnabled,
+            ephemeralSkillsToggle,
+          }),
+        computeSkillAuthoringAvailable: (handoffAgent) =>
+          canAuthorSkillFiles({
+            agent: handoffAgent,
+            scopedEditableSkillIds: resolveAgentScopedSkillIds({
               agent: handoffAgent,
-              accessibleSkillIds,
+              accessibleSkillIds: editableSkillIds,
               skillsCapabilityEnabled,
               ephemeralSkillsToggle,
             }),
-          computeSkillAuthoringAvailable: (handoffAgent) =>
-            canAuthorSkillFiles({
-              agent: handoffAgent,
-              scopedEditableSkillIds: resolveAgentScopedSkillIds({
-                agent: handoffAgent,
-                accessibleSkillIds: editableSkillIds,
-                skillsCapabilityEnabled,
-                ephemeralSkillsToggle,
-              }),
-              skillCreateAllowed,
-              skillsCapabilityEnabled,
-              ephemeralSkillsToggle,
-            }),
-          skillStates,
-          defaultActiveOnShare,
-          codeEnvAvailable: enabledCapabilities.has(AgentCapabilities.execute_code),
-          backgroundToolsAvailable: enabledCapabilities.has(AgentCapabilities.run_in_background),
-          toolIntentsAvailable: enabledCapabilities.has(AgentCapabilities.tool_intents),
-          statefulSessionsAvailable: enabledCapabilities.has(
-            AgentCapabilities.stateful_code_sessions,
-          ),
-          allowedStatefulCodeEnvironments: agentsEConfig?.statefulCodeSessions?.allowedEnvironments,
-          memoryAvailable,
-        };
-        const discoveryDeps = {
-          getAgent: db.getAgent,
-          checkPermission: async ({ userId, role, resourceId, requiredPermission }) => {
-            const permissions = await getRemoteAgentPermissions(
-              { getEffectivePermissions },
-              userId,
-              role,
-              resourceId,
-            );
-            return hasPermissions(permissions, requiredPermission);
-          },
-          logViolation,
-          db: dbMethods,
-          onAgentInitialized: (loadedAgentId, loadedAgent, config) => {
-            agentToolContexts.set(
-              loadedAgentId,
-              buildAgentToolContext({ agent: loadedAgent, config }),
-            );
-          },
-          initializeAgent,
-        };
-        if (primaryConfig.edges?.length) {
-          ({
-            agentConfigs: handoffAgentConfigs,
-            edges: discoveredEdges,
-            userMCPAuthMap: discoveredMCPAuthMap,
-          } = await discoverConnectedAgents(discoveryParams, discoveryDeps));
-        }
-        if (subagentsCapabilityEnabled) {
-          discoveredMCPAuthMap = await resolveSubagentGraphs(
-            {
-              ...discoveryParams,
-              rootConfigs: [primaryConfig, ...handoffAgentConfigs.values()],
-            },
-            discoveryDeps,
+            skillCreateAllowed,
+            skillsCapabilityEnabled,
+            ephemeralSkillsToggle,
+          }),
+        skillStates,
+        defaultActiveOnShare,
+        codeEnvAvailable: enabledCapabilities.has(AgentCapabilities.execute_code),
+        backgroundToolsAvailable: enabledCapabilities.has(AgentCapabilities.run_in_background),
+        toolIntentsAvailable: enabledCapabilities.has(AgentCapabilities.tool_intents),
+        statefulSessionsAvailable: enabledCapabilities.has(
+          AgentCapabilities.stateful_code_sessions,
+        ),
+        allowedStatefulCodeEnvironments: agentsEConfig?.statefulCodeSessions?.allowedEnvironments,
+        memoryAvailable,
+      };
+      const discoveryDeps = {
+        getAgent: db.getAgent,
+        checkPermission: async ({ userId, role, resourceId, requiredPermission }) => {
+          const permissions = await getRemoteAgentPermissions(
+            { getEffectivePermissions },
+            userId,
+            role,
+            resourceId,
           );
-        }
+          return hasPermissions(permissions, requiredPermission);
+        },
+        logViolation,
+        db: dbMethods,
+        onAgentInitialized: (loadedAgentId, loadedAgent, config) => {
+          agentToolContexts.set(
+            loadedAgentId,
+            buildAgentToolContext({ agent: loadedAgent, config }),
+          );
+        },
+        initializeAgent,
+      };
+      if (needsHandoffDiscovery) {
+        ({
+          agentConfigs: handoffAgentConfigs,
+          edges: discoveredEdges,
+          userMCPAuthMap: discoveredMCPAuthMap,
+          skippedAgentIds: discoveredSkippedIds,
+        } = await discoverConnectedAgents(discoveryParams, discoveryDeps));
+      }
+      if (subagentsCapabilityEnabled && (needsHandoffDiscovery || primaryHasGraphSubagents)) {
+        discoveredMCPAuthMap = await resolveSubagentGraphs(
+          {
+            ...discoveryParams,
+            rootConfigs: [primaryConfig, ...handoffAgentConfigs.values()],
+          },
+          discoveryDeps,
+        );
+      }
+      const explicitSubagentMCPAuthMap = await resolveSubagents(
+        {
+          ...discoveryParams,
+          agentConfigs: handoffAgentConfigs,
+          edges: discoveredEdges,
+          subagentsCapabilityEnabled,
+          skippedAgentIds: discoveredSkippedIds,
+        },
+        discoveryDeps,
+      );
+      if (explicitSubagentMCPAuthMap) {
+        discoveredMCPAuthMap = {
+          ...discoveredMCPAuthMap,
+          ...explicitSubagentMCPAuthMap,
+        };
       }
 
       primaryConfig.edges = discoveredEdges;

--- a/packages/api/src/agents/discovery.spec.ts
+++ b/packages/api/src/agents/discovery.spec.ts
@@ -1,4 +1,11 @@
-import { ErrorTypes, EModelEndpoint, MAX_SUBAGENT_GRAPH_NODES } from 'librechat-data-provider';
+import {
+  ErrorTypes,
+  ResourceType,
+  EModelEndpoint,
+  PermissionBits,
+  MAX_SUBAGENT_DEPTH,
+  MAX_SUBAGENT_GRAPH_NODES,
+} from 'librechat-data-provider';
 import type { Agent, GraphEdge } from 'librechat-data-provider';
 import type { Response } from 'express';
 import type { GraphSubagentHostConfig } from './discovery';
@@ -24,7 +31,7 @@ jest.mock('./validation', () => ({
   validateAgentModel: (...args: unknown[]) => mockValidateAgentModel(...args),
 }));
 
-import { discoverConnectedAgents, resolveSubagentGraphs } from './discovery';
+import { discoverConnectedAgents, resolveSubagentGraphs, resolveSubagents } from './discovery';
 
 const makeReq = (userId = 'u1', role = 'USER'): ServerRequest =>
   ({
@@ -1489,5 +1496,239 @@ describe('resolveSubagentGraphs', () => {
 
     expect(getAgent).toHaveBeenCalledTimes(firstMemberIds.length);
     expect(primaryConfig.subagentGraphConfigs).toEqual([]);
+  });
+});
+
+describe('resolveSubagents', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockValidateAgentModel.mockResolvedValue({ isValid: true });
+    mockInitializeAgent.mockImplementation(async ({ agent }: { agent: Agent }) =>
+      makeConfig(agent.id),
+    );
+  });
+
+  it('loads explicit subagents onto the primary and prunes pure subagents from agentConfigs', async () => {
+    const primaryConfig = makeConfig('A');
+    primaryConfig.subagents = { enabled: true, allowSelf: false, agent_ids: ['B'] };
+    const agentConfigs = new Map<string, InitializedAgent>();
+    mockInitializeAgent.mockImplementationOnce(async ({ agent }: { agent: Agent }) => ({
+      ...makeConfig(agent.id),
+      userMCPAuthMap: { subagent: { token: 'subagent-token' } },
+    }));
+    const onAgentInitialized = jest.fn();
+
+    const userMCPAuthMap = await resolveSubagents(
+      {
+        req: makeReq(),
+        res: makeRes(),
+        primaryConfig,
+        agentConfigs,
+        edges: [],
+        subagentsCapabilityEnabled: true,
+        allowedProviders: new Set(),
+        modelsConfig: { openai: ['gpt-4o'] },
+        loadTools: jest.fn(),
+      },
+      {
+        getAgent: jest.fn(async ({ id }: { id: string }) => makeAgent(id)),
+        checkPermission: jest.fn().mockResolvedValue(true),
+        logViolation: jest.fn(),
+        db: {} as never,
+        onAgentInitialized,
+      },
+    );
+
+    expect(primaryConfig.subagentAgentConfigs).toHaveLength(1);
+    expect(primaryConfig.subagentAgentConfigs?.[0].id).toBe('B');
+    expect(agentConfigs.has('B')).toBe(false);
+    expect(onAgentInitialized).toHaveBeenCalledWith('B', expect.anything(), expect.anything());
+    expect(userMCPAuthMap).toEqual({ subagent: { token: 'subagent-token' } });
+  });
+
+  it('keeps handoff targets that are also subagents in agentConfigs', async () => {
+    const sharedConfig = makeConfig('B');
+    const primaryConfig = makeConfig('A');
+    primaryConfig.subagents = { enabled: true, allowSelf: false, agent_ids: ['B'] };
+    const agentConfigs = new Map<string, InitializedAgent>([['B', sharedConfig]]);
+    const edges: GraphEdge[] = [{ from: 'A', to: 'B', edgeType: 'direct' }];
+
+    await resolveSubagents(
+      {
+        req: makeReq(),
+        res: makeRes(),
+        primaryConfig,
+        agentConfigs,
+        edges,
+        subagentsCapabilityEnabled: true,
+        allowedProviders: new Set(),
+        modelsConfig: { openai: ['gpt-4o'] },
+        loadTools: jest.fn(),
+      },
+      {
+        getAgent: jest.fn(),
+        checkPermission: jest.fn(),
+        logViolation: jest.fn(),
+        db: {} as never,
+      },
+    );
+
+    expect(primaryConfig.subagentAgentConfigs).toEqual([sharedConfig]);
+    expect(agentConfigs.has('B')).toBe(true);
+    expect(mockInitializeAgent).not.toHaveBeenCalled();
+  });
+
+  it('clears subagents when the capability is disabled', async () => {
+    const primaryConfig = makeConfig('A');
+    primaryConfig.subagents = { enabled: true, allowSelf: true, agent_ids: [] };
+    primaryConfig.subagentAgentConfigs = [makeConfig('B')];
+    const handoffConfig = makeConfig('C');
+    handoffConfig.subagents = { enabled: true, agent_ids: ['B'] };
+    const agentConfigs = new Map<string, InitializedAgent>([['C', handoffConfig]]);
+    const getAgent = jest.fn();
+
+    await resolveSubagents(
+      {
+        req: makeReq(),
+        res: makeRes(),
+        primaryConfig,
+        agentConfigs,
+        edges: [],
+        subagentsCapabilityEnabled: false,
+        allowedProviders: new Set(),
+        modelsConfig: {},
+        loadTools: jest.fn(),
+      },
+      {
+        getAgent,
+        checkPermission: jest.fn(),
+        logViolation: jest.fn(),
+        db: {} as never,
+      },
+    );
+
+    expect(primaryConfig.subagents).toBeUndefined();
+    expect(primaryConfig.subagentAgentConfigs).toEqual([]);
+    expect(handoffConfig.subagents).toBeUndefined();
+    expect(handoffConfig.subagentAgentConfigs).toBeUndefined();
+    expect(getAgent).not.toHaveBeenCalled();
+  });
+
+  it('rejects graphs deeper than MAX_SUBAGENT_DEPTH', async () => {
+    const ids = Array.from({ length: MAX_SUBAGENT_DEPTH + 1 }, (_, index) => `agent_depth_${index}`);
+    const nestedById = new Map(
+      ids.map((id, index) => {
+        const config = makeConfig(id);
+        if (index < ids.length - 1) {
+          config.subagents = { enabled: true, allowSelf: false, agent_ids: [ids[index + 1]] };
+        }
+        return [id, config];
+      }),
+    );
+    const primaryConfig = makeConfig('A');
+    primaryConfig.subagents = { enabled: true, allowSelf: false, agent_ids: [ids[0]] };
+    mockInitializeAgent.mockImplementation(async ({ agent }: { agent: Agent }) =>
+      nestedById.get(agent.id),
+    );
+
+    await expect(
+      resolveSubagents(
+        {
+          req: makeReq(),
+          res: makeRes(),
+          primaryConfig,
+          agentConfigs: new Map(),
+          edges: [],
+          subagentsCapabilityEnabled: true,
+          allowedProviders: new Set(),
+          modelsConfig: { openai: ['gpt-4o'] },
+          loadTools: jest.fn(),
+        },
+        {
+          getAgent: jest.fn(async ({ id }: { id: string }) => makeAgent(id)),
+          checkPermission: jest.fn().mockResolvedValue(true),
+          logViolation: jest.fn(),
+          db: {} as never,
+        },
+      ),
+    ).rejects.toThrow(`maximum depth of ${MAX_SUBAGENT_DEPTH}`);
+  });
+
+  it('rejects graphs with more than MAX_SUBAGENT_GRAPH_NODES unique agents', async () => {
+    const firstLevelIds = Array.from({ length: 10 }, (_, index) => `agent_graph_${index}`);
+    const secondLevelIdsByParent = new Map(
+      firstLevelIds.map((id) => [
+        id,
+        Array.from({ length: 5 }, (_, index) => `${id}_child_${index}`),
+      ]),
+    );
+    const primaryConfig = makeConfig('A');
+    primaryConfig.subagents = { enabled: true, allowSelf: false, agent_ids: firstLevelIds };
+    mockInitializeAgent.mockImplementation(async ({ agent }: { agent: Agent }) =>
+      Object.assign(makeConfig(agent.id), {
+        subagents: {
+          enabled: true,
+          allowSelf: false,
+          agent_ids: secondLevelIdsByParent.get(agent.id) ?? [],
+        },
+      }),
+    );
+
+    await expect(
+      resolveSubagents(
+        {
+          req: makeReq(),
+          res: makeRes(),
+          primaryConfig,
+          agentConfigs: new Map(),
+          edges: [],
+          subagentsCapabilityEnabled: true,
+          allowedProviders: new Set(),
+          modelsConfig: { openai: ['gpt-4o'] },
+          loadTools: jest.fn(),
+        },
+        {
+          getAgent: jest.fn(async ({ id }: { id: string }) => makeAgent(id)),
+          checkPermission: jest.fn().mockResolvedValue(true),
+          logViolation: jest.fn(),
+          db: {} as never,
+        },
+      ),
+    ).rejects.toThrow(`maximum of ${MAX_SUBAGENT_GRAPH_NODES}`);
+  });
+
+  it('uses the provided resourceType for permission checks', async () => {
+    const primaryConfig = makeConfig('A');
+    primaryConfig.subagents = { enabled: true, allowSelf: false, agent_ids: ['B'] };
+    const checkPermission = jest.fn().mockResolvedValue(false);
+
+    await resolveSubagents(
+      {
+        req: makeReq(),
+        res: makeRes(),
+        primaryConfig,
+        agentConfigs: new Map(),
+        edges: [],
+        subagentsCapabilityEnabled: true,
+        resourceType: ResourceType.REMOTE_AGENT,
+        allowedProviders: new Set(),
+        modelsConfig: { openai: ['gpt-4o'] },
+        loadTools: jest.fn(),
+      },
+      {
+        getAgent: jest.fn(async ({ id }: { id: string }) => makeAgent(id)),
+        checkPermission,
+        logViolation: jest.fn(),
+        db: {} as never,
+      },
+    );
+
+    expect(checkPermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceType: ResourceType.REMOTE_AGENT,
+        requiredPermission: PermissionBits.VIEW,
+      }),
+    );
+    expect(primaryConfig.subagentAgentConfigs).toEqual([]);
   });
 });

--- a/packages/api/src/agents/discovery.ts
+++ b/packages/api/src/agents/discovery.ts
@@ -3,6 +3,7 @@ import {
   ResourceType,
   PermissionBits,
   EModelEndpoint,
+  MAX_SUBAGENT_DEPTH,
   MAX_SUBAGENT_GRAPH_NODES,
 } from 'librechat-data-provider';
 import type {
@@ -368,6 +369,212 @@ export async function resolveSubagentGraphs(
     }
     rootConfig.subagentGraphConfigs = resolvedGraphs;
   }
+  return userMCPAuthMap;
+}
+
+export interface ResolveSubagentsParams extends DiscoverConnectedAgentsParams {
+  /** Handoff / connected agent configs discovered before subagent resolution. */
+  agentConfigs: Map<string, InitializedAgent>;
+  /** Handoff edges used to distinguish pure subagents from handoff targets. */
+  edges: GraphEdge[];
+  /** Whether the endpoint-level `subagents` capability is enabled. */
+  subagentsCapabilityEnabled: boolean;
+  /** Agent ids already skipped during handoff discovery. */
+  skippedAgentIds?: Set<string>;
+}
+
+function collectEdgeAgentIds(primaryId: string, edges: GraphEdge[]): Set<string> {
+  const edgeAgentIds = new Set<string>([primaryId]);
+  for (const edge of edges) {
+    const sources = Array.isArray(edge.from) ? edge.from : [edge.from];
+    const targets = Array.isArray(edge.to) ? edge.to : [edge.to];
+    for (const id of sources) {
+      if (typeof id === 'string') {
+        edgeAgentIds.add(id);
+      }
+    }
+    for (const id of targets) {
+      if (typeof id === 'string') {
+        edgeAgentIds.add(id);
+      }
+    }
+  }
+  return edgeAgentIds;
+}
+
+function getExplicitSubagentIds(agent: { id: string; subagents?: Agent['subagents'] }): string[] {
+  return [
+    ...new Set(
+      Array.isArray(agent.subagents?.agent_ids)
+        ? agent.subagents.agent_ids.filter(
+            (id): id is string => typeof id === 'string' && id.length > 0 && id !== agent.id,
+          )
+        : [],
+    ),
+  ];
+}
+
+/**
+ * Loads explicit `subagents.agent_ids` spawn targets for the primary and any
+ * connected agents. Pure subagents are pruned from `agentConfigs` so LangGraph
+ * does not treat them as parallel/handoff nodes; callers keep tool contexts
+ * via `onAgentInitialized` for ON_TOOL_EXECUTE.
+ */
+export async function resolveSubagents(
+  params: ResolveSubagentsParams,
+  deps: DiscoverConnectedAgentsDeps,
+): Promise<Record<string, Record<string, string>> | undefined> {
+  const {
+    primaryConfig,
+    agentConfigs,
+    edges,
+    subagentsCapabilityEnabled,
+    skippedAgentIds: seededSkippedAgentIds,
+  } = params;
+
+  const skippedAgentIds = new Set(seededSkippedAgentIds ?? []);
+  const edgeAgentIds = collectEdgeAgentIds(primaryConfig.id, edges);
+  const pureSubagentIds = new Set<string>();
+  const subagentGraphIds = new Set<string>();
+  let userMCPAuthMap: Record<string, Record<string, string>> | undefined;
+
+  const markSkipped = (agentId: string): void => {
+    skippedAgentIds.add(agentId);
+    deps.onAgentSkipped?.(agentId);
+  };
+
+  const loadAgentById = async (agentId: string): Promise<InitializedAgent | null> => {
+    if (skippedAgentIds.has(agentId)) {
+      return null;
+    }
+    const existing = agentConfigs.get(agentId);
+    if (existing) {
+      return existing;
+    }
+
+    try {
+      const loaded = await initializeReferencedAgent(agentId, params, {
+        ...deps,
+        onAgentSkipped: markSkipped,
+      });
+      if (!loaded) {
+        skippedAgentIds.add(agentId);
+        return null;
+      }
+      agentConfigs.set(agentId, loaded.config);
+      if (loaded.config.userMCPAuthMap) {
+        userMCPAuthMap = { ...userMCPAuthMap, ...loaded.config.userMCPAuthMap };
+      }
+      return loaded.config;
+    } catch (error) {
+      if (isFatalAgentInitializationError(error)) {
+        throw error;
+      }
+      logger.error(`[resolveSubagents] Error processing subagent ${agentId}:`, error);
+      skippedAgentIds.add(agentId);
+      return null;
+    }
+  };
+
+  const assertSubagentGraphRoom = (agentId: string): void => {
+    if (subagentGraphIds.has(agentId)) {
+      return;
+    }
+    if (subagentGraphIds.size >= MAX_SUBAGENT_GRAPH_NODES) {
+      logger.warn('[resolveSubagents] Subagent graph node limit exceeded', {
+        agentId,
+        primaryAgentId: primaryConfig.id,
+        loadedSubagentCount: subagentGraphIds.size,
+        maxSubagentGraphNodes: MAX_SUBAGENT_GRAPH_NODES,
+      });
+      throw new Error(
+        `Subagent graph exceeds the maximum of ${MAX_SUBAGENT_GRAPH_NODES} unique agents.`,
+      );
+    }
+  };
+
+  const loadSubagentsFor = async (config: InitializedAgent, depth = 0): Promise<void> => {
+    const sub = config.subagents;
+    if (!subagentsCapabilityEnabled || !sub?.enabled) {
+      config.subagentAgentConfigs = [];
+      return;
+    }
+
+    const explicitSubagentIds = getExplicitSubagentIds(config);
+    if (explicitSubagentIds.length > 0 && depth >= MAX_SUBAGENT_DEPTH) {
+      logger.warn('[resolveSubagents] Subagent graph depth limit exceeded', {
+        agentId: config.id,
+        primaryAgentId: primaryConfig.id,
+        depth,
+        maxSubagentDepth: MAX_SUBAGENT_DEPTH,
+        childCount: explicitSubagentIds.length,
+      });
+      throw new Error(
+        `Subagent graph exceeds the maximum depth of ${MAX_SUBAGENT_DEPTH} at agent ${config.id}.`,
+      );
+    }
+
+    const resolved: InitializedAgent[] = [];
+    for (const subagentId of explicitSubagentIds) {
+      if (skippedAgentIds.has(subagentId)) {
+        continue;
+      }
+      if (subagentId === primaryConfig.id) {
+        resolved.push(primaryConfig);
+        continue;
+      }
+
+      assertSubagentGraphRoom(subagentId);
+      const subagentConfig = await loadAgentById(subagentId);
+      if (!subagentConfig) {
+        continue;
+      }
+
+      subagentGraphIds.add(subagentConfig.id ?? subagentId);
+      resolved.push(subagentConfig);
+      if (!edgeAgentIds.has(subagentId)) {
+        pureSubagentIds.add(subagentId);
+      }
+    }
+
+    config.subagentAgentConfigs = resolved;
+  };
+
+  const maxResolvedDepthByConfigId = new Map<string, number>();
+  const pending = [primaryConfig, ...agentConfigs.values()].map((cfg) => ({ cfg, depth: 0 }));
+
+  for (let index = 0; index < pending.length; index++) {
+    const { cfg, depth } = pending[index];
+    if (!cfg?.id) {
+      continue;
+    }
+    const previousDepth = maxResolvedDepthByConfigId.get(cfg.id);
+    if (previousDepth != null && previousDepth >= depth) {
+      continue;
+    }
+    maxResolvedDepthByConfigId.set(cfg.id, depth);
+    await loadSubagentsFor(cfg, depth);
+    for (const child of cfg.subagentAgentConfigs ?? []) {
+      const childDepth = depth + 1;
+      const previousChildDepth = child?.id ? maxResolvedDepthByConfigId.get(child.id) : undefined;
+      if (child?.id && (previousChildDepth == null || previousChildDepth < childDepth)) {
+        pending.push({ cfg: child, depth: childDepth });
+      }
+    }
+  }
+
+  for (const id of pureSubagentIds) {
+    agentConfigs.delete(id);
+  }
+
+  primaryConfig.subagents = subagentsCapabilityEnabled ? primaryConfig.subagents : undefined;
+  if (!subagentsCapabilityEnabled) {
+    for (const config of agentConfigs.values()) {
+      config.subagents = undefined;
+      config.subagentAgentConfigs = undefined;
+    }
+  }
+
   return userMCPAuthMap;
 }
 

--- a/packages/api/src/agents/initialize.ts
+++ b/packages/api/src/agents/initialize.ts
@@ -511,6 +511,8 @@ export type InitializedAgent = Agent & {
    * context limits with the same numbers the UI shows — not default rates.
    */
   endpointTokenConfig?: EndpointTokenConfig;
+  /** Initialized configs for explicit subagent spawn targets (`subagents.agent_ids`). */
+  subagentAgentConfigs?: InitializedAgent[];
 };
 
 export const DEFAULT_MAX_CONTEXT_TOKENS = 32000;


### PR DESCRIPTION
## Summary

Subagents (`agent.subagents.agent_ids`) were only resolved in the chat UI
initialization path. The Responses API (`/v1/responses`) and the
OpenAI-compatible API (`/v1/chat/completions`) only ran handoff-edge discovery
and graph-team resolution, so a primary agent invoked through those endpoints
never had its subagent spawn targets loaded — the model was unaware of the
subagent and could not delegate to it.

This PR extracts explicit `agent_ids` resolution into a shared helper and wires
it into the Responses and OpenAI-compat entry points so those paths match the
chat UI.

Fixes #14249

Replaces #14250 (retargeted from `main` to `dev` and rebased onto current `dev`).

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

- **`packages/api/src/agents/discovery.ts`** — `resolveSubagents()` helper
  alongside the existing `resolveSubagentGraphs()`: nested-tree BFS,
  `MAX_SUBAGENT_DEPTH` / `MAX_SUBAGENT_GRAPH_NODES` limits, id dedupe, self-cycle
  guard, pure-subagent pruning (kept in `agentToolContexts` via
  `onAgentInitialized` for `ON_TOOL_EXECUTE`), and capability-disabled stripping.
- Wire `resolveSubagents` into `responses.js` and `openai.js`, using the same
  `REMOTE_AGENT` sharing boundary and remote permission check as the primary
  agent.
- Leave `initialize.js` (chat path) unchanged — it already resolves explicit
  subagents via the lazy descriptor walk on current `dev`.
- Add `subagentAgentConfigs` to the `InitializedAgent` type.
- Include loaded `subagentAgentConfigs` in the OpenAI-compat context walk
  (attachments, scoped context, inline memory), matching the Responses path.
- Perf: only fetch `getModelsConfig` when handoff discovery or real subagent
  loading actually needs it, keeping the common single-agent request off that
  (potentially network-bound) path.
- Hardening: call `resolveSubagents` unconditionally in the remote paths so that
  when the `subagents` capability is disabled, any persisted `subagents` are
  stripped and `createRun` can't expose self-spawn.
- Tests: add unit tests for `resolveSubagents` in `discovery.spec.ts`; add the
  `resolveSubagents` mock and controller coverage to the Responses/OpenAI specs.

## Test plan

- [x] `cd packages/api && npx jest src/agents/discovery.spec.ts` (42 passed, including 6 new `resolveSubagents` cases)
- [x] `cd api && npx jest server/controllers/agents/__tests__/responses.unit.spec.js server/controllers/agents/__tests__/openai.spec.js` (92 passed)
- [x] `npm run build:data-provider` and `packages/api` build succeed
- [x] Manual: invoke a parent agent with a configured subagent via `POST /v1/responses` and confirm the subagent spawn tool is exposed and callable

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Manual: invoke a parent agent with a configured subagent via POST /v1/responses and confirm the subagent spawn tool is exposed and callable