### PR TITLE
🚫 fix: Decline to Name a Heif Container With Unreported Compression

### DIFF
--- a/packages/api/src/files/mime.spec.ts
+++ b/packages/api/src/files/mime.spec.ts
@@ -40,4 +40,9 @@ describe('resolveImageMimeType', () => {
     expect(resolveImageMimeType({ format: 'svg' })).toBeUndefined();
     expect(resolveImageMimeType({ format: 'raw' })).toBeUndefined();
   });
+
+  it('declines to name a heif container whose compression sharp did not report', () => {
+    expect(resolveImageMimeType({ format: 'heif' })).toBeUndefined();
+    expect(resolveImageMimeType({ format: 'heif', compression: undefined })).toBeUndefined();
+  });
 });

--- a/packages/api/src/files/mime.ts
+++ b/packages/api/src/files/mime.ts
@@ -27,8 +27,9 @@ export type EncodedImageMetadata = Pick<Metadata, 'format' | 'compression'>;
  * bytes leaves a file whose `type` misdescribes its own contents, and that type is later handed
  * to providers verbatim as `media_type`/`mimeType`, so it has to describe the bytes on disk.
  *
- * Returns `undefined` when sharp reports a format with no media type of its own, leaving the
- * caller to decide what to record rather than guessing here.
+ * Returns `undefined` when the bytes cannot be named confidently — a format with no media type of
+ * its own, or a heif container whose compression sharp did not report — leaving the caller to fall
+ * back to what it already knows. Naming one of those anyway would be the guess this exists to stop.
  */
 export function resolveImageMimeType(metadata: EncodedImageMetadata): string | undefined {
   const { format } = metadata;
@@ -36,7 +37,10 @@ export function resolveImageMimeType(metadata: EncodedImageMetadata): string | u
     return undefined;
   }
   if (format === 'heif') {
-    return metadata.compression === 'av1' ? 'image/avif' : 'image/heic';
+    if (metadata.compression === 'av1') {
+      return 'image/avif';
+    }
+    return metadata.compression === 'hevc' ? 'image/heic' : undefined;
   }
   return SHARP_FORMAT_MIME_TYPES[format];
 }


### PR DESCRIPTION
Follow-up to #15606. **This is a review finding on that PR that did not make it in** — the PR merged at 15:51 while the fix was still in flight, so `dev` currently carries the defect.

## The finding

@copilot caught it on #15606: `resolveImageMimeType` returns `image/heic` for **any** heif container whose compression is not `av1` — including when sharp reports no compression at all.

```js
// on dev today
if (format === 'heif') {
  return metadata.compression === 'av1' ? 'image/avif' : 'image/heic';
}
```

`Metadata.compression` is optional (`compression?: HeifCompression`), so unreported is a real outcome rather than a theoretical one. Answering it with HEIC means **an AVIF read back without its compression is recorded as HEIC**.

That is precisely the failure #15606 exists to fix — naming bytes from something other than the bytes — reproduced inside the fix for it. It also contradicted the function's own documented contract of returning `undefined` rather than guessing.

## The fix

Unreported or unrecognized compression now yields `undefined`, which leaves `saveBase64Image` on the declared type. Still only a claim, but the caller's claim rather than one invented here — and that fallback path was already built for exactly this case.

## Testing

Copilot's second comment asked for coverage of the branch; added. It fails against `dev`:

```
✕ declines to name a heif container whose compression sharp did not report
  Received: "image/heic"
```

`packages/api/src/files/mime.spec.ts`: 9 passed.

## Note on review coverage

Worth recording: codex returned clean on the commit that carried this, twice. Copilot found it. Neither reviewer alone was sufficient.