### PR TITLE
fix(insights): stop the KPI grid orphaning a card on its own row

### DIFF
--- a/client/src/components/Insights/InsightsView.tsx
+++ b/client/src/components/Insights/InsightsView.tsx
@@ -716,11 +716,10 @@ export default function InsightsView() {
           )}
           {data && (
             <>
-              {/** Fixed column counts, not `auto-fit`: auto-fit packs as many 220px
-               *  tracks as will fit, so mid-range widths land on three columns and
-               *  orphan the fourth card on its own row. Four KPIs divide evenly by
-               *  two or four, so those are the only counts that leave no gap. */}
-              <div className="grid w-full grid-cols-2 gap-3 xl:grid-cols-4">
+              {/** Use explicit responsive counts: one column on narrow screens,
+               *  two through mid-range, and four at xl. This avoids auto-fit's
+               *  three-plus-one orphan without making mobile cards too narrow. */}
+              <div className="grid w-full grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
                 {kpiCards.map((card) => (
                   <KpiCard key={card.id} card={card} locale={locale} />
                 ))}

--- a/client/src/components/Insights/InsightsView.tsx
+++ b/client/src/components/Insights/InsightsView.tsx
@@ -716,7 +716,11 @@ export default function InsightsView() {
           )}
           {data && (
             <>
-              <div className="grid w-full grid-cols-[repeat(auto-fit,minmax(min(100%,220px),1fr))] gap-3">
+              {/** Fixed column counts, not `auto-fit`: auto-fit packs as many 220px
+               *  tracks as will fit, so mid-range widths land on three columns and
+               *  orphan the fourth card on its own row. Four KPIs divide evenly by
+               *  two or four, so those are the only counts that leave no gap. */}
+              <div className="grid w-full grid-cols-2 gap-3 xl:grid-cols-4">
                 {kpiCards.map((card) => (
                   <KpiCard key={card.id} card={card} locale={locale} />
                 ))}


### PR DESCRIPTION
The KPI grid on `/insights` uses `repeat(auto-fit, minmax(min(100%, 220px), 1fr))`, which packs as many 220px tracks as will fit. Every viewport width between three and four tracks therefore renders three cards in the top row and orphans the fourth on a row of its own, leaving a wide empty gap beside it.

Four tiles divide evenly by two and by four, so those are the only counts that leave no hole. This pins the grid to two columns, widening to four at `xl`.

Viewport breakpoints are sound here because `UnifiedSidebar` forces the panel collapsed on this route:

```js
const panelExpanded = expanded && !isInsightsRoute;
```

so the content width is a fixed function of the viewport (`vw - 52 - 64`) and cannot be changed by sidebar state. At the `xl` boundary that leaves 1164px, or 282px per tile — above the 220px the previous `minmax` floor asked for.

### Verification

Swept the rendered column and row counts across widths:

| width | layout |
|---|---|
| 640, 768, 900, 1024, 1100, 1279 | 2 x 2 |
| 1280, 1440, 1600, 1920, 2560 | 4 x 1 |

Every width renders either 4x1 or 2x2; none renders 3+1.

### Notes

Draft. The trade-off of excluding three columns is that just below `xl` the two tiles get wide (576px each at 1279px). Switching at `lg` instead would narrow that band, at the cost of four tiles at ~227px there — happy to change it if you prefer.
