### PR TITLE
🧫 fix: Reject Null Agent Management Models

### DIFF
--- a/packages/api/src/agents/creates.spec.ts
+++ b/packages/api/src/agents/creates.spec.ts
@@ -105,6 +105,22 @@ describe('Agent Management create handler', () => {
     expect(deps.createAgent).not.toHaveBeenCalled();
   });
 
+  it('rejects a null model as invalid input before persistence', async () => {
+    const deps = makeDeps();
+    const response = makeResponse();
+
+    await createAgentManagementCreateHandler(deps)(
+      makeRequest({ body: { ...validBody, model: null } }),
+      response,
+    );
+
+    expect(response.status).toHaveBeenCalledWith(400);
+    expect(response.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.objectContaining({ code: 'invalid_request' }) }),
+    );
+    expect(deps.createAgent).not.toHaveBeenCalled();
+  });
+
   it('requires the same AGENTS USE and CREATE permissions as browser creation', async () => {
     const deps = makeDeps({
       getRoleByName: jest.fn().mockResolvedValue({

--- a/packages/api/src/agents/management.spec.ts
+++ b/packages/api/src/agents/management.spec.ts
@@ -77,6 +77,12 @@ describe('Agent Management contract', () => {
         expect(schema.safeParse({ ...base, versions: [] }).success).toBe(false);
       },
     );
+
+    it('rejects a null model before Agent creation reaches persistence', () => {
+      expect(
+        agentManagementCreateSchema.safeParse({ provider: 'openAI', model: null }).success,
+      ).toBe(false);
+    });
   });
 
   describe('pagination', () => {

--- a/packages/api/src/agents/management.ts
+++ b/packages/api/src/agents/management.ts
@@ -10,7 +10,12 @@ const MAX_LIST_LIMIT = 100;
 const DEFAULT_LIST_LIMIT = 20;
 const MAX_CURSOR_LENGTH = 512;
 
-export type AgentManagementCreate = z.output<typeof agentCreateSchema>;
+export type AgentManagementCreate = Omit<z.output<typeof agentCreateSchema>, 'model'> & {
+  model: string;
+};
+type AgentManagementCreateInput = Omit<z.input<typeof agentCreateSchema>, 'model'> & {
+  model: string;
+};
 export type AgentManagementUpdate = z.output<typeof agentUpdateSchema>;
 export type AgentManagementList = {
   limit: number;
@@ -75,8 +80,8 @@ export type AgentManagementError = {
 export const agentManagementCreateSchema: z.ZodType<
   AgentManagementCreate,
   z.ZodTypeDef,
-  z.input<typeof agentCreateSchema>
-> = agentCreateSchema.strict();
+  AgentManagementCreateInput
+> = agentCreateSchema.extend({ model: z.string() }).strict();
 export const agentManagementUpdateSchema: z.ZodType<AgentManagementUpdate> =
   agentUpdateSchema.strict();
 


### PR DESCRIPTION
## Summary

I tightened the Agent Management creation contract so inputs accepted by validation cannot fail later at Mongo persistence because the required model is null.

- Require `model` to be a string in the management create type and runtime schema.
- Reject null models through the stable `invalid_request` envelope before invoking persistence.
- Add contract and handler regression coverage for the rejected input.
- Keep the browser Agent validator unchanged.

This pull request is stacked on #15564.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `src/agents/management.spec.ts` and `src/agents/creates.spec.ts` directly: 26 tests passed.
- Ran ESLint on the three touched files.
- Ran Prettier verification on the three touched files.
- Ran diff validation successfully.

### **Test Configuration**:

- Node.js 24
- Jest with the existing Agent Management fixtures
- Shared workspace dependencies from the primary LibreChat checkout

## Checklist

- [x] My code adheres to this projects style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes