### PR TITLE
🗒️ fix: Surface Agent Save Error Details

### DIFF
--- a/client/src/components/SidePanel/Agents/AgentPanel.test.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.test.tsx
@@ -109,6 +109,8 @@ jest.mock('~/utils', () => ({
   createProviderOption: jest.fn((provider: string) => ({ value: provider, label: provider })),
   getAvailableAgentSelection: jest.requireActual('~/utils/agentModelSelection')
     .getAvailableAgentSelection,
+  getApiErrorAgentIds: jest.requireActual('~/utils/errors').getApiErrorAgentIds,
+  getApiErrorMessage: jest.requireActual('~/utils/errors').getApiErrorMessage,
   getDefaultAgentFormValues: jest.fn(() => ({
     id: '',
     name: '',

--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -31,6 +31,8 @@ import {
   createProviderOption,
   getAvailableAgentSelection,
   getDefaultAgentFormValues,
+  getApiErrorAgentIds,
+  getApiErrorMessage,
 } from '~/utils';
 import { useResourcePermissions } from '~/hooks/useResourcePermissions';
 import { useSelectAgent, useLocalize, useAuthContext } from '~/hooks';
@@ -527,10 +529,13 @@ export default function AgentPanel() {
     },
     onError: (err) => {
       const error = err as Error;
+      const agentIds = getApiErrorAgentIds(err);
       showToast({
         message: `${localize('com_agents_update_error')}${
-          error.message ? ` ${localize('com_ui_error')}: ${error.message}` : ''
-        }`,
+          error.message
+            ? ` ${localize('com_ui_error')}: ${getApiErrorMessage(err, error.message)}`
+            : ''
+        }${agentIds ? ` (${agentIds.join(', ')})` : ''}`,
         status: 'error',
       });
     },
@@ -557,10 +562,13 @@ export default function AgentPanel() {
     },
     onError: (err) => {
       const error = err as Error;
+      const agentIds = getApiErrorAgentIds(err);
       showToast({
         message: `${localize('com_agents_create_error')}${
-          error.message ? ` ${localize('com_ui_error')}: ${error.message}` : ''
-        }`,
+          error.message
+            ? ` ${localize('com_ui_error')}: ${getApiErrorMessage(err, error.message)}`
+            : ''
+        }${agentIds ? ` (${agentIds.join(', ')})` : ''}`,
         status: 'error',
       });
     },

--- a/client/src/utils/__tests__/errors.spec.ts
+++ b/client/src/utils/__tests__/errors.spec.ts
@@ -1,0 +1,55 @@
+import { getApiErrorMessage, getApiErrorAgentIds } from '../errors';
+
+const axiosLikeError = (data: unknown): unknown => ({ response: { data } });
+
+describe('getApiErrorMessage', () => {
+  it('prefers response.data.error when it is a string', () => {
+    const error = axiosLikeError({ error: 'Subagents do not exist', message: 'ignored' });
+    expect(getApiErrorMessage(error, 'fallback')).toBe('Subagents do not exist');
+  });
+
+  it('uses response.data.message when data.error is absent', () => {
+    const error = axiosLikeError({ message: 'Only a message' });
+    expect(getApiErrorMessage(error, 'fallback')).toBe('Only a message');
+  });
+
+  it('falls back when there is no response (plain Error)', () => {
+    expect(getApiErrorMessage(new Error('boom'), 'fallback')).toBe('fallback');
+  });
+
+  it('falls back when data.error is not a string', () => {
+    const error = axiosLikeError({ error: { code: 400 }, message: 42 });
+    expect(getApiErrorMessage(error, 'fallback')).toBe('fallback');
+  });
+
+  it('falls back when data.error is blank', () => {
+    const error = axiosLikeError({ error: '   ' });
+    expect(getApiErrorMessage(error, 'fallback')).toBe('fallback');
+  });
+});
+
+describe('getApiErrorAgentIds', () => {
+  it('returns agent_ids when it is a non-empty string array', () => {
+    const error = axiosLikeError({
+      error: 'Subagents do not exist',
+      agent_ids: ['agent_1', 'agent_2'],
+    });
+    expect(getApiErrorAgentIds(error)).toEqual(['agent_1', 'agent_2']);
+  });
+
+  it('returns undefined when agent_ids is absent', () => {
+    expect(getApiErrorAgentIds(axiosLikeError({ error: 'nope' }))).toBeUndefined();
+  });
+
+  it('returns undefined when agent_ids is empty', () => {
+    expect(getApiErrorAgentIds(axiosLikeError({ agent_ids: [] }))).toBeUndefined();
+  });
+
+  it('returns undefined when agent_ids contains non-strings', () => {
+    expect(getApiErrorAgentIds(axiosLikeError({ agent_ids: ['agent_1', 7] }))).toBeUndefined();
+  });
+
+  it('returns undefined when there is no response', () => {
+    expect(getApiErrorAgentIds(new Error('boom'))).toBeUndefined();
+  });
+});

--- a/client/src/utils/errors.ts
+++ b/client/src/utils/errors.ts
@@ -19,3 +19,56 @@ export const getResponseStatus = (error: unknown): number | undefined => {
 };
 
 export const isNotFoundError = (error: unknown): boolean => getResponseStatus(error) === 404;
+
+type ApiErrorData = {
+  error?: unknown;
+  message?: unknown;
+  agent_ids?: unknown;
+};
+
+/**
+ * Safely extracts the `response.data` payload from an error, regardless of
+ * the HTTP client used, so callers never need to import axios.
+ */
+const getApiErrorData = (error: unknown): ApiErrorData | undefined => {
+  if (error == null || typeof error !== 'object' || !('response' in error)) {
+    return undefined;
+  }
+  const { response } = error as { response: unknown };
+  if (response == null || typeof response !== 'object' || !('data' in response)) {
+    return undefined;
+  }
+  const { data } = response as { data: unknown };
+  if (data == null || typeof data !== 'object') {
+    return undefined;
+  }
+  return data as ApiErrorData;
+};
+
+/**
+ * Returns the server's error message from a failed API response, preferring
+ * `response.data.error` over `response.data.message`; falls back to the
+ * provided message when the server sent no usable string.
+ */
+export const getApiErrorMessage = (error: unknown, fallback: string): string => {
+  const data = getApiErrorData(error);
+  if (typeof data?.error === 'string' && data.error.trim()) {
+    return data.error;
+  }
+  if (typeof data?.message === 'string' && data.message.trim()) {
+    return data.message;
+  }
+  return fallback;
+};
+
+/**
+ * Returns the offending agent ids from a failed API response when the server
+ * included them as a non-empty `response.data.agent_ids` string array.
+ */
+export const getApiErrorAgentIds = (error: unknown): string[] | undefined => {
+  const ids = getApiErrorData(error)?.agent_ids;
+  if (Array.isArray(ids) && ids.length > 0 && ids.every((id) => typeof id === 'string')) {
+    return ids;
+  }
+  return undefined;
+};


### PR DESCRIPTION
## Problem

When an agent save fails validation (e.g. a `subagents.agent_ids` reference to a deleted agent), the Agent Builder toast shows only the generic `Request failed with status code 400`. The server already returns the specific reason and offending ids in the response body — the client was discarding it.

Fixes #15614

## Changes

- Add `getApiErrorMessage` and `getApiErrorAgentIds` helpers to `client/src/utils/errors.ts` (axios-aware, following the existing `getResponseStatus` / `getMemoryApiErrorMessage` patterns).
- Use them in both AgentPanel save `onError` handlers (update + create): the toast now shows the server's error message when present, falling back to the axios message, and appends the offending `agent_ids` in parentheses when the server includes them.

Before: `There was an error updating your agent. Error: Request failed with status code 400`
After: `There was an error updating your agent. Error: One or more agents referenced in subagents do not exist (agent_1D20…, agent_…)`

## Testing

- New unit tests for both helpers (`client/src/utils/__tests__/errors.spec.ts`): server `error` field, `message`-only fallback, `agent_ids` present, no response, non-string/blank payloads (10 tests).
- Updated the existing AgentPanel test's `~/utils` mock to provide the new helpers; full existing suite passes (16/16).
- `npx tsc --noEmit` clean in the client workspace; touched files passed through `npm run sort-imports` and pre-commit lint-staged (prettier/eslint/import sorting).
