### PR TITLE
🥣 fix: Apply Agent Shaping to Built-In Summarizers

### DIFF
--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -1580,6 +1580,59 @@ describe('built-in provider request shaping', () => {
     const config = agents[0].summarizationConfig as Record<string, unknown>;
     expect(config.parameters).toBeUndefined();
   });
+
+  it('routes a reasoning model the way the agent flow would', async () => {
+    /** `getOpenAIConfig` reads the effort from modelOptions, not from the merged
+     * parameters, so it has to be handed the summarizer's own effort. */
+    expect(await summarizeWith({ reasoning_effort: 'medium' }, 'gpt-5.6')).toMatchObject({
+      firstPartyEndpoint: true,
+      useResponsesApi: true,
+      reasoning: { effort: 'medium' },
+    });
+  });
+
+  it('withholds the declaration when a reverse proxy serves the built-in endpoint', async () => {
+    process.env.OPENAI_REVERSE_PROXY = 'https://gateway.internal/v1';
+    try {
+      expect(await summarizeWith()).toBeUndefined();
+    } finally {
+      delete process.env.OPENAI_REVERSE_PROXY;
+    }
+  });
+
+  it('withholds the declaration when the base URL is user-provided', async () => {
+    process.env.OPENAI_REVERSE_PROXY = 'user_provided';
+    try {
+      expect(await summarizeWith()).toBeUndefined();
+    } finally {
+      delete process.env.OPENAI_REVERSE_PROXY;
+    }
+  });
+
+  it('declares nothing for an agent whose custom endpoint normalized to openAI', async () => {
+    /**
+     * `initializeAgent` rewrites a custom-endpoint agent's provider to `openAI`
+     * while its endpoint keeps the custom name. With summarization omitted, the
+     * summarizer reuses that agent's client — which points at the gateway, not
+     * at OpenAI.
+     */
+    const agents = await callAndCapture({
+      agents: [
+        makeAgent({
+          provider: 'openAI',
+          endpoint: 'MyGateway',
+          model: 'gpt-6-astra',
+          model_parameters: { model: 'gpt-6-astra' },
+        }),
+      ],
+      appConfig: makeAppConfig([
+        { name: 'MyGateway', baseURL: 'https://gateway.internal/v1', apiKey: 'gw-key' },
+      ]),
+      summarizationConfig: { model: 'gpt-6-astra' },
+    });
+    const config = agents[0].summarizationConfig as Record<string, unknown>;
+    expect(config.parameters).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -1490,6 +1490,99 @@ describe('custom-endpoint provider resolution', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Suite: built-in provider request shaping (#15598)
+// ---------------------------------------------------------------------------
+/**
+ * A built-in provider produces no custom-endpoint config, so `getOpenAIConfig`
+ * was skipped entirely and the summarizer learned neither which API its model
+ * takes nor whether its endpoint is first-party. The agents SDK defaults its
+ * model-specific constraints off without that declaration, so configured
+ * parameters reached the model unshaped.
+ *
+ * These assert the declaration LibreChat emits, which is the half it owns; the
+ * SDK's honoring of it is covered by its own tests.
+ */
+describe('built-in provider request shaping', () => {
+  const anthropicAgent = () =>
+    makeAgent({
+      provider: 'anthropic',
+      endpoint: 'anthropic',
+      model: 'claude-sonnet-4.6',
+      model_parameters: { model: 'claude-sonnet-4.6' },
+    });
+
+  const summarizeWith = async (
+    parameters?: Record<string, unknown>,
+    model = 'gpt-6-astra',
+  ): Promise<Record<string, unknown>> => {
+    const agents = await callAndCapture({
+      agents: [anthropicAgent()],
+      appConfig: makeAppConfig([]),
+      summarizationConfig: {
+        provider: 'openAI',
+        model,
+        parameters: parameters as SummarizationConfig['parameters'],
+      },
+    });
+    const config = agents[0].summarizationConfig as Record<string, unknown>;
+    return config.parameters as Record<string, unknown>;
+  };
+
+  it('declares the first-party endpoint for a cross-provider built-in summarizer', async () => {
+    expect(await summarizeWith(undefined, 'gpt-4o')).toMatchObject({ firstPartyEndpoint: true });
+  });
+
+  it('routes a Responses-only model to the Responses API', async () => {
+    expect(await summarizeWith()).toMatchObject({
+      firstPartyEndpoint: true,
+      useResponsesApi: true,
+    });
+  });
+
+  it('keeps the declaration alongside a translated reasoning effort', async () => {
+    /**
+     * The reachable failure from #15598: `resolveReasoningParams` translates the
+     * scalar effort for the summarizer, and without the declaration an effort
+     * the model rejects reached it verbatim.
+     */
+    expect(await summarizeWith({ reasoning_effort: 'minimal' })).toMatchObject({
+      firstPartyEndpoint: true,
+      reasoning: { effort: 'minimal' },
+    });
+  });
+
+  it('does not claim a first-party endpoint behind a user configuration.baseURL', async () => {
+    expect(
+      await summarizeWith({ configuration: { baseURL: 'https://gateway.internal/v1' } }),
+    ).toEqual({ configuration: { baseURL: 'https://gateway.internal/v1' } });
+  });
+
+  it('does not claim a first-party endpoint behind a user baseURL', async () => {
+    expect(await summarizeWith({ baseURL: 'https://gateway.internal/v1' })).toEqual({
+      baseURL: 'https://gateway.internal/v1',
+    });
+  });
+
+  it('leaves credentials and transport to the client', async () => {
+    const parameters = await summarizeWith();
+    expect(parameters.apiKey).toBeUndefined();
+    expect(parameters.model).toBeUndefined();
+    expect(parameters.modelName).toBeUndefined();
+    expect(parameters.streaming).toBeUndefined();
+    expect(parameters.configuration).toBeUndefined();
+  });
+
+  it('leaves a same-endpoint summarizer on the agent client options', async () => {
+    const agents = await callAndCapture({
+      appConfig: makeAppConfig([]),
+      summarizationConfig: { provider: 'openAI', model: 'gpt-6-astra' },
+    });
+    const config = agents[0].summarizationConfig as Record<string, unknown>;
+    expect(config.parameters).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Suite 8: subagentConfigs
 // ---------------------------------------------------------------------------
 describe('subagentConfigs', () => {

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -684,7 +684,7 @@ function resolveBuiltInClientOverrides(
     modelName: _modelName,
     streaming: _streaming,
     ...shaping
-  } = llmConfig as Record<string, unknown>;
+  } = llmConfig;
   return Object.keys(shaping).length > 0 ? shaping : undefined;
 }
 

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -5,6 +5,7 @@ import { Run, Providers, Constants, HookRegistry } from '@librechat/agents';
 import {
   KnownEndpoints,
   EModelEndpoint,
+  ReasoningEffort,
   MAX_SUBAGENT_DEPTH,
   MAX_SUBAGENT_RUN_CONFIGS,
   extractEnvVariable,
@@ -98,6 +99,7 @@ import { getLLMConfig as getAnthropicLLMConfig } from '~/endpoints/anthropic/llm
 import { CREATE_FILE_TOOL_NAME, EDIT_FILE_TOOL_NAME } from '~/agents/tools';
 import { resolveConfigHeaders, resolveModelHeaders } from '~/utils/headers';
 import { buildAgentInitialToolSessions } from '~/agents/codeFilesSession';
+import { getBuiltInBaseURL } from '~/endpoints/openai/initialize';
 import { getProviderConfig } from '~/endpoints/config/providers';
 import { buildToolApprovalHooks } from '~/agents/hitl/hooks';
 import { getAgentCheckpointer } from '~/agents/checkpointer';
@@ -605,9 +607,28 @@ function hasBaseURLOverride(parameters: SummarizationConfig['parameters']): bool
 }
 
 /**
+ * The scalar `reasoning_effort` the yaml schema accepts, when it names a known
+ * effort. `getOpenAIConfig` reads the effort from `modelOptions` — the merged
+ * `parameters` reach it too late — so a summarizer that configures one has to
+ * hand it over for the same API routing the agent flow performs.
+ */
+function summarizationReasoningEffort(
+  parameters: SummarizationConfig['parameters'],
+): ReasoningEffort | undefined {
+  if (!isPlainObject(parameters)) {
+    return undefined;
+  }
+  const effort = (parameters as Record<string, unknown>).reasoning_effort;
+  const known = Object.values(ReasoningEffort) as string[];
+  return typeof effort === 'string' && known.includes(effort)
+    ? (effort as ReasoningEffort)
+    : undefined;
+}
+
+/**
  * Builds the model-specific request shaping a built-in provider's client needs,
- * for the cross-provider case where the SDK cannot reuse the agent's own client
- * options.
+ * for the cross-provider case where the SDK builds that client from these
+ * parameters alone.
  *
  * The custom-endpoint path below already runs `getOpenAIConfig`; built-in
  * providers skipped it entirely, so a summarizer never learned which API its
@@ -615,19 +636,48 @@ function hasBaseURLOverride(parameters: SummarizationConfig['parameters']): bool
  * defaults its model-specific constraints off without that declaration
  * (LibreChat#15598).
  *
- * Credentials and transport are deliberately not touched. A built-in provider
- * has no configured key or base URL here, so the client resolves both the way
- * it does today; emitting an empty `apiKey` would break that.
+ * Credentials and transport are deliberately not returned. A built-in provider
+ * has no configured key here, so the client resolves one the way it does today;
+ * emitting an empty `apiKey` would break that. The admin-configured base URL is
+ * still passed *in*, because whether the endpoint is first-party is exactly what
+ * `OPENAI_REVERSE_PROXY` decides.
  */
 function resolveBuiltInClientOverrides(
   provider: string,
-  model: string | undefined,
-  parameters: SummarizationConfig['parameters'],
+  target: {
+    model?: string;
+    parameters?: SummarizationConfig['parameters'];
+    agentProvider?: string;
+  },
 ): SummarizationClientOverrides | undefined {
+  const { model, parameters } = target;
   if (!isNonEmptyString(model) || hasBaseURLOverride(parameters)) {
     return undefined;
   }
-  const { llmConfig } = getOpenAIConfig('', { modelOptions: { model } }, provider);
+  /**
+   * Mirrors the SDK's own condition: when the summarization provider matches the
+   * agent's, `buildSummarizationClientConfig` spreads the agent's resolved client
+   * options and these parameters layer on top. A custom-endpoint agent is
+   * normalized to the `openAI` provider while keeping its own endpoint name, so
+   * declaring built-in constraints here would claim OpenAI's contract for that
+   * gateway.
+   */
+  if (provider === target.agentProvider) {
+    return undefined;
+  }
+  const baseURL = getBuiltInBaseURL(provider);
+  /** Resolving a user-provided base URL needs a database read this path avoids. */
+  if (isUserProvided(baseURL)) {
+    return undefined;
+  }
+  const { llmConfig } = getOpenAIConfig(
+    '',
+    {
+      modelOptions: { model, reasoning_effort: summarizationReasoningEffort(parameters) },
+      reverseProxyUrl: baseURL,
+    },
+    provider,
+  );
   const {
     apiKey: _apiKey,
     model: _model,
@@ -651,7 +701,11 @@ function resolveSummarizationProvider(
   rawProvider: string,
   appConfig: AppConfig | undefined,
   headerContext: { user?: IUser; tenantId?: string; requestBody?: t.RequestBody },
-  target: { model?: string; parameters?: SummarizationConfig['parameters'] } = {},
+  target: {
+    model?: string;
+    parameters?: SummarizationConfig['parameters'];
+    agentProvider?: string;
+  } = {},
 ): {
   provider: string;
   clientOverrides?: SummarizationClientOverrides;
@@ -667,11 +721,7 @@ function resolveSummarizationProvider(
     if (!customEndpointConfig) {
       return {
         provider: overrideProvider,
-        clientOverrides: resolveBuiltInClientOverrides(
-          overrideProvider,
-          target.model,
-          target.parameters,
-        ),
+        clientOverrides: resolveBuiltInClientOverrides(overrideProvider, target),
       };
     }
     const rawApiKey = customEndpointConfig.apiKey ?? '';
@@ -840,6 +890,7 @@ function shapeSummarizationConfig(
     : resolveSummarizationProvider(rawProvider, appConfig, headerContext, {
         model,
         parameters: config?.parameters,
+        agentProvider: fallbackProvider,
       });
   const trigger =
     config?.trigger?.type && typeof config?.trigger?.value === 'number'

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -589,6 +589,56 @@ interface SummarizationClientOverrides {
 }
 
 /**
+ * A user-supplied base URL in `summarization.parameters` points the summarizer
+ * at a gateway whose contract is not the built-in provider's, so no built-in
+ * request shaping may be claimed for it.
+ */
+function hasBaseURLOverride(parameters: SummarizationConfig['parameters']): boolean {
+  if (!isPlainObject(parameters)) {
+    return false;
+  }
+  const params = parameters as Record<string, unknown>;
+  if (isNonEmptyString(params.baseURL)) {
+    return true;
+  }
+  return isPlainObject(params.configuration) && 'baseURL' in params.configuration;
+}
+
+/**
+ * Builds the model-specific request shaping a built-in provider's client needs,
+ * for the cross-provider case where the SDK cannot reuse the agent's own client
+ * options.
+ *
+ * The custom-endpoint path below already runs `getOpenAIConfig`; built-in
+ * providers skipped it entirely, so a summarizer never learned which API its
+ * model takes or whether its endpoint is first-party — and the agents SDK
+ * defaults its model-specific constraints off without that declaration
+ * (LibreChat#15598).
+ *
+ * Credentials and transport are deliberately not touched. A built-in provider
+ * has no configured key or base URL here, so the client resolves both the way
+ * it does today; emitting an empty `apiKey` would break that.
+ */
+function resolveBuiltInClientOverrides(
+  provider: string,
+  model: string | undefined,
+  parameters: SummarizationConfig['parameters'],
+): SummarizationClientOverrides | undefined {
+  if (!isNonEmptyString(model) || hasBaseURLOverride(parameters)) {
+    return undefined;
+  }
+  const { llmConfig } = getOpenAIConfig('', { modelOptions: { model } }, provider);
+  const {
+    apiKey: _apiKey,
+    model: _model,
+    modelName: _modelName,
+    streaming: _streaming,
+    ...shaping
+  } = llmConfig as Record<string, unknown>;
+  return Object.keys(shaping).length > 0 ? shaping : undefined;
+}
+
+/**
  * Resolves a summarization provider string (which may be a custom-endpoint name
  * like "Ollama") into the SDK-recognized provider and any client-option
  * overrides required to talk to that endpoint.
@@ -601,6 +651,7 @@ function resolveSummarizationProvider(
   rawProvider: string,
   appConfig: AppConfig | undefined,
   headerContext: { user?: IUser; tenantId?: string; requestBody?: t.RequestBody },
+  target: { model?: string; parameters?: SummarizationConfig['parameters'] } = {},
 ): {
   provider: string;
   clientOverrides?: SummarizationClientOverrides;
@@ -614,7 +665,14 @@ function resolveSummarizationProvider(
       appConfig,
     });
     if (!customEndpointConfig) {
-      return { provider: overrideProvider };
+      return {
+        provider: overrideProvider,
+        clientOverrides: resolveBuiltInClientOverrides(
+          overrideProvider,
+          target.model,
+          target.parameters,
+        ),
+      };
     }
     const rawApiKey = customEndpointConfig.apiKey ?? '';
     const rawBaseURL = customEndpointConfig.baseURL ?? '';
@@ -775,11 +833,14 @@ function shapeSummarizationConfig(
     isNonEmptyString(rawProvider) &&
     normalizeEndpointName(rawProvider) === normalizeEndpointName(agentEndpoint);
 
+  const model = config?.model ?? fallbackModel;
+
   const { provider, clientOverrides } = isSameEndpointAsAgent
     ? { provider: fallbackProvider, clientOverrides: undefined }
-    : resolveSummarizationProvider(rawProvider, appConfig, headerContext);
-
-  const model = config?.model ?? fallbackModel;
+    : resolveSummarizationProvider(rawProvider, appConfig, headerContext, {
+        model,
+        parameters: config?.parameters,
+      });
   const trigger =
     config?.trigger?.type && typeof config?.trigger?.value === 'number'
       ? { type: config.trigger.type, value: config.trigger.value }

--- a/packages/api/src/endpoints/openai/initialize.ts
+++ b/packages/api/src/endpoints/openai/initialize.ts
@@ -17,6 +17,25 @@ import { validateEndpointURL } from '~/auth';
 import { getOpenAIConfig } from './config';
 
 /**
+ * Admin-configured base URL for a built-in OpenAI-family endpoint, or `undefined`
+ * when the endpoint is served by OpenAI/Azure directly.
+ *
+ * Read at call time rather than module load so environment changes apply, and
+ * shared with callers that must know the endpoint a built-in provider actually
+ * talks to before claiming its contract. May be the `user_provided` sentinel,
+ * which resolves to a per-user value only after a database read.
+ */
+export function getBuiltInBaseURL(endpoint?: string | null): string | undefined {
+  if (endpoint === EModelEndpoint.openAI) {
+    return process.env.OPENAI_REVERSE_PROXY;
+  }
+  if (endpoint === EModelEndpoint.azureOpenAI) {
+    return process.env.AZURE_OPENAI_BASEURL;
+  }
+  return undefined;
+}
+
+/**
  * Initializes OpenAI options for agent usage. This function always returns configuration
  * options and never creates a client instance (equivalent to optionsOnly=true behavior).
  *
@@ -31,8 +50,7 @@ export async function initializeOpenAI(
   const { appConfig, user, requestBody } = resolveEndpointRuntime(params);
   const openAIConfig = appConfig?.endpoints?.[EModelEndpoint.openAI];
   const allConfig = appConfig?.endpoints?.all;
-  const { PROXY, OPENAI_API_KEY, AZURE_API_KEY, OPENAI_REVERSE_PROXY, AZURE_OPENAI_BASEURL } =
-    process.env;
+  const { PROXY, OPENAI_API_KEY, AZURE_API_KEY } = process.env;
 
   const { key: expiresAt } = requestBody;
   const modelName = model_parameters?.model as string | undefined;
@@ -42,13 +60,10 @@ export async function initializeOpenAI(
     [EModelEndpoint.azureOpenAI]: AZURE_API_KEY,
   };
 
-  const baseURLOptions = {
-    [EModelEndpoint.openAI]: OPENAI_REVERSE_PROXY,
-    [EModelEndpoint.azureOpenAI]: AZURE_OPENAI_BASEURL,
-  };
+  const configuredBaseURL = getBuiltInBaseURL(endpoint);
 
   const userProvidesKey = isUserProvided(credentials[endpoint as keyof typeof credentials]);
-  const userProvidesURL = isUserProvided(baseURLOptions[endpoint as keyof typeof baseURLOptions]);
+  const userProvidesURL = isUserProvided(configuredBaseURL);
 
   let userValues: UserKeyValues | null = null;
   if (expiresAt && (userProvidesKey || userProvidesURL)) {
@@ -59,9 +74,7 @@ export async function initializeOpenAI(
   let apiKey = userProvidesKey
     ? userValues?.apiKey
     : credentials[endpoint as keyof typeof credentials];
-  const baseURL = userProvidesURL
-    ? userValues?.baseURL
-    : baseURLOptions[endpoint as keyof typeof baseURLOptions];
+  const baseURL = userProvidesURL ? userValues?.baseURL : configuredBaseURL;
 
   const clientOptions: OpenAIConfigOptions = {
     proxy: PROXY ?? undefined,


### PR DESCRIPTION
Fixes #15598

> [!NOTE]
> Stacked on #15567 — it carries the `firstPartyEndpoint` declaration this builds on. Retarget to `dev` once that lands. The diff here is `packages/api/src/agents/run.ts` plus its tests.

## The gap

`resolveSummarizationProvider` returns early for a **built-in** provider:

```ts
if (!customEndpointConfig) {
  return { provider: overrideProvider };
}
```

No client overrides are produced. On the SDK side, `buildSummarizationClientConfig` spreads `agentContext.clientOptions` **only** when the summarization provider equals the agent's, so a summarizer on a different provider is constructed from `summarization.parameters` alone.

The custom-endpoint path directly below already runs `getOpenAIConfig`, precisely so summarization inherits the same shaping as the agent flow. Built-in providers skipped it, so:

- `gpt-5.6` got no Responses default on this path.
- `gpt-6-astra` got no `firstPartyEndpoint`, and the agents SDK defaults its request constraints off without that declaration.

## The reachable failure

`resolveReasoningParams` — in this same function — translates a scalar `reasoning_effort` into `reasoning.effort` for the summarizer. So:

```yaml
summarization:
  provider: openAI
  model: gpt-6-astra
  parameters:
    reasoning_effort: minimal
```

sent `minimal` to a model that rejects it. Probing `@librechat/agents@3.7.20`:

```
EFFORT-BARE      {"model":"gpt-6-astra","stream":false,"reasoning_effort":"minimal"}   → rejected
EFFORT-DECLARED  {"model":"gpt-6-astra","stream":false,"reasoning_effort":"low"}
TEMP-BARE        {"model":"gpt-6-astra","temperature":0.3,"top_p":0.9,"stream":false}  → rejected
TEMP-DECLARED    {"model":"gpt-6-astra","stream":false}
```

A **default-parameter** summarizer was never broken: LangChain does not default `temperature`, so a bare client emits only `{model, stream}`, has no tools, and Chat Completions serves it. The failure needs explicitly configured parameters — which is why this went unnoticed.

## The fix

Run the same `getOpenAIConfig` call for built-in providers and carry only its shaping. The decision about *which* models and endpoints carry constraints stays in `llm.ts`, so this adds no second place to encode model knowledge — `getOpenAIConfig` already declines to declare anything for `azureOpenAI`, and Astra's Responses default comes along for free.

Two deliberate exclusions:

- **Credentials and transport.** A built-in provider has no configured key or base URL here; the client resolves both from the environment as it does today, and emitting an empty `apiKey` would break that. `apiKey`, `model`, `modelName` and `streaming` are dropped from the overrides.
- **A user-supplied base URL.** `baseURL` or `configuration.baseURL` in `summarization.parameters` points at a gateway whose contract is not the built-in provider's, so no declaration is made at all.

## Tests

Seven cases in `run-summarization.test.ts`. Four fail with the fix reverted; the three base-URL/same-endpoint guards pass either way by design — they exist to catch a future over-broad declaration, not to prove this one.

They assert the declaration LibreChat emits, which is the half it owns. Whether the SDK honors it is covered by the SDK's own tests, and asserting it here would pin behavior across a version boundary.

## Not covered

`maxSummaryTokens` still becomes `maxTokens`, which LangChain emits as the legacy `max_tokens` on Chat Completions — rejected by every `gpt-5`+ model. Same path, same root cause, but it needs the max-tokens field to follow the *effective* API rather than the configured one, which is a wider change than this. Astra is unaffected, since it routes to Responses where `maxTokens` becomes `max_output_tokens` correctly.
