### PR TITLE
🍃 test: Restore Sweep Coverage of Typed-Criteria Methods

### DIFF
--- a/packages/data-schemas/misc/documentdb/documentdb-compat.md
+++ b/packages/data-schemas/misc/documentdb/documentdb-compat.md
@@ -263,10 +263,16 @@ matrices (`SWEEP_REPORT_PATH`).
 Corrected-harness baseline (replica-set MongoDB, real ACL cascades, index DDL
 and transaction-lifecycle instrumentation, per-invocation async attribution,
 seeded authority-transaction case, constructor exports excluded, a fresh
-method bundle per case): **370 of 509 methods issue at least one query; zero
-rejections on MongoDB**. The remaining 139 issue none (validation
+method bundle per case, criteria-shaped parameters synthesized as objects):
+**385 of 518 methods issue at least one query; zero rejections on MongoDB**.
+The remaining 133 issue none (validation
 rejected the synthesized arguments, or a guard short-circuited); they are
-listed in the matrix and shrink by adding `ARG_OVERRIDES` entries. The report's `rows` payload is normalized for
+listed in the matrix and shrink by adding `ARG_OVERRIDES` entries. Watch this count across releases: the typed
+criteria refactor (#15580) silently took six adjudicated methods to
+un-driven because the sweep synthesized a string for a `query` parameter and
+`buildFilter` fails closed on it — a coverage regression that a green suite
+hides. Diffing matrices, not reading the pass line, is what catches it. The
+report's `rows` payload is normalized for
 cross-engine diffing (`diff <(jq .rows a.json) <(jq .rows b.json)`); run
 metadata lives outside it.
 

--- a/packages/data-schemas/misc/documentdb/sweep.documentdb.spec.ts
+++ b/packages/data-schemas/misc/documentdb/sweep.documentdb.spec.ts
@@ -260,11 +260,15 @@ const ARRAY_PARAMS =
 function valueFor(name: string): unknown {
   if (name === 'mongoose') return mongoose;
   if (name === 'kind') return 'manual';
-  /** Typed-criteria parameters (see `utils/criteria.ts`) are validated
-   * key-by-key and fail closed on anything unrecognized, so a synthesized
-   * string is read as a criteria object and rejected at index '0'. An empty
-   * criteria object is valid and builds an empty filter, which still reaches
-   * the engine — the point of the sweep. */
+  /** Typed-criteria parameters (`utils/criteria.ts`) are validated key by key
+   * and fail closed, so a synthesized string is read as a criteria object and
+   * rejected at index '0'. An empty criteria object is valid, builds an empty
+   * filter, and still reaches the engine. `searchMessages` is the sole method
+   * whose `query` parameter is a genuine string (verified across
+   * `src/methods`); it carries an `ARG_OVERRIDES` entry so it keeps one. A
+   * future string-valued `query`/`criteria`/`filter` parameter would need the
+   * same treatment — the symptom is a method reporting `threw` on a type
+   * error rather than reaching the database. */
   if (/^(query|criteria|filter)$/.test(name)) return {};
   if (/pipeline/i.test(name)) return [{ $match: { _id: objectId() } }];
   if (OBJECT_ID_PARAMS.test(name)) return objectId();
@@ -295,7 +299,7 @@ function replaceValue(node: unknown, target: string, replacement: unknown): unkn
 /** Repairs synthesized arguments from a validation error's own message, so the
  * retry reaches the database instead of being reported `not-driven`. Returns
  * the repaired arguments, or null when the error is not machine-repairable. */
-function adaptArgs(args: unknown[], error: unknown): unknown[] | null {
+function adaptArgs(args: unknown[], error: unknown, paramNames: string[] = []): unknown[] | null {
   const message = String((error as { message?: string })?.message ?? '');
   let match = /Cast to (?:\[)?ObjectId(?:\])? failed for value "+?\[?'?"?([^"'\]]+)/.exec(message);
   if (match != null) {
@@ -355,6 +359,11 @@ const ARG_OVERRIDES: Record<string, () => SweepCase | Promise<SweepCase>> = {
   /** Positional (searchParameter, id): a synthesized string for the first
    * parameter lands inside a `$match` and malforms it on both engines. */
   getAgentWithVersionCount: () => ({ args: [{ id: `agent-sweep-${runId}` }] }),
+  /** Takes a genuine search string, not typed criteria: the criteria-shaped
+   * synthesis above would hand it an object, which a Meili-enabled deployment
+   * forwards verbatim into `meiliSearch` and adjudicates a harness-generated
+   * request instead of the method's real behavior. */
+  searchMessages: () => ({ args: [`sweep-search-${runId}`, { page: 1, limit: 2 }, false] }),
   /** The bounded authority snapshot is the one production path that COMMITS a
    * transaction; generic synthesis dies on target validation before a session
    * ever starts, which would leave the session instrumentation exercising

--- a/packages/data-schemas/misc/documentdb/sweep.documentdb.spec.ts
+++ b/packages/data-schemas/misc/documentdb/sweep.documentdb.spec.ts
@@ -260,6 +260,12 @@ const ARRAY_PARAMS =
 function valueFor(name: string): unknown {
   if (name === 'mongoose') return mongoose;
   if (name === 'kind') return 'manual';
+  /** Typed-criteria parameters (see `utils/criteria.ts`) are validated
+   * key-by-key and fail closed on anything unrecognized, so a synthesized
+   * string is read as a criteria object and rejected at index '0'. An empty
+   * criteria object is valid and builds an empty filter, which still reaches
+   * the engine — the point of the sweep. */
+  if (/^(query|criteria|filter)$/.test(name)) return {};
   if (/pipeline/i.test(name)) return [{ $match: { _id: objectId() } }];
   if (OBJECT_ID_PARAMS.test(name)) return objectId();
   if (ARRAY_PARAMS.test(name)) return [`sweep-${name}-${runId}`];


### PR DESCRIPTION
## Summary

Routine DocumentDB audit of `main` found no compatibility problems, but did find that the method sweep had **silently lost coverage** — with the suite still green.

The typed-criteria refactor (#15580) validates query criteria key by key and fails closed on anything unrecognized. That is correct and deliberate: a silently accepted bad criterion would widen a filter into an unscoped `find` or `deleteMany`. The sweep, however, synthesizes arguments from parameter names, so a parameter named `query` received a string, which `buildFilter` read as a criteria object and rejected at index `'0'`.

Six methods went from adjudicated to un-driven as a result: `getActions`, `getAssistants`, `deleteAction`, `deleteActions`, `deleteAssistant`, `deleteAssistants`.

## Change

Criteria-shaped parameters (`query`, `criteria`, `filter`) are synthesized as an empty object. An empty criteria object is valid, builds an empty filter, and still reaches the engine — which is the point of the sweep.

## Effect

Recovered **13** methods: the six regressions plus seven that had been silently un-driven for the same reason (prompts, groups, conversation tags) — including through the runs previously recorded as authoritative.

| | before | after |
| --- | --- | --- |
| methods enumerated | 518 | 518 |
| driven (≥1 adjudicated query) | 372 | **385** |
| un-driven | 146 | **133** |
| engine rejections | 0 | 0 |

## Why this matters beyond the fix

The suite passed in both states. Nothing in a pass/fail line distinguishes "adjudicated 385 methods" from "adjudicated 372 and quietly stopped checking six." Only diffing the emitted matrices surfaces it, which is what the normalized `rows` payload exists for. The compatibility assessment now names this count as the thing to watch across releases.

## Testing

- `SWEEP_BASELINE=true` on `main`: 518 methods, zero engine rejections, 385 driven.
- Regression attributed by sweeping the previously verified commit (`6372cb08ee`) and diffing matrices, rather than inferred.
- Typecheck and lint clean.

A live DocumentDB run against this branch is pending — 13 methods are about to be engine-adjudicated for the first time.

## Change Type

- [x] Test/infrastructure change
