### PR TITLE
👓 fix: Match Pasted Text Focus Feedback

### DIFF
--- a/client/src/components/Chat/Input/Files/FileContainer.tsx
+++ b/client/src/components/Chat/Input/Files/FileContainer.tsx
@@ -95,8 +95,10 @@ const FileContainer = ({
                  * subtitle it would otherwise read as a description rather than a control. The
                  * hit area is the label and nothing more: `inline-block` keeps it off the rest
                  * of the row, and `leading-4` keeps it inside its 20px line so the chip's own
-                 * center still opens the editor. */
-                'pointer-events-auto relative z-10 inline-block max-w-full truncate rounded text-left align-middle leading-4 text-text-secondary underline underline-offset-2 hover:text-text-primary',
+                 * center still opens the editor. The colour shift answers focus as well as
+                 * hover: the ring already announces focus, but leaving the two input modes
+                 * with different feedback is a difference with no reason behind it. */
+                'pointer-events-auto relative z-10 inline-block max-w-full truncate rounded text-left align-middle leading-4 text-text-secondary underline underline-offset-2 hover:text-text-primary focus-visible:text-text-primary',
                 focusRing,
               )}
             >

--- a/client/src/components/Chat/Input/Files/__tests__/FileContainer.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/FileContainer.spec.tsx
@@ -77,12 +77,17 @@ describe('FileContainer subtitle action', () => {
 
     /** The affordance used to live behind a `group-hover` swap, which left the chip reading as
      * an inert "Plain Text" until pointed at — so nobody found it, and touch had no pointer to
-     * find it with. Nothing about the label may be conditional on hover or focus again. */
+     * find it with. Nothing about the label may be conditional on hover or focus again.
+     *
+     * Asserted on class tokens deliberately, brittle as that is. jsdom loads no stylesheet, so
+     * a hover gate has no effect on the DOM here and a presence check cannot see one: the swap
+     * this replaced kept BOTH labels mounted, which is why the spec it replaced asserted they
+     * were both in the document at once. Only the tokens distinguish the two markups. */
     const control = screen.getByRole('button', { name: 'Move back into message' });
     expect(control.className).not.toContain('group-hover');
     expect(control.className).not.toContain('group-focus-within');
     expect(control.className).not.toContain('hover:none');
-    expect(control.textContent).toBe('Move back into message');
+    expect(control).toHaveTextContent('Move back into message');
   });
 
   it('names the subtitle control from its own visible label', () => {
@@ -162,6 +167,18 @@ describe('FileContainer subtitle action', () => {
     expect(control.className).toContain('text-text-secondary');
     expect(control.className).toContain('underline');
     expect(control.className).not.toContain('hover:underline');
+  });
+
+  it('gives keyboard focus the same feedback the pointer gets', () => {
+    render(
+      <FileContainer file={baseFile()} onClick={jest.fn()} subtitleAction={subtitleAction()} />,
+    );
+
+    /** The focus ring already announces focus, so this is parity rather than a missing
+     * indicator: whatever the colour shift signals to a pointer, it signals to a keyboard. */
+    const control = screen.getByRole('button', { name: 'Move back into message' });
+    expect(control.className).toContain('hover:text-text-primary');
+    expect(control.className).toContain('focus-visible:text-text-primary');
   });
 
   it('leaves the plain subtitle alone when no action is offered', () => {


### PR DESCRIPTION
Follow-up to #15586, which merged before this landed on it.

## Context

#15586 made the pasted-text chip's "Move back into message" action visible at rest instead of swapping it in on `group-hover`. Review on that PR raised two points that arrived after the squash merge, so they are carried here.

## Changes

**Focus feedback parity.** The label's colour shift answered the pointer only (`hover:text-text-primary`). It now answers focus too. Worth being precise about what this is and is not: the control was never without a focus indicator — `focusRing` already draws a 2px `focus-visible` ring — so this is parity between two input modes, not a missing cue. Two input modes getting different feedback for the same state was a difference with nothing behind it.

**Whitespace brittleness.** `expect(control).toHaveTextContent(...)` replaces exact `textContent` equality.

**Reasoning recorded, not changed.** Review also suggested dropping the class-token assertions in the hover-gate guard for behavioural ones. Declined, because the proposed replacement would silently stop guarding the bug: jsdom loads no stylesheet, so a `group-hover` gate has no effect on the DOM under test. The markup #15586 replaced kept *both* labels mounted and swapped them purely in CSS — the spec it replaced asserted exactly that, both texts in the document at once — so "label present before/after hover" passes on the buggy markup as readily as on the fixed one. Only the tokens tell the two apart. The behavioural half of that suggestion is already covered by `states the action on the chip instead of the file type`, which does fail against the old markup. That rationale is now a comment in the spec so the next reader does not re-litigate it.

## Testing

- `FileContainer.spec.tsx` (13) and `FileRow.spec.tsx` — 42 passed.
- The new parity test was checked against a component with the class removed, and it fails there rather than passing either way.
- Static checks green against `dev`.
