### PR TITLE
🧨 fix: Normalize Conversation Page Limits

### DIFF
--- a/api/server/routes/__tests__/convos.spec.js
+++ b/api/server/routes/__tests__/convos.spec.js
@@ -1387,6 +1387,61 @@ describe('Convos Routes', () => {
     });
   });
 
+  describe('GET / limit clamping', () => {
+    const { getConvosByCursor } = require('~/models');
+
+    beforeEach(() => {
+      getConvosByCursor.mockResolvedValue({ conversations: [], nextCursor: null });
+    });
+
+    /** `parseInt('-1', 10) || 25` is -1 (truthy), which reached Mongo as `.limit(-1 + 1)` =
+     * `.limit(0)` — MongoDB treats 0 as "no limit" and returns every conversation the user
+     * owns, a pagination bypass / self-inflicted DoS on the highest-traffic list route. */
+    it('clamps a negative limit up to the floor of 1', async () => {
+      const response = await request(app).get('/api/convos').query({ limit: '-1' });
+
+      expect(response.status).toBe(200);
+      expect(getConvosByCursor).toHaveBeenCalledWith(
+        'test-user-123',
+        expect.objectContaining({ limit: 1 }),
+      );
+    });
+
+    it('clamps an oversized limit down to the ceiling of 100', async () => {
+      const response = await request(app).get('/api/convos').query({ limit: '100000' });
+
+      expect(response.status).toBe(200);
+      expect(getConvosByCursor).toHaveBeenCalledWith(
+        'test-user-123',
+        expect.objectContaining({ limit: 100 }),
+      );
+    });
+
+    it('falls back to the default of 25 for a non-numeric or absent limit', async () => {
+      await request(app).get('/api/convos').query({ limit: 'abc' });
+      expect(getConvosByCursor).toHaveBeenLastCalledWith(
+        'test-user-123',
+        expect.objectContaining({ limit: 25 }),
+      );
+
+      await request(app).get('/api/convos');
+      expect(getConvosByCursor).toHaveBeenLastCalledWith(
+        'test-user-123',
+        expect.objectContaining({ limit: 25 }),
+      );
+    });
+
+    it('preserves a valid in-range limit unchanged', async () => {
+      const response = await request(app).get('/api/convos').query({ limit: '50' });
+
+      expect(response.status).toBe(200);
+      expect(getConvosByCursor).toHaveBeenCalledWith(
+        'test-user-123',
+        expect.objectContaining({ limit: 50 }),
+      );
+    });
+  });
+
   describe('GET / pinned filter', () => {
     const { getConvosByCursor } = require('~/models');
 

--- a/api/server/routes/convos.js
+++ b/api/server/routes/convos.js
@@ -141,7 +141,7 @@ const isValidProjectFilter = (projectId) =>
   !projectId || projectId === 'unassigned' || /^[a-f\d]{24}$/i.test(projectId);
 
 router.get('/', async (req, res) => {
-  const limit = parseInt(req.query.limit, 10) || 25;
+  const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 25, 1), 100);
   const cursor = req.query.cursor;
   const isArchived = isEnabled(req.query.isArchived);
   const pinned = isEnabled(req.query.pinned);


### PR DESCRIPTION
Fixes #15571.

### Problem

`api/server/routes/convos.js` reads the page size as `const limit = parseInt(req.query.limit, 10) || 25;` and passes it **unclamped** into `getConvosByCursor` → `.limit(limit + 1)` (`packages/data-schemas/src/methods/conversation.ts`). `GET /api/convos?limit=-1` → `parseInt('-1') || 25` = `-1` (truthy) → `.limit(0)`, which MongoDB treats as "no limit" → **all** of the user's conversations are returned in one query (pagination bypass / self-inflicted DoS on the highest-traffic list route). `?limit=999999999` forces an unbounded fetch.

Every other list route already clamps (`normalizeLimit` in `packages/api/src/projects/handlers.ts`; the agents `boundedLimit` fix from #13363). `convos.js` is the sole outlier.

### Fix (one line)

```diff
- const limit = parseInt(req.query.limit, 10) || 25;
+ const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 25, 1), 100);
```

`normalizeLimit` isn't exported, so the identical clamp is inlined. Clamps to [1,100]; keeps 25 for absent/non-numeric input.

### Test

Added a `GET / limit clamping` block to `api/server/routes/__tests__/convos.spec.js` (mirrors the existing `pinned filter` mock pattern): asserts `getConvosByCursor` receives `limit: 1` for `?limit=-1`, `limit: 100` for `?limit=100000`, `limit: 25` for `abc`/absent, and `limit: 50` unchanged.
- **Before:** the two clamp cases fail (received `-1` and `100000` unclamped).
- **After:** 4/4 clamp tests pass; full convos suite 77/77.

ESLint + Prettier clean on the touched files. (Both touched files are plain JS in the `api/` server workspace, which has no tsconfig, so `tsc --noEmit` is N/A per AGENTS.md.)
