### PR TITLE
📮 fix: Validate Invite Email Claims

### DIFF
--- a/packages/api/src/auth/invite.spec.ts
+++ b/packages/api/src/auth/invite.spec.ts
@@ -1,6 +1,6 @@
 import mongoose from 'mongoose';
-import { createMethods, createModels } from '@librechat/data-schemas';
 import { MongoMemoryServer } from 'mongodb-memory-server';
+import { createMethods, createModels } from '@librechat/data-schemas';
 import { createInvite, getInvite } from './invite';
 
 let mongoServer: MongoMemoryServer;

--- a/packages/api/src/auth/invite.spec.ts
+++ b/packages/api/src/auth/invite.spec.ts
@@ -1,0 +1,51 @@
+import mongoose from 'mongoose';
+import { createMethods, createModels } from '@librechat/data-schemas';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { createInvite, getInvite } from './invite';
+
+let mongoServer: MongoMemoryServer;
+let deps: Parameters<typeof getInvite>[2];
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+  createModels(mongoose);
+
+  const { createToken, findToken } = createMethods(mongoose);
+  deps = { createToken, findToken } as Parameters<typeof getInvite>[2];
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+beforeEach(async () => {
+  await mongoose.models.Token.deleteMany({});
+});
+
+describe('getInvite', () => {
+  it('returns the invite for the address it was issued to', async () => {
+    const token = (await createInvite('pedro@example.com', deps)) as string;
+
+    await expect(getInvite(token, 'pedro@example.com', deps)).resolves.toMatchObject({
+      email: 'pedro@example.com',
+    });
+  });
+
+  it('refuses an address the invite was not issued to', async () => {
+    const token = (await createInvite('pedro@example.com', deps)) as string;
+
+    await expect(getInvite(token, 'someone.else@example.com', deps)).resolves.toMatchObject({
+      error: true,
+    });
+  });
+
+  it('refuses a lookup carrying no address at all', async () => {
+    const token = (await createInvite('pedro@example.com', deps)) as string;
+
+    await expect(getInvite(token, undefined as unknown as string, deps)).resolves.toMatchObject({
+      error: true,
+    });
+  });
+});

--- a/packages/api/src/auth/invite.ts
+++ b/packages/api/src/auth/invite.ts
@@ -45,6 +45,13 @@ export async function getInvite(
   deps: InviteDeps,
 ): Promise<unknown> {
   try {
+    /** `findToken` builds its query from the fields it is given, so an absent email
+     * is a lookup by token alone — which would match the invite and let the caller
+     * consume it without ever proving the address. */
+    if (!email) {
+      throw new Error('Invite not found or email does not match');
+    }
+
     const token = decodeURIComponent(encodedToken);
     const hash = await hashToken(token);
     const invite = await deps.findToken({ token: hash, email });


### PR DESCRIPTION
## Summary

Fixes #15540.

`getInvite` passes its `email` argument straight to `deps.findToken({ token: hash, email })`, and `findToken` builds its query only from the fields it is given. With the field absent the email condition is never added, so the invite matches on the token alone, `checkInviteUser` deletes it, and `registerUser` then rejects the missing email. The invite is consumed and no account is created.

The guard goes in `getInvite` rather than a layer below. `findToken` legitimately serves `userId`- and `identifier`-only lookups, and the `Token` schema is shared by token types that carry no email at all. `getInvite` is the narrowest boundary whose contract is token **and** email, which its own doc comment already states:

```ts
/** Retrieves and validates a user invite by encoded token and email. */
```

An empty string was never affected: `''` satisfies `!== undefined`, so the condition is added and correctly misses. Only an absent field reached this.

The related defect — the token being deleted before the account exists, so any post-invite failure burns the invite — is #15541, and is deliberately not in this PR: it changes the registration flow rather than one helper.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

New `packages/api/src/auth/invite.spec.ts`, against the in-memory MongoDB the suite already uses, with the real `createToken`/`findToken` from `@librechat/data-schemas` rather than fakes, so `findToken`'s own condition-building is what the test exercises:

- the invite is returned for the address it was issued to
- an address it was not issued to is refused
- a lookup carrying no address is refused

The third fails on `dev` before this change, resolving to the invite document instead of an error. All three pass after it.

### **Test Configuration**:

- `cd packages/api && npx jest src/auth/invite.spec.ts` — 3 passed
- `npx eslint packages/api/src/auth/invite.ts packages/api/src/auth/invite.spec.ts` — clean
- `npx prettier --check` on both files — clean
- Branched from `dev` at `458c473d9`

Note for reviewers: four suites under `packages/api/src/auth` fail to load in my worktree with `Cannot find module 'prom-client'`, and one case in `openid.spec.ts` fails. Both reproduce identically on unmodified `dev` here, so they are an artifact of my local install rather than anything from this change.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
