### PR TITLE
fix(mcp): refresh OBO token on auth failure

### DIFF
--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -541,7 +541,9 @@ export class MCPConnectionFactory {
     });
 
     let cleanupOAuthHandlers: (() => void) | null = null;
-    if (this.useOAuth && !this.usesObo) {
+    if (this.usesObo) {
+      cleanupOAuthHandlers = this.handleOboEvents(connection);
+    } else if (this.useOAuth) {
       cleanupOAuthHandlers = this.handleOAuthEvents(connection);
     } else {
       const nonOAuthHandler = () => {
@@ -577,6 +579,57 @@ export class MCPConnectionFactory {
       }
       throw error;
     }
+  }
+
+  /** Re-resolves OBO tokens when a cached connection receives a 401/403 response. */
+  protected handleOboEvents(connection: MCPConnection): () => void {
+    let eventHandling: Promise<void> | null = null;
+
+    const handleOboEvent = async (): Promise<void> => {
+      logger.info(`${this.logPrefix} OBO authentication failure received; refreshing token`);
+
+      try {
+        const refreshedTokens = await this.getOboTokens();
+        if (!refreshedTokens) {
+          throw new Error(`OBO token exchange failed for "${this.serverName}".`);
+        }
+
+        connection.setOAuthTokens(refreshedTokens);
+        logger.info(`${this.logPrefix} OBO token refresh succeeded`);
+        connection.emit('oauthHandled', 'silent-refresh' satisfies t.OAuthHandledSource);
+      } catch (error) {
+        let connectionError: Error;
+        if (error instanceof OboTokenResolutionError) {
+          connectionError = this.createOboConnectionError(error);
+        } else if (error instanceof Error) {
+          connectionError = error;
+        } else {
+          connectionError = new Error('OBO token refresh failed');
+        }
+        logger.warn(`${this.logPrefix} OBO token refresh failed`);
+        connection.emit('oauthFailed', connectionError);
+      }
+    };
+
+    const oboHandler = (): Promise<void> => {
+      if (eventHandling) {
+        return eventHandling;
+      }
+
+      const handling = handleOboEvent().finally(() => {
+        if (eventHandling === handling) {
+          eventHandling = null;
+        }
+      });
+      eventHandling = handling;
+      return handling;
+    };
+
+    connection.on('oauthRequired', oboHandler);
+
+    return () => {
+      connection.removeListener('oauthRequired', oboHandler);
+    };
   }
 
   private shouldInitiateOAuthBeforeConnect(oauthTokens: MCPOAuthTokens | null): boolean {

--- a/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
@@ -4817,6 +4817,10 @@ describe('MCPConnectionFactory', () => {
     } as unknown as t.MCPOptions;
 
     beforeEach(() => {
+      const { resolveOboToken } = jest.requireMock('~/mcp/oauth') as {
+        resolveOboToken: jest.Mock;
+      };
+      resolveOboToken.mockReset();
       mockProcessMCPEnv.mockReturnValue(oboServerConfig);
       mockConnectionInstance.connect.mockResolvedValue(undefined);
       mockConnectionInstance.isConnected.mockResolvedValue(true);
@@ -4859,6 +4863,172 @@ describe('MCPConnectionFactory', () => {
         oboTokenResolver,
         upstreamTokenProvider,
         undefined,
+      );
+    });
+
+    it('refreshes the OBO token when a cached connection receives an authentication failure', async () => {
+      const { resolveOboToken } = jest.requireMock('~/mcp/oauth') as {
+        resolveOboToken: jest.Mock;
+      };
+      const initialTokens: MCPOAuthTokens = {
+        access_token: 'initial-obo-token',
+        token_type: 'Bearer',
+        obtained_at: Date.now(),
+        expires_at: Date.now() + 3600_000,
+      };
+      const refreshedTokens: MCPOAuthTokens = {
+        access_token: 'refreshed-obo-token',
+        token_type: 'Bearer',
+        obtained_at: Date.now(),
+        expires_at: Date.now() + 3600_000,
+      };
+      resolveOboToken.mockResolvedValueOnce(initialTokens).mockResolvedValueOnce(refreshedTokens);
+
+      const upstreamTokenProvider = jest.fn();
+      const oboTokenResolver = jest.fn();
+
+      await MCPConnectionFactory.create(
+        { serverName: 'obo-srv', serverConfig: oboServerConfig },
+        {
+          useOAuth: true,
+          user: mockUser,
+          flowManager: mockFlowManager,
+          tokenMethods: {
+            findToken: jest.fn(),
+            createToken: jest.fn(),
+            updateToken: jest.fn(),
+            deleteTokens: jest.fn(),
+          },
+          oboTokenResolver,
+          upstreamTokenProvider,
+        },
+      );
+
+      const onCall = (mockConnectionInstance.on as jest.Mock).mock.calls.find(
+        ([event]: [string]) => event === 'oauthRequired',
+      );
+      const handler = onCall![1] as () => Promise<void>;
+      await handler();
+
+      expect(resolveOboToken).toHaveBeenCalledTimes(2);
+      expect(resolveOboToken).toHaveBeenLastCalledWith(
+        mockUser,
+        oboServerConfig.obo,
+        oboTokenResolver,
+        upstreamTokenProvider,
+        undefined,
+      );
+      expect(mockConnectionInstance.setOAuthTokens).toHaveBeenCalledWith(refreshedTokens);
+      expect(mockConnectionInstance.emit).toHaveBeenCalledWith('oauthHandled', 'silent-refresh');
+      expect(mockConnectionInstance.emit).not.toHaveBeenCalledWith(
+        'oauthFailed',
+        expect.any(Error),
+      );
+    });
+
+    it('coalesces concurrent OBO refresh attempts after authentication failures', async () => {
+      const { resolveOboToken } = jest.requireMock('~/mcp/oauth') as {
+        resolveOboToken: jest.Mock;
+      };
+      const initialTokens: MCPOAuthTokens = {
+        access_token: 'initial-obo-token',
+        token_type: 'Bearer',
+        obtained_at: Date.now(),
+      };
+      const refreshedTokens: MCPOAuthTokens = {
+        access_token: 'refreshed-obo-token',
+        token_type: 'Bearer',
+        obtained_at: Date.now(),
+      };
+      let resolveRefresh!: (tokens: MCPOAuthTokens) => void;
+      const refreshPromise = new Promise<MCPOAuthTokens>((resolve) => {
+        resolveRefresh = resolve;
+      });
+      resolveOboToken.mockResolvedValueOnce(initialTokens).mockReturnValueOnce(refreshPromise);
+
+      await MCPConnectionFactory.create(
+        { serverName: 'obo-srv', serverConfig: oboServerConfig },
+        {
+          useOAuth: true,
+          user: mockUser,
+          flowManager: mockFlowManager,
+          tokenMethods: {
+            findToken: jest.fn(),
+            createToken: jest.fn(),
+            updateToken: jest.fn(),
+            deleteTokens: jest.fn(),
+          },
+          oboTokenResolver: jest.fn(),
+          upstreamTokenProvider: jest.fn(),
+        },
+      );
+
+      const onCall = (mockConnectionInstance.on as jest.Mock).mock.calls.find(
+        ([event]: [string]) => event === 'oauthRequired',
+      );
+      const handler = onCall![1] as () => Promise<void>;
+      const firstRefresh = handler();
+      const secondRefresh = handler();
+
+      expect(resolveOboToken).toHaveBeenCalledTimes(2);
+      resolveRefresh(refreshedTokens);
+      await Promise.all([firstRefresh, secondRefresh]);
+
+      expect(resolveOboToken).toHaveBeenCalledTimes(2);
+      expect(mockConnectionInstance.setOAuthTokens).toHaveBeenCalledTimes(1);
+      expect(mockConnectionInstance.setOAuthTokens).toHaveBeenCalledWith(refreshedTokens);
+      expect(mockConnectionInstance.emit).toHaveBeenCalledTimes(1);
+      expect(mockConnectionInstance.emit).toHaveBeenCalledWith('oauthHandled', 'silent-refresh');
+    });
+
+    it('reports an OBO refresh failure without reusing the rejected token', async () => {
+      const { resolveOboToken } = jest.requireMock('~/mcp/oauth') as {
+        resolveOboToken: jest.Mock;
+      };
+      const initialTokens: MCPOAuthTokens = {
+        access_token: 'initial-obo-token',
+        token_type: 'Bearer',
+        obtained_at: Date.now(),
+      };
+      const refreshError = new OboTokenResolutionError(
+        'session_refresh_failed',
+        'Your sign-in session expired and could not be refreshed. Please sign in again.',
+      );
+      resolveOboToken.mockResolvedValueOnce(initialTokens).mockRejectedValueOnce(refreshError);
+
+      await MCPConnectionFactory.create(
+        { serverName: 'obo-srv', serverConfig: oboServerConfig },
+        {
+          useOAuth: true,
+          user: mockUser,
+          flowManager: mockFlowManager,
+          tokenMethods: {
+            findToken: jest.fn(),
+            createToken: jest.fn(),
+            updateToken: jest.fn(),
+            deleteTokens: jest.fn(),
+          },
+          oboTokenResolver: jest.fn(),
+          upstreamTokenProvider: jest.fn(),
+        },
+      );
+
+      const onCall = (mockConnectionInstance.on as jest.Mock).mock.calls.find(
+        ([event]: [string]) => event === 'oauthRequired',
+      );
+      const handler = onCall![1] as () => Promise<void>;
+      await handler();
+
+      expect(mockConnectionInstance.setOAuthTokens).not.toHaveBeenCalled();
+      expect(mockConnectionInstance.emit).toHaveBeenCalledWith(
+        'oauthFailed',
+        expect.objectContaining({
+          message: expect.stringContaining('Unable to connect to OBO server "obo-srv"'),
+        }),
+      );
+      expect(mockConnectionInstance.emit).not.toHaveBeenCalledWith(
+        'oauthHandled',
+        expect.anything(),
       );
     });
 


### PR DESCRIPTION
## Summary

- register a dedicated authentication-failure handler for OBO MCP connections
- re-run the existing live upstream token resolution and OBO exchange before transport retry
- coalesce concurrent authentication failures into one token exchange
- preserve the existing standard OAuth and non-OAuth behavior

Addresses #15569.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `../../node_modules/.bin/jest src/mcp/__tests__/MCPConnectionFactory.test.ts --runInBand --coverage=false` from `packages/api` (89 tests passed)
- `./node_modules/.bin/tsc --noEmit -p packages/api/tsconfig.json`
- `npm run static-checks -- packages/api/src/mcp/MCPConnectionFactory.ts packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts`

### Test Configuration

- Node.js 24.16.0
- macOS

## Checklist

- [x] My code adheres to this projects style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes