### PR TITLE
🔬 test: Make the Paste Action's Hover-Gate Guard Actually Guard

### DIFF
--- a/client/src/components/Chat/Input/Files/__tests__/FileContainer.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/FileContainer.spec.tsx
@@ -77,17 +77,31 @@ describe('FileContainer subtitle action', () => {
 
     /** The affordance used to live behind a `group-hover` swap, which left the chip reading as
      * an inert "Plain Text" until pointed at — so nobody found it, and touch had no pointer to
-     * find it with. Nothing about the label may be conditional on hover or focus again.
+     * find it with. What the label SAYS, and whether it is there at all, may never be
+     * conditional on hover or focus again. Its colour still is, deliberately, which is why
+     * only the visibility-gating variants are named here and `hover:`/`focus-visible:` at
+     * large are not.
      *
-     * Asserted on class tokens deliberately, brittle as that is. jsdom loads no stylesheet, so
-     * a hover gate has no effect on the DOM here and a presence check cannot see one: the swap
-     * this replaced kept BOTH labels mounted, which is why the spec it replaced asserted they
-     * were both in the document at once. Only the tokens distinguish the two markups. */
+     * The anchored text is what actually catches the swap, and it has to be anchored: the gate
+     * kept BOTH labels mounted and hid one in CSS, so the control's text content read
+     * "PlainMove back into message" — which a substring match accepts. jsdom loads no
+     * stylesheet, so nothing about visibility is observable here beyond what is mounted.
+     *
+     * The token sweep covers the control's whole subtree, not its own `className`. The gate
+     * lived on child `<span>`s and never on the button, so a check scoped to the button alone
+     * passes against the exact markup this test exists to reject. */
     const control = screen.getByRole('button', { name: 'Move back into message' });
-    expect(control.className).not.toContain('group-hover');
-    expect(control.className).not.toContain('group-focus-within');
-    expect(control.className).not.toContain('hover:none');
-    expect(control).toHaveTextContent('Move back into message');
+    expect(control).toHaveTextContent(/^Move back into message$/);
+
+    const gatedTokens = ['group-hover', 'group-focus-within', 'hover:none'];
+    const classNames = [control, ...Array.from(control.querySelectorAll('[class]'))].map(
+      (element) => element.className,
+    );
+    for (const className of classNames) {
+      for (const token of gatedTokens) {
+        expect(className).not.toContain(token);
+      }
+    }
   });
 
   it('names the subtitle control from its own visible label', () => {

--- a/client/src/components/Chat/Input/Files/__tests__/FileContainer.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/FileContainer.spec.tsx
@@ -27,53 +27,6 @@ const baseFile = (overrides: Partial<TFile> = {}): Partial<TFile> => ({
   ...overrides,
 });
 
-/** Utilities that take something out of the visual flow, or put it back. Matched as whole class
- * tokens, never as substrings — `overflow-hidden` and `truncate` hide nothing on their own. */
-const HIDING_UTILITIES = new Set([
-  'hidden',
-  'invisible',
-  'collapse',
-  'opacity-0',
-  'sr-only',
-  'scale-0',
-  'w-0',
-  'h-0',
-  'size-0',
-  'max-w-0',
-  'max-h-0',
-]);
-const REVEALING_UTILITIES = new Set([
-  'visible',
-  'not-sr-only',
-  'block',
-  'inline',
-  'inline-block',
-  'flex',
-  'inline-flex',
-  'grid',
-  'inline-grid',
-  'contents',
-  'table',
-  'flow-root',
-  'opacity-100',
-]);
-
-/** A Tailwind token is `variant:variant:utility`; the utility is what follows the last colon,
- * which holds for bracketed variants too (`[@media(hover:none)]:inline` -> `inline`). */
-const utilityOf = (token: string): string => token.split(':').pop() ?? token;
-const variantOf = (token: string): string => token.slice(0, token.length - utilityOf(token).length);
-const isPointerConditional = (variant: string): boolean => /hover|focus/.test(variant);
-
-/**
- * Every class token in an element's subtree, paired with whether it applies only while the
- * element is pointed at or focused.
- */
-const classTokensIn = (root: HTMLElement): Array<{ token: string; conditional: boolean }> =>
-  [root, ...Array.from(root.querySelectorAll<HTMLElement>('[class]'))]
-    .flatMap((element) => element.className.split(/\s+/))
-    .filter(Boolean)
-    .map((token) => ({ token, conditional: isPointerConditional(variantOf(token)) }));
-
 describe('FileContainer chip label', () => {
   it('shows the raw filename when no `displayName` is supplied (upload context)', () => {
     /** A user-uploaded file whose name happens to look like the
@@ -117,45 +70,26 @@ describe('FileContainer subtitle action', () => {
     expect(screen.queryByText('Plain')).not.toBeInTheDocument();
   });
 
-  it('offers the action with no pointer or focus needed to reveal it', () => {
+  it('leaves the control holding the label and nothing else', () => {
     render(
       <FileContainer file={baseFile()} onClick={jest.fn()} subtitleAction={subtitleAction()} />,
     );
 
-    /** The affordance used to live behind a `group-hover` swap, which left the chip reading as
-     * an inert "Plain Text" until pointed at — so nobody found it, and touch had no pointer to
-     * find it with. What the label SAYS, and whether it is there at all, may never be
-     * conditional on hover or focus again. Its colour still is, deliberately, which is why
-     * only the visibility-gating variants are named here and `hover:`/`focus-visible:` at
-     * large are not.
+    /** The swap this replaced kept BOTH labels mounted and hid one in CSS, so the control read
+     * "PlainMove back into message". Anchoring the text is what catches that, and anchoring is
+     * required: a substring match accepts the gated arrangement.
      *
-     * The anchored text is what actually catches the swap, and it has to be anchored: the gate
-     * kept BOTH labels mounted and hid one in CSS, so the control's text content read
-     * "PlainMove back into message" — which a substring match accepts. jsdom loads no
-     * stylesheet, so nothing about visibility is observable here beyond what is mounted.
-     *
-     * The token sweep covers the control's whole subtree, not its own `className`. The gate
-     * lived on child `<span>`s and never on the button, so a check scoped to the button alone
-     * passes against the exact markup this test exists to reject. */
+     * It is also the only half of the invariant jsdom can decide. No stylesheet is loaded, so
+     * whether a mounted node is VISUALLY hidden is unobservable here — by `invisible`,
+     * `opacity-[0]`, `text-transparent`, `!hidden`, an ancestor's `opacity-0
+     * group-hover:opacity-100`, or a spelling nobody has written yet. Three attempts to infer
+     * it from class tokens each missed gates and each rejected innocuous styling
+     * (`hover:inline-flex` is layout, not concealment). A guard that reads as sound while
+     * missing gates is worse than no guard, so the claim is narrowed to what holds. A real
+     * visibility assertion needs a browser — `toBeVisible()` under `e2e/`, which has no
+     * composer-paste spec to hang it on yet. */
     const control = screen.getByRole('button', { name: 'Move back into message' });
     expect(control).toHaveTextContent(/^Move back into message$/);
-
-    /** Stated as what the tokens MEAN rather than as a list of the ones this bug happened to
-     * use. A denylist of `group-hover` and friends is bypassed by the next spelling of the same
-     * idea — `invisible hover:visible`, `hidden focus:block` — which is why both halves of a
-     * gate are rejected: nothing may hide the label at rest, and nothing may make it visible
-     * only under a pointer or focus. Colour under those variants stays permitted, and is
-     * asserted separately. */
-    for (const { token, conditional } of classTokensIn(control)) {
-      const utility = utilityOf(token);
-      if (conditional) {
-        expect(
-          REVEALING_UTILITIES.has(utility) || HIDING_UTILITIES.has(utility) ? token : null,
-        ).toBeNull();
-        continue;
-      }
-      expect(HIDING_UTILITIES.has(utility) ? token : null).toBeNull();
-    }
   });
 
   it('names the subtitle control from its own visible label', () => {

--- a/client/src/components/Chat/Input/Files/__tests__/FileContainer.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/FileContainer.spec.tsx
@@ -27,6 +27,53 @@ const baseFile = (overrides: Partial<TFile> = {}): Partial<TFile> => ({
   ...overrides,
 });
 
+/** Utilities that take something out of the visual flow, or put it back. Matched as whole class
+ * tokens, never as substrings — `overflow-hidden` and `truncate` hide nothing on their own. */
+const HIDING_UTILITIES = new Set([
+  'hidden',
+  'invisible',
+  'collapse',
+  'opacity-0',
+  'sr-only',
+  'scale-0',
+  'w-0',
+  'h-0',
+  'size-0',
+  'max-w-0',
+  'max-h-0',
+]);
+const REVEALING_UTILITIES = new Set([
+  'visible',
+  'not-sr-only',
+  'block',
+  'inline',
+  'inline-block',
+  'flex',
+  'inline-flex',
+  'grid',
+  'inline-grid',
+  'contents',
+  'table',
+  'flow-root',
+  'opacity-100',
+]);
+
+/** A Tailwind token is `variant:variant:utility`; the utility is what follows the last colon,
+ * which holds for bracketed variants too (`[@media(hover:none)]:inline` -> `inline`). */
+const utilityOf = (token: string): string => token.split(':').pop() ?? token;
+const variantOf = (token: string): string => token.slice(0, token.length - utilityOf(token).length);
+const isPointerConditional = (variant: string): boolean => /hover|focus/.test(variant);
+
+/**
+ * Every class token in an element's subtree, paired with whether it applies only while the
+ * element is pointed at or focused.
+ */
+const classTokensIn = (root: HTMLElement): Array<{ token: string; conditional: boolean }> =>
+  [root, ...Array.from(root.querySelectorAll<HTMLElement>('[class]'))]
+    .flatMap((element) => element.className.split(/\s+/))
+    .filter(Boolean)
+    .map((token) => ({ token, conditional: isPointerConditional(variantOf(token)) }));
+
 describe('FileContainer chip label', () => {
   it('shows the raw filename when no `displayName` is supplied (upload context)', () => {
     /** A user-uploaded file whose name happens to look like the
@@ -93,14 +140,21 @@ describe('FileContainer subtitle action', () => {
     const control = screen.getByRole('button', { name: 'Move back into message' });
     expect(control).toHaveTextContent(/^Move back into message$/);
 
-    const gatedTokens = ['group-hover', 'group-focus-within', 'hover:none'];
-    const classNames = [control, ...Array.from(control.querySelectorAll('[class]'))].map(
-      (element) => element.className,
-    );
-    for (const className of classNames) {
-      for (const token of gatedTokens) {
-        expect(className).not.toContain(token);
+    /** Stated as what the tokens MEAN rather than as a list of the ones this bug happened to
+     * use. A denylist of `group-hover` and friends is bypassed by the next spelling of the same
+     * idea — `invisible hover:visible`, `hidden focus:block` — which is why both halves of a
+     * gate are rejected: nothing may hide the label at rest, and nothing may make it visible
+     * only under a pointer or focus. Colour under those variants stays permitted, and is
+     * asserted separately. */
+    for (const { token, conditional } of classTokensIn(control)) {
+      const utility = utilityOf(token);
+      if (conditional) {
+        expect(
+          REVEALING_UTILITIES.has(utility) || HIDING_UTILITIES.has(utility) ? token : null,
+        ).toBeNull();
+        continue;
       }
+      expect(HIDING_UTILITIES.has(utility) ? token : null).toBeNull();
     }
   });
 


### PR DESCRIPTION
Follow-up to #15586 / #15588, and a correction. The guard those PRs shipped **could not fail** against the markup it exists to reject. Copilot flagged one half on #15588; checking it surfaced the rest.

Three commits, because the first two fixes were rewrites of a wrong idea and Codex was right to keep rejecting them.

## What was wrong

**1. The text assertion matched loosely.** #15588 swapped exact `textContent` equality for `toHaveTextContent(...)` to shed whitespace brittleness — but that matcher is a **substring** match. The hover swap kept both labels mounted and hid one in CSS, so the control's text read `"PlainMove back into message"`, which a substring match accepts. That line was the only assertion in the test doing real work, and #15588 turned it off.

**2. The token sweep read the wrong element.** It asserted on `control.className`. The gate never lived on the button — it was on the two child `<span>`s, so the sweep scanned an element that never carried the tokens it looked for and passed vacuously.

This also corrects the record on #15586, where I argued those token assertions were the essential guard against a CSS-only regression. The reasoning was right; the assertions were not. The exact-text assertion was carrying that test the whole time.

## Why the token sweep is gone rather than fixed

Commits 1 and 2 tried to repair it — first scoping it to the subtree, then restating it as a rule about what tokens *mean* rather than a list of spellings. Codex broke both:

- **Bypasses:** `text-transparent hover:text-text-secondary`, `opacity-[0] hover:opacity-100`, Tailwind 3's `!hidden hover:!block`, and a gate moved onto an **ancestor**, which a self-and-descendants traversal never sees.
- **Misfires:** `hover:inline-flex` is layout, not concealment, and was rejected anyway. A classed SVG descendant returns `SVGAnimatedString` from `.className`, so `.split()` throws before anything is asserted.

Missing gates *and* rejecting valid styling *and* crashing on ordinary markup is not an incomplete list — it is the wrong shape. Deciding whether a mounted node is visually hidden requires a cascade, and jsdom loads no stylesheet. Every version was a denylist in the language of an invariant, and a fourth would have earned a fifth bypass.

## What the test claims now

Only the half that holds: **the control's text is exactly the label.** That still catches the swap that actually shipped, which kept both labels mounted so the control read `"PlainMove back into message"`.

It pairs with the role query rather than duplicating it, and the two cover different reintroductions — verified with a throwaway probe:

- `getByRole('button', { name: 'Move back into message' })` is an **exact** match on the accessible name, so a label reintroduced *without* `aria-hidden` fails the query.
- `aria-hidden` text is excluded from the accessible name but **kept** in `textContent`, so a label reintroduced *with* it — how the original bug was written — is caught by the anchored `toHaveTextContent`.

The unobservable half is documented as unobservable, pointing at where a real assertion belongs: `toBeVisible()` in a browser. `e2e/` currently has no composer-paste spec to hang it on, which is a genuine gap rather than something to paper over with tokens.

## Verification

Restored the pre-#15586 component and re-ran against it:

| Assertion form | vs. old hover-swap markup |
| --- | --- |
| `control.className` token sweep | **passes** — vacuous, gate is on the children |
| `toHaveTextContent('…')` (shipped in #15588) | **passes** — substring match |
| anchored `toHaveTextContent(/^…$/)` (this PR) | **fails**, as it must |

Full suite: `FileContainer.spec.tsx` (13) + `FileRow.spec.tsx` — 42 passed. Prettier and ESLint clean; the spec file is typecheck-clean.

No production code changes — test-only.
