### PR TITLE
🔎 fix: Report Measured Skill Catalog Truncation

### DIFF
--- a/packages/api/src/agents/__tests__/skills.test.ts
+++ b/packages/api/src/agents/__tests__/skills.test.ts
@@ -1,7 +1,11 @@
 /**
  * Mock the pieces of `@librechat/agents` the installed SDK version may not
- * export yet. Includes both the `Constants.SKILL_TOOL` stub and the skill
- * catalog/tool-definition helpers needed to exercise `injectSkillCatalog`.
+ * export yet — the `Constants.SKILL_TOOL` stub and the tool definitions
+ * needed to exercise `injectSkillCatalog`.
+ *
+ * `formatSkillCatalog` is deliberately NOT stubbed. Its truncation ladder is
+ * the behaviour the catalog warnings report on, and a passthrough stub hides
+ * every truncation the model actually sees.
  */
 jest.mock('@librechat/agents', () => ({
   ...jest.requireActual('@librechat/agents'),
@@ -10,8 +14,6 @@ jest.mock('@librechat/agents', () => ({
       .Constants,
     SKILL_TOOL: 'skill',
   },
-  formatSkillCatalog: (skills: Array<{ name: string; description: string }>) =>
-    skills.map((s) => `- ${s.name}: ${s.description}`).join('\n'),
   SkillToolDefinition: { name: 'skill', description: 'skill tool', parameters: {} },
   ReadFileToolDefinition: {
     name: 'read_file',
@@ -943,35 +945,88 @@ describe('injectSkillCatalog', () => {
     expect(agent.additional_instructions).toContain('desc-my-skill');
   });
 
+  /** Descriptions the catalog truncated, as `[skillName, reached, authored]`. */
+  function truncationWarnings(warnSpy: jest.SpyInstance): Array<[string, number, number]> {
+    return warnSpy.mock.calls
+      .map((call) => String(call[0]))
+      .map((msg) =>
+        /skill "([^"]+)" description reached the model truncated to (\d+) of (\d+)/.exec(msg),
+      )
+      .filter((m): m is RegExpExecArray => m !== null)
+      .map((m) => [m[1], Number(m[2]), Number(m[3])]);
+  }
+
   it('warns when a skill description exceeds the catalog entry cap', async () => {
     const { logger } = await import('@librechat/data-schemas');
     const warnSpy = jest.spyOn(logger, 'warn');
-    const longDesc = 'x'.repeat(400);
     const longSkill: PageSkill = {
       ...makeSkill('long-skill', userObjectId),
-      description: longDesc,
+      description: 'x'.repeat(400),
     };
     const shortSkill = makeSkill('short-skill', userObjectId);
     const listSkillsByAccess = buildPager([[longSkill, shortSkill]]);
     const agent = makeAgent();
     await injectSkillCatalog(baseParams({ listSkillsByAccess, agent }));
 
-    const truncWarns = warnSpy.mock.calls
-      .map((call) => String(call[0]))
-      .filter((msg) => msg.includes('truncated to'));
-    expect(truncWarns).toHaveLength(1);
-    expect(truncWarns[0]).toContain('"long-skill"');
-    expect(truncWarns[0]).toContain('was 400');
-    /* Short description is not flagged. */
-    expect(
-      warnSpy.mock.calls
-        .map((call) => String(call[0]))
-        .filter((msg) => msg.includes('"short-skill"') && msg.includes('truncated')),
-    ).toHaveLength(0);
+    /* Only the over-cap skill is flagged, and the warning names the length
+       that actually reached the model rather than the requested cap. */
+    const warnings = truncationWarnings(warnSpy);
+    expect(warnings).toHaveLength(1);
+    const [name, reached, authored] = warnings[0];
+    expect(name).toBe('long-skill');
+    expect(authored).toBe(400);
+    expect(reached).toBeLessThan(authored);
 
     /* The catalog still reaches the model — the warning is additive. */
     expect(agent.additional_instructions).toContain('long-skill');
     expect(agent.additional_instructions).toContain('short-skill');
+    warnSpy.mockRestore();
+  });
+
+  it('warns for a sub-cap description the catalog budget still truncates', async () => {
+    const { logger } = await import('@librechat/data-schemas');
+    const warnSpy = jest.spyOn(logger, 'warn');
+    /* Every description sits under the per-entry cap, so a warning keyed to
+       that cap alone stays silent — but a catalog this size overruns its
+       context budget and gets cut well below it anyway. */
+    const skills = Array.from({ length: 8 }, (_, i) => ({
+      ...makeSkill(`budget-skill-${i}`, userObjectId),
+      description: 'x'.repeat(200),
+    }));
+    const listSkillsByAccess = buildPager([skills]);
+    const agent = makeAgent();
+    await injectSkillCatalog(
+      baseParams({ listSkillsByAccess, agent, contextWindowTokens: 20_000 }),
+    );
+
+    const warnings = truncationWarnings(warnSpy);
+    expect(warnings).toHaveLength(skills.length);
+    for (const [, reached, authored] of warnings) {
+      expect(authored).toBe(200);
+      expect(reached).toBeGreaterThan(0);
+      expect(reached).toBeLessThan(200);
+    }
+    warnSpy.mockRestore();
+  });
+
+  it('warns that descriptions were dropped when the catalog falls back to names-only', async () => {
+    const { logger } = await import('@librechat/data-schemas');
+    const warnSpy = jest.spyOn(logger, 'warn');
+    const skills = Array.from({ length: 10 }, (_, i) => ({
+      ...makeSkill(`dropped-skill-${i}`, userObjectId),
+      description: 'x'.repeat(200),
+    }));
+    const listSkillsByAccess = buildPager([skills]);
+    const agent = makeAgent();
+    await injectSkillCatalog(baseParams({ listSkillsByAccess, agent, contextWindowTokens: 2_000 }));
+
+    const dropped = warnSpy.mock.calls
+      .map((call) => String(call[0]))
+      .filter((msg) => msg.includes('description was dropped from the model catalog'));
+    expect(dropped).toHaveLength(skills.length);
+    expect(dropped[0]).toContain('was 200 chars');
+    /* Names still reach the model even when every description is dropped. */
+    expect(agent.additional_instructions).toContain('dropped-skill-0');
     warnSpy.mockRestore();
   });
 

--- a/packages/api/src/agents/__tests__/skills.test.ts
+++ b/packages/api/src/agents/__tests__/skills.test.ts
@@ -1056,6 +1056,29 @@ describe('injectSkillCatalog', () => {
     warnSpy.mockRestore();
   });
 
+  it('still flags a dropped description that collides with another skill name', async () => {
+    const { logger } = await import('@librechat/data-schemas');
+    const warnSpy = jest.spyOn(logger, 'warn');
+    /* Names-only drops every description, but a one-word description can occur
+       verbatim in the catalog as another skill's name — matching the whole
+       `- name: description` rendering is what keeps that a warning. */
+    const named = makeSkill('research', userObjectId);
+    const collider: PageSkill = {
+      ...makeSkill('other-skill', userObjectId),
+      description: 'research',
+    };
+    const filler = Array.from({ length: 20 }, (_, i) => ({
+      ...makeSkill(`filler-skill-${i}`, userObjectId),
+      description: 'y'.repeat(200),
+    }));
+    const listSkillsByAccess = buildPager([[named, collider, ...filler]]);
+    const agent = makeAgent();
+    await injectSkillCatalog(baseParams({ listSkillsByAccess, agent, contextWindowTokens: 2_000 }));
+
+    expect(truncationWarnings(warnSpy).map(([name]) => name)).toContain('other-skill');
+    warnSpy.mockRestore();
+  });
+
   it('keeps measurements aligned when a description imitates the next entry', async () => {
     const { logger } = await import('@librechat/data-schemas');
     const warnSpy = jest.spyOn(logger, 'warn');

--- a/packages/api/src/agents/__tests__/skills.test.ts
+++ b/packages/api/src/agents/__tests__/skills.test.ts
@@ -945,15 +945,24 @@ describe('injectSkillCatalog', () => {
     expect(agent.additional_instructions).toContain('desc-my-skill');
   });
 
-  /** Skills the catalog could not fit verbatim, as `[skillName, authoredChars]`. */
-  function truncationWarnings(warnSpy: jest.SpyInstance): Array<[string, number]> {
+  /** Truncated descriptions, as `[skillName, reachedChars, authoredChars]`. */
+  function truncationWarnings(warnSpy: jest.SpyInstance): Array<[string, number, number]> {
     return warnSpy.mock.calls
       .map((call) => String(call[0]))
       .map((msg) =>
-        /skill "([^"]+)" description \((\d+) chars\) does not reach the model/.exec(msg),
+        /skill "([^"]+)" description reached the model truncated to (\d+) of (\d+)/.exec(msg),
       )
       .filter((m): m is RegExpExecArray => m !== null)
-      .map((m) => [m[1], Number(m[2])]);
+      .map((m) => [m[1], Number(m[2]), Number(m[3])]);
+  }
+
+  /** Skills whose description the catalog dropped entirely. */
+  function droppedWarnings(warnSpy: jest.SpyInstance): string[] {
+    return warnSpy.mock.calls
+      .map((call) => String(call[0]))
+      .map((msg) => /skill "([^"]+)" description was dropped from the model catalog/.exec(msg))
+      .filter((m): m is RegExpExecArray => m !== null)
+      .map((m) => m[1]);
   }
 
   it('warns when a skill description exceeds the catalog entry cap', async () => {
@@ -968,7 +977,12 @@ describe('injectSkillCatalog', () => {
     const agent = makeAgent();
     await injectSkillCatalog(baseParams({ listSkillsByAccess, agent }));
 
-    expect(truncationWarnings(warnSpy)).toEqual([['long-skill', 400]]);
+    const warnings = truncationWarnings(warnSpy);
+    expect(warnings).toHaveLength(1);
+    const [name, reached, authored] = warnings[0];
+    expect(name).toBe('long-skill');
+    expect(authored).toBe(400);
+    expect(reached).toBeLessThan(authored);
     /* The catalog still reaches the model — the warning is additive. */
     expect(agent.additional_instructions).toContain('long-skill');
     expect(agent.additional_instructions).toContain('short-skill');
@@ -993,11 +1007,15 @@ describe('injectSkillCatalog', () => {
 
     const warnings = truncationWarnings(warnSpy);
     expect(warnings).toHaveLength(skills.length);
-    expect(warnings.every(([, authored]) => authored === 200)).toBe(true);
+    for (const [, reached, authored] of warnings) {
+      expect(authored).toBe(200);
+      expect(reached).toBeGreaterThan(0);
+      expect(reached).toBeLessThan(200);
+    }
     warnSpy.mockRestore();
   });
 
-  it('warns for every skill when the catalog falls back to names-only', async () => {
+  it('reports descriptions as dropped when the catalog falls back to names-only', async () => {
     const { logger } = await import('@librechat/data-schemas');
     const warnSpy = jest.spyOn(logger, 'warn');
     const skills = Array.from({ length: 10 }, (_, i) => ({
@@ -1008,17 +1026,17 @@ describe('injectSkillCatalog', () => {
     const agent = makeAgent();
     await injectSkillCatalog(baseParams({ listSkillsByAccess, agent, contextWindowTokens: 2_000 }));
 
-    expect(truncationWarnings(warnSpy)).toHaveLength(skills.length);
+    expect(droppedWarnings(warnSpy)).toHaveLength(skills.length);
     /* Names still reach the model even when every description is dropped. */
     expect(agent.additional_instructions).toContain('dropped-skill-0');
     warnSpy.mockRestore();
   });
 
-  it('flags duplicate-named skills per entry rather than collapsing them', async () => {
+  it('measures duplicate-named skills per entry rather than collapsing them', async () => {
     const { logger } = await import('@librechat/data-schemas');
     const warnSpy = jest.spyOn(logger, 'warn');
-    /* The catalog keeps both entries. Only the over-cap one is truncated;
-       measuring by name alone would report one verdict for both. */
+    /* The catalog keeps both entries. Measuring by name alone would report the
+       last entry's length for both and understate the first. */
     const longDup: PageSkill = {
       ...makeSkill('dup-skill', userObjectId),
       description: 'x'.repeat(400),
@@ -1031,7 +1049,12 @@ describe('injectSkillCatalog', () => {
     const agent = makeAgent();
     await injectSkillCatalog(baseParams({ listSkillsByAccess, agent }));
 
-    expect(truncationWarnings(warnSpy)).toEqual([['dup-skill', 400]]);
+    const warnings = truncationWarnings(warnSpy);
+    expect(warnings).toHaveLength(1);
+    const [name, reached, authored] = warnings[0];
+    expect(name).toBe('dup-skill');
+    expect(authored).toBe(400);
+    expect(reached).toBeGreaterThan(100);
     warnSpy.mockRestore();
   });
 
@@ -1053,6 +1076,27 @@ describe('injectSkillCatalog', () => {
     await injectSkillCatalog(baseParams({ listSkillsByAccess, agent }));
 
     expect(truncationWarnings(warnSpy)).toEqual([]);
+    expect(droppedWarnings(warnSpy)).toEqual([]);
+    warnSpy.mockRestore();
+  });
+
+  it('stays aligned when a description imitates the next entry', async () => {
+    const { logger } = await import('@librechat/data-schemas');
+    const warnSpy = jest.spyOn(logger, 'warn');
+    /* A continuation line can look exactly like the next entry's marker. */
+    const imitator: PageSkill = {
+      ...makeSkill('imitator-skill', userObjectId),
+      description: 'start\n- victim-skill: hijacked',
+    };
+    const victim: PageSkill = {
+      ...makeSkill('victim-skill', userObjectId),
+      description: 'y'.repeat(400),
+    };
+    const listSkillsByAccess = buildPager([[imitator, victim]]);
+    const agent = makeAgent();
+    await injectSkillCatalog(baseParams({ listSkillsByAccess, agent }));
+
+    expect(truncationWarnings(warnSpy).map(([name]) => name)).toEqual(['victim-skill']);
     warnSpy.mockRestore();
   });
 
@@ -1060,8 +1104,7 @@ describe('injectSkillCatalog', () => {
     const { logger } = await import('@librechat/data-schemas');
     const warnSpy = jest.spyOn(logger, 'warn');
     /* Names-only drops every description, but a one-word description can occur
-       verbatim in the catalog as another skill's name — matching the whole
-       `- name: description` rendering is what keeps that a warning. */
+       verbatim in the catalog as another skill's name. */
     const named = makeSkill('research', userObjectId);
     const collider: PageSkill = {
       ...makeSkill('other-skill', userObjectId),
@@ -1075,28 +1118,28 @@ describe('injectSkillCatalog', () => {
     const agent = makeAgent();
     await injectSkillCatalog(baseParams({ listSkillsByAccess, agent, contextWindowTokens: 2_000 }));
 
-    expect(truncationWarnings(warnSpy).map(([name]) => name)).toContain('other-skill');
+    expect(droppedWarnings(warnSpy)).toContain('other-skill');
     warnSpy.mockRestore();
   });
 
-  it('keeps measurements aligned when a description imitates the next entry', async () => {
+  it('flags truncation that splices an entry tail onto the next entry rendering', async () => {
     const { logger } = await import('@librechat/data-schemas');
     const warnSpy = jest.spyOn(logger, 'warn');
-    /* A continuation line can look exactly like the next entry's marker;
-       only the over-cap skill should be flagged. */
-    const imitator: PageSkill = {
-      ...makeSkill('imitator-skill', userObjectId),
-      description: 'start\n- victim-skill: hijacked',
+    /* Cutting here leaves the catalog holding this description's full text
+       across two entries, so matching the rendering would suppress the warning. */
+    const spliced: PageSkill = {
+      ...makeSkill('spliced-skill', userObjectId),
+      description: `${'z'.repeat(249)}\u2026\n- next-skill: next description`,
     };
-    const victim: PageSkill = {
-      ...makeSkill('victim-skill', userObjectId),
-      description: 'y'.repeat(400),
+    const next: PageSkill = {
+      ...makeSkill('next-skill', userObjectId),
+      description: 'next description',
     };
-    const listSkillsByAccess = buildPager([[imitator, victim]]);
+    const listSkillsByAccess = buildPager([[spliced, next]]);
     const agent = makeAgent();
     await injectSkillCatalog(baseParams({ listSkillsByAccess, agent }));
 
-    expect(truncationWarnings(warnSpy)).toEqual([['victim-skill', 400]]);
+    expect(truncationWarnings(warnSpy).map(([name]) => name)).toEqual(['spliced-skill']);
     warnSpy.mockRestore();
   });
 

--- a/packages/api/src/agents/__tests__/skills.test.ts
+++ b/packages/api/src/agents/__tests__/skills.test.ts
@@ -945,15 +945,15 @@ describe('injectSkillCatalog', () => {
     expect(agent.additional_instructions).toContain('desc-my-skill');
   });
 
-  /** Descriptions the catalog truncated, as `[skillName, reached, authored]`. */
-  function truncationWarnings(warnSpy: jest.SpyInstance): Array<[string, number, number]> {
+  /** Skills the catalog could not fit verbatim, as `[skillName, authoredChars]`. */
+  function truncationWarnings(warnSpy: jest.SpyInstance): Array<[string, number]> {
     return warnSpy.mock.calls
       .map((call) => String(call[0]))
       .map((msg) =>
-        /skill "([^"]+)" description reached the model truncated to (\d+) of (\d+)/.exec(msg),
+        /skill "([^"]+)" description \((\d+) chars\) does not reach the model/.exec(msg),
       )
       .filter((m): m is RegExpExecArray => m !== null)
-      .map((m) => [m[1], Number(m[2]), Number(m[3])]);
+      .map((m) => [m[1], Number(m[2])]);
   }
 
   it('warns when a skill description exceeds the catalog entry cap', async () => {
@@ -968,15 +968,7 @@ describe('injectSkillCatalog', () => {
     const agent = makeAgent();
     await injectSkillCatalog(baseParams({ listSkillsByAccess, agent }));
 
-    /* Only the over-cap skill is flagged, and the warning names the length
-       that actually reached the model rather than the requested cap. */
-    const warnings = truncationWarnings(warnSpy);
-    expect(warnings).toHaveLength(1);
-    const [name, reached, authored] = warnings[0];
-    expect(name).toBe('long-skill');
-    expect(authored).toBe(400);
-    expect(reached).toBeLessThan(authored);
-
+    expect(truncationWarnings(warnSpy)).toEqual([['long-skill', 400]]);
     /* The catalog still reaches the model — the warning is additive. */
     expect(agent.additional_instructions).toContain('long-skill');
     expect(agent.additional_instructions).toContain('short-skill');
@@ -1001,19 +993,32 @@ describe('injectSkillCatalog', () => {
 
     const warnings = truncationWarnings(warnSpy);
     expect(warnings).toHaveLength(skills.length);
-    for (const [, reached, authored] of warnings) {
-      expect(authored).toBe(200);
-      expect(reached).toBeGreaterThan(0);
-      expect(reached).toBeLessThan(200);
-    }
+    expect(warnings.every(([, authored]) => authored === 200)).toBe(true);
     warnSpy.mockRestore();
   });
 
-  it('measures duplicate-named skills per entry rather than collapsing them', async () => {
+  it('warns for every skill when the catalog falls back to names-only', async () => {
     const { logger } = await import('@librechat/data-schemas');
     const warnSpy = jest.spyOn(logger, 'warn');
-    /* The catalog keeps both entries, so measuring by name alone would report
-       the last entry's length for both and understate the first. */
+    const skills = Array.from({ length: 10 }, (_, i) => ({
+      ...makeSkill(`dropped-skill-${i}`, userObjectId),
+      description: 'x'.repeat(200),
+    }));
+    const listSkillsByAccess = buildPager([skills]);
+    const agent = makeAgent();
+    await injectSkillCatalog(baseParams({ listSkillsByAccess, agent, contextWindowTokens: 2_000 }));
+
+    expect(truncationWarnings(warnSpy)).toHaveLength(skills.length);
+    /* Names still reach the model even when every description is dropped. */
+    expect(agent.additional_instructions).toContain('dropped-skill-0');
+    warnSpy.mockRestore();
+  });
+
+  it('flags duplicate-named skills per entry rather than collapsing them', async () => {
+    const { logger } = await import('@librechat/data-schemas');
+    const warnSpy = jest.spyOn(logger, 'warn');
+    /* The catalog keeps both entries. Only the over-cap one is truncated;
+       measuring by name alone would report one verdict for both. */
     const longDup: PageSkill = {
       ...makeSkill('dup-skill', userObjectId),
       description: 'x'.repeat(400),
@@ -1026,34 +1031,49 @@ describe('injectSkillCatalog', () => {
     const agent = makeAgent();
     await injectSkillCatalog(baseParams({ listSkillsByAccess, agent }));
 
-    /* Only the 400-char entry is truncated; the 100-char one fits untouched. */
-    const warnings = truncationWarnings(warnSpy);
-    expect(warnings).toHaveLength(1);
-    const [name, reached, authored] = warnings[0];
-    expect(name).toBe('dup-skill');
-    expect(authored).toBe(400);
-    expect(reached).toBeGreaterThan(100);
+    expect(truncationWarnings(warnSpy)).toEqual([['dup-skill', 400]]);
     warnSpy.mockRestore();
   });
 
-  it('warns that descriptions were dropped when the catalog falls back to names-only', async () => {
+  it('does not flag multiline descriptions the catalog kept intact', async () => {
     const { logger } = await import('@librechat/data-schemas');
     const warnSpy = jest.spyOn(logger, 'warn');
-    const skills = Array.from({ length: 10 }, (_, i) => ({
-      ...makeSkill(`dropped-skill-${i}`, userObjectId),
-      description: 'x'.repeat(200),
-    }));
-    const listSkillsByAccess = buildPager([skills]);
+    /* Nothing strips newlines from a description, so a catalog entry is not
+       one physical line — and a leading newline leaves the first one empty. */
+    const multiline: PageSkill = {
+      ...makeSkill('multiline-skill', userObjectId),
+      description: 'First line of the description.\nSecond line with more triggers.',
+    };
+    const leading: PageSkill = {
+      ...makeSkill('leading-newline-skill', userObjectId),
+      description: '\nAll the real trigger text lives on line two.',
+    };
+    const listSkillsByAccess = buildPager([[multiline, leading]]);
     const agent = makeAgent();
-    await injectSkillCatalog(baseParams({ listSkillsByAccess, agent, contextWindowTokens: 2_000 }));
+    await injectSkillCatalog(baseParams({ listSkillsByAccess, agent }));
 
-    const dropped = warnSpy.mock.calls
-      .map((call) => String(call[0]))
-      .filter((msg) => msg.includes('description was dropped from the model catalog'));
-    expect(dropped).toHaveLength(skills.length);
-    expect(dropped[0]).toContain('was 200 chars');
-    /* Names still reach the model even when every description is dropped. */
-    expect(agent.additional_instructions).toContain('dropped-skill-0');
+    expect(truncationWarnings(warnSpy)).toEqual([]);
+    warnSpy.mockRestore();
+  });
+
+  it('keeps measurements aligned when a description imitates the next entry', async () => {
+    const { logger } = await import('@librechat/data-schemas');
+    const warnSpy = jest.spyOn(logger, 'warn');
+    /* A continuation line can look exactly like the next entry's marker;
+       only the over-cap skill should be flagged. */
+    const imitator: PageSkill = {
+      ...makeSkill('imitator-skill', userObjectId),
+      description: 'start\n- victim-skill: hijacked',
+    };
+    const victim: PageSkill = {
+      ...makeSkill('victim-skill', userObjectId),
+      description: 'y'.repeat(400),
+    };
+    const listSkillsByAccess = buildPager([[imitator, victim]]);
+    const agent = makeAgent();
+    await injectSkillCatalog(baseParams({ listSkillsByAccess, agent }));
+
+    expect(truncationWarnings(warnSpy)).toEqual([['victim-skill', 400]]);
     warnSpy.mockRestore();
   });
 

--- a/packages/api/src/agents/__tests__/skills.test.ts
+++ b/packages/api/src/agents/__tests__/skills.test.ts
@@ -1009,6 +1009,33 @@ describe('injectSkillCatalog', () => {
     warnSpy.mockRestore();
   });
 
+  it('measures duplicate-named skills per entry rather than collapsing them', async () => {
+    const { logger } = await import('@librechat/data-schemas');
+    const warnSpy = jest.spyOn(logger, 'warn');
+    /* The catalog keeps both entries, so measuring by name alone would report
+       the last entry's length for both and understate the first. */
+    const longDup: PageSkill = {
+      ...makeSkill('dup-skill', userObjectId),
+      description: 'x'.repeat(400),
+    };
+    const shortDup: PageSkill = {
+      ...makeSkill('dup-skill', userObjectId),
+      description: 'y'.repeat(100),
+    };
+    const listSkillsByAccess = buildPager([[longDup, shortDup]]);
+    const agent = makeAgent();
+    await injectSkillCatalog(baseParams({ listSkillsByAccess, agent }));
+
+    /* Only the 400-char entry is truncated; the 100-char one fits untouched. */
+    const warnings = truncationWarnings(warnSpy);
+    expect(warnings).toHaveLength(1);
+    const [name, reached, authored] = warnings[0];
+    expect(name).toBe('dup-skill');
+    expect(authored).toBe(400);
+    expect(reached).toBeGreaterThan(100);
+    warnSpy.mockRestore();
+  });
+
   it('warns that descriptions were dropped when the catalog falls back to names-only', async () => {
     const { logger } = await import('@librechat/data-schemas');
     const warnSpy = jest.spyOn(logger, 'warn');

--- a/packages/api/src/agents/skills.ts
+++ b/packages/api/src/agents/skills.ts
@@ -586,27 +586,36 @@ export async function resolveSkillCatalog(
 }
 
 /**
- * Description length that survived into `catalog`, per skill name.
+ * Description length that survived into `catalog`, positionally aligned to
+ * `names` — index `i` is how much of skill `i`'s description the model got.
  *
  * `formatSkillCatalog` truncates on a ladder — the per-entry cap, then a
  * proportional cut sized to its context budget, then names-only — so the
  * requested cap is an upper bound and not the delivered length. Reading the
- * emitted text back is the only accurate source. A skill missing from the
- * returned map had its description dropped entirely.
+ * emitted text back is the only accurate source.
+ *
+ * Matching is positional rather than keyed by name because the catalog
+ * deliberately keeps duplicate-named skills as separate entries; keying by
+ * name would collapse them and misreport every occurrence but the last.
+ * Entry order is the order passed to the formatter, and the names-only
+ * fallback drops from the tail, so a skill the catalog never reached keeps
+ * its `0` and reads as dropped.
  */
-function measureCatalogDescriptions(catalog: string, names: Set<string>): Map<string, number> {
-  const delivered = new Map<string, number>();
+function measureCatalogDescriptions(catalog: string, names: string[]): number[] {
+  const delivered = new Array<number>(names.length).fill(0);
+  let index = 0;
   for (const line of catalog.split('\n')) {
-    if (!line.startsWith('- ')) {
+    if (index >= names.length) {
+      break;
+    }
+    const prefix = `- ${names[index]}`;
+    if (line === prefix) {
+      index++;
       continue;
     }
-    const separator = line.indexOf(': ');
-    if (separator === -1) {
-      continue;
-    }
-    const name = line.slice(2, separator);
-    if (names.has(name)) {
-      delivered.set(name, line.length - separator - 2);
+    if (line.startsWith(`${prefix}: `)) {
+      delivered[index] = line.length - prefix.length - 2;
+      index++;
     }
   }
   return delivered;
@@ -734,10 +743,11 @@ export async function injectSkillCatalog(
     if (catalog) {
       const delivered = measureCatalogDescriptions(
         catalog,
-        new Set(catalogVisibleSkills.map((s) => s.name)),
+        catalogVisibleSkills.map((s) => s.name),
       );
-      for (const s of catalogVisibleSkills) {
-        const reached = delivered.get(s.name) ?? 0;
+      for (let i = 0; i < catalogVisibleSkills.length; i++) {
+        const s = catalogVisibleSkills[i];
+        const reached = delivered[i];
         if (reached >= s.description.length) {
           continue;
         }

--- a/packages/api/src/agents/skills.ts
+++ b/packages/api/src/agents/skills.ts
@@ -585,23 +585,52 @@ export async function resolveSkillCatalog(
   };
 }
 
+/** Filler used to build the measurement probe; never reaches the model. */
+const CATALOG_PROBE_CHAR = 'x';
+
 /**
- * Whether `catalog` carries this skill's description in full.
+ * How much of each skill's description reaches the model, aligned to `skills`.
  *
- * An entry the formatter kept renders as `- name: description` on a line of
- * its own, so the whole rendering is what gets matched. Matching the
- * description alone would miss a drop whenever its text happens to appear
- * elsewhere in the catalog — a one-word description is enough to collide with
- * another skill's name once the catalog falls back to names-only.
+ * Measured on a probe rather than on the real catalog. Every decision in
+ * `formatSkillCatalog`'s truncation ladder reads description `.length` and
+ * never description content, so formatting same-length filler reproduces the
+ * real cuts exactly — while guaranteeing the output can be parsed, since
+ * filler carries no newline and no entry marker and skill names are validated
+ * to `^[a-z0-9][a-z0-9-]*$`.
  *
- * Matching the rendering rather than parsing entries also keeps this correct
- * where boundaries are not recoverable: descriptions may contain newlines, so
- * an entry is not one physical line, and a continuation line can imitate the
- * next entry's marker.
+ * The real catalog cannot be measured: a description may contain newlines, so
+ * an entry is not one line; duplicate names share a rendering; and truncation
+ * can splice one entry's tail onto the next, so even a whole-entry match can
+ * be satisfied by text the model never received as that entry.
  */
-function catalogKeptDescription(catalog: string, name: string, description: string): boolean {
-  const entry = `\n- ${name}: ${description}`;
-  return catalog.includes(`${entry}\n`) || catalog.endsWith(entry);
+function measureCatalogDescriptions(
+  skills: Array<{ name: string; description: string }>,
+  options: Parameters<typeof formatSkillCatalog>[1],
+): number[] {
+  const probe = formatSkillCatalog(
+    skills.map((s) => ({
+      name: s.name,
+      description: CATALOG_PROBE_CHAR.repeat(s.description.length),
+    })),
+    options,
+  );
+  const delivered = new Array<number>(skills.length).fill(0);
+  let index = 0;
+  for (const line of probe.split('\n')) {
+    if (index >= skills.length) {
+      break;
+    }
+    const prefix = `- ${skills[index].name}`;
+    if (line === prefix) {
+      index++;
+      continue;
+    }
+    if (line.startsWith(`${prefix}: `)) {
+      delivered[index] = line.length - prefix.length - 2;
+      index++;
+    }
+  }
+  return delivered;
 }
 
 /**
@@ -716,20 +745,26 @@ export async function injectSkillCatalog(
    * and those reads would otherwise be impossible.
    */
   if (catalogVisibleSkills.length > 0) {
+    const catalogOptions = {
+      contextWindowTokens: contextWindowTokens || 200_000,
+      maxEntryChars: SKILL_CATALOG_MAX_ENTRY_CHARS,
+    };
     const catalog = formatSkillCatalog(
       catalogVisibleSkills.map((s) => ({ name: s.name, description: s.description })),
-      {
-        contextWindowTokens: contextWindowTokens || 200_000,
-        maxEntryChars: SKILL_CATALOG_MAX_ENTRY_CHARS,
-      },
+      catalogOptions,
     );
     if (catalog) {
-      for (const s of catalogVisibleSkills) {
-        if (!s.description || catalogKeptDescription(catalog, s.name, s.description)) {
+      const delivered = measureCatalogDescriptions(catalogVisibleSkills, catalogOptions);
+      for (let i = 0; i < catalogVisibleSkills.length; i++) {
+        const s = catalogVisibleSkills[i];
+        const reached = delivered[i];
+        if (reached >= s.description.length) {
           continue;
         }
         logger.warn(
-          `[injectSkillCatalog] skill "${s.name}" description (${s.description.length} chars) does not reach the model verbatim — the catalog caps entries at ${SKILL_CATALOG_MAX_ENTRY_CHARS} and cuts further to fit its context budget`,
+          reached === 0
+            ? `[injectSkillCatalog] skill "${s.name}" description was dropped from the model catalog (was ${s.description.length} chars) — the catalog exceeded its context budget`
+            : `[injectSkillCatalog] skill "${s.name}" description reached the model truncated to ${reached} of ${s.description.length} chars`,
         );
       }
       agent.additional_instructions = agent.additional_instructions

--- a/packages/api/src/agents/skills.ts
+++ b/packages/api/src/agents/skills.ts
@@ -95,10 +95,12 @@ const MAX_CATALOG_PAGES = 10;
 /** Page size used when paginating to fill the active-skill quota. */
 const CATALOG_PAGE_SIZE = 100;
 /**
- * Per-entry description cap applied by `formatSkillCatalog` before the
- * catalog is injected into agent context. `@librechat/agents` truncates
- * silently, so this mirrors the default so we can warn when authors' skill
- * descriptions will not reach the model verbatim.
+ * Per-entry description cap requested of `formatSkillCatalog`, mirroring the
+ * SDK default. It is a ceiling, not a guarantee: `@librechat/agents` applies
+ * it first, then truncates further — proportionally against its own context
+ * budget, and finally to names-only — so a description well under this cap
+ * can still be cut. Delivered length is measured from the emitted catalog
+ * rather than assumed from this value.
  */
 const SKILL_CATALOG_MAX_ENTRY_CHARS = 250;
 /** Hard ceiling on skill names a model spec can request by config. */
@@ -584,6 +586,33 @@ export async function resolveSkillCatalog(
 }
 
 /**
+ * Description length that survived into `catalog`, per skill name.
+ *
+ * `formatSkillCatalog` truncates on a ladder — the per-entry cap, then a
+ * proportional cut sized to its context budget, then names-only — so the
+ * requested cap is an upper bound and not the delivered length. Reading the
+ * emitted text back is the only accurate source. A skill missing from the
+ * returned map had its description dropped entirely.
+ */
+function measureCatalogDescriptions(catalog: string, names: Set<string>): Map<string, number> {
+  const delivered = new Map<string, number>();
+  for (const line of catalog.split('\n')) {
+    if (!line.startsWith('- ')) {
+      continue;
+    }
+    const separator = line.indexOf(': ');
+    if (separator === -1) {
+      continue;
+    }
+    const name = line.slice(2, separator);
+    if (names.has(name)) {
+      delivered.set(name, line.length - separator - 2);
+    }
+  }
+  return delivered;
+}
+
+/**
  * Queries accessible skills, formats a budget-aware catalog, appends it to the
  * agent's additional_instructions, and registers the SkillTool definition.
  * Returns updated toolDefinitions and the skill count.
@@ -695,13 +724,6 @@ export async function injectSkillCatalog(
    * and those reads would otherwise be impossible.
    */
   if (catalogVisibleSkills.length > 0) {
-    for (const s of catalogVisibleSkills) {
-      if (s.description.length > SKILL_CATALOG_MAX_ENTRY_CHARS) {
-        logger.warn(
-          `[injectSkillCatalog] skill "${s.name}" description truncated to ${SKILL_CATALOG_MAX_ENTRY_CHARS} chars for the model catalog (was ${s.description.length})`,
-        );
-      }
-    }
     const catalog = formatSkillCatalog(
       catalogVisibleSkills.map((s) => ({ name: s.name, description: s.description })),
       {
@@ -710,6 +732,21 @@ export async function injectSkillCatalog(
       },
     );
     if (catalog) {
+      const delivered = measureCatalogDescriptions(
+        catalog,
+        new Set(catalogVisibleSkills.map((s) => s.name)),
+      );
+      for (const s of catalogVisibleSkills) {
+        const reached = delivered.get(s.name) ?? 0;
+        if (reached >= s.description.length) {
+          continue;
+        }
+        logger.warn(
+          reached === 0
+            ? `[injectSkillCatalog] skill "${s.name}" description was dropped from the model catalog (was ${s.description.length} chars) — the catalog exceeded its context budget`
+            : `[injectSkillCatalog] skill "${s.name}" description reached the model truncated to ${reached} of ${s.description.length} chars`,
+        );
+      }
       agent.additional_instructions = agent.additional_instructions
         ? `${agent.additional_instructions}\n\n${catalog}`
         : catalog;

--- a/packages/api/src/agents/skills.ts
+++ b/packages/api/src/agents/skills.ts
@@ -586,42 +586,6 @@ export async function resolveSkillCatalog(
 }
 
 /**
- * Description length that survived into `catalog`, positionally aligned to
- * `names` — index `i` is how much of skill `i`'s description the model got.
- *
- * `formatSkillCatalog` truncates on a ladder — the per-entry cap, then a
- * proportional cut sized to its context budget, then names-only — so the
- * requested cap is an upper bound and not the delivered length. Reading the
- * emitted text back is the only accurate source.
- *
- * Matching is positional rather than keyed by name because the catalog
- * deliberately keeps duplicate-named skills as separate entries; keying by
- * name would collapse them and misreport every occurrence but the last.
- * Entry order is the order passed to the formatter, and the names-only
- * fallback drops from the tail, so a skill the catalog never reached keeps
- * its `0` and reads as dropped.
- */
-function measureCatalogDescriptions(catalog: string, names: string[]): number[] {
-  const delivered = new Array<number>(names.length).fill(0);
-  let index = 0;
-  for (const line of catalog.split('\n')) {
-    if (index >= names.length) {
-      break;
-    }
-    const prefix = `- ${names[index]}`;
-    if (line === prefix) {
-      index++;
-      continue;
-    }
-    if (line.startsWith(`${prefix}: `)) {
-      delivered[index] = line.length - prefix.length - 2;
-      index++;
-    }
-  }
-  return delivered;
-}
-
-/**
  * Queries accessible skills, formats a budget-aware catalog, appends it to the
  * agent's additional_instructions, and registers the SkillTool definition.
  * Returns updated toolDefinitions and the skill count.
@@ -741,20 +705,19 @@ export async function injectSkillCatalog(
       },
     );
     if (catalog) {
-      const delivered = measureCatalogDescriptions(
-        catalog,
-        catalogVisibleSkills.map((s) => s.name),
-      );
-      for (let i = 0; i < catalogVisibleSkills.length; i++) {
-        const s = catalogVisibleSkills[i];
-        const reached = delivered[i];
-        if (reached >= s.description.length) {
+      /**
+       * A description the catalog kept intact appears in it verbatim, so
+       * containment detects truncation from any rung of the ladder without
+       * needing entry boundaries. Boundaries are not recoverable anyway:
+       * descriptions may contain newlines, so an entry is not one physical
+       * line, and a continuation line can imitate the next entry's marker.
+       */
+      for (const s of catalogVisibleSkills) {
+        if (catalog.includes(s.description)) {
           continue;
         }
         logger.warn(
-          reached === 0
-            ? `[injectSkillCatalog] skill "${s.name}" description was dropped from the model catalog (was ${s.description.length} chars) — the catalog exceeded its context budget`
-            : `[injectSkillCatalog] skill "${s.name}" description reached the model truncated to ${reached} of ${s.description.length} chars`,
+          `[injectSkillCatalog] skill "${s.name}" description (${s.description.length} chars) does not reach the model verbatim — the catalog caps entries at ${SKILL_CATALOG_MAX_ENTRY_CHARS} and cuts further to fit its context budget`,
         );
       }
       agent.additional_instructions = agent.additional_instructions

--- a/packages/api/src/agents/skills.ts
+++ b/packages/api/src/agents/skills.ts
@@ -586,6 +586,25 @@ export async function resolveSkillCatalog(
 }
 
 /**
+ * Whether `catalog` carries this skill's description in full.
+ *
+ * An entry the formatter kept renders as `- name: description` on a line of
+ * its own, so the whole rendering is what gets matched. Matching the
+ * description alone would miss a drop whenever its text happens to appear
+ * elsewhere in the catalog — a one-word description is enough to collide with
+ * another skill's name once the catalog falls back to names-only.
+ *
+ * Matching the rendering rather than parsing entries also keeps this correct
+ * where boundaries are not recoverable: descriptions may contain newlines, so
+ * an entry is not one physical line, and a continuation line can imitate the
+ * next entry's marker.
+ */
+function catalogKeptDescription(catalog: string, name: string, description: string): boolean {
+  const entry = `\n- ${name}: ${description}`;
+  return catalog.includes(`${entry}\n`) || catalog.endsWith(entry);
+}
+
+/**
  * Queries accessible skills, formats a budget-aware catalog, appends it to the
  * agent's additional_instructions, and registers the SkillTool definition.
  * Returns updated toolDefinitions and the skill count.
@@ -705,15 +724,8 @@ export async function injectSkillCatalog(
       },
     );
     if (catalog) {
-      /**
-       * A description the catalog kept intact appears in it verbatim, so
-       * containment detects truncation from any rung of the ladder without
-       * needing entry boundaries. Boundaries are not recoverable anyway:
-       * descriptions may contain newlines, so an entry is not one physical
-       * line, and a continuation line can imitate the next entry's marker.
-       */
       for (const s of catalogVisibleSkills) {
-        if (catalog.includes(s.description)) {
+        if (!s.description || catalogKeptDescription(catalog, s.name, s.description)) {
           continue;
         }
         logger.warn(


### PR DESCRIPTION
## Summary

`injectSkillCatalog` warns when a skill's description will not reach the model verbatim. The warning assumed `SKILL_CATALOG_MAX_ENTRY_CHARS` (250) was the delivered length. It isn't — 250 is only the first rung of the SDK's truncation ladder.

`formatSkillCatalog` in `@librechat/agents` applies the per-entry cap, then truncates **further** proportionally against its own context budget (`contextWindowTokens × 0.01 × 4` chars), and finally falls back to names-only, dropping descriptions entirely.

That leaves two silent failure modes:

- **A description *under* the cap can still be cut, with no warning at all.** Measured against the real SDK: 8 skills × 200 chars at a 20k context window each reach the model at 85 chars. The old check (`length > 250`) never fires.
- **When the ladder engages past the cap, the warning overstated what landed.** A 499-char description in a 100-skill catalog was reported as "truncated to 250" when 60 chars actually reached the model.

Measured 2026-09-04 at a 200k window: ≤26 skills get the full 250, 50 skills get 141, 100 (the catalog limit) get 61. A smaller context window tightens it independently — the same six-skill catalog gets 189 chars each at 32k, 29 at 8k.

## Change

Measure delivered lengths on a **length-equivalent probe** rather than on the real catalog.

Every decision in `formatSkillCatalog`'s truncation ladder reads description `.length` and never description content (`skillCatalog.ts` lines 51-89). So formatting a second catalog whose descriptions are same-length filler reproduces the real cuts exactly, and that probe is parseable by construction: filler carries no newline and no entry marker, and skill names are validated to `^[a-z0-9][a-z0-9-]*$`.

This arrived by elimination. Four review rounds showed the real catalog cannot be parsed or matched, because descriptions are arbitrary text that can imitate any structure a check relies on:

- **Keying by name** collapsed duplicate-named skills, which the catalog deliberately keeps as separate entries — a 400-char and a 100-char description sharing a name warned "truncated to 100 of 400" when the first actually reached 250.
- **Parsing physical lines** broke on multiline descriptions, which nothing strips (`validateSkillDescription` checks type, length and trim-emptiness only). One kept intact was flagged truncated; one starting with a newline measured 0 and read as dropped; and a continuation line imitating the next entry's marker desynchronized everything after it, measuring a 400-char entry at 8.
- **Matching the description text** missed a drop whenever that text occurred elsewhere. Under names-only, a one-word description such as `research` collides with a skill *named* `research`, so the check held for a description that had been dropped entirely.
- **Matching the whole entry rendering** still missed the case where truncation splices one entry's tail onto the next: cut a description at `…\n- next-skill: next description` with a real matching `next-skill`, and the full rendering is present across two entries.

Measuring on the probe closes the class rather than the instance, and keeps the delivered length in the warning.

Model-facing behaviour is unchanged throughout: this is an observability fix. The catalog text, the cap, and the injected instructions are untouched.

## On the mock

`formatSkillCatalog` is no longer stubbed in the spec. The stub was a passthrough that never truncated, which is exactly why no existing test could observe this class of defect. The SDK exports the real function, so the spec now exercises it — per the repo's "real logic over mocks" guidance.

## Testing

`packages/api/src/agents/__tests__/skills.test.ts` — 163 passed. Coverage added for over-cap truncation, sub-cap budget truncation, the names-only fallback, duplicate names, multiline and leading-newline descriptions, the imitator case, the name-collision drop, and the spliced-boundary case.

Test selection came from codegraph (`tests.mjs`), which put this spec at depth 1 and everything else at depth ≥ 2.

The truncation tests were confirmed to **fail** with the fix reverted, so they pin the behaviour rather than passing either way. Every approach was also diffed against the real formatter across the six adversarial cases raised in review: probe measurement correct on 6/6, entry-scoped containment on 5/6, bare containment on 4/6, positional parsing on 3/6.

`npx tsc --noEmit` in `packages/api` reports 30 errors, identical to the `dev` baseline on a clean tree — all in `memory.*`, `management.*` and `telemetry/logs.*`, none in touched files.

## Not addressed here

Whether 250 is still the right per-entry number is a separate design question, left alone deliberately. Worth noting the SDK already implements a per-catalog token budget — the ladder — so LibreChat's fixed 250 is a per-entry ceiling feeding into it, not the budget itself.

Companion docs fix, which is where authors actually learn this: danny-avila/codegraph-poc#4
