### PR TITLE
📧 fix: Normalize Token Emails on Write, as Every Read Already Does

### DIFF
--- a/packages/data-schemas/src/methods/token.spec.ts
+++ b/packages/data-schemas/src/methods/token.spec.ts
@@ -1105,3 +1105,69 @@ describe('Token Methods - Detailed Tests', () => {
     });
   });
 });
+
+describe('Token email normalization', () => {
+  const userId = new mongoose.Types.ObjectId();
+
+  const createFor = (email: string) =>
+    methods.createToken({
+      userId,
+      email,
+      token: 'hashed-token-value',
+      expiresIn: 3600,
+    });
+
+  it('stores the email normalized so reads can find it again', async () => {
+    await createFor('User@Example.COM');
+
+    const stored = await Token.findOne({ userId });
+    expect(stored?.email).toBe('user@example.com');
+  });
+
+  it('trims surrounding whitespace on write', async () => {
+    await createFor('  spaced@example.com  ');
+
+    const stored = await Token.findOne({ userId });
+    expect(stored?.email).toBe('spaced@example.com');
+  });
+
+  it('finds a token created with mixed case, whatever case the lookup uses', async () => {
+    await createFor('User@Example.COM');
+
+    for (const lookup of ['User@Example.COM', 'user@example.com', 'USER@EXAMPLE.COM']) {
+      const found = await methods.findToken({ token: 'hashed-token-value', email: lookup });
+      expect(found).not.toBeNull();
+    }
+  });
+
+  it('finds a token created with padding when the lookup is clean', async () => {
+    await createFor('  spaced@example.com  ');
+
+    const found = await methods.findToken({
+      token: 'hashed-token-value',
+      email: 'spaced@example.com',
+    });
+
+    expect(found).not.toBeNull();
+  });
+
+  it('deletes a token created with mixed case', async () => {
+    await createFor('User@Example.COM');
+
+    const result = await methods.deleteTokens({ email: 'user@example.com' });
+
+    expect(result.deletedCount).toBe(1);
+    expect(await Token.countDocuments({ userId })).toBe(0);
+  });
+
+  it('leaves a null email alone', async () => {
+    await methods.createToken({
+      userId,
+      token: 'no-email-token',
+      expiresIn: 3600,
+    });
+
+    const stored = await Token.findOne({ userId });
+    expect(stored?.email).toBeUndefined();
+  });
+});

--- a/packages/data-schemas/src/methods/token.spec.ts
+++ b/packages/data-schemas/src/methods/token.spec.ts
@@ -1160,7 +1160,7 @@ describe('Token email normalization', () => {
     expect(await Token.countDocuments({ userId })).toBe(0);
   });
 
-  it('leaves a null email alone', async () => {
+  it('leaves a token written without an email alone', async () => {
     await methods.createToken({
       userId,
       token: 'no-email-token',
@@ -1169,5 +1169,24 @@ describe('Token email normalization', () => {
 
     const stored = await Token.findOne({ userId });
     expect(stored?.email).toBeUndefined();
+  });
+
+  it('leaves an explicitly null email as null, which the read side matches on', async () => {
+    /** `TokenCreateData.email` is `string | undefined`, so a null is only reachable by
+     *  writing the model directly — but `findToken` and `deleteTokens` both branch on
+     *  `email === null`, so the setters must not coerce it into something else. */
+    await Token.create({
+      userId,
+      email: null,
+      token: 'null-email-token',
+      createdAt: new Date(),
+      expiresAt: new Date(Date.now() + 3600000),
+    });
+
+    const stored = await Token.findOne({ userId });
+    expect(stored?.email).toBeNull();
+
+    const found = await methods.findToken({ token: 'null-email-token', email: null });
+    expect(found).not.toBeNull();
   });
 });

--- a/packages/data-schemas/src/schema/token.ts
+++ b/packages/data-schemas/src/schema/token.ts
@@ -9,10 +9,11 @@ const tokenSchema: Schema<IToken> = new Schema({
   },
   email: {
     type: String,
-    /** `findToken` and `deleteTokens` normalize the email before querying, so the
-     * write side has to match or a token created with mixed case or surrounding
-     * whitespace can never be found again — an invite issued to `User@Example.com`
-     * was unredeemable. Mirrors `User.email`, which is already normalized here. */
+    /** `findToken` and `deleteTokens` both apply `.trim().toLowerCase()` to the email
+     * before querying, so the write side has to match on both counts or a token
+     * created with mixed case or surrounding whitespace can never be found again —
+     * an invite issued to `User@Example.com` was unredeemable. `User.email` sets
+     * `lowercase` alone; the read contract here also trims, so this adds `trim`. */
     lowercase: true,
     trim: true,
   },

--- a/packages/data-schemas/src/schema/token.ts
+++ b/packages/data-schemas/src/schema/token.ts
@@ -9,6 +9,12 @@ const tokenSchema: Schema<IToken> = new Schema({
   },
   email: {
     type: String,
+    /** `findToken` and `deleteTokens` normalize the email before querying, so the
+     * write side has to match or a token created with mixed case or surrounding
+     * whitespace can never be found again — an invite issued to `User@Example.com`
+     * was unredeemable. Mirrors `User.email`, which is already normalized here. */
+    lowercase: true,
+    trim: true,
   },
   type: {
     type: String,


### PR DESCRIPTION
Fixes #15529

## The asymmetry

`findToken` and `deleteTokens` both normalize before querying — and `findToken`'s own doc comment states it as a guarantee:

```ts
// packages/data-schemas/src/methods/token.ts
const email = query.email === null ? null : query.email.trim().toLowerCase();
```

Nothing normalized the write. `createToken` stores whatever it is handed. So a token written with mixed case or surrounding whitespace can never be found or deleted again — an invite issued to `User@Example.com` is unredeemable, and its cleanup query misses it too.

## Fixed at the schema, not the caller

@lailson's report is precise that no in-tree flow breaks today: #14436 normalized `config/invite-user.js`, the only upstream caller of `createInvite`. That makes it tempting to patch `createInvite` and be done.

But the defect isn't `createInvite`'s. It belongs to `Token`: **every** writer had the same trap, and any new caller of the exported helpers — which is exactly the case the report is about — would inherit it. Normalizing in one helper leaves the schema still disagreeing with itself.

`User.email` is already declared `lowercase: true` in this same package, so this only brings `Token.email` in line with the convention sitting next to it:

```ts
email: {
  type: String,
  lowercase: true,
  trim: true,
},
```

A schema-level setter also can't be bypassed the way a helper can, and it needs no per-caller discipline to stay correct.

## Scope

Existing documents are not migrated — a token already stored with mixed case stays unfindable, exactly as it is today. Only new writes are corrected. A backfill would be a separate change, and given tokens expire on their own I don't think it earns one.

The one place a stored token's email is read back (`getEmailVerificationTokenDeleteQuery` in `AuthService.js`) feeds it straight into a delete query, which normalizes anyway — so the round trip is consistent either way.

## Testing

Six cases in `token.spec.ts`, against the real in-memory MongoDB the suite already uses: normalized on write, trimmed on write, found under any lookup casing, found when created padded, deleted when created mixed-case, and a null email left alone.

`token.spec.ts` — 54 passed. `packages/data-schemas` typecheck clean, ESLint, Prettier and import-sort clean.

Note for reviewers: 24 suites in `packages/data-schemas` fail to *load* in my worktree with `TypeError: Cannot convert undefined or null to object` at schema init, and 5 `has no exported member` typecheck errors appear against `librechat-data-provider`. Both reproduce identically on unmodified `dev` here, so they are a stale local build artifact rather than anything from this change — CI builds the package chain properly.
