### PR TITLE
🧳 test: Define Portable Tenant Isolation Contract

### DIFF
--- a/packages/data-schemas/src/tenant/conformance.mongoose.spec.ts
+++ b/packages/data-schemas/src/tenant/conformance.mongoose.spec.ts
@@ -1,0 +1,83 @@
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import type { TenantRow, TenantEngineHarness } from './conformance';
+import { applyTenantIsolation } from '~/models/plugins/tenantIsolation';
+import { describeTenantIsolationConformance } from './conformance';
+
+/**
+ * The Mongoose binding's answer to the portable contract. A PostgreSQL engine
+ * satisfies the same suite by supplying its own harness — that is what makes
+ * the seam real rather than hypothetical.
+ */
+
+interface ConformanceDocument {
+  name: string;
+  tenantId?: string;
+}
+
+let server: MongoMemoryServer;
+let Model: mongoose.Model<ConformanceDocument>;
+
+/** Reads and writes that must not be tenant-scoped, for fixtures and assertions. */
+const raw = () => mongoose.connection.db!.collection<ConformanceDocument>('conformances');
+
+const harness: TenantEngineHarness = {
+  name: 'mongoose',
+
+  async setup() {
+    server = await MongoMemoryServer.create();
+    await mongoose.connect(server.getUri());
+
+    const schema = new mongoose.Schema<ConformanceDocument>({
+      name: String,
+      tenantId: { type: String, index: true },
+    });
+    applyTenantIsolation(schema);
+    Model = mongoose.model<ConformanceDocument>('Conformance', schema);
+  },
+
+  async teardown() {
+    await mongoose.disconnect();
+    await server.stop();
+  },
+
+  async reset() {
+    await raw().deleteMany({});
+  },
+
+  async seed(rows) {
+    await raw().insertMany(rows.map((row) => ({ ...row })));
+  },
+
+  async readAllUnscoped() {
+    const rows = await raw().find({}).toArray();
+    return rows.map((row): TenantRow => ({ name: row.name, tenantId: row.tenantId }));
+  },
+
+  async insert(row) {
+    await Model.create({ ...row });
+  },
+
+  async findNames() {
+    const rows = await Model.find({}).lean();
+    return rows.map((row) => row.name);
+  },
+
+  async count() {
+    return Model.countDocuments({});
+  },
+
+  async rename(from, to) {
+    await Model.updateOne({ name: from }, { $set: { name: to } });
+  },
+
+  async renameAndReassign(from, to, tenantId) {
+    await Model.updateOne({ name: from }, { $set: { name: to, tenantId } });
+  },
+
+  async remove(name) {
+    await Model.deleteOne({ name });
+  },
+};
+
+describeTenantIsolationConformance(harness);

--- a/packages/data-schemas/src/tenant/conformance.ts
+++ b/packages/data-schemas/src/tenant/conformance.ts
@@ -1,0 +1,208 @@
+/* eslint-disable jest/no-export -- This file is a shared contract-test suite, not a
+   spec: it exports the harness interface and the suite factory that each engine's
+   own spec imports. The rule guards against accidental exports from spec files. */
+/**
+ * The portable tenant-isolation contract.
+ *
+ * `~/tenant/policy` defines the rules and `policy.spec.ts` proves them with no
+ * database. This file covers what only an engine can be asked: whether a given
+ * binding actually wires those rules to the operations it exposes.
+ *
+ * An engine satisfies the contract by implementing `TenantEngineHarness` and
+ * calling `describeTenantIsolationConformance` from a spec. The suite is
+ * deliberately small — it pins portable behaviour, not any one engine's
+ * surface, which is why the Mongoose-specific cases stay in
+ * `models/plugins/tenantIsolation.spec.ts`.
+ */
+
+import { tenantStorage, SYSTEM_TENANT_ID } from '~/config/tenantContext';
+import { resetTenantStrictCache } from './policy';
+
+/** A row as the engine stores it. */
+export interface TenantRow {
+  readonly name: string;
+  readonly tenantId?: string;
+}
+
+/**
+ * The operations an engine must expose for the contract to be checkable.
+ *
+ * Every method except `seed` and `readAllUnscoped` runs under whatever tenant
+ * context the suite has established, and is expected to be subject to the
+ * engine's tenant enforcement. Those two deliberately bypass it so the suite
+ * can build and inspect cross-tenant fixtures.
+ */
+export interface TenantEngineHarness {
+  readonly name: string;
+  setup(): Promise<void>;
+  teardown(): Promise<void>;
+  /** Removes all rows, bypassing enforcement. */
+  reset(): Promise<void>;
+  /** Inserts rows bypassing enforcement, for cross-tenant fixtures. */
+  seed(rows: readonly TenantRow[]): Promise<void>;
+  /** Reads every row bypassing enforcement, for assertions. */
+  readAllUnscoped(): Promise<readonly TenantRow[]>;
+
+  insert(row: TenantRow): Promise<void>;
+  findNames(): Promise<readonly string[]>;
+  count(): Promise<number>;
+  rename(from: string, to: string): Promise<void>;
+  /** Applies an update that also attempts to set `tenantId`. */
+  renameAndReassign(from: string, to: string, tenantId: string): Promise<void>;
+  remove(name: string): Promise<void>;
+}
+
+const withStrict = async (value: boolean, fn: () => Promise<void>): Promise<void> => {
+  const previous = process.env.TENANT_ISOLATION_STRICT;
+  process.env.TENANT_ISOLATION_STRICT = String(value);
+  resetTenantStrictCache();
+  try {
+    await fn();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.TENANT_ISOLATION_STRICT;
+    } else {
+      process.env.TENANT_ISOLATION_STRICT = previous;
+    }
+    resetTenantStrictCache();
+  }
+};
+
+const A = 'tenant-a';
+const B = 'tenant-b';
+
+export function describeTenantIsolationConformance(harness: TenantEngineHarness): void {
+  const asA = <T>(fn: () => Promise<T>): Promise<T> => tenantStorage.run({ tenantId: A }, fn);
+  const asSystem = <T>(fn: () => Promise<T>): Promise<T> =>
+    tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, fn);
+
+  describe(`tenant isolation conformance: ${harness.name}`, () => {
+    beforeAll(() => harness.setup());
+    afterAll(() => harness.teardown());
+    beforeEach(async () => {
+      resetTenantStrictCache();
+      await harness.reset();
+    });
+
+    describe('reads', () => {
+      it('sees only the active tenant', async () => {
+        await harness.seed([
+          { name: 'mine', tenantId: A },
+          { name: 'theirs', tenantId: B },
+        ]);
+
+        expect(await asA(() => harness.findNames())).toEqual(['mine']);
+      });
+
+      it('counts only the active tenant', async () => {
+        await harness.seed([
+          { name: 'mine', tenantId: A },
+          { name: 'theirs', tenantId: B },
+        ]);
+
+        expect(await asA(() => harness.count())).toBe(1);
+      });
+
+      it('sees every tenant under the system sentinel', async () => {
+        await harness.seed([
+          { name: 'mine', tenantId: A },
+          { name: 'theirs', tenantId: B },
+        ]);
+
+        expect([...(await asSystem(() => harness.findNames()))].sort()).toEqual(['mine', 'theirs']);
+      });
+
+      it('sees every tenant with no context, for pre-tenancy deployments', async () => {
+        await harness.seed([
+          { name: 'mine', tenantId: A },
+          { name: 'theirs', tenantId: B },
+        ]);
+
+        expect([...(await harness.findNames())].sort()).toEqual(['mine', 'theirs']);
+      });
+    });
+
+    describe('writes', () => {
+      it('stamps the active tenant onto an insert', async () => {
+        await asA(() => harness.insert({ name: 'fresh' }));
+
+        const rows = await harness.readAllUnscoped();
+        expect(rows).toEqual([expect.objectContaining({ name: 'fresh', tenantId: A })]);
+      });
+
+      /**
+       * A sharp edge worth stating explicitly rather than discovering: an insert
+       * that names another tenant is REFUSED in strict mode but TOLERATED
+       * otherwise, because pre-tenancy backfill has to be able to write rows for
+       * a tenant other than the ambient one. An engine must reproduce both
+       * halves, or deliberately decide not to.
+       */
+      it('refuses a caller-chosen tenant on insert in strict mode', async () => {
+        await withStrict(true, async () => {
+          await expect(
+            asA(() => harness.insert({ name: 'smuggled', tenantId: B })),
+          ).rejects.toThrow('[TenantIsolation]');
+        });
+
+        expect(await harness.readAllUnscoped()).toHaveLength(0);
+      });
+
+      it('tolerates a caller-chosen tenant on insert outside strict mode', async () => {
+        await withStrict(false, async () => {
+          await asA(() => harness.insert({ name: 'backfilled', tenantId: B }));
+        });
+
+        const rows = await harness.readAllUnscoped();
+        expect(rows[0]).toEqual(expect.objectContaining({ name: 'backfilled', tenantId: B }));
+      });
+
+      it('cannot rename another tenant row', async () => {
+        await harness.seed([{ name: 'theirs', tenantId: B }]);
+
+        await asA(() => harness.rename('theirs', 'stolen'));
+
+        const rows = await harness.readAllUnscoped();
+        expect(rows[0].name).toBe('theirs');
+      });
+
+      it('cannot delete another tenant row', async () => {
+        await harness.seed([{ name: 'theirs', tenantId: B }]);
+
+        await asA(() => harness.remove('theirs'));
+
+        expect(await harness.readAllUnscoped()).toHaveLength(1);
+      });
+
+      it('refuses an update that reassigns the tenant', async () => {
+        await harness.seed([{ name: 'mine', tenantId: A }]);
+
+        await expect(asA(() => harness.renameAndReassign('mine', 'moved', B))).rejects.toThrow(
+          '[TenantIsolation]',
+        );
+
+        const rows = await harness.readAllUnscoped();
+        expect(rows[0]).toEqual(expect.objectContaining({ name: 'mine', tenantId: A }));
+      });
+    });
+
+    describe('strict mode', () => {
+      it('refuses a read with no tenant context', async () => {
+        await withStrict(true, async () => {
+          await expect(harness.findNames()).rejects.toThrow('[TenantIsolation]');
+        });
+      });
+
+      it('refuses a write with no tenant context', async () => {
+        await withStrict(true, async () => {
+          await expect(harness.insert({ name: 'orphan' })).rejects.toThrow('[TenantIsolation]');
+        });
+      });
+
+      it('still allows the system sentinel through', async () => {
+        await withStrict(true, async () => {
+          await expect(asSystem(() => harness.findNames())).resolves.toEqual([]);
+        });
+      });
+    });
+  });
+}


### PR DESCRIPTION
**Stack 4/4** — based on #15582, not `dev`. Test-only.

## Why

The stack so far proves two different things:

- #15575 — `policy.spec.ts` proves the **rules** with no database at all
- #15578 — `probe.spec.ts` proves the Mongoose binding reaches the wire **scoped**

Neither answers the question a second engine actually asks: *what am I required
to do?*

`describeTenantIsolationConformance(harness)` is that answer. 13 behaviours an
engine must exhibit — reads scoped to the active tenant, system sentinel seeing
across tenants, no-context reads passing through for pre-tenancy deployments,
inserts stamped, cross-tenant renames and deletes refused, tenant reassignment
refused, and strict mode failing closed — expressed against a small harness
interface rather than any engine's query surface.

Mongoose supplies the first harness. A PostgreSQL engine satisfies the same
suite, which is what turns this seam from hypothetical into real. Engine-specific
behaviour stays where it is, in `models/plugins/tenantIsolation.spec.ts`.

## One sharp edge, now documented

Writing the contract surfaced an asymmetry worth stating explicitly rather than
leaving to be rediscovered: **an insert naming another tenant is refused in
strict mode but tolerated outside it**, because pre-tenancy backfill has to be
able to write rows for a tenant other than the ambient one.

My first draft of the contract asserted the stricter behaviour and failed. That
is the suite doing its job — both halves are now pinned, so an engine reproduces
this deliberately instead of by accident.

## Testing

Mutation-tested to confirm it is load-bearing: un-scoping queries turns 4 tests
red, dropping the insert stamp turns 2 red.

`conformance.ts` carries a narrow `jest/no-export` disable with a written
justification — it is a shared contract suite rather than a spec, and that rule
exists to catch accidental exports from spec files.

81 suites / 2806 tests green.

## Honest caveat

This is the one piece in the stack whose value is **deferred**: with a single
adapter the contract is a well-documented description of current behaviour, and
it only starts earning its keep when a second engine is written against it. It is
also the cheapest to drop if you would rather wait for the Postgres spike.