### PR TITLE
docs: align JSDoc blocks with actual function signatures

### DIFF
--- a/api/server/controllers/tools.js
+++ b/api/server/controllers/tools.js
@@ -102,8 +102,7 @@ const verifyToolAuth = async (req, res) => {
 /**
  * @param {ServerRequest} req - The request object, containing information about the HTTP request.
  * @param {ServerResponse} res - The response object, used to send back the desired HTTP response.
- * @param {NextFunction} next - The next middleware function to call.
- * @returns {Promise<void>} A promise that resolves when the function has completed.
+  * @returns {Promise<void>} A promise that resolves when the function has completed.
  */
 const callTool = async (req, res) => {
   try {

--- a/api/server/services/Files/Azure/crud.js
+++ b/api/server/services/Files/Azure/crud.js
@@ -116,9 +116,8 @@ async function getAzureURL({ fileName, basePath = defaultBasePath, userId, conta
 /**
  * Deletes a blob from Azure Blob Storage.
  *
- * @param {Object} params
- * @param {ServerRequest} params.req - The Express request object.
- * @param {MongoFile} params.file - The file object.
+ * @param {ServerRequest} req - The Express request object.
+ * @param {MongoFile} file - The file object.
  */
 async function deleteFileFromAzure(req, file) {
   await deleteRagFile({ userId: req.user.id, file });

--- a/api/server/services/Files/Firebase/crud.js
+++ b/api/server/services/Files/Firebase/crud.js
@@ -16,7 +16,7 @@ const { getBufferMetadata } = require('~/server/utils');
 
 /**
  * Deletes a file from Firebase Storage.
- * @param {string} directory - The directory name
+ * @param {string} basePath - The base directory path
  * @param {string} fileName - The name of the file to delete.
  * @returns {Promise<void>} A promise that resolves when the file is deleted.
  */

--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -282,10 +282,10 @@ async function resolveAgentCapabilities(req, appConfig, agentId) {
 }
 
 /**
- * Processes the required actions by calling the appropriate tools and returning the outputs.
+ * Builds the tool output for a vision required action.
  * @param {OpenAIClient} client - OpenAI or StreamRunManager Client.
- * @param {RequiredAction} requiredActions - The current required action.
- * @returns {Promise<ToolOutput>} The outputs of the tools.
+ * @param {RequiredAction} currentAction - The current required action.
+ * @returns {Promise<ToolOutput>} The output of the vision action.
  */
 const processVisionRequest = async (client, currentAction) => {
   if (!client.visionPromise) {


### PR DESCRIPTION
Four JSDoc blocks documented parameters that don't match the actual signatures, each verified against the signature and the callers:

- `api/server/controllers/tools.js` `callTool`: a `@param {NextFunction} next` entry on a terminal route handler that takes `(req, res)` only
- `api/server/services/ToolService.js` `processVisionRequest`: the summary and `requiredActions` param were copied from the adjacent `processRequiredActions`; the function builds a single vision action's output and takes `(client, currentAction)`
- `api/server/services/Files/Azure/crud.js` `deleteFileFromAzure(req, file)`: documented a `params` object destructuring
- `api/server/services/Files/Firebase/crud.js` `deleteFile(basePath, fileName)`: documented the pre-rename `directory` name

Docs-only (JSDoc comments feed IDE hints).