### PR TITLE
⏱️ test: Size the Subagent Lease TTL Above Shard Jitter

### DIFF
--- a/packages/api/src/agents/subagentThreads.spec.ts
+++ b/packages/api/src/agents/subagentThreads.spec.ts
@@ -1224,7 +1224,12 @@ describe('SubagentThreadTaskStore', () => {
         return methods.getMessages(...args);
       }),
     };
-    const options = { leaseTtlMs: 500, leaseHeartbeatMs: 50 };
+    /** The heartbeat fences itself when a renewal commits after the deadline it was
+     * issued against, so the TTL is this test's tolerance for runner jitter, not just
+     * its pace. Keep it well above the scheduling stalls a loaded shard produces: a
+     * half-second lease turns an ordinary pause into a lapse and the prepared run is
+     * refused instead of executed. */
+    const options = { leaseTtlMs: 2_000, leaseHeartbeatMs: 50 };
     const firstWorker = new SubagentThreadTaskStore(slowMethods, options);
     const secondWorker = new SubagentThreadTaskStore(methods, options);
     const config = buildSubagentThreadTaskConfig(firstWorker, { userId, parentConversationId });
@@ -1250,8 +1255,9 @@ describe('SubagentThreadTaskStore', () => {
     const heartbeatIndex =
       heartbeatCall == null ? -1 : intervalSpy.mock.calls.indexOf(heartbeatCall);
     const heartbeat = intervalSpy.mock.results[heartbeatIndex]?.value as NodeJS.Timeout | undefined;
-    const warningIndex = timeoutSpy.mock.calls.length - 1;
-    expect(timeoutSpy.mock.calls[warningIndex]?.[1]).toBe(5_000);
+    const warningCall = [...timeoutSpy.mock.calls].reverse().find(([, delay]) => delay === 5_000);
+    const warningIndex = warningCall == null ? -1 : timeoutSpy.mock.calls.lastIndexOf(warningCall);
+    expect(warningCall?.[1]).toBe(5_000);
     const warning = timeoutSpy.mock.results[warningIndex]?.value as NodeJS.Timeout | undefined;
     expect(heartbeat?.hasRef()).toBe(true);
     expect(warning?.hasRef()).toBe(true);


### PR DESCRIPTION
## Summary

`SubagentThreadTaskStore › renews the shared lease while a continuation transcript is being prepared` failed the `@librechat/api` shard 4/4 on an unrelated pull request ([run 33774019182](https://github.com/danny-avila/LibreChat/actions/runs/33774019182/job/100740549169)):

```
● renews the shared lease while a continuation transcript is being prepared
  expect(jest.fn()).toHaveBeenCalledTimes(expected)
  Expected number of calls: 1
  Received number of calls: 0
```

The provider was never invoked. `renewSharedLeaseFence` deliberately treats a renewal that commits at or after the deadline it was issued against as a lapse — the write still lands, but an owner drain reading active leases in that gap could already have stepped over the thread, so the executor fences itself off. `subagentThreads.ts` then gates the run on `renewSharedLease` once preparation returns, and a fenced lease turns into `This child thread is already being continued by another run.` before `request.run` is reached.

That rule needs a lease long enough that only a real stall trips it. The test ran it at `leaseTtlMs: 500`, which makes every consecutive heartbeat commit within half a second of the previous one's start — narrower than the scheduling stalls a loaded coverage shard produces, and the whole overlapping-worker check sits inside that window. The signature matches: the earlier `expect(overlappingRun).not.toHaveBeenCalled()` passed, so the lease row was still held by the first worker when the second tried to take it. The first worker fenced *itself*.

Two seconds keeps every assertion intact — the heartbeat still has to carry the lease past the deadline its acquisition set, and the second worker still has to be refused — while giving the renewal four times the room. Locally, a 600ms event-loop stall injected into one heartbeat fails the test at `leaseTtlMs: 500` and passes at `2_000`; the case costs ~1.5s more wall clock (2.4s in a 15s `testTimeout`).

The second hunk takes the slow-preparation warning timer by its own 5s delay, the way the heartbeat interval right above it is already taken, rather than assuming it is the last timer scheduled before `await preparing` resumes — driver and poll timers can land in that gap.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `cd packages/api && npx jest src/agents/subagentThreads.spec.ts` — 87 passed, twice
- Fault injection, to confirm the diagnosis rather than assume it: a synchronous 600ms stall in one heartbeat renewal reproduces a failure at `leaseTtlMs: 500` and none at `2_000`
- `npx eslint` and `npx prettier --check` on the file — clean

Test-only; no product code changes.