### PR TITLE
fix: enforce FILE_SEARCH role permission server-side

### DIFF
--- a/api/app/clients/tools/util/handleTools.fileSearchPermission.test.js
+++ b/api/app/clients/tools/util/handleTools.fileSearchPermission.test.js
@@ -1,0 +1,99 @@
+/**
+ * The `FILE_SEARCH` role permission must gate the `file_search` tool the same way
+ * `RUN_CODE` gates `execute_code` in `~/server/controllers/tools.js`.
+ *
+ * Before this gate existed, a user whose role had `FILE_SEARCH.USE = false` still
+ * got the tool equipped — and could upload and embed documents through the API.
+ * The permission was stored and served, but never checked.
+ */
+
+const mockCheckAccess = jest.fn();
+const mockGetRoleByName = jest.fn();
+const mockPrimeSearchFiles = jest.fn(async () => ({ files: [], toolContext: undefined }));
+const mockCreateFileSearchTool = jest.fn(async () => ({ name: 'file_search' }));
+
+jest.mock('@librechat/data-schemas', () => ({
+  ...jest.requireActual('@librechat/data-schemas'),
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock('@librechat/api', () => ({
+  ...jest.requireActual('@librechat/api'),
+  checkAccess: (...args) => mockCheckAccess(...args),
+}));
+
+jest.mock('~/models', () => ({
+  ...jest.requireActual('~/models'),
+  getRoleByName: (...args) => mockGetRoleByName(...args),
+}));
+
+jest.mock('./fileSearch', () => ({
+  primeFiles: (...args) => mockPrimeSearchFiles(...args),
+  createFileSearchTool: (...args) => mockCreateFileSearchTool(...args),
+}));
+
+const { Tools, Permissions, PermissionTypes } = require('librechat-data-provider');
+const { logger } = require('@librechat/data-schemas');
+const { loadTools } = require('./handleTools');
+
+/** `loadTools` takes the request under a nested `options` key — passing `req` at
+ * the top level silently skips every `options.req`-guarded branch. */
+const buildOptions = () => ({
+  user: 'user-1',
+  tools: [Tools.file_search],
+  options: {
+    req: { user: { id: 'user-1', role: 'USER' }, config: {}, app: { locals: {} } },
+  },
+});
+
+describe('loadTools — FILE_SEARCH permission gate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('equips file_search when the role permits it', async () => {
+    mockCheckAccess.mockResolvedValue(true);
+
+    const { loadedTools } = await loadTools(buildOptions());
+
+    expect(mockCheckAccess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        permissionType: PermissionTypes.FILE_SEARCH,
+        permissions: [Permissions.USE],
+      }),
+    );
+    expect(loadedTools.map((tool) => tool.name)).toContain(Tools.file_search);
+  });
+
+  it('does not equip file_search when the role denies it', async () => {
+    mockCheckAccess.mockResolvedValue(false);
+
+    const { loadedTools } = await loadTools(buildOptions());
+
+    expect(loadedTools.map((tool) => tool.name)).not.toContain(Tools.file_search);
+    /** The tool must not even be constructed — a denied user should never get a
+     * tool that merely fails later. */
+    expect(mockCreateFileSearchTool).not.toHaveBeenCalled();
+  });
+
+  it('logs the denial with the permission type, matching the RUN_CODE gate', async () => {
+    mockCheckAccess.mockResolvedValue(false);
+
+    await loadTools(buildOptions());
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(PermissionTypes.FILE_SEARCH),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('user-1'));
+  });
+
+  it('denies when the permission check itself throws', async () => {
+    mockCheckAccess.mockRejectedValue(new Error('role lookup failed'));
+
+    const { loadedTools } = await loadTools(buildOptions());
+
+    /** Fail closed: an unreachable role store must not hand out the tool. */
+    expect(loadedTools.map((tool) => tool.name)).not.toContain(Tools.file_search);
+    expect(logger.error).toHaveBeenCalled();
+  });
+});

--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -391,6 +391,29 @@ const loadTools = async ({
       };
       continue;
     } else if (tool === Tools.file_search) {
+      /** The role permission gates the tool the same way `RUN_CODE` gates
+       * `execute_code` in `~/server/controllers/tools.js`. Checked here rather
+       * than inside the loader so a denied user never gets the tool equipped,
+       * instead of getting one that fails when called. */
+      if (options.req?.user != null) {
+        let hasFileSearchAccess = false;
+        try {
+          hasFileSearchAccess = await checkAccess({
+            user: options.req.user,
+            permissionType: PermissionTypes.FILE_SEARCH,
+            permissions: [Permissions.USE],
+            getRoleByName,
+          });
+        } catch (error) {
+          logger.error('[handleTools] FILE_SEARCH permission check failed:', error);
+        }
+        if (!hasFileSearchAccess) {
+          logger.warn(
+            `[${PermissionTypes.FILE_SEARCH}] Forbidden: Insufficient permissions for User ${options.req.user.id}: ${Permissions.USE}`,
+          );
+          continue;
+        }
+      }
       requestedTools[tool] = async () => {
         const { files, toolContext } = await primeSearchFiles({
           ...options,

--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -18,6 +18,7 @@ const {
   assertUploadContentAllowed,
   hasActiveFilePolicy,
   sanitizeFilename,
+  checkAccess,
 } = require('@librechat/api');
 const {
   Time,
@@ -27,7 +28,9 @@ const {
   ResourceType,
   EModelEndpoint,
   EToolResources,
+  Permissions,
   PermissionBits,
+  PermissionTypes,
   checkOpenAIStorage,
   isAssistantsEndpoint,
   hasActivePiiPatterns,
@@ -43,6 +46,7 @@ const { fileAccess } = require('~/server/middleware/accessResources/fileAccess')
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { getOpenAIClient } = require('~/server/controllers/assistants/helpers');
 const { hasCapability } = require('~/server/middleware/roles/capabilities');
+const { getRoleByName } = require('~/models');
 const { checkPermission } = require('~/server/services/PermissionService');
 const { cleanFileName, getContentDisposition } = require('~/server/utils/files');
 const { getLogStores } = require('~/cache');
@@ -725,6 +729,16 @@ router.get('/download/:userId/:file_id', fileAccess, async (req, res) => {
   }
 });
 
+/**
+ * Role permission required to upload for a given tool resource. Mirrors
+ * `toolAccessPermType` in `~/server/controllers/tools.js`, which gates the
+ * matching tool call — the upload is the other half of the same door.
+ */
+const toolResourcePermType = {
+  [EToolResources.file_search]: PermissionTypes.FILE_SEARCH,
+  [EToolResources.execute_code]: PermissionTypes.RUN_CODE,
+};
+
 router.post('/', async (req, res) => {
   const metadata = req.body;
   let cleanup = true;
@@ -752,6 +766,22 @@ router.post('/', async (req, res) => {
       ragConfigured: !!process.env.RAG_API_URL,
       readFile: fs.readFile,
     });
+
+    const requiredPermission = toolResourcePermType[metadata.tool_resource];
+    if (requiredPermission != null) {
+      const hasAccess = await checkAccess({
+        user: req.user,
+        permissionType: requiredPermission,
+        permissions: [Permissions.USE],
+        getRoleByName,
+      });
+      if (!hasAccess) {
+        logger.warn(
+          `[${requiredPermission}] Forbidden: Insufficient permissions for User ${req.user.id}: ${Permissions.USE}`,
+        );
+        return res.status(403).json({ message: 'Forbidden: Insufficient permissions' });
+      }
+    }
 
     metadata.temp_file_id = metadata.file_id;
     metadata.file_id = req.file_id;

--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -756,17 +756,8 @@ router.post('/', async (req, res) => {
     req.file.originalname = sanitizeFilename(req.file.originalname);
     filterFile({ req });
 
-    await assertUploadContentAllowed({
-      filters: req.config?.filters,
-      file: req.file,
-      endpoint: metadata.endpoint,
-      toolResource: metadata.tool_resource,
-      fileConfig: mergeFileConfig(req.config?.fileConfig),
-      ocrConfigured: req.config?.ocr != null,
-      ragConfigured: !!process.env.RAG_API_URL,
-      readFile: fs.readFile,
-    });
-
+    /** Check the role permission before any content inspection: a forbidden upload
+     * must be rejected without reading or embedding the file. */
     const requiredPermission = toolResourcePermType[metadata.tool_resource];
     if (requiredPermission != null) {
       const hasAccess = await checkAccess({
@@ -782,6 +773,17 @@ router.post('/', async (req, res) => {
         return res.status(403).json({ message: 'Forbidden: Insufficient permissions' });
       }
     }
+
+    await assertUploadContentAllowed({
+      filters: req.config?.filters,
+      file: req.file,
+      endpoint: metadata.endpoint,
+      toolResource: metadata.tool_resource,
+      fileConfig: mergeFileConfig(req.config?.fileConfig),
+      ocrConfigured: req.config?.ocr != null,
+      ragConfigured: !!process.env.RAG_API_URL,
+      readFile: fs.readFile,
+    });
 
     metadata.temp_file_id = metadata.file_id;
     metadata.file_id = req.file_id;


### PR DESCRIPTION
The FILE_SEARCH role permission is stored, served by GET /api/roles/:name and settable through the admin API, but nothing ever checks it. PermissionTypes.FILE_SEARCH occurs zero times under api/server; the three occurrences in @librechat/api are all in the interface-to-role sync, which writes the permission rather than checking it.

Measured on v0.8.8-rc1 and confirmed unchanged in rc2: a user whose role has FILE_SEARCH.USE = false can still upload a document with tool_resource=file_search and gets 200 with "embedded": true. The same user calling execute_code correctly gets 403.

Two gates, both mirroring toolAccessPermType in ~/server/controllers/tools.js:

* Upload (api/server/routes/files/files.js): a tool-resource-to-permission map checked before any branching, so it also covers the assistants path. Returns 403 with the same log line as the RUN_CODE gate. execute_code is included because it had the same hole: the tool CALL was gated, the upload was not.

* Tool loading (api/app/clients/tools/util/handleTools.js): checked outside the lazy loader so a denied user never gets the tool equipped, rather than one that fails when called. Fails closed if the permission check itself throws. All four required imports were already present in that file, next to an existing FILE_CITATIONS check.

Both changes live in /api (JavaScript) rather than /packages/api (TypeScript) as CLAUDE.md prefers for new backend code: each mirrors an existing pattern in exactly these files, and a second permission gate in another language and package would be harder to keep in step with the first.

Tests: api/app/clients/tools/util/handleTools.fileSearchPermission.test.js covers permit, deny, the log line, and the fail-closed path.


Claude-Session: https://claude.ai/code/session_01CiiQawwcLi8Yx9RSaPuEyD

# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

Please provide a brief summary of your changes and the related issue. Include any motivation and context that is relevant to your changes. If there are any dependencies necessary for your changes, please list them here.

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [ ] My code adheres to this project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [ ] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
