### PR TITLE
🛎️ fix: Start Code Environment Reconciliation After Mongo Connects

### DIFF
--- a/api/server/experimental.js
+++ b/api/server/experimental.js
@@ -15,6 +15,7 @@ const Redis = require('ioredis');
 const cors = require('cors');
 const axios = require('axios');
 const express = require('express');
+const mongoose = require('mongoose');
 const passport = require('passport');
 const compression = require('compression');
 const cookieParser = require('cookie-parser');
@@ -48,6 +49,7 @@ const {
   configureAgentEventRuntime,
   GenerationJobManager,
   createAgentEventTerminalHandler,
+  startCodeEnvironmentLifecycleReconciler,
   waitForKeyvRedisClient,
 } = require('@librechat/api');
 const { connectDb, indexSync } = require('~/db');
@@ -466,6 +468,7 @@ if (cluster.isMaster) {
     /** Connect to MongoDB */
     await connectDb();
     logger.info(`Worker ${process.pid}: Connected to MongoDB`);
+    startCodeEnvironmentLifecycleReconciler({ mongoose });
 
     /** Background index sync (non-blocking) */
     indexSync().catch((err) => {

--- a/api/server/experimental.spec.js
+++ b/api/server/experimental.spec.js
@@ -45,6 +45,19 @@ describe('Experimental server configuration', () => {
     expect(source.match(/initializeScheduleErasureSweep\(\);/g)).toHaveLength(1);
   });
 
+  it('starts code-environment lifecycle reconciliation after Mongo connects in each worker', () => {
+    const connectIndex = source.indexOf('await connectDb();');
+    const reconcileIndex = source.indexOf('startCodeEnvironmentLifecycleReconciler({ mongoose });');
+    const listenIndex = source.indexOf('const server = app.listen');
+
+    expect(connectIndex).toBeGreaterThan(-1);
+    expect(reconcileIndex).toBeGreaterThan(connectIndex);
+    expect(listenIndex).toBeGreaterThan(reconcileIndex);
+    expect(
+      source.match(/startCodeEnvironmentLifecycleReconciler\(\{ mongoose \}\);/g),
+    ).toHaveLength(1);
+  });
+
   it('never arms the full schedule engine in a clustered worker', () => {
     // The clustered entrypoint runs erasure-only maintenance: arming the engine here
     // would claim/fire/absence-reconcile runs whose peer generations it cannot see.

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -7,6 +7,7 @@ require('module-alias')({ base: path.resolve(__dirname, '..') });
 const cors = require('cors');
 const axios = require('axios');
 const express = require('express');
+const mongoose = require('mongoose');
 const passport = require('passport');
 const compression = require('compression');
 const cookieParser = require('cookie-parser');
@@ -54,6 +55,7 @@ const {
   configureAgentEventRuntime,
   createAgentEventTerminalHandler,
   createScheduleWriteGate,
+  startCodeEnvironmentLifecycleReconciler,
   waitForKeyvRedisClient,
 } = require('@librechat/api');
 const { connectDb, indexSync } = require('~/db');
@@ -190,6 +192,7 @@ const startServer = async () => {
   await connectDb();
 
   logger.info('Connected to MongoDB');
+  startCodeEnvironmentLifecycleReconciler({ mongoose });
   indexSync().catch((err) => {
     logger.error('[indexSync] Background sync failed:', err);
   });

--- a/api/server/index.spec.js
+++ b/api/server/index.spec.js
@@ -118,6 +118,19 @@ describe('Telemetry wiring', () => {
 describe('Startup readiness wiring', () => {
   const source = fs.readFileSync(path.join(__dirname, 'index.js'), 'utf8');
 
+  it('starts code-environment lifecycle reconciliation only after Mongo connects', () => {
+    const connectIndex = source.indexOf('await connectDb();');
+    const reconcileIndex = source.indexOf('startCodeEnvironmentLifecycleReconciler({ mongoose });');
+    const listenIndex = source.indexOf('const server = app.listen');
+
+    expect(connectIndex).toBeGreaterThan(-1);
+    expect(reconcileIndex).toBeGreaterThan(connectIndex);
+    expect(listenIndex).toBeGreaterThan(reconcileIndex);
+    expect(
+      source.match(/startCodeEnvironmentLifecycleReconciler\(\{ mongoose \}\);/g),
+    ).toHaveLength(1);
+  });
+
   it('awaits the shared Redis client before startup cache access', () => {
     const redisReadyIndex = source.indexOf('await waitForKeyvRedisClient();');
     const connectDbIndex = source.indexOf('await connectDb();');

--- a/api/server/routes/code-environments.js
+++ b/api/server/routes/code-environments.js
@@ -1,9 +1,5 @@
 const express = require('express');
-const mongoose = require('mongoose');
-const {
-  createCodeEnvironmentHttpHandlers,
-  startCodeEnvironmentLifecycleReconciler,
-} = require('@librechat/api');
+const { createCodeEnvironmentHttpHandlers } = require('@librechat/api');
 const { SystemCapabilities } = require('@librechat/data-schemas');
 const { requireCapability } = require('~/server/middleware/roles/capabilities');
 const { codeEnvironmentPairingLimiter } = require('~/server/middleware/limiters/code');
@@ -12,7 +8,6 @@ const { requireJwtAuth } = require('~/server/middleware');
 const db = require('~/models');
 
 const router = express.Router();
-startCodeEnvironmentLifecycleReconciler({ mongoose });
 let handlers;
 function getHandlers() {
   if (handlers == null) {

--- a/api/server/routes/code-environments.test.js
+++ b/api/server/routes/code-environments.test.js
@@ -35,7 +35,6 @@ jest.mock('@librechat/data-schemas', () => ({
 jest.mock('@librechat/api', () => ({
   createCodeEnvironmentRegistry: jest.fn(() => mockRegistry),
   createCodeEnvironmentHttpHandlers: jest.fn(() => mockHandlers),
-  startCodeEnvironmentLifecycleReconciler: jest.fn(),
 }));
 
 jest.mock('~/server/middleware/roles/capabilities', () => ({


### PR DESCRIPTION
## Summary

I moved code-environment lifecycle reconciliation out of route-module initialization and into the database-ready startup phase for both LibreChat server entrypoints. This prevents the first reconciliation pass from failing before MongoDB connects and removes the resulting one-minute recovery gap.

- Start the reconciler immediately after `connectDb()` succeeds in the standard server.
- Start one reconciler per connected clustered worker in the experimental server.
- Keep route loading free of background lifecycle side effects.
- Add startup-order regression coverage for both server entrypoints.
- Stack this change on #15618, which supplies BYOM worker readiness and the strengthened live acceptance test.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran the focused server suites: 41 tests passed.
- Ran affected static checks against the parent stack head: ESLint, Prettier, import sorting, package validation, and circular-dependency checks passed.
- Ran the live attached-BYOM Playwright lane with LibreChat on 44080, Code API on 43112, Redis on 46379, memory Mongo on a non-default dynamic port, principal JWT auth, and a native Anthropic SRT worker. Both tests passed, the startup reconciliation error disappeared, approval/resume executed twice, and workspace state persisted across turns.

### **Test Configuration**:

- macOS
- Node.js 24
- Native `@anthropic-ai/sandbox-runtime` worker
- Isolated non-default service ports

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
