### PR TITLE
🧪 test: Add Agent Management CRUD Smoke Runner

### DIFF
--- a/scripts/agents-preview/README.md
+++ b/scripts/agents-preview/README.md
@@ -1,0 +1,48 @@
+# Agent Management CRUD smoke test
+
+Exercise the Agent Management HTTP API against a configured LibreChat instance.
+
+## Run the smoke test
+
+Requires Node 24. Run from the repository root. The runner uses
+native Node APIs and does not require installing LibreChat dependencies. It creates
+one uniquely named Agent and deletes it in a `finally` block, including after failed
+assertions. It never executes an Agent or calls a model. Use a configured provider
+and model permitted for the restricted management user.
+
+Set these environment variables through your normal local secret mechanism:
+
+| Variable                    | Value                                                                   |
+| --------------------------- | ----------------------------------------------------------------------- |
+| `AGENT_PREVIEW_URL`         | Agent collection URL, including its route prefix                        |
+| `AGENT_PREVIEW_TOKEN`       | Bearer token for an authorized management caller                        |
+| `AGENT_PREVIEW_PROVIDER`    | Permitted provider                                                      |
+| `AGENT_PREVIEW_MODEL`       | Permitted model                                                         |
+| `AGENT_PREVIEW_REVISION`    | Deployed LibreChat revision                                             |
+| `AGENT_PREVIEW_ENVIRONMENT` | Test environment name                                                   |
+| `AGENT_PREVIEW_FOREIGN_ID`  | Optional known Agent ID in a separate test tenant; tested with GET only |
+
+```sh
+node scripts/agents-preview/run.mts
+```
+
+Set the collection URL to the management endpoint (`/api/agents/v1/agents`). Redirects are refused and HTTPS is
+required except on localhost. Tokens and response bodies are not logged by the
+request reporter; it emits step names, HTTP statuses, and request IDs for correlation.
+
+Checks: missing/invalid authentication, optional foreign-tenant read rejection,
+create/retrieve/list, rejection of ownership/tenant fields, update persistence,
+delete, missing-after-delete, and repeated deletion. List traversal is bounded at
+100 pages. If a request times out after server-side creation, or the server fails to
+return an ID, inspect the restricted user's Agents for the `CRUD preview` fixture
+and clean it up. A process kill can also prevent cleanup.
+
+## Verify the runner locally
+
+```sh
+node --test scripts/agents-preview/run.test.mts
+npx tsc --noEmit -p scripts/agents-preview/tsconfig.json
+```
+
+The local HTTP fixture verifies the runner's lifecycle, failure cleanup, and URL
+handling. It does not substitute for deployed integration tests.

--- a/scripts/agents-preview/run.mts
+++ b/scripts/agents-preview/run.mts
@@ -1,0 +1,237 @@
+import { randomUUID } from 'node:crypto';
+import { pathToFileURL } from 'node:url';
+import assert from 'node:assert/strict';
+
+type JsonObject = { [key: string]: unknown };
+
+export interface PreviewOptions {
+  collectionUrl: string;
+  token: string;
+  provider: string;
+  model: string;
+  revision: string;
+  environment: string;
+  foreignAgentId?: string;
+  report?: (event: PreviewEvent) => void;
+}
+
+interface PreviewEvent {
+  step: string;
+  requestId: string;
+  status: number;
+}
+
+function object(value: unknown): JsonObject {
+  assert(value !== null && typeof value === 'object' && !Array.isArray(value));
+  return value as JsonObject;
+}
+
+function agent(value: unknown, id?: string): JsonObject {
+  const result = object(value);
+  assert(typeof result.id === 'string' && result.id.length > 0, 'Missing Agent ID');
+  if (id) assert.equal(result.id, id);
+  assert(typeof result.provider === 'string');
+  assert(typeof result.model === 'string' || result.model === null);
+  assert(Number.isInteger(result.version));
+  for (const field of ['createdAt', 'updatedAt']) {
+    assert(typeof result[field] === 'string' && Number.isFinite(Date.parse(result[field])));
+  }
+  for (const field of ['tenantId', 'author', 'versions', '_id', 'credentials']) {
+    assert(!(field in result), `Internal field exposed: ${field}`);
+  }
+  return result;
+}
+
+/** Exercise only a newly created Agent; a supplied foreign ID is read-only. */
+export async function runPreview(options: PreviewOptions): Promise<void> {
+  const collection = new URL(options.collectionUrl);
+  assert(!collection.username && !collection.password && !collection.search && !collection.hash);
+  assert(
+    collection.protocol === 'https:' ||
+      (collection.protocol === 'http:' &&
+        ['localhost', '127.0.0.1', '[::1]'].includes(collection.hostname)),
+    'Use HTTPS outside localhost',
+  );
+  collection.pathname = collection.pathname.replace(/\/$/, '');
+  const report = options.report ?? ((event: PreviewEvent) => console.log(JSON.stringify(event)));
+  const runId = randomUUID();
+  let createdId: string | undefined;
+
+  async function request({
+    step,
+    method = 'GET',
+    id,
+    body,
+    token = options.token,
+    query,
+  }: {
+    step: string;
+    method?: string;
+    id?: string;
+    body?: JsonObject;
+    token?: string;
+    query?: URLSearchParams;
+  }): Promise<{ status: number; body: unknown }> {
+    const url = new URL(collection);
+    if (id) {
+      assert(id !== '.' && id !== '..', 'Invalid Agent ID');
+      url.pathname += `/${encodeURIComponent(id)}`;
+    }
+    if (query) url.search = query.toString();
+    const requestId = `${runId}-${step}`;
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      'x-request-id': requestId,
+    };
+    if (token) headers.Authorization = `Bearer ${token}`;
+    if (body) headers['Content-Type'] = 'application/json';
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method,
+        headers,
+        body: body ? JSON.stringify(body) : undefined,
+        redirect: 'error',
+        signal: AbortSignal.timeout(30_000),
+      });
+    } catch {
+      throw new Error(`${step}: request failed (${requestId})`);
+    }
+    report({ step, requestId, status: response.status });
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch {
+      throw new Error(`${step}: expected JSON (${requestId})`);
+    }
+    return { status: response.status, body: payload };
+  }
+
+  function status(actual: number, expected: number | number[]): void {
+    assert(
+      (Array.isArray(expected) ? expected : [expected]).includes(actual),
+      `Unexpected HTTP ${actual}`,
+    );
+  }
+
+  for (const [step, token] of [
+    ['missing-token', ''],
+    ['invalid-token', 'invalid-preview-token'],
+  ]) {
+    const response = await request({ step: step!, token: token! });
+    status(response.status, [401, 403]);
+  }
+  if (options.foreignAgentId) {
+    const response = await request({ step: 'foreign-agent', id: options.foreignAgentId });
+    status(response.status, 404);
+  }
+
+  try {
+    const name = `CRUD preview ${runId}`;
+    const created = await request({
+      step: 'create',
+      method: 'POST',
+      body: {
+        name,
+        provider: options.provider,
+        model: options.model,
+        instructions: 'Preview fixture. Do not execute.',
+      },
+    });
+    // Capture the ID before validating the projection so failed assertions still clean up.
+    const createdBody = object(created.body);
+    if (typeof createdBody.id === 'string' && createdBody.id) createdId = createdBody.id;
+    status(created.status, 201);
+    agent(createdBody);
+    assert(createdId);
+    assert.equal(createdBody.name, name);
+
+    const read = await request({ step: 'retrieve', id: createdId });
+    status(read.status, 200);
+    assert.equal(agent(read.body, createdId).name, name);
+
+    let cursor: string | undefined;
+    let found = false;
+    const cursors = new Set<string>();
+    for (let page = 0; page < 100 && !found; page++) {
+      const query = new URLSearchParams({ limit: '100' });
+      if (cursor) query.set('cursor', cursor);
+      const listed = await request({ step: `list-${page}`, query });
+      status(listed.status, 200);
+      const list = object(listed.body);
+      assert.equal(list.object, 'list');
+      assert(Array.isArray(list.data));
+      found = list.data.some((entry: unknown) => agent(entry).id === createdId);
+      if (found || list.has_more === false) break;
+      assert.equal(list.has_more, true);
+      assert(typeof list.after === 'string' && list.after.length > 0 && !cursors.has(list.after));
+      cursor = list.after;
+      cursors.add(cursor);
+    }
+    assert(found, 'Created Agent missing from first 100 list pages');
+
+    const malformed = await request({
+      step: 'reject-ownership',
+      method: 'PATCH',
+      id: createdId,
+      body: { author: 'forged-preview-owner', tenantId: 'forged-preview-tenant' },
+    });
+    status(malformed.status, 400);
+    assert.equal(object(object(malformed.body).error).code, 'invalid_request');
+
+    const updatedName = `${name} updated`;
+    const updated = await request({
+      step: 'update',
+      method: 'PATCH',
+      id: createdId,
+      body: { name: updatedName },
+    });
+    status(updated.status, 200);
+    assert.equal(agent(updated.body, createdId).name, updatedName);
+    const persisted = await request({ step: 'verify-update', id: createdId });
+    status(persisted.status, 200);
+    assert.equal(agent(persisted.body, createdId).name, updatedName);
+  } finally {
+    if (createdId) {
+      const deleted = await request({ step: 'delete', method: 'DELETE', id: createdId });
+      status(deleted.status, 200);
+      assert.deepEqual(deleted.body, { id: createdId, deleted: true });
+      const missing = await request({ step: 'verify-deletion', id: createdId });
+      status(missing.status, 404);
+      const repeated = await request({ step: 'repeat-deletion', method: 'DELETE', id: createdId });
+      status(repeated.status, 404);
+    }
+  }
+}
+
+function required(name: string): string {
+  const value = process.env[name];
+  assert(value, `Set ${name}`);
+  return value;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const options: PreviewOptions = {
+      collectionUrl: required('AGENT_PREVIEW_URL'),
+      token: required('AGENT_PREVIEW_TOKEN'),
+      provider: required('AGENT_PREVIEW_PROVIDER'),
+      model: required('AGENT_PREVIEW_MODEL'),
+      revision: required('AGENT_PREVIEW_REVISION'),
+      environment: required('AGENT_PREVIEW_ENVIRONMENT'),
+      foreignAgentId: process.env.AGENT_PREVIEW_FOREIGN_ID,
+    };
+    console.log(
+      JSON.stringify({
+        revision: options.revision,
+        environment: options.environment,
+        startedAt: new Date().toISOString(),
+      }),
+    );
+    await runPreview(options);
+    console.log('CRUD smoke checks passed.');
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : 'Preview failed');
+    process.exitCode = 1;
+  }
+}

--- a/scripts/agents-preview/run.test.mts
+++ b/scripts/agents-preview/run.test.mts
@@ -1,0 +1,107 @@
+import { once } from 'node:events';
+import { createServer } from 'node:http';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { runPreview } from './run.mts';
+
+for (const failUpdate of [false, true]) {
+  test(`CRUD runner ${failUpdate ? 'cleans up after failure' : 'completes lifecycle'}`, async () => {
+    let saved: { id: string; name: string } | undefined;
+    const steps: string[] = [];
+    const server = createServer(async (req, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      const send = (status: number, body: object): void => {
+        res.writeHead(status);
+        res.end(JSON.stringify(body));
+      };
+      assert(req.headers['x-request-id']);
+      if (req.headers.authorization !== 'Bearer fixture-token') {
+        send(401, { error: 'Unauthorized' });
+        return;
+      }
+      if (req.url?.endsWith('/foreign-agent')) {
+        send(404, { error: { code: 'not_found' } });
+        return;
+      }
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) chunks.push(Buffer.from(chunk));
+      const input = chunks.length ? JSON.parse(Buffer.concat(chunks).toString()) : {};
+      const projection = (): object => ({
+        ...saved,
+        provider: 'openAI',
+        model: 'fixture',
+        version: 1,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+      if (req.method === 'POST') {
+        saved = { id: 'agent-preview', name: input.name };
+        send(201, projection());
+      } else if (req.method === 'PATCH' && input.author) {
+        send(400, { error: { code: 'invalid_request' } });
+      } else if (req.method === 'PATCH') {
+        if (failUpdate) send(500, { error: { code: 'internal_error' } });
+        else {
+          assert(saved);
+          saved.name = input.name;
+          send(200, projection());
+        }
+      } else if (req.method === 'DELETE') {
+        if (!saved) send(404, { error: { code: 'not_found' } });
+        else {
+          saved = undefined;
+          send(200, { id: 'agent-preview', deleted: true });
+        }
+      } else if (req.url?.includes('?')) {
+        send(200, {
+          object: 'list',
+          data: saved ? [projection()] : [],
+          has_more: false,
+          after: null,
+        });
+      } else if (saved) send(200, projection());
+      else send(404, { error: { code: 'not_found' } });
+    });
+    server.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+    const address = server.address();
+    assert(address && typeof address === 'object');
+    try {
+      const result = runPreview({
+        collectionUrl: `http://127.0.0.1:${address.port}/agents`,
+        token: 'fixture-token',
+        provider: 'openAI',
+        model: 'fixture',
+        revision: 'fixture',
+        environment: 'local',
+        foreignAgentId: 'foreign-agent',
+        report: (event) => {
+          steps.push(event.step);
+        },
+      });
+      if (failUpdate) await assert.rejects(result, /Unexpected HTTP 500/);
+      else await result;
+      assert.equal(saved, undefined);
+      assert(steps.includes('foreign-agent'));
+      assert(steps.includes('reject-ownership'));
+      assert.deepEqual(steps.slice(-3), ['delete', 'verify-deletion', 'repeat-deletion']);
+    } finally {
+      server.close();
+      await once(server, 'close');
+    }
+  });
+}
+
+test('rejects non-local plaintext endpoints before sending credentials', async () => {
+  await assert.rejects(
+    runPreview({
+      collectionUrl: 'http://example.com/agents',
+      token: 'secret',
+      provider: 'openAI',
+      model: 'fixture',
+      revision: 'fixture',
+      environment: 'test',
+    }),
+    /Use HTTPS/,
+  );
+});

--- a/scripts/agents-preview/tsconfig.json
+++ b/scripts/agents-preview/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ES2023", "DOM"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2023",
+    "types": ["node"],
+    "verbatimModuleSyntax": true
+  },
+  "include": ["./*.mts"]
+}


### PR DESCRIPTION
## Summary

I added a standalone Agent Management CRUD smoke test for a configured LibreChat instance.

- Exercise authentication rejection, create/retrieve/list, rejected ownership fields, update persistence, deletion, and repeated deletion.
- Check foreign-tenant read rejection when a test fixture ID is supplied, report request IDs, and clean up the created Agent after assertion failures.
- Document configuration, cleanup limitations, and local verification.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing

- Passed `node --test scripts/agents-preview/run.test.mts` (3 local HTTP fixture tests).
- Passed TypeScript checking for `scripts/agents-preview/tsconfig.json`.
- Passed Prettier formatting and `git diff --check`.

### Test Configuration

Node v24.16.0. The runner requires no installed runtime dependencies. Local fixtures verify runner behavior; deployed integration testing has not been performed.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
