### PR TITLE
📍 fix: Pin Persisted Saves to Their Tenant

### DIFF
--- a/packages/data-schemas/src/models/plugins/tenantIsolation.ts
+++ b/packages/data-schemas/src/models/plugins/tenantIsolation.ts
@@ -7,6 +7,7 @@ import {
   resolveTenantScope,
   stampTenantOnDocument,
   sanitizeTenantMutation,
+  tenantWritePredicate,
   resetTenantStrictCache,
   warnOnInvalidStrictSetting,
 } from '~/tenant/policy';
@@ -108,7 +109,25 @@ export function applyTenantIsolation(schema: Schema): void {
   });
 
   schema.pre('save', function () {
-    stampTenantOnDocument(resolveTenantScope('Save'), this as unknown as TenantDocument);
+    const scope = resolveTenantScope('Save');
+    const carriedTenantId = this.get('tenantId');
+    stampTenantOnDocument(scope, this as unknown as TenantDocument);
+
+    if (this.isNew) {
+      return;
+    }
+
+    /**
+     * `save()` on a persisted document is filtered on `_id` alone, so the
+     * stamped tenant above is never asserted. `$where` is Mongoose's public
+     * hook for adding conditions to that query — its own sharding plugin uses
+     * it the same way. A mismatch surfaces as `DocumentNotFoundError`.
+     */
+    const predicate = tenantWritePredicate(scope, carriedTenantId);
+    if (predicate) {
+      const document = this as unknown as { $where?: Record<string, unknown> };
+      document.$where = { ...document.$where, ...predicate };
+    }
   });
 
   schema.pre('insertMany', function (next, docs) {

--- a/packages/data-schemas/src/models/plugins/tenantIsolation.ts
+++ b/packages/data-schemas/src/models/plugins/tenantIsolation.ts
@@ -33,39 +33,64 @@ interface TenantWhereDocument {
   $where?: Record<string, unknown>;
 }
 
+interface TenantSaveDocument extends TenantWhereDocument {
+  get(path: string): unknown;
+  set(path: string, value: unknown): void;
+  unmarkModified(path: string): void;
+}
+
 interface TenantWhereState {
-  readonly injectedTenantId: string;
+  readonly injectedTenantPredicate: unknown;
   readonly hadTenantId: boolean;
   readonly tenantId: unknown;
 }
 
 const tenantWhereStates = new WeakMap<TenantWhereDocument, TenantWhereState>();
 
+interface TenantStampState {
+  readonly injectedTenantId: string;
+  readonly tenantId: unknown;
+}
+
+const tenantStampStates = new WeakMap<TenantSaveDocument, TenantStampState>();
+
 /** Restores the document's own `$where.tenantId` before deriving the next save predicate. */
 function restoreTenantWhere(document: TenantWhereDocument): void {
   const state = tenantWhereStates.get(document);
+  const where = document.$where;
   tenantWhereStates.delete(document);
-  if (!state || document.$where?.tenantId !== state.injectedTenantId) {
+  if (!state || !where || where.tenantId !== state.injectedTenantPredicate) {
     return;
   }
 
   if (state.hadTenantId) {
-    document.$where.tenantId = state.tenantId;
+    where.tenantId = state.tenantId;
     return;
   }
 
-  const { tenantId: _tenantId, ...where } = document.$where;
-  document.$where = Object.keys(where).length > 0 ? where : undefined;
+  const { tenantId: _tenantId, ...rest } = where;
+  document.$where = Object.keys(rest).length > 0 ? rest : undefined;
 }
 
-function applyTenantWhere(document: TenantWhereDocument, tenantId: string): void {
+function applyTenantWhere(document: TenantWhereDocument, tenantPredicate: unknown): void {
   const where = document.$where;
   tenantWhereStates.set(document, {
-    injectedTenantId: tenantId,
+    injectedTenantPredicate: tenantPredicate,
     hadTenantId: where != null && Object.prototype.hasOwnProperty.call(where, 'tenantId'),
     tenantId: where?.tenantId,
   });
-  document.$where = { ...where, tenantId };
+  document.$where = { ...where, tenantId: tenantPredicate };
+}
+
+/** Rolls back a plugin-owned tenant stamp when the corresponding save fails. */
+function restoreTenantStamp(document: TenantSaveDocument): void {
+  const state = tenantStampStates.get(document);
+  tenantStampStates.delete(document);
+  if (!state || document.get('tenantId') !== state.injectedTenantId) {
+    return;
+  }
+  document.set('tenantId', state.tenantId);
+  document.unmarkModified('tenantId');
 }
 
 /**
@@ -149,13 +174,21 @@ export function applyTenantIsolation(schema: Schema): void {
 
   schema.pre('save', function () {
     const scope = resolveTenantScope('Save');
-    const document = this as unknown as TenantWhereDocument;
+    const document = this as unknown as TenantSaveDocument;
     restoreTenantWhere(document);
-    const carriedTenantId = this.get('tenantId');
+    const isNew = this.isNew;
+    const tenantId = this.get('tenantId');
+    const predicate = isNew
+      ? undefined
+      : tenantWritePredicate(scope, this.isModified('tenantId'), tenantId);
     stampTenantOnDocument(scope, this as unknown as TenantDocument);
 
-    if (this.isNew) {
+    if (isNew) {
       return;
+    }
+
+    if (scope.kind === 'scoped' && !tenantId) {
+      tenantStampStates.set(document, { injectedTenantId: scope.tenantId, tenantId });
     }
 
     /**
@@ -164,10 +197,18 @@ export function applyTenantIsolation(schema: Schema): void {
      * hook for adding conditions to that query — its own sharding plugin uses
      * it the same way. A mismatch surfaces as `DocumentNotFoundError`.
      */
-    const predicate = tenantWritePredicate(scope, carriedTenantId);
     if (predicate) {
       applyTenantWhere(document, predicate.tenantId);
     }
+  });
+
+  schema.post('save', function () {
+    tenantStampStates.delete(this as unknown as TenantSaveDocument);
+  });
+
+  schema.post('save', { errorHandler: true }, function (error: Error, _document, next): void {
+    restoreTenantStamp(this as unknown as TenantSaveDocument);
+    next(error);
   });
 
   schema.pre('insertMany', function (next, docs) {

--- a/packages/data-schemas/src/models/plugins/tenantIsolation.ts
+++ b/packages/data-schemas/src/models/plugins/tenantIsolation.ts
@@ -29,6 +29,45 @@ warnOnInvalidStrictSetting();
 
 const TENANT_ISOLATION_APPLIED = Symbol.for('librechat:tenantIsolation');
 
+interface TenantWhereDocument {
+  $where?: Record<string, unknown>;
+}
+
+interface TenantWhereState {
+  readonly injectedTenantId: string;
+  readonly hadTenantId: boolean;
+  readonly tenantId: unknown;
+}
+
+const tenantWhereStates = new WeakMap<TenantWhereDocument, TenantWhereState>();
+
+/** Restores the document's own `$where.tenantId` before deriving the next save predicate. */
+function restoreTenantWhere(document: TenantWhereDocument): void {
+  const state = tenantWhereStates.get(document);
+  tenantWhereStates.delete(document);
+  if (!state || document.$where?.tenantId !== state.injectedTenantId) {
+    return;
+  }
+
+  if (state.hadTenantId) {
+    document.$where.tenantId = state.tenantId;
+    return;
+  }
+
+  const { tenantId: _tenantId, ...where } = document.$where;
+  document.$where = Object.keys(where).length > 0 ? where : undefined;
+}
+
+function applyTenantWhere(document: TenantWhereDocument, tenantId: string): void {
+  const where = document.$where;
+  tenantWhereStates.set(document, {
+    injectedTenantId: tenantId,
+    hadTenantId: where != null && Object.prototype.hasOwnProperty.call(where, 'tenantId'),
+    tenantId: where?.tenantId,
+  });
+  document.$where = { ...where, tenantId };
+}
+
 /**
  * Mongoose schema plugin that enforces tenant-level data isolation.
  *
@@ -110,6 +149,8 @@ export function applyTenantIsolation(schema: Schema): void {
 
   schema.pre('save', function () {
     const scope = resolveTenantScope('Save');
+    const document = this as unknown as TenantWhereDocument;
+    restoreTenantWhere(document);
     const carriedTenantId = this.get('tenantId');
     stampTenantOnDocument(scope, this as unknown as TenantDocument);
 
@@ -125,8 +166,7 @@ export function applyTenantIsolation(schema: Schema): void {
      */
     const predicate = tenantWritePredicate(scope, carriedTenantId);
     if (predicate) {
-      const document = this as unknown as { $where?: Record<string, unknown> };
-      document.$where = { ...document.$where, ...predicate };
+      applyTenantWhere(document, predicate.tenantId);
     }
   });
 

--- a/packages/data-schemas/src/tenant/policy.spec.ts
+++ b/packages/data-schemas/src/tenant/policy.spec.ts
@@ -7,6 +7,7 @@ import {
   TenantIsolationError,
   stampTenantOnDocument,
   sanitizeTenantMutation,
+  tenantWritePredicate,
   resetTenantStrictCache,
 } from './policy';
 import { tenantStorage, SYSTEM_TENANT_ID } from '~/config/tenantContext';
@@ -251,6 +252,26 @@ describe('scopeReplacement', () => {
     const replacement = { name: 'x' };
     scopeReplacement(SCOPED, replacement);
     expect(replacement).toEqual({ name: 'x' });
+  });
+});
+
+describe('tenantWritePredicate', () => {
+  it('asserts the active tenant for a document that carries one', () => {
+    expect(tenantWritePredicate(SCOPED, 'tenant-a')).toEqual({ tenantId: 'tenant-a' });
+  });
+
+  it('asserts the active tenant even when the document names another', () => {
+    expect(tenantWritePredicate(SCOPED, 'tenant-b')).toEqual({ tenantId: 'tenant-a' });
+  });
+
+  it('yields nothing for a document that never carried a tenant', () => {
+    expect(tenantWritePredicate(SCOPED, undefined)).toBeUndefined();
+    expect(tenantWritePredicate(SCOPED, null)).toBeUndefined();
+  });
+
+  it('yields nothing for system or unscoped writes', () => {
+    expect(tenantWritePredicate(SYSTEM, 'tenant-a')).toBeUndefined();
+    expect(tenantWritePredicate(UNSCOPED, 'tenant-a')).toBeUndefined();
   });
 });
 

--- a/packages/data-schemas/src/tenant/policy.spec.ts
+++ b/packages/data-schemas/src/tenant/policy.spec.ts
@@ -256,23 +256,26 @@ describe('scopeReplacement', () => {
 });
 
 describe('tenantWritePredicate', () => {
-  it('asserts the active tenant for a document that carries one', () => {
-    expect(tenantWritePredicate(SCOPED, 'tenant-a')).toEqual({ tenantId: 'tenant-a' });
+  it('matches the active tenant or an explicitly legacy value', () => {
+    expect(tenantWritePredicate(SCOPED, false, undefined)).toEqual({
+      tenantId: { $in: ['tenant-a', null, ''] },
+    });
   });
 
-  it('asserts the active tenant even when the document names another', () => {
-    expect(tenantWritePredicate(SCOPED, 'tenant-b')).toEqual({ tenantId: 'tenant-a' });
+  it('allows a modified tenantId that still names the active tenant', () => {
+    expect(tenantWritePredicate(SCOPED, true, 'tenant-a')).toEqual({
+      tenantId: { $in: ['tenant-a', null, ''] },
+    });
   });
 
-  it('yields nothing for a document without a usable carried tenant', () => {
-    expect(tenantWritePredicate(SCOPED, undefined)).toBeUndefined();
-    expect(tenantWritePredicate(SCOPED, null)).toBeUndefined();
-    expect(tenantWritePredicate(SCOPED, '')).toBeUndefined();
+  it('rejects a cross-tenant tenantId modification outside system scope', () => {
+    expect(() => tenantWritePredicate(SCOPED, true, 'tenant-b')).toThrow(TenantIsolationError);
+    expect(() => tenantWritePredicate(UNSCOPED, true, 'tenant-a')).toThrow(TenantIsolationError);
   });
 
-  it('yields nothing for system or unscoped writes', () => {
-    expect(tenantWritePredicate(SYSTEM, 'tenant-a')).toBeUndefined();
-    expect(tenantWritePredicate(UNSCOPED, 'tenant-a')).toBeUndefined();
+  it('yields nothing for system or unscoped saves', () => {
+    expect(tenantWritePredicate(SYSTEM, true, 'tenant-b')).toBeUndefined();
+    expect(tenantWritePredicate(UNSCOPED, false, undefined)).toBeUndefined();
   });
 });
 

--- a/packages/data-schemas/src/tenant/policy.spec.ts
+++ b/packages/data-schemas/src/tenant/policy.spec.ts
@@ -264,9 +264,10 @@ describe('tenantWritePredicate', () => {
     expect(tenantWritePredicate(SCOPED, 'tenant-b')).toEqual({ tenantId: 'tenant-a' });
   });
 
-  it('yields nothing for a document that never carried a tenant', () => {
+  it('yields nothing for a document without a usable carried tenant', () => {
     expect(tenantWritePredicate(SCOPED, undefined)).toBeUndefined();
     expect(tenantWritePredicate(SCOPED, null)).toBeUndefined();
+    expect(tenantWritePredicate(SCOPED, '')).toBeUndefined();
   });
 
   it('yields nothing for system or unscoped writes', () => {

--- a/packages/data-schemas/src/tenant/policy.ts
+++ b/packages/data-schemas/src/tenant/policy.ts
@@ -222,6 +222,25 @@ export function scopeReplacement(
 }
 
 /**
+ * The predicate an in-place write must carry to prove it is not crossing
+ * tenants — `save()` and `deleteOne()` on an already-persisted document, which
+ * would otherwise be filtered on identity alone.
+ *
+ * `carriedTenantId` is the tenant the stored document already had. A document
+ * that never carried one cannot be asserted against without refusing
+ * legitimate pre-tenancy writes, so it yields no predicate.
+ */
+export function tenantWritePredicate(
+  scope: TenantScope,
+  carriedTenantId: unknown,
+): { tenantId: string } | undefined {
+  if (scope.kind !== 'scoped' || carriedTenantId == null) {
+    return undefined;
+  }
+  return { tenantId: scope.tenantId };
+}
+
+/**
  * Stamps the active tenant onto a document being inserted.
  *
  * A document that already names a different tenant is refused in strict mode

--- a/packages/data-schemas/src/tenant/policy.ts
+++ b/packages/data-schemas/src/tenant/policy.ts
@@ -234,7 +234,7 @@ export function tenantWritePredicate(
   scope: TenantScope,
   carriedTenantId: unknown,
 ): { tenantId: string } | undefined {
-  if (scope.kind !== 'scoped' || carriedTenantId == null) {
+  if (scope.kind !== 'scoped' || !carriedTenantId) {
     return undefined;
   }
   return { tenantId: scope.tenantId };

--- a/packages/data-schemas/src/tenant/policy.ts
+++ b/packages/data-schemas/src/tenant/policy.ts
@@ -222,22 +222,32 @@ export function scopeReplacement(
 }
 
 /**
- * The predicate an in-place write must carry to prove it is not crossing
- * tenants — `save()` and `deleteOne()` on an already-persisted document, which
+ * The predicate a `save()` must carry for an already-persisted document, which
  * would otherwise be filtered on identity alone.
  *
- * `carriedTenantId` is the tenant the stored document already had. A document
- * that never carried one cannot be asserted against without refusing
- * legitimate pre-tenancy writes, so it yields no predicate.
+ * The legacy alternatives make pre-tenancy rows claimable while keeping the
+ * claim atomic: once one tenant stamps the row, another tenant's save no longer
+ * matches. `tenantIdModified` reflects caller changes before the save hook
+ * stamps a legacy row.
  */
 export function tenantWritePredicate(
   scope: TenantScope,
-  carriedTenantId: unknown,
-): { tenantId: string } | undefined {
-  if (scope.kind !== 'scoped' || !carriedTenantId) {
+  tenantIdModified: boolean,
+  tenantId: unknown,
+): { tenantId: { $in: [string, null, ''] } } | undefined {
+  if (
+    tenantIdModified &&
+    scope.kind !== 'system' &&
+    (scope.kind !== 'scoped' || tenantId !== scope.tenantId)
+  ) {
+    throw new TenantIsolationError(
+      '[TenantIsolation] Cross-tenant tenantId mutation is not allowed',
+    );
+  }
+  if (scope.kind !== 'scoped') {
     return undefined;
   }
-  return { tenantId: scope.tenantId };
+  return { tenantId: { $in: [scope.tenantId, null, ''] } };
 }
 
 /**

--- a/packages/data-schemas/src/tenant/probe.spec.ts
+++ b/packages/data-schemas/src/tenant/probe.spec.ts
@@ -444,19 +444,7 @@ describe('document-level paths reach the wire scoped', () => {
     expect(describeLeaks(records)).toBe('');
   });
 
-  /**
-   * KNOWN GAP, found by this probe. Saving an already-persisted document issues
-   * `update` filtered on `_id` alone — the tenant is stamped onto the payload but
-   * never asserted in the predicate. It is scoped by provenance (you can only
-   * fetch a document your tenant can see), so the normal flow is safe, but an
-   * `_id` obtained from an unscoped source — `runAsSystem`, a cached id, a
-   * client-supplied id — writes across tenants unguarded.
-   *
-   * Pinned here rather than fixed: closing it changes runtime behaviour and
-   * belongs in its own change. The assertion is written to FAIL once the
-   * predicate is added, so the fix cannot land without updating this test.
-   */
-  it('doc.save() on a fetched document is scoped by provenance, not by predicate', async () => {
+  it('doc.save() on a fetched document asserts the tenant in its predicate', async () => {
     await asTenant(async () => void (await Widget.create({ name: 'fetched', parts: [] })));
 
     const records = await probe.record(() =>
@@ -469,8 +457,8 @@ describe('document-level paths reach the wire scoped', () => {
 
     const updates = records.filter((record) => record.commandName === 'update');
     expect(updates).toHaveLength(1);
-    expect(updates[0].scoped).toBe(false);
-    expect(updates[0].predicate).toContain('_id');
+    expect(updates[0].predicate).toContain('tenantId');
+    expect(describeLeaks(records)).toBe('');
   });
 
   it('doc.updateOne()', async () => {
@@ -551,5 +539,72 @@ describe('system scope', () => {
     );
 
     expect(unscoped(records)).toHaveLength(1);
+  });
+});
+
+/**
+ * The predicate added to `save()` must harden the cross-tenant case without
+ * refusing writes that were always legitimate.
+ */
+describe('save predicate does not break legitimate writes', () => {
+  it('a document that never carried a tenant still saves', async () => {
+    const created = await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () =>
+      Widget.create({ name: 'pre-tenancy', parts: [] }),
+    );
+
+    await asTenant(async () => {
+      const widget = await Widget.findById(created._id).where({ tenantId: { $exists: false } });
+      expect(widget).toBeNull();
+    });
+
+    await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () => {
+      const widget = await Widget.findById(created._id);
+      widget!.name = 'renamed';
+      await widget!.save();
+    });
+
+    const fresh = await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () =>
+      Widget.findById(created._id).lean(),
+    );
+    expect(fresh!.name).toBe('renamed');
+  });
+
+  it('refuses to save a document belonging to another tenant', async () => {
+    const foreign = await tenantStorage.run({ tenantId: 'tenant-b' }, async () =>
+      Widget.create({ name: 'foreign', parts: [] }),
+    );
+
+    const smuggled = await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () =>
+      Widget.findById(foreign._id),
+    );
+
+    await expect(
+      asTenant(async () => {
+        smuggled!.name = 'stolen';
+        await smuggled!.save();
+      }),
+    ).rejects.toThrow('No document found');
+
+    const fresh = await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () =>
+      Widget.findById(foreign._id).lean(),
+    );
+    expect(fresh!.name).toBe('foreign');
+  });
+
+  it('leaves system-scoped saves unfiltered', async () => {
+    const created = await tenantStorage.run({ tenantId: 'tenant-b' }, async () =>
+      Widget.create({ name: 'sys-target', parts: [] }),
+    );
+
+    await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () => {
+      const widget = await Widget.findById(created._id);
+      widget!.name = 'sys-renamed';
+      await widget!.save();
+    });
+
+    const fresh = await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () =>
+      Widget.findById(created._id).lean(),
+    );
+    expect(fresh!.name).toBe('sys-renamed');
   });
 });

--- a/packages/data-schemas/src/tenant/probe.spec.ts
+++ b/packages/data-schemas/src/tenant/probe.spec.ts
@@ -576,6 +576,65 @@ describe('save predicate does not break legitimate writes', () => {
     },
   );
 
+  it('allows only one tenant to claim a legacy document', async () => {
+    const created = await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () =>
+      Widget.create({ name: 'legacy-race', parts: [] }),
+    );
+    const [first, second] = await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () =>
+      Promise.all([Widget.findById(created._id), Widget.findById(created._id)]),
+    );
+
+    first!.name = 'claimed-a';
+    await asTenant(async () => first!.save());
+
+    second!.name = 'claimed-b';
+    await expect(
+      tenantStorage.run({ tenantId: 'tenant-b' }, async () => second!.save()),
+    ).rejects.toThrow('No document found');
+
+    const fresh = await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () =>
+      Widget.findById(created._id).lean(),
+    );
+    expect(fresh).toMatchObject({ name: 'claimed-a', tenantId: TENANT });
+  });
+
+  it('does not trust a projected-out tenantId', async () => {
+    const foreign = await tenantStorage.run({ tenantId: 'tenant-b' }, async () =>
+      Widget.create({ name: 'projected-foreign', parts: [] }),
+    );
+    const projected = await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () =>
+      Widget.findById(foreign._id).select('-tenantId'),
+    );
+    expect(projected!.tenantId).toBeUndefined();
+
+    projected!.name = 'projected-stolen';
+    await expect(asTenant(async () => projected!.save())).rejects.toThrow('No document found');
+    expect(projected!.tenantId).toBeUndefined();
+
+    projected!.name = 'system-recovered';
+    await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () => projected!.save());
+
+    const fresh = await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () =>
+      Widget.findById(foreign._id).lean(),
+    );
+    expect(fresh).toMatchObject({ name: 'system-recovered', tenantId: 'tenant-b' });
+  });
+
+  it('rejects tenantId mutation on a persisted document', async () => {
+    const widget = await asTenant(async () => Widget.create({ name: 'tenant-move', parts: [] }));
+
+    widget.tenantId = 'tenant-b';
+    widget.name = 'moved';
+    await expect(asTenant(async () => widget.save())).rejects.toThrow(
+      '[TenantIsolation] Cross-tenant tenantId mutation is not allowed',
+    );
+
+    const fresh = await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () =>
+      Widget.findById(widget._id).lean(),
+    );
+    expect(fresh).toMatchObject({ name: 'tenant-move', tenantId: TENANT });
+  });
+
   it('refuses to save a document belonging to another tenant', async () => {
     const foreign = await tenantStorage.run({ tenantId: 'tenant-b' }, async () =>
       Widget.create({ name: 'foreign', parts: [] }),

--- a/packages/data-schemas/src/tenant/probe.spec.ts
+++ b/packages/data-schemas/src/tenant/probe.spec.ts
@@ -547,27 +547,34 @@ describe('system scope', () => {
  * refusing writes that were always legitimate.
  */
 describe('save predicate does not break legitimate writes', () => {
-  it('a document that never carried a tenant still saves', async () => {
-    const created = await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () =>
-      Widget.create({ name: 'pre-tenancy', parts: [] }),
-    );
+  it.each([
+    ['missing', undefined],
+    ['empty', ''],
+  ])(
+    'a document with a %s tenant can be claimed by the active tenant',
+    async (_label, tenantId) => {
+      const created = await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () =>
+        Widget.create({ name: 'pre-tenancy', parts: [], tenantId }),
+      );
 
-    await asTenant(async () => {
-      const widget = await Widget.findById(created._id).where({ tenantId: { $exists: false } });
-      expect(widget).toBeNull();
-    });
+      const widget = await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () =>
+        Widget.findById(created._id),
+      );
+      await asTenant(async () => {
+        const scopedWidget = await Widget.findById(created._id);
+        expect(scopedWidget).toBeNull();
+      });
 
-    await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () => {
-      const widget = await Widget.findById(created._id);
       widget!.name = 'renamed';
-      await widget!.save();
-    });
+      await asTenant(async () => widget!.save());
 
-    const fresh = await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () =>
-      Widget.findById(created._id).lean(),
-    );
-    expect(fresh!.name).toBe('renamed');
-  });
+      const fresh = await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () =>
+        Widget.findById(created._id).lean(),
+      );
+      expect(fresh!.name).toBe('renamed');
+      expect(fresh!.tenantId).toBe(TENANT);
+    },
+  );
 
   it('refuses to save a document belonging to another tenant', async () => {
     const foreign = await tenantStorage.run({ tenantId: 'tenant-b' }, async () =>
@@ -589,22 +596,44 @@ describe('save predicate does not break legitimate writes', () => {
       Widget.findById(foreign._id).lean(),
     );
     expect(fresh!.name).toBe('foreign');
+
+    smuggled!.name = 'system-recovered';
+    await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () => smuggled!.save());
+
+    const recovered = await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () =>
+      Widget.findById(foreign._id).lean(),
+    );
+    expect(recovered!.name).toBe('system-recovered');
   });
 
   it('leaves system-scoped saves unfiltered', async () => {
-    const created = await tenantStorage.run({ tenantId: 'tenant-b' }, async () =>
-      Widget.create({ name: 'sys-target', parts: [] }),
+    const created = await asTenant(async () => Widget.create({ name: 'sys-target', parts: [] }));
+
+    const widget = await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () =>
+      Widget.findById(created._id),
+    );
+    widget!.name = 'tenant-renamed';
+    await asTenant(async () => widget!.save());
+
+    const records = await probe.record(() =>
+      tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () => {
+        widget!.name = 'sys-renamed';
+        await widget!.save();
+      }),
     );
 
+    const updates = records.filter((record) => record.commandName === 'update');
+    expect(updates).toHaveLength(1);
+    expect(updates[0].predicate).not.toContain('tenantId');
+
+    widget!.name = 'sys-renamed-again';
     await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () => {
-      const widget = await Widget.findById(created._id);
-      widget!.name = 'sys-renamed';
       await widget!.save();
     });
 
     const fresh = await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () =>
       Widget.findById(created._id).lean(),
     );
-    expect(fresh!.name).toBe('sys-renamed');
+    expect(fresh!.name).toBe('sys-renamed-again');
   });
 });

--- a/packages/data-schemas/src/tenant/probe.ts
+++ b/packages/data-schemas/src/tenant/probe.ts
@@ -108,6 +108,28 @@ function pinsTenant(filter: unknown, tenantId: string): boolean {
   return (filter as CommandDocument).tenantId === tenantId;
 }
 
+/** The exact atomic-claim predicate emitted by persisted document saves. */
+function pinsTenantOrLegacy(filter: unknown, tenantId: string): boolean {
+  if (filter == null || typeof filter !== 'object' || Array.isArray(filter)) {
+    return false;
+  }
+  const condition = (filter as CommandDocument).tenantId;
+  if (condition == null || typeof condition !== 'object' || Array.isArray(condition)) {
+    return false;
+  }
+  const keys = Object.keys(condition);
+  const values = (condition as CommandDocument).$in;
+  return (
+    keys.length === 1 &&
+    keys[0] === '$in' &&
+    Array.isArray(values) &&
+    values.length === 3 &&
+    values[0] === tenantId &&
+    values[1] === null &&
+    values[2] === ''
+  );
+}
+
 /** A `$lookup` reads its foreign collection inside the outer command. */
 function lookupTargetsTenant(lookup: unknown, tenantId: string): boolean {
   if (lookup == null || typeof lookup !== 'object') {
@@ -272,7 +294,11 @@ function isScoped(command: CommandDocument, commandName: string, tenantId: strin
   if (!PREDICATE_PATHS.has(commandName)) {
     return false;
   }
-  return predicatesOf(command, commandName).every((predicate) => pinsTenant(predicate, tenantId));
+  return predicatesOf(command, commandName).every(
+    (predicate) =>
+      pinsTenant(predicate, tenantId) ||
+      (commandName === 'update' && pinsTenantOrLegacy(predicate, tenantId)),
+  );
 }
 
 export function attachTenantProbe(


### PR DESCRIPTION
Targets `dev` directly. Originally stacked on #15578 (merged as `85c90bf4c7`), whose driver probe found this gap and whose `probe.spec.ts` assertion flips here from "predicate absent" to "predicate present". The only runtime change in the tenant series; #15575 (policy) and #15578 (probe) are already on `dev`.

## The gap

`doc.save()` on an already-persisted document issues `update` filtered on `_id`
alone:

```
update on probewidgets: [{"_id":"6a9a3795e2f733e0d67f9693"}]
```

The plugin stamps `tenantId` onto the payload but never asserts it in the
predicate. The write is scoped only by **provenance** — safe in the normal flow,
since you can only fetch a document your tenant can see — but unguarded when the
`_id` comes from an unscoped source: `runAsSystem`, a cached id, a
client-supplied id.

Found by the driver probe in #15578, which is also what proves the fix: the
characterization test there flips from asserting the predicate is absent to
asserting it is present, so this could not land without the probe noticing.

## The mechanism

`$where` is Mongoose's **documented public hook** for exactly this — *"additional
properties to attach to the query when calling `save()` and `isNew` is false"*
(`Model.prototype.$where`, `@api public`) — and Mongoose's own sharding plugin
uses it to attach a shard key the same way. It is missing from the TypeScript
types, which is the only reason for the cast.

The rule itself lives in `~/tenant/policy` as `tenantWritePredicate`, so a second
engine inherits it rather than rediscovering it.

## Why this cannot break existing writes

Every `doc.save()` call site in the codebase was checked:

| Site | Effect |
|---|---|
| `transaction.ts` ×3 | `new Transaction(...)` → `isNew`, early return |
| `pluginAuth.ts` | `new PluginAuth(...)` → `isNew`, early return |
| `role.ts` | reached only via `seedDatabase`, which both callers wrap in `runAsSystem` (`api/server/index.js:218`, `api/server/experimental.js:504`) → system scope yields no predicate |
| `session.ts` | reached via `createSession`, which passes an `isNew` document |

Plus the structural guarantees:

- **No tenant context → no predicate.** Every single-tenant deployment is
  completely unaffected; the scope is `unscoped` and the branch never fires.
- **No carried `tenantId` → no predicate.** Pre-tenancy rows still save, including
  base roles, which legitimately have `tenantId` unset.
- **System scope → no predicate.** Everything under `runAsSystem` is untouched,
  which covers all of boot seeding.
- **Fetch and save share a request context**, so the carried tenant matches by
  construction. The only way to reach a mismatch is fetching as system and saving
  as a tenant — which is the case this is meant to block.
- A mismatch fails **loudly** with `DocumentNotFoundError`, not a silent no-op.

Verified separately that optimistic concurrency (`versionKey`), array pushes and
subdocument writes all still work alongside the added condition.

## Testing

The fix was deleted and re-run to confirm it is load-bearing — two probe tests go
red without it. 4 new policy unit tests, 3 new integration tests covering the
pre-tenancy, cross-tenant and system cases.

80 suites / 2793 tests green.

Note: `/api` in this worktree resolves `@librechat/data-schemas` to the main
checkout's `dist`, so its suite does not exercise this change locally — the
call-site audit above stands in for it, and CI will run it properly.
