### PR TITLE
🛰️ fix: Repair BYOM Live Integration

### DIFF
--- a/packages/api/src/admin/code.spec.ts
+++ b/packages/api/src/admin/code.spec.ts
@@ -28,7 +28,7 @@ function mockResponse(): MockResponse {
 function request(): ServerRequest {
   return {
     params: { environmentId: 'attached-vm' },
-    user: { id: 'admin-1', role: 'ADMIN' },
+    user: { id: 'admin-1', role: 'ADMIN', tenantId: 'tenant-1' },
   } as unknown as ServerRequest;
 }
 
@@ -85,7 +85,13 @@ describe('createAdminCodeEnvironmentHandlers', () => {
           Authorization: 'Bearer administrator-bootstrap-token',
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ workerId: 'vm-1' }),
+        body: JSON.stringify({
+          workerId: 'vm-1',
+          binding: {
+            tenantId: 'tenant-1',
+            principal: { type: 'deployment', id: 'attached-vm' },
+          },
+        }),
       }),
     );
     expect(response.statusCode).toBe(200);
@@ -96,6 +102,25 @@ describe('createAdminCodeEnvironmentHandlers', () => {
       expiresAt: '2099-08-30T12:00:00.000Z',
     });
     expect(JSON.stringify(response.body)).not.toContain('administrator-bootstrap-token');
+  });
+
+  it('fails closed before outbound traffic when tenant context is unavailable', async () => {
+    const fetchImpl = jest.fn();
+    const handlers = createAdminCodeEnvironmentHandlers({
+      getAppConfig: jest.fn().mockResolvedValue(config()),
+      resolveTenantId: jest.fn(() => {
+        throw new Error('missing tenant context');
+      }),
+      readSecret: jest.fn().mockReturnValue('administrator-bootstrap-token'),
+      fetchImpl,
+    });
+    const response = mockResponse();
+
+    await handlers.createPairing(request(), response);
+
+    expect(response.statusCode).toBe(503);
+    expect(response.body).toEqual({ error: 'Code environment tenant context is unavailable' });
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 
   it('uses only YAML config when resolving pairing secrets and destinations', async () => {

--- a/packages/api/src/admin/code.ts
+++ b/packages/api/src/admin/code.ts
@@ -5,6 +5,8 @@ import type { Response } from 'express';
 import type { GetAppConfigOptions } from '~/app/service';
 import type { ServerRequest } from '~/types/http';
 
+import { getCodeApiTenantId } from '~/auth/codeapi';
+
 const CODE_BRIDGE_REQUEST_TIMEOUT_MS = 10_000;
 
 type AgentsEndpointConfig = NonNullable<AppConfig['endpoints']>[EModelEndpoint.agents];
@@ -31,6 +33,7 @@ interface CodeRevocationResponse {
 
 export interface AdminCodeEnvironmentDeps {
   getAppConfig: (options: GetAppConfigOptions) => Promise<AppConfig>;
+  resolveTenantId?: (req: ServerRequest) => string;
   readSecret?: (name: string) => string | undefined;
   fetchImpl?: FetchImpl;
 }
@@ -91,6 +94,7 @@ export function createAdminCodeEnvironmentHandlers(deps: AdminCodeEnvironmentDep
   revokeWorker: (req: ServerRequest, res: Response) => Promise<Response>;
 } {
   const fetchImpl = deps.fetchImpl ?? fetch;
+  const resolveTenantId = deps.resolveTenantId ?? getCodeApiTenantId;
   const readSecret =
     deps.readSecret ??
     ((name: string) =>
@@ -134,6 +138,12 @@ export function createAdminCodeEnvironmentHandlers(deps: AdminCodeEnvironmentDep
   async function createPairing(req: ServerRequest, res: Response): Promise<Response> {
     const resolved = await resolve(req, res);
     if ('statusCode' in resolved) return resolved;
+    let tenantId: string;
+    try {
+      tenantId = resolveTenantId(req);
+    } catch {
+      return res.status(503).json({ error: 'Code environment tenant context is unavailable' });
+    }
     try {
       const response = await fetchImpl(bridgeUrl(resolved.environment, '/bridge/pairings'), {
         method: 'POST',
@@ -141,7 +151,13 @@ export function createAdminCodeEnvironmentHandlers(deps: AdminCodeEnvironmentDep
           Authorization: `Bearer ${resolved.token}`,
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ workerId: resolved.pairing.workerId }),
+        body: JSON.stringify({
+          workerId: resolved.pairing.workerId,
+          binding: {
+            tenantId,
+            principal: { type: 'deployment', id: resolved.id },
+          },
+        }),
         redirect: 'error',
         signal: AbortSignal.timeout(CODE_BRIDGE_REQUEST_TIMEOUT_MS),
       });

--- a/packages/api/src/code/command.spec.ts
+++ b/packages/api/src/code/command.spec.ts
@@ -1,5 +1,5 @@
 import type { CodeBridgeFetch } from './bridge';
-import { createAttachedWorkspaceBashTool } from './command';
+import { ATTACHED_WORKSPACE_BASH_SCHEMA, createAttachedWorkspaceBashTool } from './command';
 
 function commandResponse(overrides: Record<string, unknown> = {}): Response {
   return new Response(
@@ -67,6 +67,9 @@ describe('createAttachedWorkspaceBashTool', () => {
     await expect(bashTool.invoke({ command: 'pwd' })).resolves.toBeDefined();
 
     expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(
+      Object.getOwnPropertyDescriptor(ATTACHED_WORKSPACE_BASH_SCHEMA, '__absolute_uri__'),
+    ).toBeUndefined();
   });
 
   test('preserves legacy positional args without interpolating shell metacharacters', async () => {

--- a/packages/api/src/code/command.spec.ts
+++ b/packages/api/src/code/command.spec.ts
@@ -56,6 +56,19 @@ describe('createAttachedWorkspaceBashTool', () => {
     });
   });
 
+  test('validates and invokes commands through the LangChain tool runtime', async () => {
+    const fetchImpl: CodeBridgeFetch = jest.fn(async () => commandResponse());
+    const bashTool = createAttachedWorkspaceBashTool({
+      baseUrl: 'https://code.example.com/v1',
+      authHeaders: () => ({}),
+      fetchImpl,
+    });
+
+    await expect(bashTool.invoke({ command: 'pwd' })).resolves.toBeDefined();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
   test('preserves legacy positional args without interpolating shell metacharacters', async () => {
     const fetchImpl: CodeBridgeFetch = jest.fn(async () => commandResponse());
     const bashTool = createAttachedWorkspaceBashTool({

--- a/packages/api/src/code/command.ts
+++ b/packages/api/src/code/command.ts
@@ -30,14 +30,18 @@ const attachedCommandSchema: NonNullable<LCTool['parameters']> = {
     'The bash command or script to execute from the attached workspace root. Files written in the workspace persist between calls, but each call starts a fresh process.',
 };
 
-export const ATTACHED_WORKSPACE_BASH_SCHEMA: NonNullable<LCTool['parameters']> = Object.freeze({
+/**
+ * LangChain's JSON Schema dereferencer annotates schemas during validation, so
+ * this object must remain extensible while it is owned by the tool runtime.
+ */
+export const ATTACHED_WORKSPACE_BASH_SCHEMA: NonNullable<LCTool['parameters']> = {
   type: 'object',
   properties: {
     ...bashSchema.properties,
     command: attachedCommandSchema,
   },
   required: ['command'],
-});
+};
 
 export function buildAttachedWorkspaceBashDescription(enableToolOutputReferences: boolean): string {
   return enableToolOutputReferences

--- a/packages/api/src/code/command.ts
+++ b/packages/api/src/code/command.ts
@@ -31,17 +31,18 @@ const attachedCommandSchema: NonNullable<LCTool['parameters']> = {
 };
 
 /**
- * LangChain's JSON Schema dereferencer annotates schemas during validation, so
- * this object must remain extensible while it is owned by the tool runtime.
+ * This definition is shared with agent metadata. LangChain's JSON Schema
+ * dereferencer annotates schemas during validation, so each tool receives an
+ * isolated mutable clone instead of mutating this shared definition.
  */
-export const ATTACHED_WORKSPACE_BASH_SCHEMA: NonNullable<LCTool['parameters']> = {
+export const ATTACHED_WORKSPACE_BASH_SCHEMA: NonNullable<LCTool['parameters']> = Object.freeze({
   type: 'object',
   properties: {
     ...bashSchema.properties,
     command: attachedCommandSchema,
   },
   required: ['command'],
-};
+});
 
 export function buildAttachedWorkspaceBashDescription(enableToolOutputReferences: boolean): string {
   return enableToolOutputReferences
@@ -108,7 +109,7 @@ export function createAttachedWorkspaceBashTool({
     {
       name: BashExecutionToolDefinition.name,
       description: ATTACHED_WORKSPACE_BASH_DESCRIPTION,
-      schema: ATTACHED_WORKSPACE_BASH_SCHEMA,
+      schema: structuredClone(ATTACHED_WORKSPACE_BASH_SCHEMA),
       responseFormat: 'content_and_artifact',
     },
   ) as unknown as DynamicStructuredTool;


### PR DESCRIPTION
## Summary

I repaired the two LibreChat integration defects found during live native-BYOM acceptance testing.

- Bind deployment-worker pairing requests to the resolved tenant and canonical deployment environment principal required by dynamic Code API routing.
- Fail closed before outbound pairing traffic when LibreChat cannot resolve tenant context.
- Keep the attached Bash JSON schema extensible so LangChain can annotate and validate it at invocation time.
- Add regressions for tenant-bound pairing and the real LangChain tool invocation path.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran the focused admin pairing and attached Bash tool suites: 15 tests passed.
- Ran ESLint against all four changed files.
- Built `@librechat/api` successfully.
- Ran the live native-SRT BYOM flow with LibreChat on 34080, MongoDB on 37028, Redis on 36379, and Code API on 33112. The test paired through the LibreChat admin endpoint, started the real `librechat-code` worker, approved two Bash calls, and verified persisted workspace state across two conversation turns.

### **Test Configuration**:

- macOS native SRT command sandbox
- Dynamic paired Code API worker routing
- Redis-backed generation streams
- Explicit tool approval for command execution

## Checklist

- [x] My code adheres to this project style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of the code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.