### PR TITLE
feat: add minimal Docker Compose deployment

### DIFF
--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -10,9 +10,10 @@ services:
       - mongodb
     image: registry.librechat.ai/danny-avila/librechat-dev:latest
     restart: always
-    user: "${UID}:${GID}"
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    env_file:
+      - .env
     environment:
       - HOST=0.0.0.0
       - MONGO_URI=mongodb://mongodb:27017/LibreChat
@@ -25,9 +26,6 @@ services:
       - https_proxy=${https_proxy:-}
       - no_proxy=${no_proxy:-localhost,127.0.0.1,::1},${NO_PROXY:-},mongodb,chat-mongodb,host.docker.internal
     volumes:
-      - type: bind
-        source: ./.env
-        target: /app/.env
       - ./images:/app/client/public/images
       - ./uploads:/app/uploads
       - ./logs:/app/logs
@@ -37,7 +35,6 @@ services:
     container_name: chat-mongodb
     image: mongo:8.0.20
     restart: always
-    user: "${UID}:${GID}"
     volumes:
       - ./data-node:/data/db
     command: mongod --noauth

--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -1,0 +1,46 @@
+# Minimal LibreChat deployment with only the services required for the core experience.
+# Optional services such as Meilisearch and the RAG API can be configured externally in .env.
+
+services:
+  api:
+    container_name: LibreChat
+    ports:
+      - "${PORT}:${PORT}"
+    depends_on:
+      - mongodb
+    image: registry.librechat.ai/danny-avila/librechat-dev:latest
+    restart: always
+    user: "${UID}:${GID}"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      - HOST=0.0.0.0
+      - MONGO_URI=mongodb://mongodb:27017/LibreChat
+      - LIBRECHAT_TEMP_CREDENTIALS_PATH=/app/data/.env.temp
+      - PROXY=${PROXY:-}
+      - HTTP_PROXY=${HTTP_PROXY:-}
+      - HTTPS_PROXY=${HTTPS_PROXY:-}
+      - NO_PROXY=${NO_PROXY:-localhost,127.0.0.1,::1},${no_proxy:-},mongodb,chat-mongodb,host.docker.internal
+      - http_proxy=${http_proxy:-}
+      - https_proxy=${https_proxy:-}
+      - no_proxy=${no_proxy:-localhost,127.0.0.1,::1},${NO_PROXY:-},mongodb,chat-mongodb,host.docker.internal
+    volumes:
+      - type: bind
+        source: ./.env
+        target: /app/.env
+      - ./images:/app/client/public/images
+      - ./uploads:/app/uploads
+      - ./logs:/app/logs
+      - ./skill:/app/skill
+      - librechat-data:/app/data
+  mongodb:
+    container_name: chat-mongodb
+    image: mongo:8.0.20
+    restart: always
+    user: "${UID}:${GID}"
+    volumes:
+      - ./data-node:/data/db
+    command: mongod --noauth
+
+volumes:
+  librechat-data:


### PR DESCRIPTION
## Summary

- add a standalone minimal Docker Compose deployment
- run only the LibreChat API and MongoDB
- leave RAG, Meilisearch, pgvector, and the Admin Panel optional
- preserve support for externally configured RAG and Meilisearch services through .env

Refs #15554

## Validation

- docker compose -f docker-compose.minimal.yml --env-file .env.example config --quiet
- confirmed config --services contains only mongodb and api
- git diff --check
- started the stack with an isolated project directory and confirmed only the api and mongodb containers run
- confirmed /readyz and the application root return HTTP 200
- recreated both containers and confirmed MongoDB data and /app/data volume contents persist