### PR TITLE
🕳️ feat: Hide Empty MCP Servers from Selectors

### DIFF
--- a/api/server/controllers/mcp.js
+++ b/api/server/controllers/mcp.js
@@ -250,6 +250,9 @@ const getMCPTools = async (req, res) => {
           authenticated: true,
           authConfig: [],
           tools: [],
+          /** Distinguishes "catalog loaded, zero tools" from "catalog unknown" (connection
+           * or OAuth pending) — clients must not treat the latter as an empty server. */
+          catalogLoaded: serverTools != null,
         };
 
         // Set authentication config once for the server

--- a/client/src/Providers/AgentPanelContext.tsx
+++ b/client/src/Providers/AgentPanelContext.tsx
@@ -52,7 +52,8 @@ export function AgentPanelProvider({ children }: { children: React.ReactNode }) 
   const [action, setAction] = useState<Action | undefined>(undefined);
   const [activePanel, setActivePanel] = useState<Panel>(Panel.builder);
   const [agent_id, setCurrentAgentId] = useState<string | undefined>(undefined);
-  const { availableMCPServers, isLoading, availableMCPServersMap } = useMCPServerManager();
+  const { availableMCPServers, isLoading, availableMCPServersMap, hiddenEmptyServers } =
+    useMCPServerManager();
   const { data: startupConfig } = useGetStartupConfig();
   const { data: actions } = useGetActionsQuery(EModelEndpoint.agents, {
     enabled: !isEphemeralAgent(agent_id),
@@ -91,6 +92,10 @@ export function AgentPanelProvider({ children }: { children: React.ReactNode }) 
 
     if (mcpData?.servers) {
       for (const [serverName, serverData] of Object.entries(mcpData.servers)) {
+        /** `hideWhenEmpty` servers with a loaded-but-empty catalog are hidden here too. */
+        if (hiddenEmptyServers.has(serverName)) {
+          continue;
+        }
         // Get title and description from config with fallbacks
         const serverConfig = availableMCPServersMap?.[serverName];
         const serverStatus = connectionStatus?.[serverName];
@@ -136,7 +141,7 @@ export function AgentPanelProvider({ children }: { children: React.ReactNode }) 
 
     // Add configured servers that don't have tools yet
     for (const mcpServerName of mcpServerNames) {
-      if (serversMap.has(mcpServerName)) {
+      if (serversMap.has(mcpServerName) || hiddenEmptyServers.has(mcpServerName)) {
         continue;
       }
       // Get title and description from config with fallbacks
@@ -171,7 +176,14 @@ export function AgentPanelProvider({ children }: { children: React.ReactNode }) 
     }
 
     return serversMap;
-  }, [mcpData, localize, mcpServerNames, connectionStatus, availableMCPServersMap]);
+  }, [
+    mcpData,
+    localize,
+    mcpServerNames,
+    connectionStatus,
+    availableMCPServersMap,
+    hiddenEmptyServers,
+  ]);
 
   const value: AgentPanelContextType = {
     mcp,

--- a/client/src/components/MCP/mcpServerUtils.spec.ts
+++ b/client/src/components/MCP/mcpServerUtils.spec.ts
@@ -1,5 +1,10 @@
 import type { MCPServerStatus } from 'librechat-data-provider';
-import { isMCPServerReadyForAgent, shouldShowActionButton } from './mcpServerUtils';
+import {
+  getHiddenEmptyServers,
+  isMCPServerReadyForAgent,
+  resolveHiddenEmptyServers,
+  shouldShowActionButton,
+} from './mcpServerUtils';
 
 const status = (
   connectionState: MCPServerStatus['connectionState'],
@@ -62,5 +67,111 @@ describe('shouldShowActionButton', () => {
 
     expect(shouldShowActionButton({ ...baseProps, hasCustomUserVars: true })).toBe(true);
     expect(shouldShowActionButton({ ...baseProps, hasCustomUserVars: false })).toBe(false);
+  });
+});
+
+describe('getHiddenEmptyServers', () => {
+  const definition = (serverName: string, hideWhenEmpty?: boolean) =>
+    ({
+      serverName,
+      config: { type: 'streamable-http', url: 'https://example.com/mcp', hideWhenEmpty },
+      effectivePermissions: 1,
+    }) as Parameters<typeof getHiddenEmptyServers>[0][number];
+
+  const toolServer = (catalogLoaded: boolean | undefined, toolCount: number) => ({
+    name: 'srv',
+    icon: '',
+    authenticated: true,
+    authConfig: [],
+    tools: Array.from({ length: toolCount }, (_, i) => ({
+      name: `tool-${i}`,
+      pluginKey: `tool-${i}_mcp_srv`,
+      description: '',
+    })),
+    ...(catalogLoaded !== undefined && { catalogLoaded }),
+  });
+
+  it('hides an opted-in server whose catalog loaded with zero tools', () => {
+    const hidden = getHiddenEmptyServers([definition('empty', true)], {
+      empty: toolServer(true, 0),
+    });
+    expect(hidden).toEqual(new Set(['empty']));
+  });
+
+  it('keeps servers without the hideWhenEmpty opt-in', () => {
+    const hidden = getHiddenEmptyServers([definition('empty')], {
+      empty: toolServer(true, 0),
+    });
+    expect(hidden.size).toBe(0);
+  });
+
+  it('keeps an opted-in server whose catalog has tools', () => {
+    const hidden = getHiddenEmptyServers([definition('busy', true)], {
+      busy: toolServer(true, 2),
+    });
+    expect(hidden.size).toBe(0);
+  });
+
+  it('keeps an opted-in server whose catalog did not load (connection or OAuth pending)', () => {
+    const hidden = getHiddenEmptyServers([definition('pending', true)], {
+      pending: toolServer(false, 0),
+    });
+    expect(hidden.size).toBe(0);
+  });
+
+  it('keeps an opted-in server absent from the tools response or on legacy backends', () => {
+    expect(getHiddenEmptyServers([definition('missing', true)], {}).size).toBe(0);
+    expect(
+      getHiddenEmptyServers([definition('legacy', true)], {
+        legacy: toolServer(undefined, 0),
+      }).size,
+    ).toBe(0);
+    expect(getHiddenEmptyServers([definition('noData', true)], undefined).size).toBe(0);
+  });
+});
+
+describe('resolveHiddenEmptyServers', () => {
+  const definition = (serverName: string, hideWhenEmpty?: boolean) =>
+    ({
+      serverName,
+      config: { type: 'streamable-http', url: 'https://example.com/mcp', hideWhenEmpty },
+      effectivePermissions: 1,
+    }) as Parameters<typeof resolveHiddenEmptyServers>[0][number];
+
+  const emptyLoadedServer = {
+    name: 'srv',
+    icon: '',
+    authenticated: true,
+    authConfig: [],
+    tools: [],
+    catalogLoaded: true,
+  };
+
+  it('fails open: hides nothing when the catalog query errored, even with loaded-empty data', () => {
+    const definitions = [definition('empty', true), definition('other', true)];
+    expect(resolveHiddenEmptyServers(definitions, { empty: emptyLoadedServer }, true).size).toBe(0);
+    expect(resolveHiddenEmptyServers(definitions, undefined, true).size).toBe(0);
+  });
+
+  it('keeps flagged servers out of pickers while the catalog is pending, but never unflagged ones', () => {
+    const hidden = resolveHiddenEmptyServers(
+      [definition('flagged', true), definition('unflagged')],
+      undefined,
+      false,
+    );
+    expect(hidden).toEqual(new Set(['flagged']));
+  });
+
+  it('hides exactly the flagged loaded-empty servers once the catalog is available', () => {
+    const hidden = resolveHiddenEmptyServers(
+      [definition('empty', true), definition('unflaggedEmpty')],
+      { empty: emptyLoadedServer, unflaggedEmpty: emptyLoadedServer },
+      false,
+    );
+    expect(hidden).toEqual(new Set(['empty']));
+  });
+
+  it('returns an empty set when no server opts in, regardless of catalog state', () => {
+    expect(resolveHiddenEmptyServers([definition('plain')], undefined, false).size).toBe(0);
   });
 });

--- a/client/src/components/MCP/mcpServerUtils.ts
+++ b/client/src/components/MCP/mcpServerUtils.ts
@@ -243,21 +243,14 @@ export function shouldShowActionButton(statusIconProps?: MCPServerStatusIconProp
 }
 
 /**
- * Servers to hide from pickers because the current user's loaded tool catalog is empty.
- *
- * A server is hidden only when all of the following hold:
- * - its config opts in via `hideWhenEmpty: true`;
- * - the user's tool catalog for it was actually loaded (`catalogLoaded`), so a server whose
- *   catalog is unknown (not yet connected, or OAuth pending) stays visible and reachable;
- * - the loaded catalog contains zero tools.
- */
-/**
- * Full visibility decision for `hideWhenEmpty` servers, including the catalog's
- * lifecycle states. Kept pure so the fail-open rule stays under test:
+ * Full visibility decision for `hideWhenEmpty` servers, covering the catalog's
+ * lifecycle states. Servers without the flag are never affected. Kept pure so
+ * the fail-open rule stays under test:
  * - catalog query errored -> hide NOTHING (a timeout must not empty the picker);
  * - catalog not yet loaded -> keep flagged servers out of the pickers (no
  *   show-then-yank flash); they appear once the catalog proves them non-empty;
- * - catalog loaded -> hide exactly the flagged servers with zero tools.
+ * - catalog loaded -> hide exactly the flagged servers with zero tools
+ *   (`catalogLoaded && tools.length === 0`, see `getHiddenEmptyServers`).
  */
 export function resolveHiddenEmptyServers(
   definitions: MCPServerDefinition[],
@@ -274,6 +267,12 @@ export function resolveHiddenEmptyServers(
   return getHiddenEmptyServers(definitions, toolServers);
 }
 
+/**
+ * The loaded-catalog rule of `resolveHiddenEmptyServers`: flagged servers whose
+ * catalog actually loaded (`catalogLoaded`) with zero tools. Servers missing from
+ * the response, or with an unknown catalog (legacy backends without the field),
+ * are never hidden here.
+ */
 export function getHiddenEmptyServers(
   definitions: MCPServerDefinition[],
   toolServers?: MCPServersResponse['servers'],

--- a/client/src/components/MCP/mcpServerUtils.ts
+++ b/client/src/components/MCP/mcpServerUtils.ts
@@ -1,4 +1,4 @@
-import type { MCPServerStatus } from 'librechat-data-provider';
+import type { MCPServersResponse, MCPServerStatus } from 'librechat-data-provider';
 import type { MCPServerDefinition } from '~/hooks/MCP/useMCPServerManager';
 import type { MCPServerStatusIconProps } from './MCPServerStatusIcon';
 
@@ -240,4 +240,56 @@ export function shouldShowActionButton(statusIconProps?: MCPServerStatusIconProp
   if (connectionState === 'connected') return hasCustomUserVars || requiresOAuth;
 
   return false;
+}
+
+/**
+ * Servers to hide from pickers because the current user's loaded tool catalog is empty.
+ *
+ * A server is hidden only when all of the following hold:
+ * - its config opts in via `hideWhenEmpty: true`;
+ * - the user's tool catalog for it was actually loaded (`catalogLoaded`), so a server whose
+ *   catalog is unknown (not yet connected, or OAuth pending) stays visible and reachable;
+ * - the loaded catalog contains zero tools.
+ */
+/**
+ * Full visibility decision for `hideWhenEmpty` servers, including the catalog's
+ * lifecycle states. Kept pure so the fail-open rule stays under test:
+ * - catalog query errored -> hide NOTHING (a timeout must not empty the picker);
+ * - catalog not yet loaded -> keep flagged servers out of the pickers (no
+ *   show-then-yank flash); they appear once the catalog proves them non-empty;
+ * - catalog loaded -> hide exactly the flagged servers with zero tools.
+ */
+export function resolveHiddenEmptyServers(
+  definitions: MCPServerDefinition[],
+  toolServers: MCPServersResponse['servers'] | undefined,
+  catalogErrored: boolean,
+): Set<string> {
+  const flagged = definitions.filter((d) => d.config?.hideWhenEmpty === true);
+  if (flagged.length === 0 || catalogErrored) {
+    return new Set();
+  }
+  if (!toolServers) {
+    return new Set(flagged.map((d) => d.serverName));
+  }
+  return getHiddenEmptyServers(definitions, toolServers);
+}
+
+export function getHiddenEmptyServers(
+  definitions: MCPServerDefinition[],
+  toolServers?: MCPServersResponse['servers'],
+): Set<string> {
+  const hidden = new Set<string>();
+  if (!toolServers) {
+    return hidden;
+  }
+  for (const definition of definitions) {
+    if (definition.config?.hideWhenEmpty !== true) {
+      continue;
+    }
+    const entry = toolServers[definition.serverName];
+    if (entry?.catalogLoaded === true && entry.tools.length === 0) {
+      hidden.add(definition.serverName);
+    }
+  }
+  return hidden;
 }

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -41,7 +41,8 @@ import {
   useCatalogReady,
   useMCPConnectionStatus,
 } from '~/hooks';
-import { useGetStartupConfig, useMCPServersQuery } from '~/data-provider';
+import { useGetStartupConfig, useMCPServersQuery, useMCPToolsQuery } from '~/data-provider';
+import { resolveHiddenEmptyServers } from '~/components/MCP/mcpServerUtils';
 import { mcpServerInitStatesAtom, getServerInitState } from '~/store/mcp';
 import { getMCPReinitializeErrorMessage } from './errors';
 
@@ -125,10 +126,33 @@ export function useMCPServerManager({
     return definitions;
   }, [loadedServers, permissionsMap]);
 
+  /** The per-user tool catalog is only requested here when some server opts into
+   * `hideWhenEmpty` — otherwise this hook adds no request. The query key is shared
+   * with the app-startup warmup and the agent builder, so it never duplicates fetches. */
+  const anyHideWhenEmpty = useMemo(
+    () => availableMCPServers.some((s) => s.config.hideWhenEmpty === true),
+    [availableMCPServers],
+  );
+  const mcpToolsReady = useCatalogReady('mcpTools');
+  const { data: mcpToolsData, isError: mcpToolsError } = useMCPToolsQuery({
+    enabled: mcpEnabled && mcpToolsReady && anyHideWhenEmpty,
+  });
+  /** Servers hidden from pickers: opted into `hideWhenEmpty`, catalog loaded, zero tools.
+   * Pending catalogs keep flagged servers hidden (no flash); catalog errors hide
+   * nothing (fail-open). The rules live in `resolveHiddenEmptyServers` under test. */
+  const hiddenEmptyServers = useMemo(
+    () => resolveHiddenEmptyServers(availableMCPServers, mcpToolsData?.servers, mcpToolsError),
+    [availableMCPServers, mcpToolsData, mcpToolsError],
+  );
+
   // Memoize filtered servers for useMCPSelect to prevent infinite loops
   const selectableServers = useMemo(
-    () => availableMCPServers.filter((s) => s.config.chatMenu !== false && !s.consumeOnly),
-    [availableMCPServers],
+    () =>
+      availableMCPServers.filter(
+        (s) =>
+          s.config.chatMenu !== false && !s.consumeOnly && !hiddenEmptyServers.has(s.serverName),
+      ),
+    [availableMCPServers, hiddenEmptyServers],
   );
 
   const { mcpValues, setMCPValues, isPinned, setIsPinned } = useMCPSelect({
@@ -821,8 +845,10 @@ export function useMCPServerManager({
 
   return {
     availableMCPServers,
-    /** MCP servers filtered for chat menu selection (chatMenu !== false && !consumeOnly) */
+    /** MCP servers filtered for chat menu selection (chatMenu !== false && !consumeOnly && not hidden-empty) */
     selectableServers,
+    /** Servers hidden because `hideWhenEmpty` is set and the user's loaded catalog is empty */
+    hiddenEmptyServers,
     availableMCPServersMap: loadedServers,
     isLoading,
     connectionStatus,

--- a/packages/api/src/mcp/utils.ts
+++ b/packages/api/src/mcp/utils.ts
@@ -609,6 +609,7 @@ export function redactServerSecrets(
     description: config.description,
     iconPath: config.iconPath,
     chatMenu: config.chatMenu,
+    hideWhenEmpty: config.hideWhenEmpty,
     requiresOAuth: config.requiresOAuth,
     capabilities: config.capabilities,
     tools: config.tools,

--- a/packages/data-provider/src/mcp.ts
+++ b/packages/data-provider/src/mcp.ts
@@ -190,8 +190,10 @@ const BaseOptionsSchema = z.object({
   /**
    * When true, hide this server from the chat dropdown and the agent builder for users whose
    * loaded tool catalog for it is empty (e.g. every tool is filtered out per-user by an MCP
-   * gateway enforcing authorization). The server stays visible while its catalog has not
-   * loaded yet (not connected, or OAuth pending), so authentication flows remain reachable.
+   * gateway enforcing authorization). While the catalog is still loading, a flagged server is
+   * kept out of the pickers (it appears once the catalog proves it non-empty); if the catalog
+   * request fails, nothing is hidden. Do NOT set this on OAuth-gated servers: their catalog
+   * cannot load before the user authenticates, so the auth flow would be unreachable.
    */
   hideWhenEmpty: z.boolean().optional(),
   /**

--- a/packages/data-provider/src/mcp.ts
+++ b/packages/data-provider/src/mcp.ts
@@ -188,6 +188,13 @@ const BaseOptionsSchema = z.object({
    */
   chatMenu: z.boolean().optional(),
   /**
+   * When true, hide this server from the chat dropdown and the agent builder for users whose
+   * loaded tool catalog for it is empty (e.g. every tool is filtered out per-user by an MCP
+   * gateway enforcing authorization). The server stays visible while its catalog has not
+   * loaded yet (not connected, or OAuth pending), so authentication flows remain reachable.
+   */
+  hideWhenEmpty: z.boolean().optional(),
+  /**
    * Controls server instruction behavior:
    * - undefined/not set: No instructions included (default)
    * - true: Use server-provided instructions
@@ -428,6 +435,7 @@ const omitServerManagedFields = <T extends z.ZodObject<z.ZodRawShape>>(schema: T
     sseReadTimeout: true,
     initTimeout: true,
     chatMenu: true,
+    hideWhenEmpty: true,
     serverInstructions: true,
     requiresOAuth: true,
     customUserVars: true,

--- a/packages/data-provider/src/types/queries.ts
+++ b/packages/data-provider/src/types/queries.ts
@@ -142,6 +142,10 @@ export type MCPServer = {
   authenticated: boolean;
   authConfig: s.TPluginAuthConfig[];
   tools: MCPTool[];
+  /** True when the user's tool catalog for this server was actually loaded; an empty
+   * `tools` with `catalogLoaded: false` means the catalog is unknown (connection or
+   * OAuth pending), not that the server has no tools for the user. */
+  catalogLoaded?: boolean;
 };
 
 export type MCPServersResponse = {


### PR DESCRIPTION
## Summary

Adds an opt-in per-server `hideWhenEmpty` option for `mcpServers` in `librechat.yaml`. When set, a server whose per-user tool catalog loaded with zero tools is hidden from the chat dropdown (MCPSelect) and the agent builder.

Proposed and discussed in #15460 (feature request, with positive review of the semantics).

Motivation: our deployment (and, we believe, a growing number of enterprise deployments) puts LibreChat behind an MCP gateway that enforces per-user authorization: the gateway forwards the user's identity (`Authorization: Bearer {{LIBRECHAT_OPENID_ACCESS_TOKEN}}` headers) to an external policy engine (OPA via ext_authz), which filters `tools/list` per user. Different users therefore see different tool sets for the same configured server — and for some users a given server legitimately resolves to zero tools. Today every YAML-configured server is always shown to every user; a user without access still sees the entry, can toggle it on, and gets an empty server.

How it works:
- `GET /api/mcp/tools` now marks each server with `catalogLoaded`, so clients can distinguish "loaded and empty" from "catalog unknown" (connection or OAuth pending). Servers without the flag are never affected.
- The visibility rules live in a pure `resolveHiddenEmptyServers` helper, under test:
  - hide only when `catalogLoaded && tools.length === 0`;
  - fail open on catalog errors — a timeout must not empty the picker;
  - while the catalog is pending, flagged servers stay out of the pickers (no show-then-yank flash) and appear once the catalog proves them non-empty;
  - the same filter applies in the agent builder.
- `useMCPServerManager` computes `hiddenEmptyServers` from that helper and filters `selectableServers`; the agent builder skips hidden servers as well. The tools catalog is only requested from this hook when at least one server opts in (shared query key with the startup warmup — no duplicate fetches).
- `hideWhenEmpty` flows through the redaction allowlist and is a server-managed field (not user-editable on DB-stored servers).

Default behavior is unchanged: without the flag nothing is hidden and no extra request is made. Operators should not set `hideWhenEmpty` on OAuth-gated servers (their auth flows must stay reachable); unflagged servers are never affected.

This complements MCP server ACLs (#9731): ACLs cover DB-stored servers managed inside LibreChat, while this option covers deployments where per-user tool authorization lives outside LibreChat (MCP gateway / ext_authz), with servers defined in `librechat.yaml`.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

- Unit tests for the pure visibility helpers (`mcpServerUtils.spec.ts`):
  - `resolveHiddenEmptyServers`: fail-open on catalog error (hides nothing, even with loaded-empty data), pending catalog hides only flagged servers, loaded catalog hides exactly the flagged empty ones, no opt-in → nothing hidden;
  - `getHiddenEmptyServers`: opt-in only; keeps not-loaded/OAuth-pending servers, legacy backends without `catalogLoaded`, and servers with tools.
- Ran: client typecheck + ESLint; client MCP suites, `packages/api` mcp utils, `packages/data-provider` mcp — all passing (rebased on current `dev`).
- Manual: deployment behind an MCP gateway (agentgateway + OPA ext_authz) where `tools/list` is filtered per user; with `hideWhenEmpty: true` a zero-tool server disappears from the dropdown and the agent builder for that user, users with access see it with its tools, and granting a permission in our IdM made the server appear within minutes. The fail-open and pending semantics were validated against real-world deploy races (a backend redeploy briefly yielding empty catalogs).

### **Test Configuration**:

LibreChat behind Kong + agentgateway (MCP gateway with OPA ext_authz filtering `tools/list` per user via Entra ID tokens); `mcpServers` entries of type `streamable-http` with `startup: false`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] A pull request for updating the documentation has been submitted.
