### PR TITLE
🗓️ fix: Surface a Run Now Scheduled Chat in the Sidebar

### DIFF
--- a/client/src/data-provider/Schedules/admission.ts
+++ b/client/src/data-provider/Schedules/admission.ts
@@ -1,0 +1,169 @@
+/* Scheduled chats */
+import { QueryKeys, dataService } from 'librechat-data-provider';
+import type { TUser, TConversation } from 'librechat-data-provider';
+import type { QueryClient } from '@tanstack/react-query';
+import { extendActiveJobsGrace, queueTitleGeneration } from '~/data-provider/SSE/queries';
+import { upsertConvoInAllQueries, getResponseStatus } from '~/utils';
+
+/**
+ * Waits before each probe, so the first is not spent on a conversation that
+ * cannot exist yet. Admission is normally a second or two, but a dispatch that
+ * keeps failing is retried, and the budget has to outlast that or the watch
+ * gives up on a run the server is still going to admit: the trigger engine
+ * allows eight attempts backing off from a second and doubling, which is about
+ * two minutes of retries in the worst case. Roughly five minutes of probes
+ * covers that window twice over in eleven requests.
+ *
+ * It does not cover everything, deliberately. A dispatch refused with a long
+ * `Retry-After` can be re-driven hours later, and holding a watch open for that
+ * is worse than what already happens without one — the chat arrives with the
+ * next list refetch. A later announcement of the same run restarts the watch.
+ */
+const ADMISSION_DELAYS_MS = [
+  750, 1_500, 3_000, 6_000, 10_000, 15_000, 30_000, 45_000, 60_000, 60_000, 60_000,
+];
+
+/** 404 is the run not having started yet, which is the whole reason for waiting.
+ *  408 and 429 ask to be retried by definition, and a proxy in front of the app
+ *  can raise either without the run being involved at all. */
+const RETRYABLE_CLIENT_STATUS = new Set([404, 408, 429]);
+
+/**
+ * Whether a failed probe has answered the question for good. A 5xx, or a request
+ * that never got a response, has not — those are the probe failing rather than the
+ * run, and the durable delivery is still free to admit afterwards. Only a client
+ * error that is not asking to be retried settles it: waiting longer will not make
+ * this client able to read that conversation.
+ */
+const isTerminalProbeFailure = (error: unknown): boolean => {
+  const status = getResponseStatus(error);
+  return status != null && status >= 400 && status < 500 && !RETRYABLE_CLIENT_STATUS.has(status);
+};
+
+const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Who this cache belongs to. Both sign-in and sign-out empty it wholesale, so a
+ *  watch outliving either has no business writing to whatever replaced it. An
+ *  `undefined` is "not loaded yet" or "emptied", and the two read the same. */
+const cacheOwner = (queryClient: QueryClient): string | undefined =>
+  queryClient.getQueryData<TUser>([QueryKeys.user])?.id;
+
+/**
+ * Runs with a watch in flight or already landed. A run can be announced twice —
+ * by the click that started it, and by the schedules poll that then lists it —
+ * and must be watched once. A watch that gave up is forgotten, so a later
+ * announcement of a run admitted after the budget can try again.
+ */
+const tracked = new Set<string>();
+
+/** @internal Test seam. */
+export function resetTrackedRuns(): void {
+  tracked.clear();
+}
+
+/**
+ * The session fence, in one place. The server enforces ownership on the probe
+ * itself — a request sent under one account can never return another's chat —
+ * so the only dangerous response is one SENT under the account that clicked and
+ * LANDING after someone else signed in. That fixes the shape of the fence:
+ *
+ * - The owner is bound only from a reading taken BEFORE a probe goes out. A
+ *   reading taken after one cannot tell a cache that finished loading from a
+ *   cache that changed hands, so it is never adopted as the baseline.
+ * - Once bound, any different reading — another id, or none — ends the watch.
+ * - A successful probe with no baseline yet is not written and not abandoned:
+ *   the budget is kept, and the next iteration binds before it probes.
+ */
+async function admit(queryClient: QueryClient, conversationId: string): Promise<boolean> {
+  let startedFor = cacheOwner(queryClient);
+  for (const delay of ADMISSION_DELAYS_MS) {
+    await wait(delay);
+    const before = cacheOwner(queryClient);
+    if (startedFor === undefined) {
+      startedFor = before;
+    } else if (before !== startedFor) {
+      return false;
+    }
+    let conversation: TConversation;
+    try {
+      conversation = await dataService.getConversationById(conversationId);
+    } catch (error) {
+      if (isTerminalProbeFailure(error)) {
+        return false;
+      }
+      continue;
+    }
+    if (startedFor === undefined) {
+      continue;
+    }
+    if (cacheOwner(queryClient) !== startedFor) {
+      return false;
+    }
+    /** The conversation route serves an archived chat; the list query filters one
+     *  out. Another tab archiving this run between its first write and this probe
+     *  would otherwise put a row in the sidebar that no refetch agrees belongs
+     *  there — and the archive was deliberate, so there is nothing else to do. */
+    if (conversation.isArchived === true) {
+      return true;
+    }
+    /** Warms the key the chat route reads, so opening the row it just added does
+     *  not have to ask again. Absent-only: anything already cached under this id
+     *  was put there by the chat itself and knows more than one list read does. */
+    queryClient.setQueryData<TConversation>(
+      [QueryKeys.conversation, conversationId],
+      (current) => current ?? conversation,
+    );
+    upsertConvoInAllQueries(queryClient, conversation);
+    /** The same bookkeeping the foreground path does when a chat lands in a
+     *  project: the project's count and recent-activity ordering live on the
+     *  project rows, which the conversation caches above do not touch. */
+    if (conversation.chatProjectId) {
+      queryClient.invalidateQueries([QueryKeys.projects]);
+      queryClient.invalidateQueries([QueryKeys.project, conversation.chatProjectId]);
+    }
+    /** A generation is live by definition here. The active-job list is the only
+     *  thing that can mark the row as running, and it stops polling while nothing
+     *  is listed — so re-arm it at admission, which is when a job exists, rather
+     *  than at the click, which is before one does. */
+    extendActiveJobsGrace();
+    queryClient.invalidateQueries([QueryKeys.activeJobs]);
+    /** A conversation admitted mid-run has not been titled yet, so the row lands
+     *  as "New Chat". The foreground paths hand that to the title queue, which
+     *  owns the timing the server was configured for; a scheduled run has no
+     *  foreground path, so hand it over here rather than leaving the placeholder
+     *  until an unrelated refetch. */
+    queueTitleGeneration(conversationId);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Puts a scheduled run's chat in the sidebar once the server actually has it.
+ *
+ * The generation that writes the conversation starts after the run is announced
+ * — after run-now answers, after the schedules poll first lists the occurrence —
+ * so at the moment of the announcement there is nothing to refetch. The
+ * conversation route answers 404 until that write commits and applies the same
+ * visibility rule the list query does, which makes it an exact admission probe:
+ * a 200 means the chat is listable now, and carries the server's own row rather
+ * than a guess assembled from the client's cached schedule.
+ *
+ * Deliberately detached from the caller: the sidebar has to gain the chat whether
+ * or not the panel the run was announced in is still mounted. Bounded, and it
+ * writes only what the server returned — a delivery that never admits leaves
+ * every cache exactly as it found it.
+ */
+export async function trackScheduledRun(
+  queryClient: QueryClient,
+  conversationId: string,
+): Promise<void> {
+  if (!conversationId || tracked.has(conversationId)) {
+    return;
+  }
+  tracked.add(conversationId);
+  const landed = await admit(queryClient, conversationId);
+  if (!landed) {
+    tracked.delete(conversationId);
+  }
+}

--- a/client/src/data-provider/Schedules/mutations.ts
+++ b/client/src/data-provider/Schedules/mutations.ts
@@ -2,6 +2,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { QueryKeys, MutationKeys, dataService } from 'librechat-data-provider';
 import type {
+  TUser,
   TSchedule,
   TConversation,
   TCreateSchedule,
@@ -9,8 +10,8 @@ import type {
   TScheduleRunNowResponse,
 } from 'librechat-data-provider';
 import type { QueryClient, UseMutationOptions } from '@tanstack/react-query';
+import { extendActiveJobsGrace, queueTitleGeneration } from '~/data-provider/SSE/queries';
 import { upsertConvoInAllQueries, getResponseStatus } from '~/utils';
-import { extendActiveJobsGrace } from '~/data-provider/SSE/queries';
 
 export const useCreateScheduleMutation = (
   options?: UseMutationOptions<TSchedule, Error, TCreateSchedule>,
@@ -100,6 +101,11 @@ const isTerminalProbeFailure = (error: unknown): boolean => {
 
 const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
+/** Who this cache belongs to. Both sign-in and sign-out empty it wholesale, so a
+ *  watch outliving either has no business writing to whatever replaced it. */
+const cacheOwner = (queryClient: QueryClient): string | undefined =>
+  queryClient.getQueryData<TUser>([QueryKeys.user])?.id;
+
 /**
  * Puts a manual run's chat in the sidebar once the server actually has it.
  *
@@ -120,8 +126,15 @@ const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(
  * every cache exactly as it found it.
  */
 async function trackStartedRun(queryClient: QueryClient, conversationId: string): Promise<void> {
+  const startedFor = cacheOwner(queryClient);
   for (const delay of ADMISSION_DELAYS_MS) {
     await wait(delay);
+    /** Minutes can pass in here, and signing out or signing in as someone else
+     *  empties the cache in between. Re-check before probing and again before
+     *  writing, or a late response files one user's chat in another's sidebar. */
+    if (cacheOwner(queryClient) !== startedFor) {
+      return;
+    }
     let conversation: TConversation;
     try {
       conversation = await dataService.getConversationById(conversationId);
@@ -130,6 +143,9 @@ async function trackStartedRun(queryClient: QueryClient, conversationId: string)
         return;
       }
       continue;
+    }
+    if (cacheOwner(queryClient) !== startedFor) {
+      return;
     }
     /** Warms the key the chat route reads, so opening the row it just added does
      *  not have to ask again. Absent-only: anything already cached under this id
@@ -145,6 +161,12 @@ async function trackStartedRun(queryClient: QueryClient, conversationId: string)
      *  than at the click, which is before one does. */
     extendActiveJobsGrace();
     queryClient.invalidateQueries([QueryKeys.activeJobs]);
+    /** A conversation admitted mid-run has not been titled yet, so the row lands
+     *  as "New Chat". The foreground paths hand that to the title queue, which
+     *  owns the timing the server was configured for; a scheduled run has no
+     *  foreground path, so hand it over here rather than leaving the placeholder
+     *  until an unrelated refetch. */
+    queueTitleGeneration(conversationId);
     return;
   }
 }

--- a/client/src/data-provider/Schedules/mutations.ts
+++ b/client/src/data-provider/Schedules/mutations.ts
@@ -159,7 +159,11 @@ async function trackStartedRun(queryClient: QueryClient, conversationId: string)
       }
       continue;
     }
-    if (startedFor !== undefined && cacheOwner(queryClient) !== startedFor) {
+    /** An owner that is still unknown cannot be compared, so it cannot be cleared
+     *  either — "loading" and "changed hands" are the same reading. Refuse the
+     *  write rather than risk seeding one account's chat into another's sidebar;
+     *  a signed-in session is what every caller of this actually has. */
+    if (cacheOwner(queryClient) !== startedFor || startedFor === undefined) {
       return;
     }
     /** The conversation route serves an archived chat; the list query filters one

--- a/client/src/data-provider/Schedules/mutations.ts
+++ b/client/src/data-provider/Schedules/mutations.ts
@@ -1,16 +1,16 @@
 /* Scheduled chats */
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { QueryKeys, MutationKeys, EModelEndpoint, dataService } from 'librechat-data-provider';
+import { QueryKeys, MutationKeys, dataService } from 'librechat-data-provider';
 import type {
   TSchedule,
+  TConversation,
   TCreateSchedule,
   TUpdateSchedule,
-  TSchedulesResponse,
   TScheduleRunNowResponse,
 } from 'librechat-data-provider';
 import type { QueryClient, UseMutationOptions } from '@tanstack/react-query';
 import { extendActiveJobsGrace } from '~/data-provider/SSE/queries';
-import { upsertConvoInAllQueries } from '~/utils';
+import { upsertConvoInAllQueries, isNotFoundError } from '~/utils';
 
 export const useCreateScheduleMutation = (
   options?: UseMutationOptions<TSchedule, Error, TCreateSchedule>,
@@ -68,48 +68,65 @@ export const useDeleteScheduleMutation = (
 };
 
 /**
- * Puts the started run's chat in the sidebar straight away.
- *
- * The conversation does not exist yet when this response lands: run-now answers
- * once the trigger delivery is durable, and the generation that writes the
- * conversation starts after it. Refetching the lists here would come back
- * without the chat and leave the sidebar exactly as it was — the bug this
- * closes — so the row is seeded from what the response and the cached schedule
- * already name, the same way a locally started chat is seeded before its first
- * message persists. The next natural list refetch replaces it with the server's
- * own row, generated title included.
+ * Waits before each probe, so the first one is not spent on a conversation that
+ * cannot exist yet. Admission is normally a second or two, but a failed dispatch
+ * is retried with exponential backoff, so the wait has a long tail: eight probes
+ * over roughly forty seconds cover the ordinary case without turning one click
+ * into an open-ended poll. A run admitted after that is left to the next list
+ * refetch rather than watched forever.
  */
-function seedStartedRunConversation(
-  queryClient: QueryClient,
-  { scheduleId, conversationId }: TScheduleRunNowResponse,
-): void {
-  if (!conversationId) {
+const ADMISSION_DELAYS_MS = [750, 1_500, 3_000, 6_000, 8_000, 8_000, 8_000, 8_000];
+
+const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Puts a manual run's chat in the sidebar once the server actually has it.
+ *
+ * Run-now answers as soon as the trigger delivery is durable, and the generation
+ * that writes the conversation starts after that — so at the moment the response
+ * lands there is nothing to refetch, which is why the click appeared to do
+ * nothing at all. The conversation route answers 404 until that write commits and
+ * applies the same visibility rule the list query does, which makes it an exact
+ * admission probe: a 200 means the chat is listable now, and carries the server's
+ * own row rather than a guess assembled from the client's cached schedule.
+ *
+ * A 404 is the run not having started yet; any other failure is not, and ends the
+ * watch rather than spending the budget on a request that is not going to change
+ * its answer.
+ *
+ * Deliberately detached from the caller: the sidebar has to gain the chat whether
+ * or not the panel the run was started from is still mounted. Bounded, and it
+ * writes only what the server returned — a delivery that never admits leaves
+ * every cache exactly as it found it.
+ */
+async function trackStartedRun(queryClient: QueryClient, conversationId: string): Promise<void> {
+  for (const delay of ADMISSION_DELAYS_MS) {
+    await wait(delay);
+    let conversation: TConversation;
+    try {
+      conversation = await dataService.getConversationById(conversationId);
+    } catch (error) {
+      if (isNotFoundError(error)) {
+        continue;
+      }
+      return;
+    }
+    /** Warms the key the chat route reads, so opening the row it just added does
+     *  not have to ask again. Absent-only: anything already cached under this id
+     *  was put there by the chat itself and knows more than one list read does. */
+    queryClient.setQueryData<TConversation>(
+      [QueryKeys.conversation, conversationId],
+      (current) => current ?? conversation,
+    );
+    upsertConvoInAllQueries(queryClient, conversation);
+    /** A generation is live by definition here. The active-job list is the only
+     *  thing that can mark the row as running, and it stops polling while nothing
+     *  is listed — so re-arm it at admission, which is when a job exists, rather
+     *  than at the click, which is before one does. */
+    extendActiveJobsGrace();
+    queryClient.invalidateQueries([QueryKeys.activeJobs]);
     return;
   }
-  const cached = queryClient.getQueryData<TSchedulesResponse>([QueryKeys.schedules]);
-  const schedule = cached?.schedules.find((entry) => entry.id === scheduleId);
-  if (schedule == null) {
-    return;
-  }
-  const now = new Date().toISOString();
-  upsertConvoInAllQueries(queryClient, {
-    conversationId,
-    /** Mirrors the fire path's own resolution — an operator pin outranks the
-     *  schedule's stored destination — so the row is seeded into the project
-     *  list the run is actually filed under, and into no other. */
-    chatProjectId: cached?.limits.projectId ?? schedule.chatProjectId ?? null,
-    endpoint: EModelEndpoint.agents,
-    agent_id: schedule.agent_id,
-    title: schedule.name,
-    createdAt: now,
-    updatedAt: now,
-  });
-  /** Nothing here will open a stream for this run, so the active-job list is the
-   *  only thing that can show the row as running — and it stops polling while
-   *  nothing is listed. Report the generation this click just started and re-arm
-   *  the query, which picks the interval back up once it has fetched. */
-  extendActiveJobsGrace();
-  queryClient.invalidateQueries([QueryKeys.activeJobs]);
 }
 
 export const useRunScheduleNowMutation = (
@@ -122,7 +139,9 @@ export const useRunScheduleNowMutation = (
     {
       ...options,
       onSuccess: (data, ...rest) => {
-        seedStartedRunConversation(queryClient, data);
+        if (data.conversationId) {
+          void trackStartedRun(queryClient, data.conversationId);
+        }
         options?.onSuccess?.(data, ...rest);
       },
       // Invalidate on SETTLED, not just success: several run-now 409 paths are still

--- a/client/src/data-provider/Schedules/mutations.ts
+++ b/client/src/data-provider/Schedules/mutations.ts
@@ -86,17 +86,21 @@ const ADMISSION_DELAYS_MS = [
   750, 1_500, 3_000, 6_000, 10_000, 15_000, 30_000, 45_000, 60_000, 60_000, 60_000,
 ];
 
+/** 404 is the run not having started yet, which is the whole reason for waiting.
+ *  408 and 429 ask to be retried by definition, and a proxy in front of the app
+ *  can raise either without the run being involved at all. */
+const RETRYABLE_CLIENT_STATUS = new Set([404, 408, 429]);
+
 /**
- * Whether a failed probe has answered the question for good. A 404 has not: the
- * run has not started yet, which is the whole reason for waiting. Neither has a
- * 5xx or a request that never got a response — those are the probe failing, not
- * the run, and the durable delivery is still free to admit. A different 4xx is a
- * real answer: waiting longer will not make this client able to read that
- * conversation.
+ * Whether a failed probe has answered the question for good. A 5xx, or a request
+ * that never got a response, has not — those are the probe failing rather than the
+ * run, and the durable delivery is still free to admit afterwards. Only a client
+ * error that is not asking to be retried settles it: waiting longer will not make
+ * this client able to read that conversation.
  */
 const isTerminalProbeFailure = (error: unknown): boolean => {
   const status = getResponseStatus(error);
-  return status != null && status >= 400 && status < 500 && status !== 404;
+  return status != null && status >= 400 && status < 500 && !RETRYABLE_CLIENT_STATUS.has(status);
 };
 
 const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
@@ -145,6 +149,13 @@ async function trackStartedRun(queryClient: QueryClient, conversationId: string)
       continue;
     }
     if (cacheOwner(queryClient) !== startedFor) {
+      return;
+    }
+    /** The conversation route serves an archived chat; the list query filters one
+     *  out. Another tab archiving this run between its first write and this probe
+     *  would otherwise put a row in the sidebar that no refetch agrees belongs
+     *  there — and the archive was deliberate, so there is nothing else to do. */
+    if (conversation.isArchived === true) {
       return;
     }
     /** Warms the key the chat route reads, so opening the row it just added does

--- a/client/src/data-provider/Schedules/mutations.ts
+++ b/client/src/data-provider/Schedules/mutations.ts
@@ -1,13 +1,16 @@
 /* Scheduled chats */
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { QueryKeys, MutationKeys, dataService } from 'librechat-data-provider';
+import { QueryKeys, MutationKeys, EModelEndpoint, dataService } from 'librechat-data-provider';
 import type {
   TSchedule,
   TCreateSchedule,
   TUpdateSchedule,
+  TSchedulesResponse,
   TScheduleRunNowResponse,
 } from 'librechat-data-provider';
-import type { UseMutationOptions } from '@tanstack/react-query';
+import type { QueryClient, UseMutationOptions } from '@tanstack/react-query';
+import { extendActiveJobsGrace } from '~/data-provider/SSE/queries';
+import { upsertConvoInAllQueries } from '~/utils';
 
 export const useCreateScheduleMutation = (
   options?: UseMutationOptions<TSchedule, Error, TCreateSchedule>,
@@ -64,6 +67,51 @@ export const useDeleteScheduleMutation = (
   );
 };
 
+/**
+ * Puts the started run's chat in the sidebar straight away.
+ *
+ * The conversation does not exist yet when this response lands: run-now answers
+ * once the trigger delivery is durable, and the generation that writes the
+ * conversation starts after it. Refetching the lists here would come back
+ * without the chat and leave the sidebar exactly as it was — the bug this
+ * closes — so the row is seeded from what the response and the cached schedule
+ * already name, the same way a locally started chat is seeded before its first
+ * message persists. The next natural list refetch replaces it with the server's
+ * own row, generated title included.
+ */
+function seedStartedRunConversation(
+  queryClient: QueryClient,
+  { scheduleId, conversationId }: TScheduleRunNowResponse,
+): void {
+  if (!conversationId) {
+    return;
+  }
+  const cached = queryClient.getQueryData<TSchedulesResponse>([QueryKeys.schedules]);
+  const schedule = cached?.schedules.find((entry) => entry.id === scheduleId);
+  if (schedule == null) {
+    return;
+  }
+  const now = new Date().toISOString();
+  upsertConvoInAllQueries(queryClient, {
+    conversationId,
+    /** Mirrors the fire path's own resolution — an operator pin outranks the
+     *  schedule's stored destination — so the row is seeded into the project
+     *  list the run is actually filed under, and into no other. */
+    chatProjectId: cached?.limits.projectId ?? schedule.chatProjectId ?? null,
+    endpoint: EModelEndpoint.agents,
+    agent_id: schedule.agent_id,
+    title: schedule.name,
+    createdAt: now,
+    updatedAt: now,
+  });
+  /** Nothing here will open a stream for this run, so the active-job list is the
+   *  only thing that can show the row as running — and it stops polling while
+   *  nothing is listed. Report the generation this click just started and re-arm
+   *  the query, which picks the interval back up once it has fetched. */
+  extendActiveJobsGrace();
+  queryClient.invalidateQueries([QueryKeys.activeJobs]);
+}
+
 export const useRunScheduleNowMutation = (
   options?: UseMutationOptions<TScheduleRunNowResponse, Error, string>,
 ) => {
@@ -73,6 +121,10 @@ export const useRunScheduleNowMutation = (
     (id: string) => dataService.runScheduleNow(id),
     {
       ...options,
+      onSuccess: (data, ...rest) => {
+        seedStartedRunConversation(queryClient, data);
+        options?.onSuccess?.(data, ...rest);
+      },
       // Invalidate on SETTLED, not just success: several run-now 409 paths are still
       // server-side mutations (a balance skip updates lastRun/counters and can
       // auto-disable; agent/permission/invalid-schedule skips disable the schedule

--- a/client/src/data-provider/Schedules/mutations.ts
+++ b/client/src/data-provider/Schedules/mutations.ts
@@ -9,8 +9,8 @@ import type {
   TScheduleRunNowResponse,
 } from 'librechat-data-provider';
 import type { QueryClient, UseMutationOptions } from '@tanstack/react-query';
+import { upsertConvoInAllQueries, getResponseStatus } from '~/utils';
 import { extendActiveJobsGrace } from '~/data-provider/SSE/queries';
-import { upsertConvoInAllQueries, isNotFoundError } from '~/utils';
 
 export const useCreateScheduleMutation = (
   options?: UseMutationOptions<TSchedule, Error, TCreateSchedule>,
@@ -68,14 +68,35 @@ export const useDeleteScheduleMutation = (
 };
 
 /**
- * Waits before each probe, so the first one is not spent on a conversation that
- * cannot exist yet. Admission is normally a second or two, but a failed dispatch
- * is retried with exponential backoff, so the wait has a long tail: eight probes
- * over roughly forty seconds cover the ordinary case without turning one click
- * into an open-ended poll. A run admitted after that is left to the next list
- * refetch rather than watched forever.
+ * Waits before each probe, so the first is not spent on a conversation that
+ * cannot exist yet. Admission is normally a second or two, but a dispatch that
+ * keeps failing is retried, and the budget has to outlast that or the watch
+ * gives up on a run the server is still going to admit: the trigger engine
+ * allows eight attempts backing off from a second and doubling, which is about
+ * two minutes of retries in the worst case. Roughly five minutes of probes
+ * covers that window twice over in eleven requests.
+ *
+ * It does not cover everything, deliberately. A dispatch refused with a long
+ * `Retry-After` can be re-driven hours later, and holding a watch open for that
+ * is worse than what already happens without one — the chat arrives with the
+ * next list refetch, which is what an automatic occurrence relies on anyway.
  */
-const ADMISSION_DELAYS_MS = [750, 1_500, 3_000, 6_000, 8_000, 8_000, 8_000, 8_000];
+const ADMISSION_DELAYS_MS = [
+  750, 1_500, 3_000, 6_000, 10_000, 15_000, 30_000, 45_000, 60_000, 60_000, 60_000,
+];
+
+/**
+ * Whether a failed probe has answered the question for good. A 404 has not: the
+ * run has not started yet, which is the whole reason for waiting. Neither has a
+ * 5xx or a request that never got a response — those are the probe failing, not
+ * the run, and the durable delivery is still free to admit. A different 4xx is a
+ * real answer: waiting longer will not make this client able to read that
+ * conversation.
+ */
+const isTerminalProbeFailure = (error: unknown): boolean => {
+  const status = getResponseStatus(error);
+  return status != null && status >= 400 && status < 500 && status !== 404;
+};
 
 const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -90,9 +111,8 @@ const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(
  * admission probe: a 200 means the chat is listable now, and carries the server's
  * own row rather than a guess assembled from the client's cached schedule.
  *
- * A 404 is the run not having started yet; any other failure is not, and ends the
- * watch rather than spending the budget on a request that is not going to change
- * its answer.
+ * A probe that fails keeps the watch alive unless the failure settles the matter;
+ * see {@link isTerminalProbeFailure}.
  *
  * Deliberately detached from the caller: the sidebar has to gain the chat whether
  * or not the panel the run was started from is still mounted. Bounded, and it
@@ -106,10 +126,10 @@ async function trackStartedRun(queryClient: QueryClient, conversationId: string)
     try {
       conversation = await dataService.getConversationById(conversationId);
     } catch (error) {
-      if (isNotFoundError(error)) {
-        continue;
+      if (isTerminalProbeFailure(error)) {
+        return;
       }
-      return;
+      continue;
     }
     /** Warms the key the chat route reads, so opening the row it just added does
      *  not have to ask again. Absent-only: anything already cached under this id

--- a/client/src/data-provider/Schedules/mutations.ts
+++ b/client/src/data-provider/Schedules/mutations.ts
@@ -106,7 +106,11 @@ const isTerminalProbeFailure = (error: unknown): boolean => {
 const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 /** Who this cache belongs to. Both sign-in and sign-out empty it wholesale, so a
- *  watch outliving either has no business writing to whatever replaced it. */
+ *  watch outliving either has no business writing to whatever replaced it.
+ *
+ *  `undefined` is two different things, and the difference decides the fence: not
+ *  loaded yet, or emptied. Which one it is depends on whether an owner has been
+ *  seen before — see {@link trackStartedRun}. */
 const cacheOwner = (queryClient: QueryClient): string | undefined =>
   queryClient.getQueryData<TUser>([QueryKeys.user])?.id;
 
@@ -130,13 +134,20 @@ const cacheOwner = (queryClient: QueryClient): string | undefined =>
  * every cache exactly as it found it.
  */
 async function trackStartedRun(queryClient: QueryClient, conversationId: string): Promise<void> {
-  const startedFor = cacheOwner(queryClient);
+  /** Bound late when the user query has not resolved yet. Run-now answering 200 is
+   *  itself proof that a session existed at the click, so an empty entry then is a
+   *  cache still loading rather than nobody signed in — reading it as a session
+   *  change would abandon the watch the moment the account's own query arrived. */
+  let startedFor = cacheOwner(queryClient);
   for (const delay of ADMISSION_DELAYS_MS) {
     await wait(delay);
     /** Minutes can pass in here, and signing out or signing in as someone else
      *  empties the cache in between. Re-check before probing and again before
      *  writing, or a late response files one user's chat in another's sidebar. */
-    if (cacheOwner(queryClient) !== startedFor) {
+    const owner = cacheOwner(queryClient);
+    if (startedFor === undefined) {
+      startedFor = owner;
+    } else if (owner !== startedFor) {
       return;
     }
     let conversation: TConversation;
@@ -148,7 +159,7 @@ async function trackStartedRun(queryClient: QueryClient, conversationId: string)
       }
       continue;
     }
-    if (cacheOwner(queryClient) !== startedFor) {
+    if (startedFor !== undefined && cacheOwner(queryClient) !== startedFor) {
       return;
     }
     /** The conversation route serves an archived chat; the list query filters one

--- a/client/src/data-provider/Schedules/mutations.ts
+++ b/client/src/data-provider/Schedules/mutations.ts
@@ -2,16 +2,13 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { QueryKeys, MutationKeys, dataService } from 'librechat-data-provider';
 import type {
-  TUser,
   TSchedule,
-  TConversation,
   TCreateSchedule,
   TUpdateSchedule,
   TScheduleRunNowResponse,
 } from 'librechat-data-provider';
-import type { QueryClient, UseMutationOptions } from '@tanstack/react-query';
-import { extendActiveJobsGrace, queueTitleGeneration } from '~/data-provider/SSE/queries';
-import { upsertConvoInAllQueries, getResponseStatus } from '~/utils';
+import type { UseMutationOptions } from '@tanstack/react-query';
+import { trackScheduledRun } from './admission';
 
 export const useCreateScheduleMutation = (
   options?: UseMutationOptions<TSchedule, Error, TCreateSchedule>,
@@ -68,135 +65,6 @@ export const useDeleteScheduleMutation = (
   );
 };
 
-/**
- * Waits before each probe, so the first is not spent on a conversation that
- * cannot exist yet. Admission is normally a second or two, but a dispatch that
- * keeps failing is retried, and the budget has to outlast that or the watch
- * gives up on a run the server is still going to admit: the trigger engine
- * allows eight attempts backing off from a second and doubling, which is about
- * two minutes of retries in the worst case. Roughly five minutes of probes
- * covers that window twice over in eleven requests.
- *
- * It does not cover everything, deliberately. A dispatch refused with a long
- * `Retry-After` can be re-driven hours later, and holding a watch open for that
- * is worse than what already happens without one — the chat arrives with the
- * next list refetch, which is what an automatic occurrence relies on anyway.
- */
-const ADMISSION_DELAYS_MS = [
-  750, 1_500, 3_000, 6_000, 10_000, 15_000, 30_000, 45_000, 60_000, 60_000, 60_000,
-];
-
-/** 404 is the run not having started yet, which is the whole reason for waiting.
- *  408 and 429 ask to be retried by definition, and a proxy in front of the app
- *  can raise either without the run being involved at all. */
-const RETRYABLE_CLIENT_STATUS = new Set([404, 408, 429]);
-
-/**
- * Whether a failed probe has answered the question for good. A 5xx, or a request
- * that never got a response, has not — those are the probe failing rather than the
- * run, and the durable delivery is still free to admit afterwards. Only a client
- * error that is not asking to be retried settles it: waiting longer will not make
- * this client able to read that conversation.
- */
-const isTerminalProbeFailure = (error: unknown): boolean => {
-  const status = getResponseStatus(error);
-  return status != null && status >= 400 && status < 500 && !RETRYABLE_CLIENT_STATUS.has(status);
-};
-
-const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
-
-/** Who this cache belongs to. Both sign-in and sign-out empty it wholesale, so a
- *  watch outliving either has no business writing to whatever replaced it.
- *
- *  `undefined` is two different things, and the difference decides the fence: not
- *  loaded yet, or emptied. Which one it is depends on whether an owner has been
- *  seen before — see {@link trackStartedRun}. */
-const cacheOwner = (queryClient: QueryClient): string | undefined =>
-  queryClient.getQueryData<TUser>([QueryKeys.user])?.id;
-
-/**
- * Puts a manual run's chat in the sidebar once the server actually has it.
- *
- * Run-now answers as soon as the trigger delivery is durable, and the generation
- * that writes the conversation starts after that — so at the moment the response
- * lands there is nothing to refetch, which is why the click appeared to do
- * nothing at all. The conversation route answers 404 until that write commits and
- * applies the same visibility rule the list query does, which makes it an exact
- * admission probe: a 200 means the chat is listable now, and carries the server's
- * own row rather than a guess assembled from the client's cached schedule.
- *
- * A probe that fails keeps the watch alive unless the failure settles the matter;
- * see {@link isTerminalProbeFailure}.
- *
- * Deliberately detached from the caller: the sidebar has to gain the chat whether
- * or not the panel the run was started from is still mounted. Bounded, and it
- * writes only what the server returned — a delivery that never admits leaves
- * every cache exactly as it found it.
- */
-async function trackStartedRun(queryClient: QueryClient, conversationId: string): Promise<void> {
-  /** Bound late when the user query has not resolved yet. Run-now answering 200 is
-   *  itself proof that a session existed at the click, so an empty entry then is a
-   *  cache still loading rather than nobody signed in — reading it as a session
-   *  change would abandon the watch the moment the account's own query arrived. */
-  let startedFor = cacheOwner(queryClient);
-  for (const delay of ADMISSION_DELAYS_MS) {
-    await wait(delay);
-    /** Minutes can pass in here, and signing out or signing in as someone else
-     *  empties the cache in between. Re-check before probing and again before
-     *  writing, or a late response files one user's chat in another's sidebar. */
-    const owner = cacheOwner(queryClient);
-    if (startedFor === undefined) {
-      startedFor = owner;
-    } else if (owner !== startedFor) {
-      return;
-    }
-    let conversation: TConversation;
-    try {
-      conversation = await dataService.getConversationById(conversationId);
-    } catch (error) {
-      if (isTerminalProbeFailure(error)) {
-        return;
-      }
-      continue;
-    }
-    /** An owner that is still unknown cannot be compared, so it cannot be cleared
-     *  either — "loading" and "changed hands" are the same reading. Refuse the
-     *  write rather than risk seeding one account's chat into another's sidebar;
-     *  a signed-in session is what every caller of this actually has. */
-    if (cacheOwner(queryClient) !== startedFor || startedFor === undefined) {
-      return;
-    }
-    /** The conversation route serves an archived chat; the list query filters one
-     *  out. Another tab archiving this run between its first write and this probe
-     *  would otherwise put a row in the sidebar that no refetch agrees belongs
-     *  there — and the archive was deliberate, so there is nothing else to do. */
-    if (conversation.isArchived === true) {
-      return;
-    }
-    /** Warms the key the chat route reads, so opening the row it just added does
-     *  not have to ask again. Absent-only: anything already cached under this id
-     *  was put there by the chat itself and knows more than one list read does. */
-    queryClient.setQueryData<TConversation>(
-      [QueryKeys.conversation, conversationId],
-      (current) => current ?? conversation,
-    );
-    upsertConvoInAllQueries(queryClient, conversation);
-    /** A generation is live by definition here. The active-job list is the only
-     *  thing that can mark the row as running, and it stops polling while nothing
-     *  is listed — so re-arm it at admission, which is when a job exists, rather
-     *  than at the click, which is before one does. */
-    extendActiveJobsGrace();
-    queryClient.invalidateQueries([QueryKeys.activeJobs]);
-    /** A conversation admitted mid-run has not been titled yet, so the row lands
-     *  as "New Chat". The foreground paths hand that to the title queue, which
-     *  owns the timing the server was configured for; a scheduled run has no
-     *  foreground path, so hand it over here rather than leaving the placeholder
-     *  until an unrelated refetch. */
-    queueTitleGeneration(conversationId);
-    return;
-  }
-}
-
 export const useRunScheduleNowMutation = (
   options?: UseMutationOptions<TScheduleRunNowResponse, Error, string>,
 ) => {
@@ -207,9 +75,7 @@ export const useRunScheduleNowMutation = (
     {
       ...options,
       onSuccess: (data, ...rest) => {
-        if (data.conversationId) {
-          void trackStartedRun(queryClient, data.conversationId);
-        }
+        void trackScheduledRun(queryClient, data.conversationId);
         options?.onSuccess?.(data, ...rest);
       },
       // Invalidate on SETTLED, not just success: several run-now 409 paths are still

--- a/client/src/data-provider/__tests__/scheduleRunNow.test.tsx
+++ b/client/src/data-provider/__tests__/scheduleRunNow.test.tsx
@@ -10,6 +10,7 @@ import {
   resetActiveJobsGrace,
   getActiveJobsRefetchInterval,
 } from '../SSE/queries';
+import * as sseQueries from '../SSE/queries';
 import { useRunScheduleNowMutation } from '../Schedules/mutations';
 
 const mockRunScheduleNow = jest.fn<Promise<TScheduleRunNowResponse>, [string]>();
@@ -76,6 +77,10 @@ const createWrapper = (queryClient: QueryClient) =>
   function Wrapper({ children }: { children: ReactNode }) {
     return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
   };
+
+const signIn = (queryClient: QueryClient, id: string) => {
+  queryClient.setQueryData([QueryKeys.user], { id });
+};
 
 const seedList = (queryClient: QueryClient, params?: ListParams) => {
   queryClient.setQueryData<ConversationPages>(
@@ -221,6 +226,46 @@ describe('run-now conversation tracking', () => {
     await settleAdmission(6_000);
 
     expect(readList(queryClient)[0].conversationId).toBe('run-convo-1');
+    queryClient.clear();
+  });
+
+  it('hands the admitted chat to the title queue, since it lands as "New Chat"', async () => {
+    const queryClient = createQueryClient();
+    signIn(queryClient, 'user-a');
+    seedList(queryClient);
+    mockGetConversationById.mockResolvedValue(serverConversation());
+    /** A spy that calls through: the queue is module state with no reader of its
+     *  own, and the point is that the tracker joins it at all. */
+    const queueTitle = jest.spyOn(sseQueries, 'queueTitleGeneration');
+
+    await runNow(queryClient);
+    await settleAdmission();
+
+    expect(queueTitle).toHaveBeenCalledWith('run-convo-1');
+    queueTitle.mockRestore();
+    queryClient.clear();
+  });
+
+  it('does not file the chat into a cache that changed hands mid-watch', async () => {
+    const queryClient = createQueryClient();
+    signIn(queryClient, 'user-a');
+    seedList(queryClient);
+
+    /** The switch lands while the probe is IN FLIGHT, which is the window that
+     *  matters: sign-out and sign-in both empty the cache, and the response then
+     *  arrives holding a chat that belongs to whoever was here before. */
+    mockGetConversationById.mockImplementation(async () => {
+      queryClient.removeQueries([QueryKeys.user]);
+      seedList(queryClient);
+      signIn(queryClient, 'user-b');
+      return serverConversation();
+    });
+
+    await runNow(queryClient);
+    await settleAdmission();
+
+    expect(readList(queryClient).map((convo) => convo.conversationId)).toEqual(['existing-convo']);
+    expect(queryClient.getQueryData([QueryKeys.conversation, 'run-convo-1'])).toBeUndefined();
     queryClient.clear();
   });
 

--- a/client/src/data-provider/__tests__/scheduleRunNow.test.tsx
+++ b/client/src/data-provider/__tests__/scheduleRunNow.test.tsx
@@ -38,8 +38,8 @@ type ListParams = { projectId?: string };
  *  admission opens — a test asserting that window must not advance the clock
  *  beyond it and read its own fast-forward as the poll having lapsed. */
 const PAST_ADMISSION_MS = 3_000;
-/** The whole probe budget, so a test can run the watch to exhaustion. */
-const ADMISSION_BUDGET_MS = 60_000;
+/** Past the whole probe budget, so a test can run the watch to exhaustion. */
+const ADMISSION_BUDGET_MS = 600_000;
 
 /** `isNotFoundError` reads the status off an axios error, so the marker matters:
  *  a bare `{ response: { status } }` is not one, and the watch would read a 404 as
@@ -62,7 +62,11 @@ const serverConversation = (chatProjectId?: string): TConversation =>
 function createQueryClient() {
   return new QueryClient({
     defaultOptions: {
-      queries: { retry: false },
+      /** These tests run the fake clock past the whole probe budget, which is
+       *  longer than the default five-minute cacheTime — without this the list
+       *  query is garbage collected mid-test and its emptiness reads as the
+       *  watch having removed something. */
+      queries: { retry: false, cacheTime: Infinity },
       mutations: { retry: false },
     },
   });
@@ -205,7 +209,22 @@ describe('run-now conversation tracking', () => {
     queryClient.clear();
   });
 
-  it('stops on a failure that is not the conversation being absent', async () => {
+  it('keeps waiting through a probe that fails for its own reasons', async () => {
+    const queryClient = createQueryClient();
+    seedList(queryClient);
+    mockGetConversationById
+      .mockRejectedValueOnce(httpError(502, 'Bad Gateway'))
+      .mockRejectedValueOnce(new Error('Network Error'))
+      .mockResolvedValue(serverConversation());
+
+    await runNow(queryClient);
+    await settleAdmission(6_000);
+
+    expect(readList(queryClient)[0].conversationId).toBe('run-convo-1');
+    queryClient.clear();
+  });
+
+  it('stops on a failure that settles the matter', async () => {
     const queryClient = createQueryClient();
     seedList(queryClient);
     mockGetConversationById.mockRejectedValue(httpError(403, 'Forbidden'));
@@ -215,6 +234,22 @@ describe('run-now conversation tracking', () => {
 
     expect(mockGetConversationById).toHaveBeenCalledTimes(1);
     expect(readList(queryClient).map((convo) => convo.conversationId)).toEqual(['existing-convo']);
+    queryClient.clear();
+  });
+
+  it("outlasts the trigger engine's own retry window", async () => {
+    const queryClient = createQueryClient();
+    seedList(queryClient);
+    /** The engine allows eight attempts backing off from a second and doubling,
+     *  so a dispatch that keeps failing can admit around two minutes in. */
+    mockGetConversationById.mockRejectedValue(httpError(404, 'Not Found'));
+
+    await runNow(queryClient);
+    await settleAdmission(150_000);
+    mockGetConversationById.mockResolvedValue(serverConversation());
+    await settleAdmission(120_000);
+
+    expect(readList(queryClient)[0].conversationId).toBe('run-convo-1');
     queryClient.clear();
   });
 });

--- a/client/src/data-provider/__tests__/scheduleRunNow.test.tsx
+++ b/client/src/data-provider/__tests__/scheduleRunNow.test.tsx
@@ -49,6 +49,9 @@ const ADMISSION_BUDGET_MS = 600_000;
 const httpError = (status: number, message: string) =>
   Object.assign(new Error(message), { isAxiosError: true, response: { status } });
 
+const archivedConversation = (): TConversation =>
+  ({ ...serverConversation(), isArchived: true }) as TConversation;
+
 const serverConversation = (chatProjectId?: string): TConversation =>
   ({
     conversationId: 'run-convo-1',
@@ -119,7 +122,12 @@ const settleAdmission = async (ms = PAST_ADMISSION_MS) => {
 
 describe('run-now conversation tracking', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    /** `resetAllMocks`, not `clearAllMocks`: a test whose `mockRejectedValueOnce`
+     *  queue is not fully drained — which is what a failing retry assertion looks
+     *  like — leaves the remainder queued for the next test, where it silently
+     *  answers the first probe. That coupling let an assertion here pass against a
+     *  missing guard. */
+    jest.resetAllMocks();
     jest.useFakeTimers();
     resetActiveJobsGrace();
     mockRunScheduleNow.mockResolvedValue({
@@ -266,6 +274,35 @@ describe('run-now conversation tracking', () => {
 
     expect(readList(queryClient).map((convo) => convo.conversationId)).toEqual(['existing-convo']);
     expect(queryClient.getQueryData([QueryKeys.conversation, 'run-convo-1'])).toBeUndefined();
+    queryClient.clear();
+  });
+
+  it('keeps waiting through a client error that asks to be retried', async () => {
+    const queryClient = createQueryClient();
+    signIn(queryClient, 'user-a');
+    seedList(queryClient);
+    mockGetConversationById
+      .mockRejectedValueOnce(httpError(429, 'Too Many Requests'))
+      .mockRejectedValueOnce(httpError(408, 'Request Timeout'))
+      .mockResolvedValue(serverConversation());
+
+    await runNow(queryClient);
+    await settleAdmission(6_000);
+
+    expect(readList(queryClient)[0].conversationId).toBe('run-convo-1');
+    queryClient.clear();
+  });
+
+  it('does not put an archived chat in the active sidebar', async () => {
+    const queryClient = createQueryClient();
+    signIn(queryClient, 'user-a');
+    seedList(queryClient);
+    mockGetConversationById.mockResolvedValue(archivedConversation());
+
+    await runNow(queryClient);
+    await settleAdmission();
+
+    expect(readList(queryClient).map((convo) => convo.conversationId)).toEqual(['existing-convo']);
     queryClient.clear();
   });
 

--- a/client/src/data-provider/__tests__/scheduleRunNow.test.tsx
+++ b/client/src/data-provider/__tests__/scheduleRunNow.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { QueryKeys } from 'librechat-data-provider';
 import { act, renderHook } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import type { TConversation, TSchedule, TSchedulesResponse } from 'librechat-data-provider';
+import type { TConversation, TScheduleRunNowResponse } from 'librechat-data-provider';
 import type { InfiniteData } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 import {
@@ -12,7 +12,8 @@ import {
 } from '../SSE/queries';
 import { useRunScheduleNowMutation } from '../Schedules/mutations';
 
-const mockRunScheduleNow = jest.fn();
+const mockRunScheduleNow = jest.fn<Promise<TScheduleRunNowResponse>, [string]>();
+const mockGetConversationById = jest.fn<Promise<TConversation>, [string]>();
 
 jest.mock('librechat-data-provider', () => {
   const actual = jest.requireActual('librechat-data-provider');
@@ -20,7 +21,8 @@ jest.mock('librechat-data-provider', () => {
     ...actual,
     dataService: {
       ...actual.dataService,
-      runScheduleNow: (...args: unknown[]) => mockRunScheduleNow(...args),
+      runScheduleNow: (id: string) => mockRunScheduleNow(id),
+      getConversationById: (id: string) => mockGetConversationById(id),
     },
   };
 });
@@ -30,21 +32,32 @@ type ConversationPages = InfiniteData<{
   nextCursor: string | null;
 }>;
 
-const schedule: TSchedule = {
-  id: 'schedule-1',
-  user: 'user-1',
-  name: 'Morning briefing',
-  prompt: 'Summarize overnight activity',
-  agent_id: 'agent-1',
-  cadence: { frequency: 'daily', hour: 9, minute: 0 },
-  timezone: 'UTC',
-  target: 'new',
-  enabled: true,
-  runCount: 0,
-  failureCount: 0,
-  createdAt: '2026-09-01T00:00:00.000Z',
-  updatedAt: '2026-09-01T00:00:00.000Z',
-};
+type ListParams = { projectId?: string };
+
+/** Past the first two probes, and still inside the active-job grace window that
+ *  admission opens — a test asserting that window must not advance the clock
+ *  beyond it and read its own fast-forward as the poll having lapsed. */
+const PAST_ADMISSION_MS = 3_000;
+/** The whole probe budget, so a test can run the watch to exhaustion. */
+const ADMISSION_BUDGET_MS = 60_000;
+
+/** `isNotFoundError` reads the status off an axios error, so the marker matters:
+ *  a bare `{ response: { status } }` is not one, and the watch would read a 404 as
+ *  an unrelated failure and stop — passing the never-admits tests for the wrong
+ *  reason while failing the ones that retry. */
+const httpError = (status: number, message: string) =>
+  Object.assign(new Error(message), { isAxiosError: true, response: { status } });
+
+const serverConversation = (chatProjectId?: string): TConversation =>
+  ({
+    conversationId: 'run-convo-1',
+    title: 'Overnight activity summary',
+    endpoint: 'agents',
+    agent_id: 'agent-1',
+    ...(chatProjectId != null ? { chatProjectId } : {}),
+    createdAt: '2026-09-04T09:00:01.000Z',
+    updatedAt: '2026-09-04T09:00:01.000Z',
+  }) as TConversation;
 
 function createQueryClient() {
   return new QueryClient({
@@ -60,19 +73,7 @@ const createWrapper = (queryClient: QueryClient) =>
     return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
   };
 
-const seedSchedules = (queryClient: QueryClient, overrides?: Partial<TSchedule>, pin?: string) => {
-  queryClient.setQueryData<TSchedulesResponse>([QueryKeys.schedules], {
-    schedules: [{ ...schedule, ...overrides }],
-    limits: {
-      maxPerUser: 10,
-      minIntervalMinutes: 15,
-      requireProject: false,
-      ...(pin != null ? { projectId: pin } : {}),
-    },
-  });
-};
-
-const seedList = (queryClient: QueryClient, params?: Record<string, unknown>) => {
+const seedList = (queryClient: QueryClient, params?: ListParams) => {
   queryClient.setQueryData<ConversationPages>(
     params ? [QueryKeys.allConversations, params] : [QueryKeys.allConversations],
     {
@@ -87,7 +88,7 @@ const seedList = (queryClient: QueryClient, params?: Record<string, unknown>) =>
   );
 };
 
-const readList = (queryClient: QueryClient, params?: Record<string, unknown>) =>
+const readList = (queryClient: QueryClient, params?: ListParams) =>
   queryClient.getQueryData<ConversationPages>(
     params ? [QueryKeys.allConversations, params] : [QueryKeys.allConversations],
   )?.pages[0].conversations ?? [];
@@ -101,9 +102,16 @@ const runNow = async (queryClient: QueryClient) => {
   });
 };
 
-describe('run-now cache updates', () => {
+const settleAdmission = async (ms = PAST_ADMISSION_MS) => {
+  await act(async () => {
+    await jest.advanceTimersByTimeAsync(ms);
+  });
+};
+
+describe('run-now conversation tracking', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useFakeTimers();
     resetActiveJobsGrace();
     mockRunScheduleNow.mockResolvedValue({
       scheduleId: 'schedule-1',
@@ -112,72 +120,100 @@ describe('run-now cache updates', () => {
     });
   });
 
-  it('puts the started run at the head of the sidebar list', async () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('adds the run to the sidebar once the server has the conversation', async () => {
     const queryClient = createQueryClient();
-    seedSchedules(queryClient);
     seedList(queryClient);
+    mockGetConversationById
+      .mockRejectedValueOnce(httpError(404, 'Not Found'))
+      .mockResolvedValue(serverConversation());
 
     await runNow(queryClient);
+    expect(readList(queryClient).map((convo) => convo.conversationId)).toEqual(['existing-convo']);
+
+    await settleAdmission();
 
     const [first, ...rest] = readList(queryClient);
     expect(first.conversationId).toBe('run-convo-1');
-    expect(first.title).toBe('Morning briefing');
-    expect(first.endpoint).toBe('agents');
-    expect(first.agent_id).toBe('agent-1');
+    expect(first.title).toBe('Overnight activity summary');
     expect(rest.map((convo) => convo.conversationId)).toEqual(['existing-convo']);
     queryClient.clear();
   });
 
-  it('files the row under the project the run will use, and no other', async () => {
+  it('files the row by the server row, not by a client snapshot of the schedule', async () => {
     const queryClient = createQueryClient();
-    seedSchedules(queryClient, { chatProjectId: 'project-a' });
-    seedList(queryClient, { projectId: 'project-a' });
-    seedList(queryClient, { projectId: 'project-b' });
+    seedList(queryClient, { projectId: 'project-server' });
+    seedList(queryClient, { projectId: 'project-stale' });
+    mockGetConversationById.mockResolvedValue(serverConversation('project-server'));
 
     await runNow(queryClient);
+    await settleAdmission();
 
-    expect(readList(queryClient, { projectId: 'project-a' })[0].conversationId).toBe('run-convo-1');
-    expect(readList(queryClient, { projectId: 'project-b' })[0].conversationId).toBe(
-      'existing-convo',
-    );
-    queryClient.clear();
-  });
-
-  it('follows the operator pin over the schedule’s stored project', async () => {
-    const queryClient = createQueryClient();
-    seedSchedules(queryClient, { chatProjectId: 'project-a' }, 'project-pinned');
-    seedList(queryClient, { projectId: 'project-a' });
-    seedList(queryClient, { projectId: 'project-pinned' });
-
-    await runNow(queryClient);
-
-    expect(readList(queryClient, { projectId: 'project-pinned' })[0].conversationId).toBe(
+    expect(readList(queryClient, { projectId: 'project-server' })[0].conversationId).toBe(
       'run-convo-1',
     );
-    expect(readList(queryClient, { projectId: 'project-a' })[0].conversationId).toBe(
+    expect(readList(queryClient, { projectId: 'project-stale' })[0].conversationId).toBe(
       'existing-convo',
     );
     queryClient.clear();
   });
 
-  it('re-arms the active-job poll so the seeded row can show as running', async () => {
+  it('warms the chat route cache so the new row opens without a 404', async () => {
     const queryClient = createQueryClient();
-    seedSchedules(queryClient);
     seedList(queryClient);
-    expect(getActiveJobsRefetchInterval({ activeJobIds: [] })).toBe(false);
+    mockGetConversationById.mockResolvedValue(serverConversation());
 
     await runNow(queryClient);
+    await settleAdmission();
+
+    expect(
+      queryClient.getQueryData<TConversation>([QueryKeys.conversation, 'run-convo-1'])?.title,
+    ).toBe('Overnight activity summary');
+    queryClient.clear();
+  });
+
+  it('re-arms the active-job poll only once a generation is known to exist', async () => {
+    const queryClient = createQueryClient();
+    seedList(queryClient);
+    mockGetConversationById
+      .mockRejectedValueOnce(httpError(404, 'Not Found'))
+      .mockResolvedValue(serverConversation());
+
+    await runNow(queryClient);
+    expect(getActiveJobsRefetchInterval({ activeJobIds: [] })).toBe(false);
+
+    await settleAdmission();
 
     expect(getActiveJobsRefetchInterval({ activeJobIds: [] })).toBe(ACTIVE_JOBS_POLL_MS);
     queryClient.clear();
   });
 
-  it('leaves the list alone when the schedule is not cached', async () => {
+  it('leaves every cache untouched when the delivery never admits', async () => {
     const queryClient = createQueryClient();
     seedList(queryClient);
+    mockGetConversationById.mockRejectedValue(httpError(404, 'Not Found'));
 
     await runNow(queryClient);
+    await settleAdmission(ADMISSION_BUDGET_MS);
 
+    expect(readList(queryClient).map((convo) => convo.conversationId)).toEqual(['existing-convo']);
+    expect(queryClient.getQueryData([QueryKeys.conversation, 'run-convo-1'])).toBeUndefined();
+    expect(getActiveJobsRefetchInterval({ activeJobIds: [] })).toBe(false);
+    queryClient.clear();
+  });
+
+  it('stops on a failure that is not the conversation being absent', async () => {
+    const queryClient = createQueryClient();
+    seedList(queryClient);
+    mockGetConversationById.mockRejectedValue(httpError(403, 'Forbidden'));
+
+    await runNow(queryClient);
+    await settleAdmission(ADMISSION_BUDGET_MS);
+
+    expect(mockGetConversationById).toHaveBeenCalledTimes(1);
     expect(readList(queryClient).map((convo) => convo.conversationId)).toEqual(['existing-convo']);
     queryClient.clear();
   });

--- a/client/src/data-provider/__tests__/scheduleRunNow.test.tsx
+++ b/client/src/data-provider/__tests__/scheduleRunNow.test.tsx
@@ -10,8 +10,8 @@ import {
   resetActiveJobsGrace,
   getActiveJobsRefetchInterval,
 } from '../SSE/queries';
-import * as sseQueries from '../SSE/queries';
 import { useRunScheduleNowMutation } from '../Schedules/mutations';
+import * as sseQueries from '../SSE/queries';
 
 const mockRunScheduleNow = jest.fn<Promise<TScheduleRunNowResponse>, [string]>();
 const mockGetConversationById = jest.fn<Promise<TConversation>, [string]>();
@@ -303,6 +303,21 @@ describe('run-now conversation tracking', () => {
     await settleAdmission();
 
     expect(readList(queryClient).map((convo) => convo.conversationId)).toEqual(['existing-convo']);
+    queryClient.clear();
+  });
+
+  it('still tracks a run started before the user query resolved', async () => {
+    const queryClient = createQueryClient();
+    seedList(queryClient);
+    mockGetConversationById.mockResolvedValue(serverConversation());
+
+    /** No user in cache at the click; run-now answering 200 already proved there
+     *  is a session, so its arrival is a load, not a change of hands. */
+    await runNow(queryClient);
+    signIn(queryClient, 'user-a');
+    await settleAdmission();
+
+    expect(readList(queryClient)[0].conversationId).toBe('run-convo-1');
     queryClient.clear();
   });
 

--- a/client/src/data-provider/__tests__/scheduleRunNow.test.tsx
+++ b/client/src/data-provider/__tests__/scheduleRunNow.test.tsx
@@ -143,6 +143,7 @@ describe('run-now conversation tracking', () => {
 
   it('adds the run to the sidebar once the server has the conversation', async () => {
     const queryClient = createQueryClient();
+    signIn(queryClient, 'user-a');
     seedList(queryClient);
     mockGetConversationById
       .mockRejectedValueOnce(httpError(404, 'Not Found'))
@@ -162,6 +163,7 @@ describe('run-now conversation tracking', () => {
 
   it('files the row by the server row, not by a client snapshot of the schedule', async () => {
     const queryClient = createQueryClient();
+    signIn(queryClient, 'user-a');
     seedList(queryClient, { projectId: 'project-server' });
     seedList(queryClient, { projectId: 'project-stale' });
     mockGetConversationById.mockResolvedValue(serverConversation('project-server'));
@@ -180,6 +182,7 @@ describe('run-now conversation tracking', () => {
 
   it('warms the chat route cache so the new row opens without a 404', async () => {
     const queryClient = createQueryClient();
+    signIn(queryClient, 'user-a');
     seedList(queryClient);
     mockGetConversationById.mockResolvedValue(serverConversation());
 
@@ -194,6 +197,7 @@ describe('run-now conversation tracking', () => {
 
   it('re-arms the active-job poll only once a generation is known to exist', async () => {
     const queryClient = createQueryClient();
+    signIn(queryClient, 'user-a');
     seedList(queryClient);
     mockGetConversationById
       .mockRejectedValueOnce(httpError(404, 'Not Found'))
@@ -210,6 +214,7 @@ describe('run-now conversation tracking', () => {
 
   it('leaves every cache untouched when the delivery never admits', async () => {
     const queryClient = createQueryClient();
+    signIn(queryClient, 'user-a');
     seedList(queryClient);
     mockGetConversationById.mockRejectedValue(httpError(404, 'Not Found'));
 
@@ -224,6 +229,7 @@ describe('run-now conversation tracking', () => {
 
   it('keeps waiting through a probe that fails for its own reasons', async () => {
     const queryClient = createQueryClient();
+    signIn(queryClient, 'user-a');
     seedList(queryClient);
     mockGetConversationById
       .mockRejectedValueOnce(httpError(502, 'Bad Gateway'))
@@ -311,8 +317,9 @@ describe('run-now conversation tracking', () => {
     seedList(queryClient);
     mockGetConversationById.mockResolvedValue(serverConversation());
 
-    /** No user in cache at the click; run-now answering 200 already proved there
-     *  is a session, so its arrival is a load, not a change of hands. */
+    /** Deliberately signed out of the CACHE at the click, not signed in later:
+     *  run-now answering 200 already proved a session exists, so the query
+     *  resolving is a load rather than a change of hands. */
     await runNow(queryClient);
     signIn(queryClient, 'user-a');
     await settleAdmission();
@@ -321,8 +328,28 @@ describe('run-now conversation tracking', () => {
     queryClient.clear();
   });
 
+  it('refuses the write when the cache is claimed while the owner is still unknown', async () => {
+    const queryClient = createQueryClient();
+    seedList(queryClient);
+    /** Never known at the click, and someone else's session arrives while the
+     *  probe is in flight — "loading" and "changed hands" read identically here,
+     *  so the only safe answer is to write nothing. */
+    mockGetConversationById.mockImplementation(async () => {
+      signIn(queryClient, 'user-b');
+      return serverConversation();
+    });
+
+    await runNow(queryClient);
+    await settleAdmission();
+
+    expect(readList(queryClient).map((convo) => convo.conversationId)).toEqual(['existing-convo']);
+    expect(queryClient.getQueryData([QueryKeys.conversation, 'run-convo-1'])).toBeUndefined();
+    queryClient.clear();
+  });
+
   it('stops on a failure that settles the matter', async () => {
     const queryClient = createQueryClient();
+    signIn(queryClient, 'user-a');
     seedList(queryClient);
     mockGetConversationById.mockRejectedValue(httpError(403, 'Forbidden'));
 
@@ -336,6 +363,7 @@ describe('run-now conversation tracking', () => {
 
   it("outlasts the trigger engine's own retry window", async () => {
     const queryClient = createQueryClient();
+    signIn(queryClient, 'user-a');
     seedList(queryClient);
     /** The engine allows eight attempts backing off from a second and doubling,
      *  so a dispatch that keeps failing can admit around two minutes in. */

--- a/client/src/data-provider/__tests__/scheduleRunNow.test.tsx
+++ b/client/src/data-provider/__tests__/scheduleRunNow.test.tsx
@@ -1,0 +1,184 @@
+import React from 'react';
+import { QueryKeys } from 'librechat-data-provider';
+import { act, renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { TConversation, TSchedule, TSchedulesResponse } from 'librechat-data-provider';
+import type { InfiniteData } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import {
+  ACTIVE_JOBS_POLL_MS,
+  resetActiveJobsGrace,
+  getActiveJobsRefetchInterval,
+} from '../SSE/queries';
+import { useRunScheduleNowMutation } from '../Schedules/mutations';
+
+const mockRunScheduleNow = jest.fn();
+
+jest.mock('librechat-data-provider', () => {
+  const actual = jest.requireActual('librechat-data-provider');
+  return {
+    ...actual,
+    dataService: {
+      ...actual.dataService,
+      runScheduleNow: (...args: unknown[]) => mockRunScheduleNow(...args),
+    },
+  };
+});
+
+type ConversationPages = InfiniteData<{
+  conversations: TConversation[];
+  nextCursor: string | null;
+}>;
+
+const schedule: TSchedule = {
+  id: 'schedule-1',
+  user: 'user-1',
+  name: 'Morning briefing',
+  prompt: 'Summarize overnight activity',
+  agent_id: 'agent-1',
+  cadence: { frequency: 'daily', hour: 9, minute: 0 },
+  timezone: 'UTC',
+  target: 'new',
+  enabled: true,
+  runCount: 0,
+  failureCount: 0,
+  createdAt: '2026-09-01T00:00:00.000Z',
+  updatedAt: '2026-09-01T00:00:00.000Z',
+};
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+const createWrapper = (queryClient: QueryClient) =>
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+
+const seedSchedules = (queryClient: QueryClient, overrides?: Partial<TSchedule>, pin?: string) => {
+  queryClient.setQueryData<TSchedulesResponse>([QueryKeys.schedules], {
+    schedules: [{ ...schedule, ...overrides }],
+    limits: {
+      maxPerUser: 10,
+      minIntervalMinutes: 15,
+      requireProject: false,
+      ...(pin != null ? { projectId: pin } : {}),
+    },
+  });
+};
+
+const seedList = (queryClient: QueryClient, params?: Record<string, unknown>) => {
+  queryClient.setQueryData<ConversationPages>(
+    params ? [QueryKeys.allConversations, params] : [QueryKeys.allConversations],
+    {
+      pages: [
+        {
+          conversations: [{ conversationId: 'existing-convo' } as TConversation],
+          nextCursor: null,
+        },
+      ],
+      pageParams: [],
+    },
+  );
+};
+
+const readList = (queryClient: QueryClient, params?: Record<string, unknown>) =>
+  queryClient.getQueryData<ConversationPages>(
+    params ? [QueryKeys.allConversations, params] : [QueryKeys.allConversations],
+  )?.pages[0].conversations ?? [];
+
+const runNow = async (queryClient: QueryClient) => {
+  const { result } = renderHook(() => useRunScheduleNowMutation(), {
+    wrapper: createWrapper(queryClient),
+  });
+  await act(async () => {
+    await result.current.mutateAsync('schedule-1');
+  });
+};
+
+describe('run-now cache updates', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetActiveJobsGrace();
+    mockRunScheduleNow.mockResolvedValue({
+      scheduleId: 'schedule-1',
+      conversationId: 'run-convo-1',
+      status: 'started',
+    });
+  });
+
+  it('puts the started run at the head of the sidebar list', async () => {
+    const queryClient = createQueryClient();
+    seedSchedules(queryClient);
+    seedList(queryClient);
+
+    await runNow(queryClient);
+
+    const [first, ...rest] = readList(queryClient);
+    expect(first.conversationId).toBe('run-convo-1');
+    expect(first.title).toBe('Morning briefing');
+    expect(first.endpoint).toBe('agents');
+    expect(first.agent_id).toBe('agent-1');
+    expect(rest.map((convo) => convo.conversationId)).toEqual(['existing-convo']);
+    queryClient.clear();
+  });
+
+  it('files the row under the project the run will use, and no other', async () => {
+    const queryClient = createQueryClient();
+    seedSchedules(queryClient, { chatProjectId: 'project-a' });
+    seedList(queryClient, { projectId: 'project-a' });
+    seedList(queryClient, { projectId: 'project-b' });
+
+    await runNow(queryClient);
+
+    expect(readList(queryClient, { projectId: 'project-a' })[0].conversationId).toBe('run-convo-1');
+    expect(readList(queryClient, { projectId: 'project-b' })[0].conversationId).toBe(
+      'existing-convo',
+    );
+    queryClient.clear();
+  });
+
+  it('follows the operator pin over the schedule’s stored project', async () => {
+    const queryClient = createQueryClient();
+    seedSchedules(queryClient, { chatProjectId: 'project-a' }, 'project-pinned');
+    seedList(queryClient, { projectId: 'project-a' });
+    seedList(queryClient, { projectId: 'project-pinned' });
+
+    await runNow(queryClient);
+
+    expect(readList(queryClient, { projectId: 'project-pinned' })[0].conversationId).toBe(
+      'run-convo-1',
+    );
+    expect(readList(queryClient, { projectId: 'project-a' })[0].conversationId).toBe(
+      'existing-convo',
+    );
+    queryClient.clear();
+  });
+
+  it('re-arms the active-job poll so the seeded row can show as running', async () => {
+    const queryClient = createQueryClient();
+    seedSchedules(queryClient);
+    seedList(queryClient);
+    expect(getActiveJobsRefetchInterval({ activeJobIds: [] })).toBe(false);
+
+    await runNow(queryClient);
+
+    expect(getActiveJobsRefetchInterval({ activeJobIds: [] })).toBe(ACTIVE_JOBS_POLL_MS);
+    queryClient.clear();
+  });
+
+  it('leaves the list alone when the schedule is not cached', async () => {
+    const queryClient = createQueryClient();
+    seedList(queryClient);
+
+    await runNow(queryClient);
+
+    expect(readList(queryClient).map((convo) => convo.conversationId)).toEqual(['existing-convo']);
+    queryClient.clear();
+  });
+});

--- a/client/src/data-provider/__tests__/scheduleRunNow.test.tsx
+++ b/client/src/data-provider/__tests__/scheduleRunNow.test.tsx
@@ -11,6 +11,7 @@ import {
   getActiveJobsRefetchInterval,
 } from '../SSE/queries';
 import { useRunScheduleNowMutation } from '../Schedules/mutations';
+import { resetTrackedRuns } from '../Schedules/admission';
 import * as sseQueries from '../SSE/queries';
 
 const mockRunScheduleNow = jest.fn<Promise<TScheduleRunNowResponse>, [string]>();
@@ -130,6 +131,7 @@ describe('run-now conversation tracking', () => {
     jest.resetAllMocks();
     jest.useFakeTimers();
     resetActiveJobsGrace();
+    resetTrackedRuns();
     mockRunScheduleNow.mockResolvedValue({
       scheduleId: 'schedule-1',
       conversationId: 'run-convo-1',
@@ -328,19 +330,75 @@ describe('run-now conversation tracking', () => {
     queryClient.clear();
   });
 
+  it('keeps its budget when admitted before the owner is known, and lands once it is', async () => {
+    const queryClient = createQueryClient();
+    seedList(queryClient);
+    mockGetConversationById.mockResolvedValue(serverConversation());
+
+    /** The first probe succeeds with nobody to attribute it to: the user query is
+     *  still loading. That must not end the watch — the same account resolves a
+     *  moment later, and the next probe is the one that gets to write. */
+    await runNow(queryClient);
+    await settleAdmission(1_000);
+    expect(readList(queryClient).map((convo) => convo.conversationId)).toEqual(['existing-convo']);
+
+    signIn(queryClient, 'user-a');
+    await settleAdmission(3_000);
+
+    expect(readList(queryClient)[0].conversationId).toBe('run-convo-1');
+    expect(mockGetConversationById).toHaveBeenCalledTimes(2);
+    queryClient.clear();
+  });
+
+  it('refreshes the project rows when the run was filed under a project', async () => {
+    const queryClient = createQueryClient();
+    signIn(queryClient, 'user-a');
+    seedList(queryClient);
+    queryClient.setQueryData([QueryKeys.projects], { pages: [], pageParams: [] });
+    queryClient.setQueryData([QueryKeys.project, 'project-a'], { _id: 'project-a' });
+    mockGetConversationById.mockResolvedValue(serverConversation('project-a'));
+
+    await runNow(queryClient);
+    await settleAdmission();
+
+    expect(queryClient.getQueryState([QueryKeys.projects])?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState([QueryKeys.project, 'project-a'])?.isInvalidated).toBe(true);
+    queryClient.clear();
+  });
+
+  it('watches a run once however many times it is announced', async () => {
+    const queryClient = createQueryClient();
+    signIn(queryClient, 'user-a');
+    seedList(queryClient);
+    mockGetConversationById.mockResolvedValue(serverConversation());
+
+    await runNow(queryClient);
+    await runNow(queryClient);
+    await settleAdmission();
+
+    expect(mockGetConversationById).toHaveBeenCalledTimes(1);
+    expect(readList(queryClient).filter((c) => c.conversationId === 'run-convo-1')).toHaveLength(1);
+    queryClient.clear();
+  });
+
   it('refuses the write when the cache is claimed while the owner is still unknown', async () => {
     const queryClient = createQueryClient();
     seedList(queryClient);
     /** Never known at the click, and someone else's session arrives while the
      *  probe is in flight — "loading" and "changed hands" read identically here,
-     *  so the only safe answer is to write nothing. */
-    mockGetConversationById.mockImplementation(async () => {
-      signIn(queryClient, 'user-b');
-      return serverConversation();
-    });
+     *  so the response that was sent for the first account must not be written.
+     *  Every probe after that goes out under the second account, and the server
+     *  enforces ownership on the read, so those answer 404: the watch drains its
+     *  budget and nothing lands. */
+    mockGetConversationById
+      .mockImplementationOnce(async () => {
+        signIn(queryClient, 'user-b');
+        return serverConversation();
+      })
+      .mockRejectedValue(httpError(404, 'Not Found'));
 
     await runNow(queryClient);
-    await settleAdmission();
+    await settleAdmission(ADMISSION_BUDGET_MS);
 
     expect(readList(queryClient).map((convo) => convo.conversationId)).toEqual(['existing-convo']);
     expect(queryClient.getQueryData([QueryKeys.conversation, 'run-convo-1'])).toBeUndefined();


### PR DESCRIPTION
## Problem

Hitting **Run now** on a scheduled chat did not refresh the conversation list in any way, so the chat the run started was invisible until a page reload.

The obvious fix — invalidate `[QueryKeys.allConversations]` on success — does not work. **Run-now answers before its conversation exists.** `fireSchedule` pre-generates the `conversationId`, reserves the run row, and enqueues a *durable* trigger delivery; the loopback generation that actually writes the conversation starts afterwards. A refetch on success comes back without the chat.

## Fix

Wait for the run to be admitted, then add the chat the server actually has.

`GET /api/convos/:conversationId` answers 404 until that first write commits, and applies the same `subagentThread == null` rule the list query does — an exact admission probe: a 200 means the chat is listable *now*, and carries the server's own row. `trackScheduledRun` (`client/src/data-provider/Schedules/admission.ts`) probes on a bounded schedule (11 tries over ~5 minutes; the trigger engine's own retry window is ~127s at worst) and on admission:

- `upsertConvoInAllQueries` with what came back, filed by the server's own `chatProjectId`
- warms `[QueryKeys.conversation, id]` (absent-only) so opening the row does not ask again
- invalidates `[QueryKeys.projects]` and `[QueryKeys.project, chatProjectId]` for a project chat — the same bookkeeping the foreground path does, since the project's count and recent-activity ordering live on the project rows
- `extendActiveJobsGrace()` + `[QueryKeys.activeJobs]` invalidation, at admission (a job exists) rather than the click (one does not)
- `queueTitleGeneration(id)` — a conversation admitted mid-run lands as "New Chat"; the foreground paths hand that to the existing title queue, which owns the server's configured timing

A 404, 408 or 429 keeps the watch alive; a 5xx or a request that never got a response does too. Only a client error that is not asking to be retried ends it. An archived row is skipped: the conversation route serves one, the list query would not.

### The session fence, written once

The watch runs for minutes, and both sign-in and sign-out empty the query cache. Four review rounds patched one cell of this at a time; it is now one state machine, on the property that makes it tractable: **the server enforces ownership on the probe itself**, so a request sent under one account can never return another's chat. The only dangerous response is one sent under the account that clicked and landing after someone else signed in. So the owner is bound only from a reading taken *before* a probe goes out (a post-probe reading cannot tell "finished loading" from "changed hands"), a successful probe with no baseline yet is skipped rather than abandoned, and once bound any different reading ends the watch.

The watch is idempotent per id — a run announced by both the click and the schedules poll (#15631) is watched once — and deliberately detached from the caller, so the sidebar gains the chat whether or not the panel the run was started from is still mounted.

## Tests

`client/src/data-provider/__tests__/scheduleRunNow.test.tsx` — 17 tests, real `QueryClient` and real cache helpers, only the two data-service calls stubbed. Deleting the tracking call fails 9; each guard has its own cell that fails against its removal, including the three fence cells (bind-late, skip-and-keep-budget, refuse-on-ambiguity). Client suites 255/255; ESLint, Prettier, `sort-imports`, `tsc --noEmit` clean.

## Not in this PR

An automatic occurrence — #15631, stacked on this, gives the panel the running occurrence's conversation id and hands it to the same watch.
