### PR TITLE
🪤 chore: Scope Assistant Tool-Resource Lookups

### DIFF
--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -289,10 +289,10 @@ router.delete('/', async (req, res) => {
     /* Handle assistant unlinking even if no valid files to delete */
     if (req.body.assistant_id && req.body.tool_resource && dbFiles.length === 0) {
       const assistant = await db.getAssistant({
-        id: req.body.assistant_id,
+        assistant_id: req.body.assistant_id,
       });
 
-      const toolResourceFiles = assistant.tool_resources?.[req.body.tool_resource]?.file_ids ?? [];
+      const toolResourceFiles = assistant?.tool_resources?.[req.body.tool_resource]?.file_ids ?? [];
       const assistantFiles = files.filter((f) => toolResourceFiles.includes(f.file_id));
 
       const result = await processDeleteRequest({ req, files: assistantFiles });

--- a/api/server/routes/files/files.test.js
+++ b/api/server/routes/files/files.test.js
@@ -694,6 +694,83 @@ describe('File Routes - Delete with Agent Access', () => {
     });
   });
 
+  /* Mirrors api/db/connect.js, which sets strictQuery for the running server. Under it
+     Mongoose DROPS filter keys absent from the schema, so a lookup on a misspelled path
+     degrades to findOne({}) — the first document in the collection, whoever owns it. */
+  describe('DELETE /files - assistant tool resource unlinking', () => {
+    let previousStrictQuery;
+
+    beforeAll(() => {
+      previousStrictQuery = mongoose.get('strictQuery');
+      mongoose.set('strictQuery', true);
+    });
+
+    afterAll(async () => {
+      mongoose.set('strictQuery', previousStrictQuery);
+      await mongoose.connection.collection('assistants').deleteMany({});
+    });
+
+    beforeEach(async () => {
+      await mongoose.connection.collection('assistants').deleteMany({});
+    });
+
+    it("does not unlink another user's assistant files when the requested assistant is missing", async () => {
+      const strangerFileId = uuidv4();
+      /* Written straight to the collection: `tool_resources` predates the current schema. */
+      await mongoose.connection.collection('assistants').insertOne({
+        user: new mongoose.Types.ObjectId(),
+        assistant_id: 'asst_belonging_to_someone_else',
+        tool_resources: { file_search: { file_ids: [strangerFileId] } },
+      });
+
+      const response = await request(app)
+        .delete('/files')
+        .send({
+          assistant_id: 'asst_that_does_not_exist',
+          tool_resource: 'file_search',
+          files: [{ file_id: strangerFileId, filepath: '/uploads/stranger.txt' }],
+        });
+
+      expect(response.status).toBe(200);
+      expect(processDeleteRequest).toHaveBeenCalledWith(expect.objectContaining({ files: [] }));
+    });
+
+    it('unlinks the requested assistant own files', async () => {
+      const ownFileId = uuidv4();
+      await mongoose.connection.collection('assistants').insertOne({
+        user: new mongoose.Types.ObjectId(),
+        assistant_id: 'asst_requested',
+        tool_resources: { file_search: { file_ids: [ownFileId] } },
+      });
+
+      const response = await request(app)
+        .delete('/files')
+        .send({
+          assistant_id: 'asst_requested',
+          tool_resource: 'file_search',
+          files: [{ file_id: ownFileId, filepath: '/uploads/own.txt' }],
+        });
+
+      expect(response.status).toBe(200);
+      expect(processDeleteRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ files: [expect.objectContaining({ file_id: ownFileId })] }),
+      );
+    });
+
+    it('answers instead of throwing when no assistants exist at all', async () => {
+      const response = await request(app)
+        .delete('/files')
+        .send({
+          assistant_id: 'asst_that_does_not_exist',
+          tool_resource: 'file_search',
+          files: [{ file_id: uuidv4(), filepath: '/uploads/ghost.txt' }],
+        });
+
+      expect(response.status).toBe(200);
+      expect(processDeleteRequest).toHaveBeenCalledWith(expect.objectContaining({ files: [] }));
+    });
+  });
+
   describe('GET /files/download-url/:userId/:file_id', () => {
     it('returns a direct signed download URL when the strategy supports it', async () => {
       const userFileId = uuidv4();


### PR DESCRIPTION
CI ran green locally: `api` files route suite 41/41.

## What is wrong

`DELETE /api/files` looks the assistant up by `id`:

```js
const assistant = await db.getAssistant({ id: req.body.assistant_id });
```

The Assistant schema has no `id` path — it stores `assistant_id`. `api/db/connect.js` sets `mongoose.set('strictQuery', true)`, and under `strictQuery` Mongoose **drops filter keys that are not in the schema**. The filter therefore degrades to `{}`, and the lookup returns whichever assistant is first in the collection, whoever owns it.

Verified against Mongoose 8.24.1:

```
strictQuery=false -> findOne({id:'nonexistent'}) = null
strictQuery=true  -> findOne({id:'nonexistent'}) = RETURNED asst_owner_A (user userA)  <-- FOREIGN DOC
```

Two consequences:

1. The unlink path reads that stranger's `tool_resources` and intersects it with the files named in the request, so a file the caller named can be unlinked on the strength of another user's assistant record.
2. When no assistant exists at all the same lookup returns `null`, and the unguarded `assistant.tool_resources` throws — the route answers `400 Error in request` instead of completing.

Impact is bounded: `tool_resources` is not in the current schema, so only documents written by an older version carry it, and the earlier ownership check means every file in play already belongs to the caller. It is a correctness bug with a cross-user edge, not a data-disclosure hole.

## The fix

Filter on `assistant_id`, and guard the dereference.

## Tests

Three route tests in `files.test.js`. They set `strictQuery` to match `connect.js` — **without that the harness cannot reproduce either failure**, because the default (`false`) returns `null` and only ever shows the crash.

Each was confirmed against the unfixed code:

| test | unfixed |
|---|---|
| does not unlink another user's assistant files | ❌ stranger's file selected |
| unlinks the requested assistant own files | ✅ (guards against over-fixing) |
| answers instead of throwing when no assistants exist | ❌ 400 crash |

## Note

Found while removing `FilterQuery` from `@librechat/data-schemas`' public surface. The follow-up (#15580) makes this class of bug unrepresentable: `getAssistant` takes a typed `AssistantQuery`, and the translator throws on an unrecognized criterion rather than silently widening the filter.