### PR TITLE
style(insights): 14px muted KPI labels and 32/12 page spacing

### DIFF
--- a/client/src/components/Insights/InsightsView.tsx
+++ b/client/src/components/Insights/InsightsView.tsx
@@ -238,7 +238,7 @@ function KpiCard({ card, locale }: { card: KpiCardData; locale: string }) {
   const localize = useLocalize();
   return (
     <Panel>
-      <h2 className="text-lg font-normal text-text-secondary">{card.title}</h2>
+      <h2 className="text-sm font-normal text-text-muted">{card.title}</h2>
       <div className="mt-3 text-4xl font-semibold tabular-nums leading-none text-text-primary">
         {formatValue(card.value, locale)}
       </div>
@@ -706,7 +706,7 @@ export default function InsightsView() {
         </div>
       </header>
       <main className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden">
-        <div className="flex w-full min-w-0 flex-col gap-5 px-4 py-4 sm:px-5 md:px-6 lg:px-8">
+        <div className="flex w-full min-w-0 flex-col gap-3 px-8 pb-4 pt-8">
           {insights.isLoading && <LoadingState message={localize('com_insights_loading')} />}
           {insights.isError && (
             <Panel className="flex items-center gap-2">

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -153,6 +153,7 @@ html {
   --text-secondary: var(--gray-600);
   --text-secondary-alt: var(--gray-500);
   --text-tertiary: var(--gray-500);
+  --text-muted: 105 110 121; /* Click UI global.color.text.muted #696e79 */
   --shimmer-dip: 129 130 134;
   --shimmer-dip-alpha: 0.18;
   --text-warning: var(--amber-700);
@@ -261,6 +262,7 @@ html {
   --text-secondary: var(--gray-300);
   --text-secondary-alt: var(--gray-400);
   --text-tertiary: var(--gray-400);
+  --text-muted: 179 182 189; /* Click UI global.color.text.muted #b3b6bd */
   --shimmer-base: 255 255 255;
   --shimmer-base-alpha: 0.8;
   --shimmer-dip: 179 179 179;
@@ -351,6 +353,7 @@ html {
   --text-primary: var(--gizmo-gray-950);
   --text-secondary: var(--gizmo-gray-600);
   --text-tertiary: var(--gizmo-gray-500);
+  --text-muted: 105 110 121; /* Click UI global.color.text.muted #696e79 */
   --surface-primary: var(--white);
   --surface-secondary: var(--gray-50);
   --surface-tertiary: var(--gray-100);
@@ -367,6 +370,7 @@ html {
   --text-primary: var(--gray-100);
   --text-secondary: var(--gray-300);
   --text-tertiary: var(--gizmo-gray-500);
+  --text-muted: 179 182 189; /* Click UI global.color.text.muted #b3b6bd */
   --surface-primary: var(--gray-900);
   --surface-secondary: var(--gray-800);
   --surface-tertiary: var(--gray-700);

--- a/packages/client/src/theme/utils/createTailwindColors.js
+++ b/packages/client/src/theme/utils/createTailwindColors.js
@@ -69,6 +69,7 @@ function createTailwindColors() {
     'text-secondary': cssVar('--text-secondary'),
     'text-secondary-alt': cssVar('--text-secondary-alt'),
     'text-tertiary': cssVar('--text-tertiary'),
+    'text-muted': cssVar('--text-muted'),
     'text-warning': cssVar('--text-warning'),
     'text-destructive': cssVar('--text-destructive'),
 


### PR DESCRIPTION
The KPI tile labels on `/insights` render at 18px (`text-lg`) in `text-secondary`, which reads as a heading competing with the number beneath it rather than as a caption for it.

Click UI sizes a muted label at `400 0.875rem/1.5`, so the label moves to `text-sm` at weight 400.

No existing text token carried Click UI's muted value — `text-secondary` (`#424242`) and `text-tertiary` (`#595959`) are both darker and warmer than `#696e79` — so rather than hardcode a hex in the component this adds `--text-muted` alongside the other text tokens in all four theme blocks and registers it in `createTailwindColors`. It therefore themes and accepts opacity modifiers like its neighbours, and dark mode is covered:

| | light | dark |
|---|---|---|
| `--text-muted` | `#696e79` | `#b3b6bd` |

The content column also drops its responsive padding ramp (`px-4 sm:px-5 md:px-6 lg:px-8`) for a flat 32px on left/top/right, and its row gap goes from 20px to 12px to agree with the 12px the inner grids already used. Bottom padding is unchanged at 16px.

### Verification

Computed styles on `/insights` at 1440x900:

- label `font-size: 14px`, `color: rgb(105, 110, 121)`, `font-weight: 400`
- container `padding: 32px 32px 16px`, `row-gap: 12px`
- KPI grid `column-gap: 12px`, `row-gap: 12px`

### Notes

Draft — opened for review of the approach, in particular whether a new `--text-muted` token is welcome versus reusing `text-tertiary` and accepting the slightly darker, warmer tone.
