### PR TITLE
🌌 feat: Add GPT-6 Astra Support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -587,7 +587,7 @@ GOOGLE_KEY=user_provided
 #============#
 
 OPENAI_API_KEY=user_provided
-# OPENAI_MODELS=gpt-5.6,gpt-5.6-terra,gpt-5.6-luna,gpt-5.5,gpt-5.5-pro,chat-latest,gpt-5.4,gpt-5.4-pro,gpt-5.4-mini,gpt-5.4-nano,gpt-5.3-codex,gpt-5.2,gpt-5,gpt-5-codex,gpt-5-mini,gpt-5-nano,o3-pro,o3,o4-mini,gpt-4.1,gpt-4.1-mini,gpt-4.1-nano,o3-mini,o1-pro,o1,gpt-4o,gpt-4o-mini
+# OPENAI_MODELS=gpt-6-astra,gpt-5.6,gpt-5.6-terra,gpt-5.6-luna,gpt-5.5,gpt-5.5-pro,chat-latest,gpt-5.4,gpt-5.4-pro,gpt-5.4-mini,gpt-5.4-nano,gpt-5.3-codex,gpt-5.2,gpt-5,gpt-5-codex,gpt-5-mini,gpt-5-nano,o3-pro,o3,o4-mini,gpt-4.1,gpt-4.1-mini,gpt-4.1-nano,o3-mini,o1-pro,o1,gpt-4o,gpt-4o-mini
 
 DEBUG_OPENAI=false
 

--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "5.1.6",
-    "@librechat/agents": "^3.7.19",
+    "@librechat/agents": "^3.7.20",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "5.1.6",
-        "@librechat/agents": "^3.7.19",
+        "@librechat/agents": "^3.7.20",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -10627,9 +10627,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.7.19",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.7.19.tgz",
-      "integrity": "sha512-/dHHKBvLoXjX1hFkDJBGP5CjkMp1vS+e3OyLqffa4c7JCenFhOHThBDUdZmCDvoEylRhima0h3fYl/JqCR8+hQ==",
+      "version": "3.7.20",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.7.20.tgz",
+      "integrity": "sha512-YnfBpC5MK7QDgP+6VpmOYBTA2mXbaA+fDggfi7n/bsB56FSqenCzizSpC+Nn83lhwJz7GNntJpYNX53nRhFGgw==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
@@ -42681,7 +42681,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "5.1.6",
-        "@librechat/agents": "^3.7.19",
+        "@librechat/agents": "^3.7.20",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/api": "^1.9.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -113,7 +113,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "5.1.6",
-    "@librechat/agents": "^3.7.19",
+    "@librechat/agents": "^3.7.20",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@opentelemetry/api": "^1.9.0",

--- a/packages/api/src/endpoints/openai/config.backward-compat.spec.ts
+++ b/packages/api/src/endpoints/openai/config.backward-compat.spec.ts
@@ -166,6 +166,7 @@ describe('getOpenAIConfig - Backward Compatibility', () => {
           model: 'gpt-5',
           useResponsesApi: true,
           firstPartyEndpoint: true,
+          servedModel: 'gpt-5',
           user: 'some_user_id',
           apiKey: 'some_azure_key',
           reasoning: {

--- a/packages/api/src/endpoints/openai/config.backward-compat.spec.ts
+++ b/packages/api/src/endpoints/openai/config.backward-compat.spec.ts
@@ -33,6 +33,7 @@ describe('getOpenAIConfig - Backward Compatibility', () => {
           streaming: true,
           model: 'gpt-5-nano',
           useResponsesApi: true,
+          firstPartyEndpoint: true,
           user: 'some-user',
           apiKey: 'sk-proj-somekey',
           reasoning: {
@@ -164,6 +165,7 @@ describe('getOpenAIConfig - Backward Compatibility', () => {
           streaming: true,
           model: 'gpt-5',
           useResponsesApi: true,
+          firstPartyEndpoint: true,
           user: 'some_user_id',
           apiKey: 'some_azure_key',
           reasoning: {

--- a/packages/api/src/endpoints/openai/config.backward-compat.spec.ts
+++ b/packages/api/src/endpoints/openai/config.backward-compat.spec.ts
@@ -165,8 +165,6 @@ describe('getOpenAIConfig - Backward Compatibility', () => {
           streaming: true,
           model: 'gpt-5',
           useResponsesApi: true,
-          firstPartyEndpoint: true,
-          servedModel: 'gpt-5',
           user: 'some_user_id',
           apiKey: 'some_azure_key',
           reasoning: {

--- a/packages/api/src/endpoints/openai/llm.spec.ts
+++ b/packages/api/src/endpoints/openai/llm.spec.ts
@@ -709,6 +709,60 @@ describe('getOpenAILLMConfig', () => {
     });
   });
 
+  describe('GPT-6 Astra Responses API routing', () => {
+    const astraConfig = (overrides: Record<string, unknown> = {}) =>
+      getOpenAILLMConfig({
+        apiKey: 'test-api-key',
+        streaming: true,
+        endpoint: EModelEndpoint.openAI,
+        modelOptions: { model: 'gpt-6-astra' },
+        ...overrides,
+      });
+
+    it('routes every Astra turn to the Responses API, not only reasoning ones', () => {
+      expect(astraConfig().llmConfig).toHaveProperty('useResponsesApi', true);
+    });
+
+    /**
+     * The reason routing is decided here rather than at invocation time: the
+     * max-tokens field is shaped from `useResponsesApi`, so switching APIs later
+     * would send `max_completion_tokens` to an endpoint expecting
+     * `max_output_tokens`.
+     */
+    it('shapes max tokens for the API it actually uses', () => {
+      const result = astraConfig({
+        modelOptions: { model: 'gpt-6-astra', max_tokens: 4096 },
+      });
+      const kwargs = (result.llmConfig.modelKwargs ?? {}) as Record<string, unknown>;
+      expect(kwargs).not.toHaveProperty('max_completion_tokens');
+      expect(kwargs.max_output_tokens ?? result.llmConfig.maxTokens).toBeDefined();
+    });
+
+    it('respects an explicit opt-out', () => {
+      expect(astraConfig({ dropParams: ['useResponsesApi'] }).llmConfig).not.toHaveProperty(
+        'useResponsesApi',
+        true,
+      );
+    });
+
+    it('leaves a custom gateway on its configured path', () => {
+      expect(astraConfig({ baseURL: 'https://gateway.internal/v1' }).llmConfig).not.toHaveProperty(
+        'useResponsesApi',
+        true,
+      );
+    });
+
+    it('does not change routing for other models', () => {
+      const result = getOpenAILLMConfig({
+        apiKey: 'test-api-key',
+        streaming: true,
+        endpoint: EModelEndpoint.openAI,
+        modelOptions: { model: 'gpt-5.5' },
+      });
+      expect(result.llmConfig).not.toHaveProperty('useResponsesApi', true);
+    });
+  });
+
   describe('First-party endpoint declaration', () => {
     /**
      * The agents SDK gates its model-specific request constraints on this flag

--- a/packages/api/src/endpoints/openai/llm.spec.ts
+++ b/packages/api/src/endpoints/openai/llm.spec.ts
@@ -801,10 +801,14 @@ describe('getOpenAILLMConfig', () => {
       );
     });
 
-    it('declares it for Azure OpenAI', () => {
-      expect(configFor({ endpoint: EModelEndpoint.azureOpenAI }).llmConfig).toHaveProperty(
+    /**
+     * Astra is not documented as available on Azure OpenAI, and Azure's
+     * first-party hosts do not satisfy the OpenAI-host check, so declaring it
+     * there would claim a surface this cannot verify.
+     */
+    it('does not declare it for Azure OpenAI', () => {
+      expect(configFor({ endpoint: EModelEndpoint.azureOpenAI }).llmConfig).not.toHaveProperty(
         'firstPartyEndpoint',
-        true,
       );
     });
 

--- a/packages/api/src/endpoints/openai/llm.spec.ts
+++ b/packages/api/src/endpoints/openai/llm.spec.ts
@@ -709,6 +709,53 @@ describe('getOpenAILLMConfig', () => {
     });
   });
 
+  describe('First-party endpoint declaration', () => {
+    /**
+     * The agents SDK gates its model-specific request constraints on this flag
+     * and defaults them off, rather than inferring the endpoint from a base
+     * URL. Only this layer can tell a faithful first-party route from a
+     * gateway, so the decision is made here and declared downstream.
+     */
+    const configFor = (overrides: Record<string, unknown> = {}) =>
+      getOpenAILLMConfig({
+        apiKey: 'test-api-key',
+        streaming: true,
+        endpoint: EModelEndpoint.openAI,
+        modelOptions: { model: 'gpt-6-astra' },
+        ...overrides,
+      });
+
+    it('declares the first-party endpoint for canonical OpenAI', () => {
+      expect(configFor().llmConfig).toHaveProperty('firstPartyEndpoint', true);
+    });
+
+    it('declares it for an explicit api.openai.com base URL', () => {
+      expect(configFor({ baseURL: 'https://api.openai.com/v1' }).llmConfig).toHaveProperty(
+        'firstPartyEndpoint',
+        true,
+      );
+    });
+
+    it('declares it for Azure OpenAI', () => {
+      expect(configFor({ endpoint: EModelEndpoint.azureOpenAI }).llmConfig).toHaveProperty(
+        'firstPartyEndpoint',
+        true,
+      );
+    });
+
+    it('does not declare it for a custom gateway base URL', () => {
+      expect(configFor({ baseURL: 'https://gateway.internal/v1' }).llmConfig).not.toHaveProperty(
+        'firstPartyEndpoint',
+      );
+    });
+
+    it('does not declare it for a non-OpenAI endpoint', () => {
+      expect(configFor({ endpoint: EModelEndpoint.custom }).llmConfig).not.toHaveProperty(
+        'firstPartyEndpoint',
+      );
+    });
+  });
+
   describe('GPT-5.6 Responses API Requirement', () => {
     it.each(['gpt-5.6-terra', 'gpt-5.6-luna', 'gpt-5.6-sol', 'gpt-5.6'])(
       'should default to Responses API for %s when reasoning_effort is set',

--- a/packages/api/src/endpoints/openai/llm.spec.ts
+++ b/packages/api/src/endpoints/openai/llm.spec.ts
@@ -738,6 +738,17 @@ describe('getOpenAILLMConfig', () => {
       expect(kwargs.max_output_tokens ?? result.llmConfig.maxTokens).toBeDefined();
     });
 
+    it('keeps routing when a drop rule only clears reasoning_effort', () => {
+      /**
+       * Unlike the GPT-5.6 default, Astra's routing is not reasoning-driven, so
+       * a rule clearing an unsupported stored effort must not disable it.
+       */
+      expect(astraConfig({ dropParams: ['reasoning_effort'] }).llmConfig).toHaveProperty(
+        'useResponsesApi',
+        true,
+      );
+    });
+
     it('respects an explicit opt-out', () => {
       expect(astraConfig({ dropParams: ['useResponsesApi'] }).llmConfig).not.toHaveProperty(
         'useResponsesApi',

--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -893,7 +893,7 @@ export function getOpenAILLMConfig({
    */
   if (
     !useOpenRouter &&
-    isOpenAIEndpoint(endpoint) &&
+    endpoint === EModelEndpoint.openAI &&
     isCanonicalOpenAIBaseURL(baseURL) &&
     llmConfig.useResponsesApi == null &&
     !responsesApiExplicitlyOptedOut &&
@@ -908,8 +908,13 @@ export function getOpenAILLMConfig({
    * above uses, so the decision lives in one place: OpenRouter and custom
    * gateways route through endpoints whose contract is not OpenAI's, and only
    * this layer can tell them apart.
+   *
+   * Scoped to the canonical OpenAI endpoint. Astra is not documented as
+   * available on Azure OpenAI, and Azure's first-party hosts do not satisfy the
+   * OpenAI-host check, so declaring it there would claim a surface this cannot
+   * verify.
    */
-  if (!useOpenRouter && isOpenAIEndpoint(endpoint) && isCanonicalOpenAIBaseURL(baseURL)) {
+  if (!useOpenRouter && endpoint === EModelEndpoint.openAI && isCanonicalOpenAIBaseURL(baseURL)) {
     llmConfig.firstPartyEndpoint = true;
   }
 
@@ -1055,15 +1060,6 @@ export function getOpenAILLMConfig({
 
   constructAzureResponsesApi();
 
-  /**
-   * Azure addresses a deployment, not a model, so `model` becomes the deployment
-   * name. Record what it actually serves first: the agents SDK's model-specific
-   * request constraints cannot recognize an arbitrary deployment alias, and this
-   * is the last point that still knows the real id.
-   */
-  if (llmConfig.firstPartyEndpoint === true && llmConfig.model != null) {
-    llmConfig.servedModel = llmConfig.model;
-  }
   llmConfig.model = updatedAzure.azureOpenAIApiDeploymentName;
   return { llmConfig, tools, azure: updatedAzure };
 }

--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -860,6 +860,17 @@ export function getOpenAILLMConfig({
     llmConfig.useResponsesApi = true;
   }
 
+  /**
+   * Declare the first-party surface for the agents SDK's model-specific request
+   * constraints. Computed here, from the same checks the Responses default
+   * above uses, so the decision lives in one place: OpenRouter and custom
+   * gateways route through endpoints whose contract is not OpenAI's, and only
+   * this layer can tell them apart.
+   */
+  if (!useOpenRouter && isOpenAIEndpoint(endpoint) && isCanonicalOpenAIBaseURL(baseURL)) {
+    llmConfig.firstPartyEndpoint = true;
+  }
+
   if (!useOpenRouter) {
     hasModelKwargs =
       applyReasoningConfig({

--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -1047,6 +1047,15 @@ export function getOpenAILLMConfig({
 
   constructAzureResponsesApi();
 
+  /**
+   * Azure addresses a deployment, not a model, so `model` becomes the deployment
+   * name. Record what it actually serves first: the agents SDK's model-specific
+   * request constraints cannot recognize an arbitrary deployment alias, and this
+   * is the last point that still knows the real id.
+   */
+  if (llmConfig.firstPartyEndpoint === true && llmConfig.model != null) {
+    llmConfig.servedModel = llmConfig.model;
+  }
   llmConfig.model = updatedAzure.azureOpenAIApiDeploymentName;
   return { llmConfig, tools, azure: updatedAzure };
 }

--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -866,6 +866,14 @@ export function getOpenAILLMConfig({
   const responsesApiOptedOut =
     dropParams != null &&
     (dropParams.includes('reasoning_effort') || dropParams.includes('useResponsesApi'));
+  /**
+   * The GPT-5.6 default above is reasoning-driven, so dropping `reasoning_effort`
+   * removes its reason to route. Astra's is not: it takes Responses for every
+   * turn, and a drop rule clearing an unsupported stored effort must not also
+   * disable its routing. Only an explicit `useResponsesApi` drop does that.
+   */
+  const responsesApiExplicitlyOptedOut =
+    dropParams != null && dropParams.includes('useResponsesApi');
   if (
     !useOpenRouter &&
     endpoint === EModelEndpoint.openAI &&
@@ -888,7 +896,7 @@ export function getOpenAILLMConfig({
     isOpenAIEndpoint(endpoint) &&
     isCanonicalOpenAIBaseURL(baseURL) &&
     llmConfig.useResponsesApi == null &&
-    !responsesApiOptedOut &&
+    !responsesApiExplicitlyOptedOut &&
     prefersResponsesApi(llmConfig.model)
   ) {
     llmConfig.useResponsesApi = true;

--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -130,6 +130,24 @@ function isOpenAIEndpoint(endpoint?: EModelEndpoint | string | null): boolean {
  */
 const responsesApiRequiredPattern = /\bgpt-5\.6\b/;
 
+/**
+ * Models that take the Responses API for every turn, not only reasoning ones.
+ * OpenAI's guidance for GPT-6 Astra is to use Responses, and tool calls require
+ * it outright.
+ *
+ * Decided here rather than in the agents SDK at invocation time: the max-tokens
+ * field below is shaped from `useResponsesApi`, so a later switch would send
+ * `max_completion_tokens` to an endpoint expecting `max_output_tokens`. Config
+ * time is also the only place that knows the model before Azure replaces it
+ * with a deployment name.
+ * @see https://developers.openai.com/api/docs/guides/latest-model
+ */
+const responsesApiPreferredPattern = /^gpt-6-astra(?:-|$)/i;
+
+function prefersResponsesApi(model?: string): boolean {
+  return typeof model === 'string' && responsesApiPreferredPattern.test(model);
+}
+
 function requiresResponsesApiForReasoning({
   model,
   reasoningEffort,
@@ -856,6 +874,22 @@ export function getOpenAILLMConfig({
     llmConfig.useResponsesApi == null &&
     !responsesApiOptedOut &&
     requiresResponsesApiForReasoning({ model: llmConfig.model, reasoningEffort })
+  ) {
+    llmConfig.useResponsesApi = true;
+  }
+
+  /**
+   * Route GPT-6 Astra to the Responses API for every turn. Unlike the GPT-5.6
+   * rule above this does not depend on reasoning params: Astra serves tool calls
+   * only from Responses, and OpenAI recommends it generally.
+   */
+  if (
+    !useOpenRouter &&
+    isOpenAIEndpoint(endpoint) &&
+    isCanonicalOpenAIBaseURL(baseURL) &&
+    llmConfig.useResponsesApi == null &&
+    !responsesApiOptedOut &&
+    prefersResponsesApi(llmConfig.model)
   ) {
     llmConfig.useResponsesApi = true;
   }

--- a/packages/api/src/types/openai.ts
+++ b/packages/api/src/types/openai.ts
@@ -45,13 +45,6 @@ export type OAIClientOptions = Omit<OpenAIClientOptions, 'verbosity'> & {
    * layer knows whether a URL is a faithful first-party route or a gateway.
    */
   firstPartyEndpoint?: boolean;
-  /**
-   * The model actually serving the request, when `model` carries something
-   * else. Azure addresses a deployment, so `model` is overwritten with the
-   * deployment name below and the served model would otherwise be unknowable
-   * downstream.
-   */
-  servedModel?: string;
   _lc_stream_delay?: number;
   verbosity?: string | null;
 };

--- a/packages/api/src/types/openai.ts
+++ b/packages/api/src/types/openai.ts
@@ -45,6 +45,13 @@ export type OAIClientOptions = Omit<OpenAIClientOptions, 'verbosity'> & {
    * layer knows whether a URL is a faithful first-party route or a gateway.
    */
   firstPartyEndpoint?: boolean;
+  /**
+   * The model actually serving the request, when `model` carries something
+   * else. Azure addresses a deployment, so `model` is overwritten with the
+   * deployment name below and the served model would otherwise be unknowable
+   * downstream.
+   */
+  servedModel?: string;
   _lc_stream_delay?: number;
   verbosity?: string | null;
 };

--- a/packages/api/src/types/openai.ts
+++ b/packages/api/src/types/openai.ts
@@ -36,6 +36,15 @@ export type OAIClientOptions = Omit<OpenAIClientOptions, 'verbosity'> & {
   includeReasoningContent?: boolean;
   promptCache?: boolean;
   promptCacheTtl?: '5m' | '1h';
+  /**
+   * Declares that this client talks to the first-party OpenAI surface, which is
+   * what gates the agents SDK's model-specific request constraints (GPT-6
+   * Astra: Responses-only tool calls, rejected sampling parameters,
+   * unsupported reasoning efforts). The SDK defaults them off and takes this as
+   * a declaration rather than inferring it from a base URL, because only this
+   * layer knows whether a URL is a faithful first-party route or a gateway.
+   */
+  firstPartyEndpoint?: boolean;
   _lc_stream_delay?: number;
   verbosity?: string | null;
 };

--- a/packages/api/src/utils/tokens.spec.ts
+++ b/packages/api/src/utils/tokens.spec.ts
@@ -91,6 +91,17 @@ describe('Gemini 3.8 Flash', () => {
   });
 });
 
+describe('GPT-6 Astra', () => {
+  it('resolves the 1,050,000-token context window', () => {
+    expect(getModelMaxTokens('gpt-6-astra', EModelEndpoint.openAI)).toBe(1050000);
+  });
+
+  it('matches its own key for snapshots and provider prefixes', () => {
+    expect(getModelMaxTokens('gpt-6-astra-2026-04-30', EModelEndpoint.openAI)).toBe(1050000);
+    expect(getModelMaxTokens('openai/gpt-6-astra', EModelEndpoint.openAI)).toBe(1050000);
+  });
+});
+
 describe('Qwen3.5 and later generations', () => {
   it('resolves 262K for the vLLM model id that regressed to the qwen3 window', () => {
     expect(getModelMaxTokens('Qwen/Qwen3.5-397B-A17B-FP8', EModelEndpoint.openAI)).toBe(262144);

--- a/packages/api/src/utils/tokens.spec.ts
+++ b/packages/api/src/utils/tokens.spec.ts
@@ -92,13 +92,20 @@ describe('Gemini 3.8 Flash', () => {
 });
 
 describe('GPT-6 Astra', () => {
-  it('resolves the 1,050,000-token context window', () => {
+  it('resolves 1.05M context and 128K output', () => {
     expect(getModelMaxTokens('gpt-6-astra', EModelEndpoint.openAI)).toBe(1050000);
+    expect(getModelMaxOutputTokens('gpt-6-astra', EModelEndpoint.openAI)).toBe(128000);
   });
 
   it('matches its own key for snapshots and provider prefixes', () => {
-    expect(getModelMaxTokens('gpt-6-astra-2026-04-30', EModelEndpoint.openAI)).toBe(1050000);
-    expect(getModelMaxTokens('openai/gpt-6-astra', EModelEndpoint.openAI)).toBe(1050000);
+    for (const model of [
+      'gpt-6-astra-2026-04-30',
+      'openai/gpt-6-astra',
+      'gpt-6-astra-2026-04-30/openai',
+    ]) {
+      expect(getModelMaxTokens(model, EModelEndpoint.openAI)).toBe(1050000);
+      expect(getModelMaxOutputTokens(model, EModelEndpoint.openAI)).toBe(128000);
+    }
   });
 });
 

--- a/packages/api/src/utils/tokens.ts
+++ b/packages/api/src/utils/tokens.ts
@@ -64,6 +64,7 @@ const openAIModels = {
   'gpt-5.6': 1050000,
   'gpt-5.6-terra': 1050000,
   'gpt-5.6-luna': 1050000,
+  'gpt-6-astra': 1050000, // >272K input prices at the long-context tier (2x input/cache, 1.5x output)
   'chat-latest': 400000,
   'gpt-5-mini': 400000,
   'gpt-5-nano': 400000,
@@ -508,6 +509,7 @@ export const modelMaxOutputs = {
   'gpt-5.6': 128000,
   'gpt-5.6-terra': 128000,
   'gpt-5.6-luna': 128000,
+  'gpt-6-astra': 128000,
   'chat-latest': 128000,
   'gpt-5-mini': 128000,
   'gpt-5-nano': 128000,

--- a/packages/data-provider/specs/astra-catalog.spec.ts
+++ b/packages/data-provider/specs/astra-catalog.spec.ts
@@ -1,5 +1,5 @@
 import { EModelEndpoint } from '../src/schemas';
-import { defaultModels } from '../src/config';
+import { defaultModels, initialModelsConfig } from '../src/config';
 
 /**
  * GPT-6 Astra serves tool calls only from the Responses API. The Assistants
@@ -15,6 +15,21 @@ describe('GPT-6 Astra catalog placement', () => {
   it('is kept out of both Assistants catalogs', () => {
     expect(defaultModels[EModelEndpoint.assistants]).not.toContain('gpt-6-astra');
     expect(defaultModels[EModelEndpoint.azureAssistants]).not.toContain('gpt-6-astra');
+  });
+
+  it('is kept out of the initial Azure and Assistants catalogs', () => {
+    /**
+     * Azure shares the OpenAI list, but Astra gets neither Responses routing nor
+     * its request constraints there — and being first in the list would let it
+     * become the default selection.
+     */
+    expect(initialModelsConfig[EModelEndpoint.azureOpenAI]).not.toContain('gpt-6-astra');
+    expect(initialModelsConfig[EModelEndpoint.assistants]).not.toContain('gpt-6-astra');
+  });
+
+  it('keeps Astra in the initial catalogs that can run it', () => {
+    expect(initialModelsConfig[EModelEndpoint.openAI]).toContain('gpt-6-astra');
+    expect(initialModelsConfig[EModelEndpoint.agents]).toContain('gpt-6-astra');
   });
 
   it('does not disturb the rest of the shared OpenAI catalog', () => {

--- a/packages/data-provider/specs/astra-catalog.spec.ts
+++ b/packages/data-provider/specs/astra-catalog.spec.ts
@@ -1,0 +1,30 @@
+import { EModelEndpoint } from '../src/schemas';
+import { defaultModels } from '../src/config';
+
+/**
+ * GPT-6 Astra serves tool calls only from the Responses API. The Assistants
+ * endpoints do not route through `getOpenAILLMConfig`, so listing it there
+ * would offer a configuration the provider rejects.
+ */
+describe('GPT-6 Astra catalog placement', () => {
+  it('is offered on the endpoints that route through the OpenAI config', () => {
+    expect(defaultModels[EModelEndpoint.openAI]).toContain('gpt-6-astra');
+    expect(defaultModels[EModelEndpoint.agents]).toContain('gpt-6-astra');
+  });
+
+  it('is kept out of both Assistants catalogs', () => {
+    expect(defaultModels[EModelEndpoint.assistants]).not.toContain('gpt-6-astra');
+    expect(defaultModels[EModelEndpoint.azureAssistants]).not.toContain('gpt-6-astra');
+  });
+
+  it('does not disturb the rest of the shared OpenAI catalog', () => {
+    for (const endpoint of [
+      EModelEndpoint.openAI,
+      EModelEndpoint.agents,
+      EModelEndpoint.assistants,
+      EModelEndpoint.azureAssistants,
+    ]) {
+      expect(defaultModels[endpoint]).toContain('gpt-5.6');
+    }
+  });
+});

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2695,8 +2695,16 @@ export const alternateName = {
   [KnownEndpoints.helicone]: 'Helicone',
 };
 
+/**
+ * Models the Assistants endpoints cannot run. GPT-6 Astra serves tool calls only
+ * from the Responses API, and the Assistants surface does not route through
+ * `getOpenAILLMConfig`, so listing it there would offer a configuration the
+ * provider rejects. Kept out of `sharedOpenAIModels`, which both Assistants
+ * catalogs consume.
+ */
+const responsesOnlyOpenAIModels = ['gpt-6-astra'];
+
 const sharedOpenAIModels = [
-  'gpt-6-astra',
   'gpt-5.6',
   'gpt-5.6-terra',
   'gpt-5.6-luna',
@@ -2798,7 +2806,8 @@ export const bedrockModels = [
 export const defaultModels = {
   [EModelEndpoint.azureAssistants]: sharedOpenAIModels,
   [EModelEndpoint.assistants]: [...sharedOpenAIModels, 'chatgpt-4o-latest'],
-  [EModelEndpoint.agents]: sharedOpenAIModels, // TODO: Add agent models (agentsModels)
+  // TODO: Add agent models (agentsModels)
+  [EModelEndpoint.agents]: [...responsesOnlyOpenAIModels, ...sharedOpenAIModels],
   [EModelEndpoint.google]: [
     // Gemini 3.8 Models
     'gemini-3.8-flash',
@@ -2823,6 +2832,7 @@ export const defaultModels = {
   ],
   [EModelEndpoint.anthropic]: sharedAnthropicModels,
   [EModelEndpoint.openAI]: [
+    ...responsesOnlyOpenAIModels,
     ...sharedOpenAIModels,
     'chatgpt-4o-latest',
     'gpt-4-vision-preview',

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2848,12 +2848,22 @@ const fitlerAssistantModels = (str: string) => {
 
 const openAIModels = defaultModels[EModelEndpoint.openAI];
 
+/**
+ * The OpenAI catalog without the models only the first-party OpenAI endpoint
+ * can run. Azure OpenAI shares this list, but Astra is neither routed to the
+ * Responses API nor given its request constraints there, and listing it first
+ * would let it become the default selection.
+ */
+const nonResponsesOnlyOpenAIModels = openAIModels.filter(
+  (model) => !responsesOnlyOpenAIModels.includes(model),
+);
+
 export const initialModelsConfig: TModelsConfig = {
   initial: [],
   [EModelEndpoint.openAI]: openAIModels,
   [EModelEndpoint.assistants]: openAIModels.filter(fitlerAssistantModels),
   [EModelEndpoint.agents]: openAIModels, // TODO: Add agent models (agentsModels)
-  [EModelEndpoint.azureOpenAI]: openAIModels,
+  [EModelEndpoint.azureOpenAI]: nonResponsesOnlyOpenAIModels,
   [EModelEndpoint.google]: defaultModels[EModelEndpoint.google],
   [EModelEndpoint.anthropic]: defaultModels[EModelEndpoint.anthropic],
   [EModelEndpoint.bedrock]: defaultModels[EModelEndpoint.bedrock],

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2696,6 +2696,7 @@ export const alternateName = {
 };
 
 const sharedOpenAIModels = [
+  'gpt-6-astra',
   'gpt-5.6',
   'gpt-5.6-terra',
   'gpt-5.6-luna',

--- a/packages/data-schemas/src/methods/tx.spec.ts
+++ b/packages/data-schemas/src/methods/tx.spec.ts
@@ -470,6 +470,59 @@ describe('getMultiplier', () => {
     }
   });
 
+  it('should use the documented gpt-6-astra pricing', () => {
+    expect(tokenValues['gpt-6-astra']).toEqual({ prompt: 10, completion: 50 });
+    expect(cacheTokenValues['gpt-6-astra']).toEqual({ write: 12.5, read: 1 });
+    expect(premiumTokenValues['gpt-6-astra']).toEqual({
+      threshold: 272000,
+      prompt: 20,
+      completion: 75,
+    });
+    expect(premiumCacheTokenValues['gpt-6-astra']).toEqual({
+      threshold: 272000,
+      write: 25,
+      read: 2,
+    });
+  });
+
+  it('should bill gpt-6-astra cache writes at the documented 1.25x input surcharge', () => {
+    expect(cacheTokenValues['gpt-6-astra'].write).toBeCloseTo(
+      tokenValues['gpt-6-astra'].prompt * 1.25,
+    );
+  });
+
+  it('should apply the documented gpt-6-astra long-context multipliers', () => {
+    const standard = tokenValues['gpt-6-astra'];
+    const premium = premiumTokenValues['gpt-6-astra'];
+    const standardCache = cacheTokenValues['gpt-6-astra'];
+    const premiumCache = premiumCacheTokenValues['gpt-6-astra'];
+    /** >272K input: 2x input and cache rates, 1.5x output, for the full request. */
+    expect(premium.prompt).toBeCloseTo(standard.prompt * 2);
+    expect(premium.completion).toBeCloseTo(standard.completion * 1.5);
+    expect(premiumCache.write).toBeCloseTo(standardCache.write * 2);
+    expect(premiumCache.read).toBeCloseTo(standardCache.read * 2);
+  });
+
+  it('should resolve gpt-6-astra to its own key rather than a gpt-6 prefix', () => {
+    for (const model of [
+      'gpt-6-astra',
+      'gpt-6-astra-2026-04-30',
+      'openai/gpt-6-astra',
+      'gpt-6-astra/openai',
+    ]) {
+      expect(getValueKey(model)).toBe('gpt-6-astra');
+      expect(getMultiplier({ model, tokenType: 'prompt' })).toBe(10);
+      expect(getMultiplier({ model, tokenType: 'completion' })).toBe(50);
+    }
+  });
+
+  it('should charge gpt-6-astra premium rates only past the 272K threshold', () => {
+    const model = 'gpt-6-astra';
+    expect(getMultiplier({ model, tokenType: 'prompt', inputTokenCount: 272000 })).toBe(10);
+    expect(getMultiplier({ model, tokenType: 'prompt', inputTokenCount: 272001 })).toBe(20);
+    expect(getMultiplier({ model, tokenType: 'completion', inputTokenCount: 272001 })).toBe(75);
+  });
+
   it('should use the documented gpt-5.6 pricing', () => {
     const expectedPricing = {
       'gpt-5.6': {

--- a/packages/data-schemas/src/methods/tx.ts
+++ b/packages/data-schemas/src/methods/tx.ts
@@ -150,6 +150,7 @@ export const tokenValues: Record<string, { prompt: number; completion: number }>
     'gpt-5.6': { prompt: 4, completion: 20 },
     'gpt-5.6-terra': { prompt: 2, completion: 12 },
     'gpt-5.6-luna': { prompt: 0.2, completion: 1.2 },
+    'gpt-6-astra': { prompt: 10, completion: 50 },
     'chat-latest': { prompt: 5, completion: 30 },
     'gpt-5-chat-latest': { prompt: 1.25, completion: 10 },
     'gpt-5.1-chat-latest': { prompt: 1.25, completion: 10 },
@@ -389,6 +390,7 @@ export const cacheTokenValues: Record<string, { write: number; read: number }> =
   'gpt-5.6': { write: 5, read: 0.4 },
   'gpt-5.6-terra': { write: 2.5, read: 0.2 },
   'gpt-5.6-luna': { write: 0.25, read: 0.02 },
+  'gpt-6-astra': { write: 12.5, read: 1 },
   'chat-latest': { write: 5, read: 0.5 },
   'gpt-5-chat-latest': { write: 1.25, read: 0.125 },
   'gpt-5.1-chat-latest': { write: 1.25, read: 0.125 },
@@ -445,6 +447,7 @@ export const premiumTokenValues: Record<
   'gpt-5.6': { threshold: 272000, prompt: 8, completion: 30 },
   'gpt-5.6-terra': { threshold: 272000, prompt: 4, completion: 18 },
   'gpt-5.6-luna': { threshold: 272000, prompt: 0.4, completion: 1.8 },
+  'gpt-6-astra': { threshold: 272000, prompt: 20, completion: 75 },
   'grok-4.5': { threshold: 200000, prompt: 4, completion: 12 },
   'grok-4-5': { threshold: 200000, prompt: 4, completion: 12 },
   'grok-4.6': { threshold: 200000, prompt: 4, completion: 12 },
@@ -466,6 +469,7 @@ export const premiumCacheTokenValues: Record<
   'gpt-5.6': { threshold: 272000, write: 10, read: 0.8 },
   'gpt-5.6-terra': { threshold: 272000, write: 5, read: 0.4 },
   'gpt-5.6-luna': { threshold: 272000, write: 0.5, read: 0.04 },
+  'gpt-6-astra': { threshold: 272000, write: 25, read: 2 },
 };
 
 export function createTxMethods(


### PR DESCRIPTION
## Summary

Registers OpenAI's [GPT-6 Astra](https://developers.openai.com/api/docs/models/gpt-6-astra) (`gpt-6-astra`) as a first-class model on the canonical OpenAI endpoint.

**Every model-specific behavior lives in [danny-avila/agents#506](https://github.com/danny-avila/agents/pull/506), not here.** What remains in this PR is registration.

## Why the behavior belongs in the SDK

Two of Astra's three constraints simply cannot be enforced from `getOpenAIConfig`:

- **Tool calling requires the Responses API.** Tools bind *after* config time. That's exactly why the existing GPT-5.6 rule has to over-approximate to "any reasoning effort set → Responses" ([#14232](https://github.com/danny-avila/LibreChat/pull/14232)) — it can't see tools, so it routes defensively. In the SDK, `_useResponsesApi(options)` runs with resolved call options, so the gate is the documented rule: tools present → Responses, everything else keeps Chat Completions.
- **`temperature`/`top_p` must be absent.** LangChain's request builders emit these from instance fields unconditionally, so not setting them here doesn't keep them off the wire. They have to be stripped after `super.invocationParams`.

The third — substituting the `none`/`minimal` reasoning efforts Astra rejects — is placed in the SDK's merged `getReasoningParams` so it covers both wire shapes (the scalar `reasoning_effort` on Chat Completions and the nested `reasoning.effort` on Responses) and every caller, including the summarizer path and stored agent configs carrying an effort a previous model accepted.

## Changes

- **`packages/data-provider/src/config.ts`** — default OpenAI model list
- **`packages/api/src/utils/tokens.ts`** — 1,050,000-token context window, 128K max output
- **`packages/data-schemas/src/methods/tx.ts`** — standard and long-context pricing
- **`.env.example`** — `OPENAI_MODELS` example

## Pricing

| | Standard | >272K input |
|---|---|---|
| Input | $10 / M | $20 / M |
| Cached input | $1 / M | $2 / M |
| Cache writes | $12.50 / M | $25 / M |
| Output | $50 / M | $75 / M |

The issue suggested the >272K tier could be tracked as a follow-up. It doesn't need to be — LibreChat already supports tiered pricing through `premiumTokenValues`/`premiumCacheTokenValues`, which the GPT-5.4/5.5/5.6 family uses, so Astra's 2×/1.5× multipliers are wired up here.

**Batch/Flex (50%) and Fast mode (2×) are not included.** Unlike the long-context tier, these vary per *request* rather than per model, and the pricing model has no request-shape signal to key them off. Tracking separately rather than inventing a representation.

## Testing

- `packages/data-schemas` `tx.spec.ts` — 267 passed
- `packages/api` `tokens.spec.ts` + `endpoints/openai` — 328 passed (7 suites)
- `npm run static-checks -- --against origin/dev` — all affected checks pass

The pricing tests assert the documented *multipliers* rather than restating the literals — cache writes as 1.25× input, the premium tier as 2×/1.5× of standard — so a future rate change that breaks the documented relationship fails rather than silently agreeing with itself. Threshold behavior is pinned either side of 272K, and `gpt-6-astra` is asserted to resolve to its own key for snapshots and provider-prefixed ids rather than collapsing onto a shorter match.

All 7 new tests were confirmed to fail with the source entries stashed.

## Merge order

This depends on an `@librechat/agents` release containing #506. Until then the model is registered but tool calls would hit Chat Completions and fail. Once that publishes, this needs one lockfile commit — `^3.7.x` already permits it, but `npm ci` honors the pin.

Resolves #15560
