### PR TITLE
🧳 fix: Carry Logical Endpoints Through Agent Runs

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "5.1.6",
-    "@librechat/agents": "^3.7.17",
+    "@librechat/agents": "^3.7.19",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "5.1.6",
-        "@librechat/agents": "^3.7.17",
+        "@librechat/agents": "^3.7.19",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -10633,9 +10633,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.7.17",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.7.17.tgz",
-      "integrity": "sha512-aJ3beJxbGNMYaXas0F9M5+e+1A8pjS1ND7TZ8EuEx7BwwN/2qqWn10aIG6Fyqcr/0GPOw8kVkz1BGwAraV3UUg==",
+      "version": "3.7.19",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.7.19.tgz",
+      "integrity": "sha512-/dHHKBvLoXjX1hFkDJBGP5CjkMp1vS+e3OyLqffa4c7JCenFhOHThBDUdZmCDvoEylRhima0h3fYl/JqCR8+hQ==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
@@ -42639,7 +42639,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "5.1.6",
-        "@librechat/agents": "^3.7.17",
+        "@librechat/agents": "^3.7.19",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/api": "^1.9.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -113,7 +113,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "5.1.6",
-    "@librechat/agents": "^3.7.17",
+    "@librechat/agents": "^3.7.19",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@opentelemetry/api": "^1.9.0",

--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -324,6 +324,35 @@ afterAll(() => {
 });
 
 // ---------------------------------------------------------------------------
+// Suite: agent endpoint projection
+// ---------------------------------------------------------------------------
+describe('agent endpoint projection', () => {
+  it('preserves each logical endpoint independently from its resolved provider', async () => {
+    const agents = await callAndCapture({
+      agents: [
+        makeAgent({ id: 'sales-copilot', provider: 'bedrock', endpoint: 'bedrock' }),
+        makeAgent({ id: 'dwaine', provider: 'openAI', endpoint: 'DWAINE' }),
+      ],
+    });
+
+    expect(agents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          agentId: 'sales-copilot',
+          endpoint: 'bedrock',
+          provider: 'bedrock',
+        }),
+        expect.objectContaining({
+          agentId: 'dwaine',
+          endpoint: 'DWAINE',
+          provider: 'openAI',
+        }),
+      ]),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Suite: custom endpoint stream usage defaults
 // ---------------------------------------------------------------------------
 describe('custom endpoint stream usage defaults', () => {

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -1768,6 +1768,7 @@ export async function createRun({
     );
 
     const reasoningKey = getReasoningKey(provider, llmConfig, agent.endpoint, agent.reasoningKey);
+    /** Preserve the configured endpoint structurally until the SDK input type includes it. */
     const agentInput: AgentInputs & { endpoint: string } = {
       provider,
       endpoint: agent.endpoint ?? provider,

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -1768,8 +1768,9 @@ export async function createRun({
     );
 
     const reasoningKey = getReasoningKey(provider, llmConfig, agent.endpoint, agent.reasoningKey);
-    const agentInput: AgentInputs = {
+    const agentInput: AgentInputs & { endpoint: string } = {
       provider,
+      endpoint: agent.endpoint ?? provider,
       reasoningKey,
       toolDefinitions,
       agentId: agent.id,

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -1768,8 +1768,7 @@ export async function createRun({
     );
 
     const reasoningKey = getReasoningKey(provider, llmConfig, agent.endpoint, agent.reasoningKey);
-    /** Preserve the configured endpoint structurally until the SDK input type includes it. */
-    const agentInput: AgentInputs & { endpoint: string } = {
+    const agentInput: AgentInputs = {
       provider,
       endpoint: agent.endpoint ?? provider,
       reasoningKey,


### PR DESCRIPTION
## Summary

I preserved each configured logical endpoint when LibreChat projects initialized agents into SDK run inputs, enabling accurate per-generation endpoint attribution after provider resolution.

- Pass the original agent endpoint alongside the resolved provider without adding another agent or message traversal.
- Preserve distinct Bedrock and OpenAI-compatible endpoint identities across a multi-agent run.
- Consume `@librechat/agents` 3.7.19, which normalizes cross-provider attachments and exposes the typed endpoint input.
- Lock the released SDK version consistently for both backend consumers.
- Add focused integration coverage for the Sales Copilot-to-DWAINE provider boundary.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx jest src/agents/__tests__/run-summarization.test.ts --runInBand` (145 tests passed against `@librechat/agents` 3.7.19)
- `./node_modules/.bin/tsc --noEmit`
- `eslint packages/api/src/agents/run.ts packages/api/src/agents/__tests__/run-summarization.test.ts`
- `npm run sort-imports -- packages/api/src/agents/run.ts packages/api/src/agents/__tests__/run-summarization.test.ts`
- `git diff --check`

### Test Configuration

- Workspace: `packages/api`
- Base branch: `origin/dev` at `458c473d9e`
- SDK: `@librechat/agents` 3.7.19 from danny-avila/agents#502

## Checklist

- [x] My code adheres to this project’s style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules