### PR TITLE
🪵 fix: Log Code API Auth Header Failures With Request Context

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "5.1.6",
-    "@librechat/agents": "^3.7.20",
+    "@librechat/agents": "^3.7.21",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "5.1.6",
-        "@librechat/agents": "^3.7.20",
+        "@librechat/agents": "^3.7.21",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -10627,9 +10627,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.7.20",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.7.20.tgz",
-      "integrity": "sha512-YnfBpC5MK7QDgP+6VpmOYBTA2mXbaA+fDggfi7n/bsB56FSqenCzizSpC+Nn83lhwJz7GNntJpYNX53nRhFGgw==",
+      "version": "3.7.21",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.7.21.tgz",
+      "integrity": "sha512-n0dd7Xzh8Rnx4TGYBOqSGzSBoDMwyV28710Xn/q/Id6p7Z0CEnv4sLuQTHR1UMvhmOHs4kz2/pYynnaz60WbaA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
@@ -42681,7 +42681,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "5.1.6",
-        "@librechat/agents": "^3.7.20",
+        "@librechat/agents": "^3.7.21",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/api": "^1.9.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -113,7 +113,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "5.1.6",
-    "@librechat/agents": "^3.7.20",
+    "@librechat/agents": "^3.7.21",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@opentelemetry/api": "^1.9.0",

--- a/packages/api/src/agents/execution.spec.ts
+++ b/packages/api/src/agents/execution.spec.ts
@@ -1,3 +1,5 @@
+import winston from 'winston';
+import { Writable } from 'node:stream';
 import { logger } from '@librechat/data-schemas';
 import {
   codeExecutionAuthHeaders,
@@ -344,6 +346,56 @@ describe('codeExecutionAuthHeaders', () => {
     expect(errorSpy).toHaveBeenCalledWith(
       '[codeExecutionAuthHeaders] Failed to resolve Code API auth headers | Profile: stateful | Worker: opaque-worker-id',
       failure,
+    );
+  });
+
+  it('renders the cause on a console format that prints only the message', async () => {
+    errorSpy.mockRestore();
+    const rendered: string[] = [];
+    const capture = new winston.transports.Stream({
+      stream: new Writable({
+        write(chunk: Buffer, _encoding: string, done: () => void) {
+          rendered.push(String(chunk));
+          done();
+        },
+      }),
+      format: winston.format.printf((info) => `${info.level}: ${info.message}`),
+    });
+    const existing = [...logger.transports];
+    existing.forEach((transport) => {
+      transport.silent = true;
+    });
+    logger.add(capture);
+
+    try {
+      await codeExecutionAuthHeaders(
+        () => Promise.reject(new Error('code API signing key is not configured')),
+        { executionProfile: 'stateful' },
+      ).catch(() => undefined);
+      await codeExecutionAuthHeaders(() => Promise.reject('signing service unreachable'), {
+        executionProfile: 'stateful',
+      }).catch(() => undefined);
+    } finally {
+      logger.remove(capture);
+      existing.forEach((transport) => {
+        transport.silent = false;
+      });
+    }
+
+    expect(rendered.join('')).toContain('code API signing key is not configured');
+    expect(rendered.join('')).toContain('signing service unreachable');
+  });
+
+  it('carries a non-Error rejection in the message, which winston would otherwise drop', async () => {
+    await expect(
+      codeExecutionAuthHeaders(() => Promise.reject('signing service unreachable'), {
+        executionProfile: 'default',
+      }),
+    ).rejects.toBe('signing service unreachable');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[codeExecutionAuthHeaders] Failed to resolve Code API auth headers | Profile: default | Cause: signing service unreachable',
+      'signing service unreachable',
     );
   });
 

--- a/packages/api/src/agents/execution.spec.ts
+++ b/packages/api/src/agents/execution.spec.ts
@@ -373,7 +373,25 @@ describe('codeExecutionAuthHeaders', () => {
     ).rejects.toBe(hostile);
 
     expect(errorSpy).toHaveBeenCalledWith(
-      '[codeExecutionAuthHeaders] Failed to resolve Code API auth headers | Profile: default | Cause: unstringifiable rejection',
+      '[codeExecutionAuthHeaders] Failed to resolve Code API auth headers | Profile: default | Cause: undescribable rejection',
+    );
+  });
+
+  it('describes a rejection whose accessors throw, and still rethrows it', async () => {
+    const hostile = new Proxy(new Error('boom'), {
+      get(): never {
+        throw new Error('accessor exploded');
+      },
+    });
+
+    await expect(
+      codeExecutionAuthHeaders(() => Promise.reject(hostile), {
+        executionProfile: 'default',
+      }),
+    ).rejects.toBe(hostile);
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[codeExecutionAuthHeaders] Failed to resolve Code API auth headers | Profile: default | Cause: undescribable rejection',
     );
   });
 

--- a/packages/api/src/agents/execution.spec.ts
+++ b/packages/api/src/agents/execution.spec.ts
@@ -344,58 +344,7 @@ describe('codeExecutionAuthHeaders', () => {
 
     expect(errorSpy).toHaveBeenCalledTimes(1);
     expect(errorSpy).toHaveBeenCalledWith(
-      '[codeExecutionAuthHeaders] Failed to resolve Code API auth headers | Profile: stateful | Worker: opaque-worker-id',
-      failure,
-    );
-  });
-
-  it('renders the cause on a console format that prints only the message', async () => {
-    errorSpy.mockRestore();
-    const rendered: string[] = [];
-    const capture = new winston.transports.Stream({
-      stream: new Writable({
-        write(chunk: Buffer, _encoding: string, done: () => void) {
-          rendered.push(String(chunk));
-          done();
-        },
-      }),
-      format: winston.format.printf((info) => `${info.level}: ${info.message}`),
-    });
-    const existing = [...logger.transports];
-    existing.forEach((transport) => {
-      transport.silent = true;
-    });
-    logger.add(capture);
-
-    try {
-      await codeExecutionAuthHeaders(
-        () => Promise.reject(new Error('code API signing key is not configured')),
-        { executionProfile: 'stateful' },
-      ).catch(() => undefined);
-      await codeExecutionAuthHeaders(() => Promise.reject('signing service unreachable'), {
-        executionProfile: 'stateful',
-      }).catch(() => undefined);
-    } finally {
-      logger.remove(capture);
-      existing.forEach((transport) => {
-        transport.silent = false;
-      });
-    }
-
-    expect(rendered.join('')).toContain('code API signing key is not configured');
-    expect(rendered.join('')).toContain('signing service unreachable');
-  });
-
-  it('carries a non-Error rejection in the message, which winston would otherwise drop', async () => {
-    await expect(
-      codeExecutionAuthHeaders(() => Promise.reject('signing service unreachable'), {
-        executionProfile: 'default',
-      }),
-    ).rejects.toBe('signing service unreachable');
-
-    expect(errorSpy).toHaveBeenCalledWith(
-      '[codeExecutionAuthHeaders] Failed to resolve Code API auth headers | Profile: default | Cause: signing service unreachable',
-      'signing service unreachable',
+      '[codeExecutionAuthHeaders] Failed to resolve Code API auth headers | Profile: stateful | Worker: opaque-worker-id | Cause: Error: code API signing key is not configured',
     );
   });
 
@@ -410,8 +359,67 @@ describe('codeExecutionAuthHeaders', () => {
     ).rejects.toThrow('boom');
 
     expect(errorSpy).toHaveBeenCalledWith(
-      '[codeExecutionAuthHeaders] Failed to resolve Code API auth headers | Profile: default',
-      expect.any(Error),
+      '[codeExecutionAuthHeaders] Failed to resolve Code API auth headers | Profile: default | Cause: Error: boom',
     );
+  });
+
+  it('describes a rejection that cannot be converted to a string, and still rethrows it', async () => {
+    const hostile = Object.create(null) as Record<string, never>;
+
+    await expect(
+      codeExecutionAuthHeaders(() => Promise.reject(hostile), {
+        executionProfile: 'default',
+      }),
+    ).rejects.toBe(hostile);
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[codeExecutionAuthHeaders] Failed to resolve Code API auth headers | Profile: default | Cause: unstringifiable rejection',
+    );
+  });
+
+  it('renders the cause verbatim through the formats a deployment actually uses', async () => {
+    errorSpy.mockRestore();
+    const rendered: string[] = [];
+    const capture = new winston.transports.Stream({
+      stream: new Writable({
+        write(chunk: Buffer, _encoding: string, done: () => void) {
+          rendered.push(String(chunk));
+          done();
+        },
+      }),
+      /* `splat()` is what would consume a `%s` in the cause as a substitution
+         token, and the bare printf is the console transport that prints
+         `info.message` alone. Both have to leave the cause intact. */
+      format: winston.format.combine(
+        winston.format.errors({ stack: true }),
+        winston.format.splat(),
+        winston.format.printf((info) => `${info.level}: ${info.message}`),
+      ),
+    });
+    const silenced = logger.transports.map((transport) => {
+      const previous = transport.silent;
+      transport.silent = true;
+      return { transport, previous };
+    });
+    logger.add(capture);
+
+    try {
+      await codeExecutionAuthHeaders(
+        () => Promise.reject(new Error('code API signing key is not configured')),
+        { executionProfile: 'stateful' },
+      ).catch(() => undefined);
+      await codeExecutionAuthHeaders(() => Promise.reject('service said %s unavailable'), {
+        executionProfile: 'stateful',
+      }).catch(() => undefined);
+    } finally {
+      logger.remove(capture);
+      silenced.forEach(({ transport, previous }) => {
+        transport.silent = previous;
+      });
+    }
+
+    const output = rendered.join('');
+    expect(output).toContain('Cause: Error: code API signing key is not configured');
+    expect(output).toContain('Cause: service said %s unavailable');
   });
 });

--- a/packages/api/src/agents/execution.spec.ts
+++ b/packages/api/src/agents/execution.spec.ts
@@ -1,3 +1,4 @@
+import { logger } from '@librechat/data-schemas';
 import {
   codeExecutionAuthHeaders,
   codeExecutionHeaders,
@@ -315,5 +316,50 @@ describe('resolveCodeExecutionContext', () => {
         userId: 'user-1',
       }),
     ).toThrow('Stateful code environment "missing-vm" is not configured');
+  });
+});
+
+describe('codeExecutionAuthHeaders', () => {
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => logger);
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('logs the failure that reaches the model as a generic authorization error', async () => {
+    const failure = new Error('code API signing key is not configured');
+
+    await expect(
+      codeExecutionAuthHeaders(() => Promise.reject(failure), {
+        executionProfile: 'stateful',
+        bridgeWorkerId: 'opaque-worker-id',
+      }),
+    ).rejects.toBe(failure);
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[codeExecutionAuthHeaders] Failed to resolve Code API auth headers | Profile: stateful | Worker: opaque-worker-id',
+      failure,
+    );
+  });
+
+  it('omits the worker from the log when the request is not bridged', async () => {
+    await expect(
+      codeExecutionAuthHeaders(
+        () => {
+          throw new Error('boom');
+        },
+        { executionProfile: 'default' },
+      ),
+    ).rejects.toThrow('boom');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[codeExecutionAuthHeaders] Failed to resolve Code API auth headers | Profile: default',
+      expect.any(Error),
+    );
   });
 });

--- a/packages/api/src/agents/execution.ts
+++ b/packages/api/src/agents/execution.ts
@@ -211,9 +211,15 @@ export async function codeExecutionAuthHeaders(
       ...codeExecutionHeaders(context),
     };
   } catch (error) {
+    /* winston folds an Error meta's message and stack into `info.message`, so
+     * an Error cause survives even the plain console format that prints
+     * `info.message` alone. A non-Error rejection is dropped by that format,
+     * so it has to ride in the message itself. */
+    const cause = error instanceof Error ? '' : ` | Cause: ${String(error)}`;
     logger.error(
       `[codeExecutionAuthHeaders] Failed to resolve Code API auth headers | Profile: ${context.executionProfile}` +
-        (context.bridgeWorkerId != null ? ` | Worker: ${context.bridgeWorkerId}` : ''),
+        (context.bridgeWorkerId != null ? ` | Worker: ${context.bridgeWorkerId}` : '') +
+        cause,
       error,
     );
     throw error;

--- a/packages/api/src/agents/execution.ts
+++ b/packages/api/src/agents/execution.ts
@@ -198,18 +198,16 @@ export function codeExecutionHeaders(
  * value passed as metadata is merged onto the log record, so a rejection
  * carrying `tenantId`, `userId` or `event_name` would overwrite the request
  * identity this log exists to provide; and any metadata makes `format.splat()`
- * treat a `%s` in the cause as a substitution token. Conversion is guarded
- * because `String()` throws on a null-prototype object, which would otherwise
- * replace the rejection with a formatting error and log nothing.
+ * treat a `%s` in the cause as a substitution token. Every read is guarded:
+ * `String()` throws on a null-prototype object and a proxy can throw from a
+ * `name` or `message` accessor, either of which would otherwise replace the
+ * rejection with a formatting error and log nothing.
  */
 function describeAuthFailure(error: unknown): string {
-  if (error instanceof Error) {
-    return `${error.name}: ${error.message}`;
-  }
   try {
-    return String(error);
+    return error instanceof Error ? `${error.name}: ${error.message}` : String(error);
   } catch {
-    return 'unstringifiable rejection';
+    return 'undescribable rejection';
   }
 }
 

--- a/packages/api/src/agents/execution.ts
+++ b/packages/api/src/agents/execution.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { logger } from '@librechat/data-schemas';
 import { Constants, getCodeBaseURL } from '@librechat/agents';
 import type {
   CodeEnvironmentUserConfigSchema,
@@ -192,14 +193,29 @@ export function codeExecutionHeaders(
   };
 }
 
+/**
+ * `@librechat/agents` replaces any throw from this callback with a fixed
+ * "not authorized" string before the model or the operator sees it, and its own
+ * console diagnostic carries no request or user id. This log is the only
+ * request-correlated record of why the headers could not be resolved.
+ */
 export async function codeExecutionAuthHeaders(
   authHeaders: (
     bridgeWorkerId?: string,
   ) => Promise<Record<string, string>> | Record<string, string>,
   context: Pick<CodeExecutionContext, 'executionProfile' | 'bridgeWorkerId'>,
 ): Promise<Record<string, string>> {
-  return {
-    ...(await authHeaders(context.bridgeWorkerId)),
-    ...codeExecutionHeaders(context),
-  };
+  try {
+    return {
+      ...(await authHeaders(context.bridgeWorkerId)),
+      ...codeExecutionHeaders(context),
+    };
+  } catch (error) {
+    logger.error(
+      `[codeExecutionAuthHeaders] Failed to resolve Code API auth headers | Profile: ${context.executionProfile}` +
+        (context.bridgeWorkerId != null ? ` | Worker: ${context.bridgeWorkerId}` : ''),
+      error,
+    );
+    throw error;
+  }
 }

--- a/packages/api/src/agents/execution.ts
+++ b/packages/api/src/agents/execution.ts
@@ -194,6 +194,26 @@ export function codeExecutionHeaders(
 }
 
 /**
+ * The cause belongs in the message rather than in winston metadata. A caught
+ * value passed as metadata is merged onto the log record, so a rejection
+ * carrying `tenantId`, `userId` or `event_name` would overwrite the request
+ * identity this log exists to provide; and any metadata makes `format.splat()`
+ * treat a `%s` in the cause as a substitution token. Conversion is guarded
+ * because `String()` throws on a null-prototype object, which would otherwise
+ * replace the rejection with a formatting error and log nothing.
+ */
+function describeAuthFailure(error: unknown): string {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`;
+  }
+  try {
+    return String(error);
+  } catch {
+    return 'unstringifiable rejection';
+  }
+}
+
+/**
  * `@librechat/agents` replaces any throw from this callback with a fixed
  * "not authorized" string before the model or the operator sees it, and its own
  * console diagnostic carries no request or user id. This log is the only
@@ -211,16 +231,10 @@ export async function codeExecutionAuthHeaders(
       ...codeExecutionHeaders(context),
     };
   } catch (error) {
-    /* winston folds an Error meta's message and stack into `info.message`, so
-     * an Error cause survives even the plain console format that prints
-     * `info.message` alone. A non-Error rejection is dropped by that format,
-     * so it has to ride in the message itself. */
-    const cause = error instanceof Error ? '' : ` | Cause: ${String(error)}`;
     logger.error(
       `[codeExecutionAuthHeaders] Failed to resolve Code API auth headers | Profile: ${context.executionProfile}` +
         (context.bridgeWorkerId != null ? ` | Worker: ${context.bridgeWorkerId}` : '') +
-        cause,
-      error,
+        ` | Cause: ${describeAuthFailure(error)}`,
     );
     throw error;
   }

--- a/packages/api/src/auth/codeapi.spec.ts
+++ b/packages/api/src/auth/codeapi.spec.ts
@@ -361,4 +361,22 @@ describe('Code API JWT minting', () => {
     delete process.env.CODEAPI_JWT_ENABLED;
     await expect(getCodeApiAuthHeaders(baseRequest())).resolves.toEqual({});
   });
+
+  it('does not echo signing material when the private JWK is malformed', async () => {
+    process.env.CODEAPI_JWT_PRIVATE_JWK_JSON =
+      '{"kty":"OKP","crv":"Ed25519","d":MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgw,"x":"abc"}';
+
+    let failure: unknown;
+    try {
+      await mintCodeApiToken(baseRequest());
+    } catch (caught) {
+      failure = caught;
+    }
+
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error).message).toBe(
+      'Code API JWT signing key could not be loaded (JWK format)',
+    );
+    expect((failure as Error).message).not.toContain('MIIEvgIBAD');
+  });
 });

--- a/packages/api/src/auth/codeapi.ts
+++ b/packages/api/src/auth/codeapi.ts
@@ -116,11 +116,24 @@ function parseCappedSeconds(value: string | undefined, fallback: number, max: nu
   return Math.min(Math.floor(parsed), max);
 }
 
+/**
+ * A parse failure here must not propagate verbatim. Node's JSON `SyntaxError`
+ * quotes an excerpt of the source around the offending token, so a malformed
+ * private JWK puts signing material into a message that callers log; the
+ * message redaction patterns do not recognize a bare base64 fragment. Callers
+ * get the failure and its key format, never the key.
+ */
 function createSigningKey(rawKey: string): KeyObject {
-  if (rawKey.startsWith('{')) {
-    return createPrivateKey({ key: JSON.parse(rawKey) as JsonWebKey, format: 'jwk' });
+  const isJwk = rawKey.startsWith('{');
+  try {
+    return isJwk
+      ? createPrivateKey({ key: JSON.parse(rawKey) as JsonWebKey, format: 'jwk' })
+      : createPrivateKey(rawKey);
+  } catch {
+    throw new Error(
+      `Code API JWT signing key could not be loaded (${isJwk ? 'JWK' : 'PEM'} format)`,
+    );
   }
-  return createPrivateKey(rawKey);
 }
 
 function getSigningConfig(): SigningConfig {


### PR DESCRIPTION
## Summary

Every Code API tool LibreChat builds — `execute_code` (`handleTools.js`, `ToolService.js`), `bash_tool`, and the PTC tools — resolves its auth headers through one funnel, `codeExecutionAuthHeaders`. When that throws, `@librechat/agents` replaces it with a fixed `Code execution is not authorized. Verify access before trying again.` and the request is never sent. Nothing on either side recorded why.

`getCodeApiAuthHeaders` → `mintCodeApiToken` can fail on signing-config resolution, claim construction, or JWT signing, and `packages/api/src/auth/codeapi.ts` logged nothing at all. So a failure that reaches the user as an authorization error left no server-side trace of its cause.

This is the LibreChat half of the fix; the SDK half is danny-avila/agents#508. That log alone is not enough here: the SDK writes to `console`, so it carries no request id, user id, or tenant id. LibreChat's winston logger attaches all three through `attachRequestContext`, which is what lets an auth failure be lined up with the `[code-env:inject]` events around it in the same request.

## What changed

**`codeExecutionAuthHeaders` logs the failure and rethrows unchanged:**

```
[codeExecutionAuthHeaders] Failed to resolve Code API auth headers | Profile: stateful | Worker: opaque-worker-id | Cause: Error: Code API JWT signing key could not be loaded (JWK format)
```

Rethrowing keeps the SDK's sanitization intact — **the model-facing message does not change.**

The cause is inlined in the message and **no metadata is passed**, which is not stylistic. Measured against real winston:

```
error('cause: %s', 'service said %s unavailable')  -> "cause: service said service said %s unavailable unavailable"
error('cause: %s', { errorStack: 'at foo' })       -> "cause: service said { errorStack: 'at foo' } unavailable"
error('cause: %s')                                 -> "cause: service said %s unavailable"   <- intact
error('plain', {tenantId,userId,event_name})       -> keys=event_name,level,message,tenantId,userId
error('err', errorWithEnumerableProps)             -> keys=level,message,stack,tenantId,userId
```

Rows 4 and 5: winston merges metadata onto the log record, and `attachRequestContext` deliberately keeps an already-present non-reserved value — so a rejection carrying `userId` would be attributed to the wrong user, and an `Error` is no safer since its *custom enumerable* properties are exactly what gets copied. Nesting under a key would not help, because rows 1 and 2 show any metadata arms `format.splat()`, which then consumes a `%s` in the cause as a substitution token. Row 3 is the resolution.

Conversion is guarded at every read: `String()` throws on a null-prototype object and a proxy can throw from a `name` or `message` accessor, either of which would replace the rejection with a formatting error and log nothing.

**`createSigningKey` no longer lets key material into its failure message.** Node 24's JSON `SyntaxError` quotes an excerpt of the source around the offending token:

```
JSON.parse('{"kty":"RSA","kid":"k1","d":MIIEvgIBAD…')
  -> SyntaxError: Unexpected token 'M', ..."":"k1","d":MIIEvgIBAD"... is not valid JSON
```

A malformed `CODEAPI_JWT_PRIVATE_JWK_JSON` therefore puts private signing material into a message that `mintCodeApiToken` propagates and this branch's log would persist on every failed execution — and the `parsers.ts` redaction patterns do not recognize a bare base64 fragment. Any load failure now becomes `Code API JWT signing key could not be loaded (JWK format)`: the failure and the format it attempted, nothing else. Safe by construction rather than by scrubbing, and it covers the PEM branch and every other caller of the signing path.

That finding is also what reshaped the SDK half, which has stopped logging upstream and host free text altogether.

## Testing

Test selection via the codegraph selector (`tests.mjs --files`, ref `dev` @ `ab0d74b4`, precise mode), run at its shallow depths:

```bash
cd packages/api && npx jest src/agents/execution.spec.ts src/auth/codeapi.spec.ts \
  src/agents/handlers.spec.ts src/agents/prewarm.spec.ts src/agents/skillFiles.spec.ts
```

5 suites, 252 tests, all passing. New tests, each verified to fail with its source change reverted:

- the logged message carries the cause, with and without a bridge worker
- a rejection that cannot be stringified, and one whose accessors throw, are both described *and* rethrown by identity
- the cause renders verbatim through `errors()` + `splat()` as well as through a bare printf that prints `info.message` alone — including a `%s`-bearing cause
- a malformed private JWK produces no excerpt of the key

`npm run static-checks -- --against origin/dev` passes ESLint, Prettier, import sorting and package.json validation. The circular-dependency gate cannot run in this worktree (`Cannot find module 'tsdown'` — absent from the shared `node_modules`, unrelated to this diff). `npx tsc --noEmit` in `packages/api` reports no errors in the changed files; those it does report are pre-existing in `src/agents/memory*`.

## Related

- danny-avila/agents#508 — the SDK half, which stops discarding the caught error and records status/endpoint on Code API rejections.
- Both are prerequisites for diagnosing a live failure on demo.librechat.ai where code execution returns `not authorized` twice after every `create_file` call, with nothing logged upstream at either timestamp.