### PR TITLE
🗓️ fix: Refresh the Sidebar When a Scheduled Run Fires or Settles

### DIFF
--- a/client/src/components/SidePanel/Schedules/SchedulePanel.tsx
+++ b/client/src/components/SidePanel/Schedules/SchedulePanel.tsx
@@ -10,10 +10,14 @@ import { useSchedulesQuery } from '~/data-provider';
 import { useLocalize, useHasAccess } from '~/hooks';
 import ScheduleDialog from './ScheduleDialog';
 import ScheduleCard from './ScheduleCard';
+import useRunSync from './useRunSync';
 
 export default function SchedulePanel() {
   const localize = useLocalize();
   const { data, isLoading, isError, refetch } = useSchedulesQuery();
+  /** The cards refresh themselves from this query; the sidebar cannot, so the
+   *  chat a run just produced is read out of the same poll. */
+  useRunSync(data?.schedules);
   const [createOpen, setCreateOpen] = useState(false);
 
   const hasCreateAccess = useHasAccess({

--- a/client/src/components/SidePanel/Schedules/SchedulePanel.tsx
+++ b/client/src/components/SidePanel/Schedules/SchedulePanel.tsx
@@ -14,10 +14,10 @@ import useRunSync from './useRunSync';
 
 export default function SchedulePanel() {
   const localize = useLocalize();
-  const { data, isLoading, isError, refetch } = useSchedulesQuery();
+  const { data, dataUpdatedAt, isLoading, isError, refetch } = useSchedulesQuery();
   /** The cards refresh themselves from this query; the sidebar cannot, so the
    *  chat a run just produced is read out of the same poll. */
-  useRunSync(data?.schedules);
+  useRunSync(data?.schedules, dataUpdatedAt);
   const [createOpen, setCreateOpen] = useState(false);
 
   const hasCreateAccess = useHasAccess({

--- a/client/src/components/SidePanel/Schedules/__tests__/useRunSync.spec.tsx
+++ b/client/src/components/SidePanel/Schedules/__tests__/useRunSync.spec.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { QueryKeys } from 'librechat-data-provider';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { TSchedule, TConversation } from 'librechat-data-provider';
+import type { ReactNode } from 'react';
+import useRunSync from '../useRunSync';
+
+const schedule: TSchedule = {
+  id: 'schedule-1',
+  user: 'user-1',
+  name: 'Morning briefing',
+  prompt: 'Summarize overnight activity',
+  agent_id: 'agent-1',
+  cadence: { frequency: 'daily', hour: 9, minute: 0 },
+  timezone: 'UTC',
+  target: 'new',
+  enabled: true,
+  runCount: 0,
+  failureCount: 0,
+  nextRunAt: '2026-09-05T09:00:00.000Z',
+  createdAt: '2026-09-01T00:00:00.000Z',
+  updatedAt: '2026-09-01T00:00:00.000Z',
+};
+
+/** What a fire actually changes: the occurrence advances to the next one. The
+ *  schedule's `lastRun` is untouched until the run settles. */
+const fired = (overrides?: Partial<TSchedule>): TSchedule => ({
+  ...schedule,
+  nextRunAt: '2026-09-06T09:00:00.000Z',
+  ...overrides,
+});
+
+const withRun = (overrides: Partial<TSchedule['lastRun']> & { status: 'started' | 'success' }) => ({
+  ...schedule,
+  lastRun: { firedAt: '2026-09-04T09:00:00.000Z', ...overrides },
+});
+
+const listKey = [QueryKeys.allConversations, { projectId: 'project-a' }];
+
+function createQueryClient() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  queryClient.setQueryData(listKey, {
+    pages: [{ conversations: [{ conversationId: 'existing' } as TConversation], nextCursor: null }],
+    pageParams: [],
+  });
+  return queryClient;
+}
+
+const createWrapper = (queryClient: QueryClient) =>
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+
+const isStale = (queryClient: QueryClient) =>
+  queryClient.getQueryState(listKey)?.isInvalidated === true;
+
+const renderWith = (queryClient: QueryClient, initial?: TSchedule[]) =>
+  renderHook((schedules?: TSchedule[]) => useRunSync(schedules), {
+    wrapper: createWrapper(queryClient),
+    initialProps: initial,
+  });
+
+describe('useRunSync', () => {
+  it('refreshes when an occurrence fires, which only moves nextRunAt', () => {
+    const queryClient = createQueryClient();
+    const { rerender } = renderWith(queryClient, [schedule]);
+    expect(isStale(queryClient)).toBe(false);
+
+    rerender([fired()]);
+
+    expect(isStale(queryClient)).toBe(true);
+    queryClient.clear();
+  });
+
+  it('refreshes again when the run settles, so the chat takes its generated title', () => {
+    const queryClient = createQueryClient();
+    const running = fired();
+    const { rerender } = renderWith(queryClient, [running]);
+    expect(isStale(queryClient)).toBe(false);
+
+    rerender([{ ...running, ...withRun({ status: 'success', conversationId: 'run-convo-1' }) }]);
+
+    expect(isStale(queryClient)).toBe(true);
+    queryClient.clear();
+  });
+
+  it('records the first observation in silence', () => {
+    const queryClient = createQueryClient();
+    renderWith(queryClient, [withRun({ status: 'success', conversationId: 'run-convo-1' })]);
+
+    expect(isStale(queryClient)).toBe(false);
+    queryClient.clear();
+  });
+
+  it('leaves the list alone when nothing about a run moved', () => {
+    const queryClient = createQueryClient();
+    const settled = withRun({ status: 'success', conversationId: 'run-convo-1' });
+    const { rerender } = renderWith(queryClient, [settled]);
+
+    rerender([{ ...settled, name: 'Renamed', enabled: false }]);
+
+    expect(isStale(queryClient)).toBe(false);
+    queryClient.clear();
+  });
+
+  it('does not refresh for a schedule it is seeing for the first time', () => {
+    const queryClient = createQueryClient();
+    const { rerender } = renderWith(queryClient, [schedule]);
+
+    rerender([
+      schedule,
+      { ...withRun({ status: 'success', conversationId: 'run-convo-2' }), id: 'schedule-2' },
+    ]);
+
+    expect(isStale(queryClient)).toBe(false);
+    queryClient.clear();
+  });
+
+  it('waits for data before recording anything', () => {
+    const queryClient = createQueryClient();
+    const { rerender } = renderWith(queryClient, undefined);
+
+    rerender([withRun({ status: 'success', conversationId: 'run-convo-1' })]);
+
+    expect(isStale(queryClient)).toBe(false);
+    queryClient.clear();
+  });
+});

--- a/client/src/components/SidePanel/Schedules/__tests__/useRunSync.spec.tsx
+++ b/client/src/components/SidePanel/Schedules/__tests__/useRunSync.spec.tsx
@@ -1,10 +1,24 @@
 import React from 'react';
-import { renderHook } from '@testing-library/react';
 import { QueryKeys } from 'librechat-data-provider';
+import { act, renderHook } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { TSchedule, TConversation } from 'librechat-data-provider';
 import type { ReactNode } from 'react';
+import { resetTrackedRuns } from '~/data-provider/Schedules/admission';
 import useRunSync from '../useRunSync';
+
+const mockGetConversationById = jest.fn<Promise<TConversation>, [string]>();
+
+jest.mock('librechat-data-provider', () => {
+  const actual = jest.requireActual('librechat-data-provider');
+  return {
+    ...actual,
+    dataService: {
+      ...actual.dataService,
+      getConversationById: (id: string) => mockGetConversationById(id),
+    },
+  };
+});
 
 const schedule: TSchedule = {
   id: 'schedule-1',
@@ -23,25 +37,30 @@ const schedule: TSchedule = {
   updatedAt: '2026-09-01T00:00:00.000Z',
 };
 
-/** What a fire actually changes: the occurrence advances to the next one. The
- *  schedule's `lastRun` is untouched until the run settles. */
-const fired = (overrides?: Partial<TSchedule>): TSchedule => ({
+/** The list naming the chat a running occurrence is producing. */
+const running = (conversationId = 'run-convo-1', overrides?: Partial<TSchedule>): TSchedule => ({
   ...schedule,
-  nextRunAt: '2026-09-06T09:00:00.000Z',
+  activeRun: { conversationId },
   ...overrides,
 });
 
-const withRun = (overrides: Partial<TSchedule['lastRun']> & { status: 'started' | 'success' }) => ({
-  ...schedule,
-  lastRun: { firedAt: '2026-09-04T09:00:00.000Z', ...overrides },
-});
+const serverConversation = (conversationId = 'run-convo-1'): TConversation =>
+  ({
+    conversationId,
+    title: 'Overnight activity summary',
+    endpoint: 'agents',
+    agent_id: 'agent-1',
+    createdAt: '2026-09-05T09:00:01.000Z',
+    updatedAt: '2026-09-05T09:00:01.000Z',
+  }) as TConversation;
 
-const listKey = [QueryKeys.allConversations, { projectId: 'project-a' }];
+const listKey = [QueryKeys.allConversations];
 
 function createQueryClient() {
   const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+    defaultOptions: { queries: { retry: false, cacheTime: Infinity } },
   });
+  queryClient.setQueryData([QueryKeys.user], { id: 'user-1' });
   queryClient.setQueryData(listKey, {
     pages: [{ conversations: [{ conversationId: 'existing' } as TConversation], nextCursor: null }],
     pageParams: [],
@@ -54,6 +73,12 @@ const createWrapper = (queryClient: QueryClient) =>
     return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
   };
 
+const listIds = (queryClient: QueryClient) =>
+  (
+    queryClient.getQueryData<{ pages: Array<{ conversations: TConversation[] }> }>(listKey)
+      ?.pages[0].conversations ?? []
+  ).map((convo) => convo.conversationId);
+
 const isStale = (queryClient: QueryClient) =>
   queryClient.getQueryState(listKey)?.isInvalidated === true;
 
@@ -63,56 +88,90 @@ const renderWith = (queryClient: QueryClient, initial?: TSchedule[]) =>
     initialProps: initial,
   });
 
+/** Lets the admission watch reach its first probe. */
+const admit = async () => {
+  await act(async () => {
+    await jest.advanceTimersByTimeAsync(3_000);
+  });
+};
+
 describe('useRunSync', () => {
-  it('refreshes when an occurrence fires, which only moves nextRunAt', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.useFakeTimers();
+    resetTrackedRuns();
+    mockGetConversationById.mockResolvedValue(serverConversation());
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('puts a running occurrence’s chat in the sidebar', async () => {
     const queryClient = createQueryClient();
-    const { rerender } = renderWith(queryClient, [schedule]);
+    renderWith(queryClient, [running()]);
+
+    await admit();
+
+    expect(listIds(queryClient)).toEqual(['run-convo-1', 'existing']);
+    queryClient.clear();
+  });
+
+  it('watches a run once, however many polls list it', async () => {
+    const queryClient = createQueryClient();
+    const { rerender } = renderWith(queryClient, [running()]);
+    rerender([running()]);
+    rerender([running()]);
+
+    await admit();
+
+    expect(mockGetConversationById).toHaveBeenCalledTimes(1);
+    queryClient.clear();
+  });
+
+  it('re-reads the list when the run settles, so the chat takes its final order', async () => {
+    const queryClient = createQueryClient();
+    const { rerender } = renderWith(queryClient, [running()]);
+    await admit();
     expect(isStale(queryClient)).toBe(false);
 
-    rerender([fired()]);
+    rerender([schedule]);
 
     expect(isStale(queryClient)).toBe(true);
     queryClient.clear();
   });
 
-  it('refreshes again when the run settles, so the chat takes its generated title', () => {
+  it('sees a settlement through an edit made while the run was in flight', async () => {
     const queryClient = createQueryClient();
-    const running = fired();
-    const { rerender } = renderWith(queryClient, [running]);
+    const { rerender } = renderWith(queryClient, [running()]);
+    await admit();
+
+    /** The edit bumps configRevision, which fences the schedule's own `lastRun`
+     *  projection; the run row is what this reads, and it is gone regardless. */
+    rerender([running('run-convo-1', { name: 'Renamed', configRevision: 2 })]);
     expect(isStale(queryClient)).toBe(false);
 
-    rerender([{ ...running, ...withRun({ status: 'success', conversationId: 'run-convo-1' }) }]);
-
+    rerender([{ ...schedule, name: 'Renamed', configRevision: 2 }]);
     expect(isStale(queryClient)).toBe(true);
     queryClient.clear();
   });
 
-  it('records the first observation in silence', () => {
+  it('records the first observation in silence', async () => {
     const queryClient = createQueryClient();
-    renderWith(queryClient, [withRun({ status: 'success', conversationId: 'run-convo-1' })]);
+    renderWith(queryClient, [schedule]);
+    await admit();
 
     expect(isStale(queryClient)).toBe(false);
+    expect(mockGetConversationById).not.toHaveBeenCalled();
     queryClient.clear();
   });
 
-  it('leaves the list alone when nothing about a run moved', () => {
-    const queryClient = createQueryClient();
-    const settled = withRun({ status: 'success', conversationId: 'run-convo-1' });
-    const { rerender } = renderWith(queryClient, [settled]);
-
-    rerender([{ ...settled, name: 'Renamed', enabled: false }]);
-
-    expect(isStale(queryClient)).toBe(false);
-    queryClient.clear();
-  });
-
-  it('does not refresh for a schedule it is seeing for the first time', () => {
+  it('leaves the list alone when nothing about a run moved', async () => {
     const queryClient = createQueryClient();
     const { rerender } = renderWith(queryClient, [schedule]);
 
     rerender([
-      schedule,
-      { ...withRun({ status: 'success', conversationId: 'run-convo-2' }), id: 'schedule-2' },
+      { ...schedule, name: 'Renamed', enabled: false, nextRunAt: '2026-09-06T09:00:00.000Z' },
     ]);
 
     expect(isStale(queryClient)).toBe(false);
@@ -123,7 +182,7 @@ describe('useRunSync', () => {
     const queryClient = createQueryClient();
     const { rerender } = renderWith(queryClient, undefined);
 
-    rerender([withRun({ status: 'success', conversationId: 'run-convo-1' })]);
+    rerender([schedule]);
 
     expect(isStale(queryClient)).toBe(false);
     queryClient.clear();

--- a/client/src/components/SidePanel/Schedules/__tests__/useRunSync.spec.tsx
+++ b/client/src/components/SidePanel/Schedules/__tests__/useRunSync.spec.tsx
@@ -40,14 +40,8 @@ const schedule: TSchedule = {
 /** The list naming the chat a running occurrence is producing. */
 const running = (conversationId = 'run-convo-1', overrides?: Partial<TSchedule>): TSchedule => ({
   ...schedule,
-  activeRuns: [{ conversationId, status: 'started' }],
+  inFlight: [{ conversationId }],
   ...overrides,
-});
-
-/** A run parked on an approval; it can sit there indefinitely. */
-const paused = (conversationId: string): NonNullable<TSchedule['activeRuns']>[number] => ({
-  conversationId,
-  status: 'requires_action',
 });
 
 /** The list after a run settled — the only trace a run short enough to start and
@@ -170,49 +164,49 @@ describe('useRunSync', () => {
     queryClient.clear();
   });
 
-  it('fetches a run that started and settled between two polls', async () => {
+  it('re-reads the list for a run that started and settled between two polls', async () => {
     const queryClient = createQueryClient();
     const { rerender } = renderWith(queryClient, [schedule]);
 
     rerender([settled()]);
     await admit();
 
-    expect(listIds(queryClient)).toEqual(['run-convo-1', 'existing']);
+    /** Never seen generating, so never handed to the watch — the refetch brings the
+     *  server's own row, and a settled run whose generation never wrote a chat
+     *  (a 404 for good) is not probed at all, let alone again. */
+    expect(isStale(queryClient)).toBe(true);
+    expect(mockGetConversationById).not.toHaveBeenCalled();
     queryClient.clear();
   });
 
-  it('fetches every concurrent occurrence that appears, a pause and a run alike', async () => {
+  it('fetches every generating occurrence a schedule names', async () => {
     const queryClient = createQueryClient();
     mockGetConversationById.mockImplementation(async (id) => serverConversation(id));
-    const { rerender } = renderWith(queryClient, [schedule]);
-
-    rerender([
+    renderWith(queryClient, [
       running('run-convo-1', {
-        activeRuns: [paused('paused-convo'), { conversationId: 'run-convo-1', status: 'started' }],
+        inFlight: [{ conversationId: 'run-convo-1' }, { conversationId: 'run-convo-2' }],
       }),
     ]);
+
     await admit();
 
     expect(listIds(queryClient)).toEqual(
-      expect.arrayContaining(['paused-convo', 'run-convo-1', 'existing']),
+      expect.arrayContaining(['run-convo-1', 'run-convo-2', 'existing']),
     );
     queryClient.clear();
   });
 
-  it('fetches only what is generating on the first observation, never history', async () => {
+  it('re-reads the list when a schedule with a run is deleted from under it', async () => {
     const queryClient = createQueryClient();
-    /** Settled long ago, parked on an approval, and actually running: only the
-     *  last is a chat the sidebar may lack. */
-    renderWith(queryClient, [
-      settled('old-convo'),
-      { ...schedule, id: 'schedule-2', activeRuns: [paused('paused-convo')] },
-      { ...running(), id: 'schedule-3' },
-    ]);
-
+    const { rerender } = renderWith(queryClient, [running(), { ...schedule, id: 'schedule-2' }]);
     await admit();
+    expect(isStale(queryClient)).toBe(false);
 
-    expect(mockGetConversationById).toHaveBeenCalledTimes(1);
-    expect(mockGetConversationById).toHaveBeenCalledWith('run-convo-1');
+    /** Deleting aborts and settles the run, and the schedule leaves the list; the
+     *  chat's final state is only visible if the vanishing counts as a move. */
+    rerender([{ ...schedule, id: 'schedule-2' }]);
+
+    expect(isStale(queryClient)).toBe(true);
     queryClient.clear();
   });
 

--- a/client/src/components/SidePanel/Schedules/__tests__/useRunSync.spec.tsx
+++ b/client/src/components/SidePanel/Schedules/__tests__/useRunSync.spec.tsx
@@ -40,7 +40,15 @@ const schedule: TSchedule = {
 /** The list naming the chat a running occurrence is producing. */
 const running = (conversationId = 'run-convo-1', overrides?: Partial<TSchedule>): TSchedule => ({
   ...schedule,
-  activeRun: { conversationId },
+  activeRuns: [{ conversationId }],
+  ...overrides,
+});
+
+/** The list after a run settled — the only trace a run short enough to start and
+ *  finish between two polls ever leaves. */
+const settled = (conversationId = 'run-convo-1', overrides?: Partial<TSchedule>): TSchedule => ({
+  ...schedule,
+  lastRun: { conversationId, status: 'success', firedAt: '2026-09-05T09:00:00.000Z' },
   ...overrides,
 });
 
@@ -153,6 +161,45 @@ describe('useRunSync', () => {
 
     rerender([{ ...schedule, name: 'Renamed', configRevision: 2 }]);
     expect(isStale(queryClient)).toBe(true);
+    queryClient.clear();
+  });
+
+  it('fetches a run that started and settled between two polls', async () => {
+    const queryClient = createQueryClient();
+    const { rerender } = renderWith(queryClient, [schedule]);
+
+    rerender([settled()]);
+    await admit();
+
+    expect(listIds(queryClient)).toEqual(['run-convo-1', 'existing']);
+    queryClient.clear();
+  });
+
+  it('fetches every concurrent occurrence, a pause and a run alike', async () => {
+    const queryClient = createQueryClient();
+    mockGetConversationById.mockImplementation(async (id) => serverConversation(id));
+    renderWith(queryClient, [
+      running('paused-convo', {
+        activeRuns: [{ conversationId: 'paused-convo' }, { conversationId: 'run-convo-1' }],
+      }),
+    ]);
+
+    await admit();
+
+    expect(listIds(queryClient)).toEqual(
+      expect.arrayContaining(['paused-convo', 'run-convo-1', 'existing']),
+    );
+    queryClient.clear();
+  });
+
+  it('does not fetch history on the first observation, only runs in flight', async () => {
+    const queryClient = createQueryClient();
+    renderWith(queryClient, [settled('old-convo'), { ...running(), id: 'schedule-2' }]);
+
+    await admit();
+
+    expect(mockGetConversationById).toHaveBeenCalledTimes(1);
+    expect(mockGetConversationById).toHaveBeenCalledWith('run-convo-1');
     queryClient.clear();
   });
 

--- a/client/src/components/SidePanel/Schedules/__tests__/useRunSync.spec.tsx
+++ b/client/src/components/SidePanel/Schedules/__tests__/useRunSync.spec.tsx
@@ -315,6 +315,49 @@ describe('useRunSync', () => {
     queryClient.clear();
   });
 
+  it('does not retain a run released before admission finishes', async () => {
+    const queryClient = createQueryClient();
+    const { rerender } = renderWith(queryClient, [running()]);
+    rerender([settled()]);
+
+    await admit();
+
+    expect(listIds(queryClient)).toContain('run-convo-1');
+    expect(trackedRunCount()).toBe(0);
+    queryClient.clear();
+  });
+
+  it.each([false, true])('releases on unmount with admission finished: %s', async (finished) => {
+    const queryClient = createQueryClient();
+    const { unmount } = renderWith(queryClient, [running()]);
+    if (finished) {
+      await admit();
+    }
+
+    unmount();
+    await admit();
+
+    expect(listIds(queryClient)).toContain('run-convo-1');
+    expect(trackedRunCount()).toBe(0);
+    expect(mockGetConversationById).toHaveBeenCalledTimes(1);
+    queryClient.clear();
+  });
+
+  it('reclaims a pending watch on remount without a duplicate probe', async () => {
+    const queryClient = createQueryClient();
+    const first = renderWith(queryClient, [running()]);
+    first.unmount();
+    const second = renderWith(queryClient, [running()]);
+
+    await admit();
+
+    expect(trackedRunCount()).toBe(1);
+    expect(mockGetConversationById).toHaveBeenCalledTimes(1);
+    second.unmount();
+    expect(trackedRunCount()).toBe(0);
+    queryClient.clear();
+  });
+
   it('leaves the list alone when nothing about a run moved', async () => {
     const queryClient = createQueryClient();
     const { rerender } = renderWith(queryClient, [schedule]);

--- a/client/src/components/SidePanel/Schedules/__tests__/useRunSync.spec.tsx
+++ b/client/src/components/SidePanel/Schedules/__tests__/useRunSync.spec.tsx
@@ -232,6 +232,30 @@ describe('useRunSync', () => {
     queryClient.clear();
   });
 
+  it('re-reads the list when a schedule created elsewhere arrives already settled', async () => {
+    const queryClient = createQueryClient();
+    const { rerender } = renderWith(queryClient, [schedule]);
+
+    /** Made in another tab, fired, and finished — all before this poll first
+     *  listed it. There is no earlier state to compare against; idle is the
+     *  baseline, and this is not idle. */
+    rerender([schedule, { ...settled('elsewhere-convo'), id: 'schedule-2' }]);
+
+    expect(isStale(queryClient)).toBe(true);
+    expect(mockGetConversationById).not.toHaveBeenCalled();
+    queryClient.clear();
+  });
+
+  it('leaves the list alone when a schedule created elsewhere arrives idle', () => {
+    const queryClient = createQueryClient();
+    const { rerender } = renderWith(queryClient, [schedule]);
+
+    rerender([schedule, { ...schedule, id: 'schedule-2' }]);
+
+    expect(isStale(queryClient)).toBe(false);
+    queryClient.clear();
+  });
+
   it('records the first observation in silence', async () => {
     const queryClient = createQueryClient();
     renderWith(queryClient, [schedule]);

--- a/client/src/components/SidePanel/Schedules/__tests__/useRunSync.spec.tsx
+++ b/client/src/components/SidePanel/Schedules/__tests__/useRunSync.spec.tsx
@@ -256,12 +256,31 @@ describe('useRunSync', () => {
     queryClient.clear();
   });
 
-  it('records the first observation in silence', async () => {
+  it('records the first observation in silence when the sidebar is fresher than the runs', async () => {
     const queryClient = createQueryClient();
-    renderWith(queryClient, [schedule]);
+    /** List read after the run fired: it has held that chat all along. */
+    renderWith(queryClient, [settled()]);
     await admit();
 
     expect(isStale(queryClient)).toBe(false);
+    expect(mockGetConversationById).not.toHaveBeenCalled();
+    queryClient.clear();
+  });
+
+  it('re-reads on the first observation when a run settled after the sidebar was read', async () => {
+    const queryClient = createQueryClient();
+    /** The panel opens after a run fired and finished with it closed; the list was
+     *  read before that and never got the chance to pick the chat up. */
+    const readAt = queryClient.getQueryState(listKey)?.dataUpdatedAt ?? 0;
+    const firedAt = new Date(readAt + 60_000).toISOString();
+    renderWith(queryClient, [
+      settled('run-convo-1', {
+        lastRun: { conversationId: 'run-convo-1', status: 'success', firedAt },
+      }),
+    ]);
+    await admit();
+
+    expect(isStale(queryClient)).toBe(true);
     expect(mockGetConversationById).not.toHaveBeenCalled();
     queryClient.clear();
   });

--- a/client/src/components/SidePanel/Schedules/__tests__/useRunSync.spec.tsx
+++ b/client/src/components/SidePanel/Schedules/__tests__/useRunSync.spec.tsx
@@ -40,8 +40,14 @@ const schedule: TSchedule = {
 /** The list naming the chat a running occurrence is producing. */
 const running = (conversationId = 'run-convo-1', overrides?: Partial<TSchedule>): TSchedule => ({
   ...schedule,
-  activeRuns: [{ conversationId }],
+  activeRuns: [{ conversationId, status: 'started' }],
   ...overrides,
+});
+
+/** A run parked on an approval; it can sit there indefinitely. */
+const paused = (conversationId: string): NonNullable<TSchedule['activeRuns']>[number] => ({
+  conversationId,
+  status: 'requires_action',
 });
 
 /** The list after a run settled — the only trace a run short enough to start and
@@ -175,15 +181,16 @@ describe('useRunSync', () => {
     queryClient.clear();
   });
 
-  it('fetches every concurrent occurrence, a pause and a run alike', async () => {
+  it('fetches every concurrent occurrence that appears, a pause and a run alike', async () => {
     const queryClient = createQueryClient();
     mockGetConversationById.mockImplementation(async (id) => serverConversation(id));
-    renderWith(queryClient, [
-      running('paused-convo', {
-        activeRuns: [{ conversationId: 'paused-convo' }, { conversationId: 'run-convo-1' }],
+    const { rerender } = renderWith(queryClient, [schedule]);
+
+    rerender([
+      running('run-convo-1', {
+        activeRuns: [paused('paused-convo'), { conversationId: 'run-convo-1', status: 'started' }],
       }),
     ]);
-
     await admit();
 
     expect(listIds(queryClient)).toEqual(
@@ -192,14 +199,42 @@ describe('useRunSync', () => {
     queryClient.clear();
   });
 
-  it('does not fetch history on the first observation, only runs in flight', async () => {
+  it('fetches only what is generating on the first observation, never history', async () => {
     const queryClient = createQueryClient();
-    renderWith(queryClient, [settled('old-convo'), { ...running(), id: 'schedule-2' }]);
+    /** Settled long ago, parked on an approval, and actually running: only the
+     *  last is a chat the sidebar may lack. */
+    renderWith(queryClient, [
+      settled('old-convo'),
+      { ...schedule, id: 'schedule-2', activeRuns: [paused('paused-convo')] },
+      { ...running(), id: 'schedule-3' },
+    ]);
 
     await admit();
 
     expect(mockGetConversationById).toHaveBeenCalledTimes(1);
     expect(mockGetConversationById).toHaveBeenCalledWith('run-convo-1');
+    queryClient.clear();
+  });
+
+  it('announces a run again once its watch has given up', async () => {
+    const queryClient = createQueryClient();
+    mockGetConversationById.mockRejectedValue(
+      Object.assign(new Error('Not Found'), { isAxiosError: true, response: { status: 404 } }),
+    );
+    const { rerender } = renderWith(queryClient, [schedule]);
+    rerender([running()]);
+    /** Deferred past the whole budget: the watch forgets the id so a later
+     *  announcement can try again — which is only useful if this hook makes one. */
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(600_000);
+    });
+    expect(listIds(queryClient)).toEqual(['existing']);
+
+    mockGetConversationById.mockResolvedValue(serverConversation());
+    rerender([running()]);
+    await admit();
+
+    expect(listIds(queryClient)).toEqual(['run-convo-1', 'existing']);
     queryClient.clear();
   });
 

--- a/client/src/components/SidePanel/Schedules/__tests__/useRunSync.spec.tsx
+++ b/client/src/components/SidePanel/Schedules/__tests__/useRunSync.spec.tsx
@@ -4,7 +4,7 @@ import { act, renderHook } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { TSchedule, TConversation } from 'librechat-data-provider';
 import type { ReactNode } from 'react';
-import { resetTrackedRuns } from '~/data-provider/Schedules/admission';
+import { resetTrackedRuns, trackedRunCount } from '~/data-provider/Schedules/admission';
 import useRunSync from '../useRunSync';
 
 const mockGetConversationById = jest.fn<Promise<TConversation>, [string]>();
@@ -90,8 +90,11 @@ const listIds = (queryClient: QueryClient) =>
 const isStale = (queryClient: QueryClient) =>
   queryClient.getQueryState(listKey)?.isInvalidated === true;
 
+/** Every render is a fresh poll observation, the way the panel feeds the hook —
+ *  including one whose data is the same reference as the last. */
+let observation = 0;
 const renderWith = (queryClient: QueryClient, initial?: TSchedule[]) =>
-  renderHook((schedules?: TSchedule[]) => useRunSync(schedules), {
+  renderHook((schedules?: TSchedule[]) => useRunSync(schedules, (observation += 1)), {
     wrapper: createWrapper(queryClient),
     initialProps: initial,
   });
@@ -256,10 +259,21 @@ describe('useRunSync', () => {
     queryClient.clear();
   });
 
-  it('records the first observation in silence when the sidebar is fresher than the runs', async () => {
+  it('re-reads on the first observation when any schedule has run', async () => {
     const queryClient = createQueryClient();
-    /** List read after the run fired: it has held that chat all along. */
+    /** The sidebar may have been read before that run and nothing here can tell;
+     *  one refetch on opening the panel is the price. Nothing is probed. */
     renderWith(queryClient, [settled()]);
+    await admit();
+
+    expect(isStale(queryClient)).toBe(true);
+    expect(mockGetConversationById).not.toHaveBeenCalled();
+    queryClient.clear();
+  });
+
+  it('records the first observation in silence when nothing has ever run', async () => {
+    const queryClient = createQueryClient();
+    renderWith(queryClient, [schedule, { ...schedule, id: 'schedule-2' }]);
     await admit();
 
     expect(isStale(queryClient)).toBe(false);
@@ -267,21 +281,37 @@ describe('useRunSync', () => {
     queryClient.clear();
   });
 
-  it('re-reads on the first observation when a run settled after the sidebar was read', async () => {
+  it('announces again on a poll whose data is the same reference', async () => {
     const queryClient = createQueryClient();
-    /** The panel opens after a run fired and finished with it closed; the list was
-     *  read before that and never got the chance to pick the chat up. */
-    const readAt = queryClient.getQueryState(listKey)?.dataUpdatedAt ?? 0;
-    const firedAt = new Date(readAt + 60_000).toISOString();
-    renderWith(queryClient, [
-      settled('run-convo-1', {
-        lastRun: { conversationId: 'run-convo-1', status: 'success', firedAt },
-      }),
-    ]);
+    mockGetConversationById.mockRejectedValue(
+      Object.assign(new Error('Not Found'), { isAxiosError: true, response: { status: 404 } }),
+    );
+    const list = [running()];
+    const { rerender } = renderWith(queryClient, list);
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(600_000);
+    });
+    expect(listIds(queryClient)).toEqual(['existing']);
+
+    /** Deep-equal refetch: React Query hands back the same array. Only the
+     *  observation stamp moves, and that has to be enough to ask again. */
+    mockGetConversationById.mockResolvedValue(serverConversation());
+    rerender(list);
     await admit();
 
-    expect(isStale(queryClient)).toBe(true);
-    expect(mockGetConversationById).not.toHaveBeenCalled();
+    expect(listIds(queryClient)).toEqual(['run-convo-1', 'existing']);
+    queryClient.clear();
+  });
+
+  it('releases a run once it leaves the list, so nothing is remembered for it', async () => {
+    const queryClient = createQueryClient();
+    const { rerender } = renderWith(queryClient, [running()]);
+    await admit();
+    expect(trackedRunCount()).toBe(1);
+
+    rerender([settled()]);
+
+    expect(trackedRunCount()).toBe(0);
     queryClient.clear();
   });
 

--- a/client/src/components/SidePanel/Schedules/useRunSync.ts
+++ b/client/src/components/SidePanel/Schedules/useRunSync.ts
@@ -1,0 +1,72 @@
+import { useRef, useEffect } from 'react';
+import { QueryKeys } from 'librechat-data-provider';
+import { useQueryClient } from '@tanstack/react-query';
+import type { TSchedule } from 'librechat-data-provider';
+
+/**
+ * A schedule's occurrence state, reduced to what the conversation list depends on.
+ *
+ * `lastRun` alone is not enough, and reading it as the fire signal was wrong: the
+ * fire path reserves its run row in the `ScheduleRun` collection, and the schedule
+ * document's own `lastRun` is not projected onto it until the run settles, pauses
+ * or skips. Keying on that missed the fire entirely, so a long-running scheduled
+ * chat stayed out of the sidebar until it finished.
+ *
+ * `nextRunAt` is what actually moves when an automatic occurrence fires — every
+ * fire advances it, before anything else about the schedule changes — and it is
+ * served with the list. A manual run deliberately does not advance it, which is
+ * the right split: Run Now is tracked to its own admission by the mutation that
+ * started it, and needs nothing from here until its title lands.
+ *
+ * An owner editing the cadence also moves `nextRunAt`. That costs one refetch of
+ * a list the edit did not change, which is cheaper than missing a fire.
+ */
+const occurrenceSignature = (schedule: TSchedule): string => {
+  const { lastRun } = schedule;
+  const settled =
+    lastRun == null ? '' : `${lastRun.firedAt}:${lastRun.status}:${lastRun.conversationId ?? ''}`;
+  return `${schedule.nextRunAt ?? ''}|${settled}`;
+};
+
+/**
+ * Refreshes the conversation list when a schedule's run fires or settles.
+ *
+ * An automatic occurrence is the one generation nothing in this client starts,
+ * so no submission, stream or event handler ever tells the sidebar its chat
+ * exists — and the list's own five-minute staleness leaves it out of a tab that
+ * stays focused. This panel's query is already polling for the cards, and what it
+ * serves moves at exactly the two moments the list should be re-read: a fire adds
+ * a chat, and a settlement is when the title generated for it lands. So the
+ * refresh rides that poll instead of adding one of its own.
+ *
+ * Only TRANSITIONS refresh, and a schedule first seen here is recorded in
+ * silence: a panel opened long after a run must not refetch a list that has
+ * held its chat all along.
+ */
+export default function useRunSync(schedules?: TSchedule[]): void {
+  const queryClient = useQueryClient();
+  const observed = useRef<Map<string, string> | null>(null);
+
+  useEffect(() => {
+    if (schedules == null) {
+      return;
+    }
+    const current = new Map(
+      schedules.map((schedule) => [schedule.id, occurrenceSignature(schedule)]),
+    );
+    const previous = observed.current;
+    observed.current = current;
+    if (previous == null) {
+      return;
+    }
+    for (const [id, signature] of current) {
+      const before = previous.get(id);
+      if (before !== undefined && before !== signature) {
+        /** One refetch answers every schedule that moved in the same tick, and
+         *  the prefix reaches the project-scoped variants a run may be filed in. */
+        queryClient.invalidateQueries([QueryKeys.allConversations]);
+        return;
+      }
+    }
+  }, [schedules, queryClient]);
+}

--- a/client/src/components/SidePanel/Schedules/useRunSync.ts
+++ b/client/src/components/SidePanel/Schedules/useRunSync.ts
@@ -58,6 +58,16 @@ export default function useRunSync(schedules?: TSchedule[], observedAt?: number)
   const states = useRef<Map<string, string> | null>(null);
   const announced = useRef<Set<string>>(new Set());
 
+  useEffect(
+    () => () => {
+      for (const conversationId of announced.current) {
+        releaseScheduledRun(conversationId);
+      }
+      announced.current.clear();
+    },
+    [],
+  );
+
   useEffect(() => {
     if (schedules == null) {
       return;
@@ -69,7 +79,7 @@ export default function useRunSync(schedules?: TSchedule[], observedAt?: number)
       current.set(schedule.id, runState(schedule));
       for (const conversationId of inFlightChats(schedule)) {
         live.add(conversationId);
-        void trackScheduledRun(queryClient, conversationId);
+        void trackScheduledRun(queryClient, conversationId, { retain: true });
       }
     }
     for (const conversationId of announced.current) {

--- a/client/src/components/SidePanel/Schedules/useRunSync.ts
+++ b/client/src/components/SidePanel/Schedules/useRunSync.ts
@@ -4,7 +4,9 @@ import { useQueryClient } from '@tanstack/react-query';
 import type { TSchedule } from 'librechat-data-provider';
 import { trackScheduledRun } from '~/data-provider/Schedules/admission';
 
-const inFlightChats = (schedule: TSchedule): string[] =>
+type Occurrences = Pick<TSchedule, 'inFlight' | 'lastRun'>;
+
+const inFlightChats = (schedule: Pick<TSchedule, 'inFlight'>): string[] =>
   (schedule.inFlight ?? []).map((run) => run.conversationId);
 
 /** Everything about a schedule's occurrences that should send the list back to
@@ -12,11 +14,16 @@ const inFlightChats = (schedule: TSchedule): string[] =>
  *  ended. A run short enough to start and settle between two polls is never seen
  *  generating; it is still seen settled, and the refetch that follows brings its
  *  chat with the server's own row. */
-const runState = (schedule: TSchedule): string => {
+const runState = (schedule: Occurrences): string => {
   const { lastRun } = schedule;
   const live = inFlightChats(schedule).sort().join(',');
   return `${live}|${lastRun?.conversationId ?? ''}:${lastRun?.status ?? ''}`;
 };
+
+/** What a schedule this client has never seen is compared against. One created
+ *  elsewhere that arrives with its first run already settled is news the list
+ *  should hear; one that arrives with no run yet is not. */
+const IDLE_STATE = runState({});
 
 /**
  * Puts an automatic occurrence's chat in the sidebar, the same way Run Now does.
@@ -33,8 +40,9 @@ const runState = (schedule: TSchedule): string => {
  * ever handed over, so a settled run whose generation never wrote a conversation
  * is never watched, let alone watched again.
  *
- * When a run's state moves — one settles, or its schedule is deleted from under it
- * — the list is re-read once for the chat, order and title the settlement changed.
+ * When a run's state moves — one settles, its schedule is deleted from under it,
+ * or a schedule created elsewhere arrives with a run already behind it — the list
+ * is re-read once for the chat, order and title the settlement changed.
  * Because the state includes the generating occurrences, an owner editing the
  * schedule mid-flight (which fences the `lastRun` projection) still cannot hide a
  * settlement. The first observation is recorded in silence: a panel opened long
@@ -60,7 +68,9 @@ export default function useRunSync(schedules?: TSchedule[]): void {
     if (previous == null) {
       return;
     }
-    const moved = [...previous].some(([id, state]) => current.get(id) !== state);
+    const moved =
+      [...previous].some(([id, state]) => current.get(id) !== state) ||
+      [...current].some(([id, state]) => !previous.has(id) && state !== IDLE_STATE);
     if (moved) {
       queryClient.invalidateQueries([QueryKeys.allConversations]);
     }

--- a/client/src/components/SidePanel/Schedules/useRunSync.ts
+++ b/client/src/components/SidePanel/Schedules/useRunSync.ts
@@ -31,12 +31,16 @@ const runState = (schedule: TSchedule): string => {
  * and the list's own five-minute staleness leaves it out of a tab that stays
  * focused. This panel's query is already polling for the cards, and it names the
  * chats each schedule is producing and has produced, read from the run rows rather
- * than inferred from the schedule. Every chat it names that has not been seen is
- * handed to the admission watch Run Now uses, which is idempotent per id.
+ * than inferred from the schedule. Every chat it names is handed to the admission
+ * watch Run Now uses on every observation: that watch is the one place that
+ * decides whether an id is already landed, in flight, or — having given up on a
+ * delivery deferred past its budget — worth trying again on a later announcement.
  *
- * The first observation is recorded in silence, except for occurrences still
- * running: a panel opened long after a run must not go and fetch history, but a
- * run in flight when it opens is exactly the chat the sidebar may lack.
+ * The exception is history. A panel opened long after a run must not go and fetch
+ * chats that were listed before it opened, so whatever the first observation names
+ * that is not actually generating — the last settled occurrence, and a pause that
+ * may sit on its approval indefinitely — is never handed over. A pause resolving
+ * later still re-reads the list, below.
  *
  * When a run's state moves — one settles, a pause resolves — the list is re-read
  * once for the order and title its settlement changed. Because the state includes
@@ -45,15 +49,15 @@ const runState = (schedule: TSchedule): string => {
  */
 export default function useRunSync(schedules?: TSchedule[]): void {
   const queryClient = useQueryClient();
-  const seen = useRef<Set<string> | null>(null);
+  const history = useRef<Set<string> | null>(null);
   const states = useRef<Map<string, string>>(new Map());
 
   useEffect(() => {
     if (schedules == null) {
       return;
     }
-    const first = seen.current == null;
-    const known = (seen.current ??= new Set());
+    const first = history.current == null;
+    const skip = (history.current ??= new Set());
     let moved = false;
     for (const schedule of schedules) {
       const state = runState(schedule);
@@ -62,13 +66,20 @@ export default function useRunSync(schedules?: TSchedule[]): void {
       if (!first && before !== undefined && before !== state) {
         moved = true;
       }
-      const inFlight = new Set((schedule.activeRuns ?? []).map((run) => run.conversationId));
-      for (const conversationId of namedChats(schedule)) {
-        if (known.has(conversationId)) {
-          continue;
+      if (first) {
+        const generating = new Set(
+          (schedule.activeRuns ?? [])
+            .filter((run) => run.status === 'started')
+            .map((run) => run.conversationId),
+        );
+        for (const conversationId of namedChats(schedule)) {
+          if (!generating.has(conversationId)) {
+            skip.add(conversationId);
+          }
         }
-        known.add(conversationId);
-        if (!first || inFlight.has(conversationId)) {
+      }
+      for (const conversationId of namedChats(schedule)) {
+        if (!skip.has(conversationId)) {
           void trackScheduledRun(queryClient, conversationId);
         }
       }

--- a/client/src/components/SidePanel/Schedules/useRunSync.ts
+++ b/client/src/components/SidePanel/Schedules/useRunSync.ts
@@ -2,46 +2,38 @@ import { useRef, useEffect } from 'react';
 import { QueryKeys } from 'librechat-data-provider';
 import { useQueryClient } from '@tanstack/react-query';
 import type { TSchedule } from 'librechat-data-provider';
+import { trackScheduledRun } from '~/data-provider/Schedules/admission';
 
-/**
- * A schedule's occurrence state, reduced to what the conversation list depends on.
- *
- * `lastRun` alone is not enough, and reading it as the fire signal was wrong: the
- * fire path reserves its run row in the `ScheduleRun` collection, and the schedule
- * document's own `lastRun` is not projected onto it until the run settles, pauses
- * or skips. Keying on that missed the fire entirely, so a long-running scheduled
- * chat stayed out of the sidebar until it finished.
- *
- * `nextRunAt` is what actually moves when an automatic occurrence fires — every
- * fire advances it, before anything else about the schedule changes — and it is
- * served with the list. A manual run deliberately does not advance it, which is
- * the right split: Run Now is tracked to its own admission by the mutation that
- * started it, and needs nothing from here until its title lands.
- *
- * An owner editing the cadence also moves `nextRunAt`. That costs one refetch of
- * a list the edit did not change, which is cheaper than missing a fire.
- */
-const occurrenceSignature = (schedule: TSchedule): string => {
-  const { lastRun } = schedule;
-  const settled =
-    lastRun == null ? '' : `${lastRun.firedAt}:${lastRun.status}:${lastRun.conversationId ?? ''}`;
-  return `${schedule.nextRunAt ?? ''}|${settled}`;
+/** Which chat each schedule is producing right now, by schedule id. */
+const runningChats = (schedules: TSchedule[]): Map<string, string> => {
+  const running = new Map<string, string>();
+  for (const schedule of schedules) {
+    if (schedule.activeRun != null) {
+      running.set(schedule.id, schedule.activeRun.conversationId);
+    }
+  }
+  return running;
 };
 
 /**
- * Refreshes the conversation list when a schedule's run fires or settles.
+ * Puts an automatic occurrence's chat in the sidebar, the same way Run Now does.
  *
- * An automatic occurrence is the one generation nothing in this client starts,
- * so no submission, stream or event handler ever tells the sidebar its chat
- * exists — and the list's own five-minute staleness leaves it out of a tab that
- * stays focused. This panel's query is already polling for the cards, and what it
- * serves moves at exactly the two moments the list should be re-read: a fire adds
- * a chat, and a settlement is when the title generated for it lands. So the
- * refresh rides that poll instead of adding one of its own.
+ * An automatic occurrence is the one generation nothing in this client starts, so
+ * no submission, stream or event handler ever tells the sidebar its chat exists —
+ * and the list's own five-minute staleness leaves it out of a tab that stays
+ * focused. This panel's query is already polling for the cards, and it now names
+ * the chat each running occurrence is producing (`activeRun`, read from the run's
+ * own row), so every id it names is handed to the admission watch Run Now uses.
+ * That watch is idempotent per id: a panel re-mounting mid-run, or a run announced
+ * by both the click and the poll, watches once.
  *
- * Only TRANSITIONS refresh, and a schedule first seen here is recorded in
- * silence: a panel opened long after a run must not refetch a list that has
- * held its chat all along.
+ * A run leaving the list has settled. The watch already put its chat in the
+ * sidebar and queued its title; what settlement changes is the conversation's
+ * `updatedAt`, which orders it, so the list is re-read once. Because the signal is
+ * the run row and not the schedule's `lastRun` projection, an owner editing the
+ * schedule mid-flight — which fences that projection — cannot hide it. The first
+ * observation is recorded in silence: a panel opened long after a run must not
+ * refetch a list that has held its chat all along.
  */
 export default function useRunSync(schedules?: TSchedule[]): void {
   const queryClient = useQueryClient();
@@ -51,19 +43,17 @@ export default function useRunSync(schedules?: TSchedule[]): void {
     if (schedules == null) {
       return;
     }
-    const current = new Map(
-      schedules.map((schedule) => [schedule.id, occurrenceSignature(schedule)]),
-    );
+    const current = runningChats(schedules);
     const previous = observed.current;
     observed.current = current;
+    for (const conversationId of current.values()) {
+      void trackScheduledRun(queryClient, conversationId);
+    }
     if (previous == null) {
       return;
     }
-    for (const [id, signature] of current) {
-      const before = previous.get(id);
-      if (before !== undefined && before !== signature) {
-        /** One refetch answers every schedule that moved in the same tick, and
-         *  the prefix reaches the project-scoped variants a run may be filed in. */
+    for (const [scheduleId, conversationId] of previous) {
+      if (current.get(scheduleId) !== conversationId) {
         queryClient.invalidateQueries([QueryKeys.allConversations]);
         return;
       }

--- a/client/src/components/SidePanel/Schedules/useRunSync.ts
+++ b/client/src/components/SidePanel/Schedules/useRunSync.ts
@@ -4,15 +4,23 @@ import { useQueryClient } from '@tanstack/react-query';
 import type { TSchedule } from 'librechat-data-provider';
 import { trackScheduledRun } from '~/data-provider/Schedules/admission';
 
-/** Which chat each schedule is producing right now, by schedule id. */
-const runningChats = (schedules: TSchedule[]): Map<string, string> => {
-  const running = new Map<string, string>();
-  for (const schedule of schedules) {
-    if (schedule.activeRun != null) {
-      running.set(schedule.id, schedule.activeRun.conversationId);
-    }
+/** The chats a schedule names: those its running occurrences are producing, and
+ *  the one its last occurrence produced. A run short enough to start and settle
+ *  between two polls is never seen running; it is still seen settled. */
+const namedChats = (schedule: TSchedule): string[] => {
+  const ids = (schedule.activeRuns ?? []).map((run) => run.conversationId);
+  if (schedule.lastRun?.conversationId != null) {
+    ids.push(schedule.lastRun.conversationId);
   }
-  return running;
+  return ids;
+};
+
+/** Everything about a schedule's occurrences that should send the list back to
+ *  the server when it moves: which runs are live, and how the last one ended. */
+const runState = (schedule: TSchedule): string => {
+  const live = (schedule.activeRuns ?? []).map((run) => run.conversationId).sort();
+  const { lastRun } = schedule;
+  return `${live.join(',')}|${lastRun?.conversationId ?? ''}:${lastRun?.status ?? ''}`;
 };
 
 /**
@@ -21,42 +29,52 @@ const runningChats = (schedules: TSchedule[]): Map<string, string> => {
  * An automatic occurrence is the one generation nothing in this client starts, so
  * no submission, stream or event handler ever tells the sidebar its chat exists —
  * and the list's own five-minute staleness leaves it out of a tab that stays
- * focused. This panel's query is already polling for the cards, and it now names
- * the chat each running occurrence is producing (`activeRun`, read from the run's
- * own row), so every id it names is handed to the admission watch Run Now uses.
- * That watch is idempotent per id: a panel re-mounting mid-run, or a run announced
- * by both the click and the poll, watches once.
+ * focused. This panel's query is already polling for the cards, and it names the
+ * chats each schedule is producing and has produced, read from the run rows rather
+ * than inferred from the schedule. Every chat it names that has not been seen is
+ * handed to the admission watch Run Now uses, which is idempotent per id.
  *
- * A run leaving the list has settled. The watch already put its chat in the
- * sidebar and queued its title; what settlement changes is the conversation's
- * `updatedAt`, which orders it, so the list is re-read once. Because the signal is
- * the run row and not the schedule's `lastRun` projection, an owner editing the
- * schedule mid-flight — which fences that projection — cannot hide it. The first
- * observation is recorded in silence: a panel opened long after a run must not
- * refetch a list that has held its chat all along.
+ * The first observation is recorded in silence, except for occurrences still
+ * running: a panel opened long after a run must not go and fetch history, but a
+ * run in flight when it opens is exactly the chat the sidebar may lack.
+ *
+ * When a run's state moves — one settles, a pause resolves — the list is re-read
+ * once for the order and title its settlement changed. Because the state includes
+ * the live occurrences, an owner editing the schedule mid-flight (which fences the
+ * `lastRun` projection) still cannot hide a settlement.
  */
 export default function useRunSync(schedules?: TSchedule[]): void {
   const queryClient = useQueryClient();
-  const observed = useRef<Map<string, string> | null>(null);
+  const seen = useRef<Set<string> | null>(null);
+  const states = useRef<Map<string, string>>(new Map());
 
   useEffect(() => {
     if (schedules == null) {
       return;
     }
-    const current = runningChats(schedules);
-    const previous = observed.current;
-    observed.current = current;
-    for (const conversationId of current.values()) {
-      void trackScheduledRun(queryClient, conversationId);
-    }
-    if (previous == null) {
-      return;
-    }
-    for (const [scheduleId, conversationId] of previous) {
-      if (current.get(scheduleId) !== conversationId) {
-        queryClient.invalidateQueries([QueryKeys.allConversations]);
-        return;
+    const first = seen.current == null;
+    const known = (seen.current ??= new Set());
+    let moved = false;
+    for (const schedule of schedules) {
+      const state = runState(schedule);
+      const before = states.current.get(schedule.id);
+      states.current.set(schedule.id, state);
+      if (!first && before !== undefined && before !== state) {
+        moved = true;
       }
+      const inFlight = new Set((schedule.activeRuns ?? []).map((run) => run.conversationId));
+      for (const conversationId of namedChats(schedule)) {
+        if (known.has(conversationId)) {
+          continue;
+        }
+        known.add(conversationId);
+        if (!first || inFlight.has(conversationId)) {
+          void trackScheduledRun(queryClient, conversationId);
+        }
+      }
+    }
+    if (moved) {
+      queryClient.invalidateQueries([QueryKeys.allConversations]);
     }
   }, [schedules, queryClient]);
 }

--- a/client/src/components/SidePanel/Schedules/useRunSync.ts
+++ b/client/src/components/SidePanel/Schedules/useRunSync.ts
@@ -1,6 +1,7 @@
 import { useRef, useEffect } from 'react';
 import { QueryKeys } from 'librechat-data-provider';
 import { useQueryClient } from '@tanstack/react-query';
+import type { QueryClient } from '@tanstack/react-query';
 import type { TSchedule } from 'librechat-data-provider';
 import { trackScheduledRun } from '~/data-provider/Schedules/admission';
 
@@ -25,6 +26,23 @@ const runState = (schedule: Occurrences): string => {
  *  should hear; one that arrives with no run yet is not. */
 const IDLE_STATE = runState({});
 
+/** When the sidebar's lists were last read from the server — the oldest across
+ *  the variants, since any one of them could be the one missing a chat. Nothing
+ *  cached means nothing stale: a list mounted later is read fresh. */
+const listsReadAt = (queryClient: QueryClient): number => {
+  const lists = queryClient.getQueryCache().findAll([QueryKeys.allConversations], { exact: false });
+  return lists.length === 0 ? Infinity : Math.min(...lists.map((list) => list.state.dataUpdatedAt));
+};
+
+/** Whether a run settled after the sidebar last heard from the server. The first
+ *  observation cannot compare against an earlier one, but it can compare against
+ *  this: a panel opened long after a run must not refetch a list that has held
+ *  that chat all along, and must refetch one that never got the chance to. */
+const settledSince = (schedules: TSchedule[], readAt: number): boolean =>
+  schedules.some(
+    (schedule) => schedule.lastRun != null && Date.parse(schedule.lastRun.firedAt) > readAt,
+  );
+
 /**
  * Puts an automatic occurrence's chat in the sidebar, the same way Run Now does.
  *
@@ -45,8 +63,9 @@ const IDLE_STATE = runState({});
  * is re-read once for the chat, order and title the settlement changed.
  * Because the state includes the generating occurrences, an owner editing the
  * schedule mid-flight (which fences the `lastRun` projection) still cannot hide a
- * settlement. The first observation is recorded in silence: a panel opened long
- * after a run must not refetch a list that has held its chat all along.
+ * settlement. The first observation has no earlier one to compare against, so it
+ * compares against the sidebar instead: it re-reads only if a run settled after
+ * the lists were last read, which is the one case where they lack its chat.
  */
 export default function useRunSync(schedules?: TSchedule[]): void {
   const queryClient = useQueryClient();
@@ -65,12 +84,11 @@ export default function useRunSync(schedules?: TSchedule[]): void {
       }
     }
     states.current = current;
-    if (previous == null) {
-      return;
-    }
     const moved =
-      [...previous].some(([id, state]) => current.get(id) !== state) ||
-      [...current].some(([id, state]) => !previous.has(id) && state !== IDLE_STATE);
+      previous == null
+        ? settledSince(schedules, listsReadAt(queryClient))
+        : [...previous].some(([id, state]) => current.get(id) !== state) ||
+          [...current].some(([id, state]) => !previous.has(id) && state !== IDLE_STATE);
     if (moved) {
       queryClient.invalidateQueries([QueryKeys.allConversations]);
     }

--- a/client/src/components/SidePanel/Schedules/useRunSync.ts
+++ b/client/src/components/SidePanel/Schedules/useRunSync.ts
@@ -1,9 +1,8 @@
 import { useRef, useEffect } from 'react';
 import { QueryKeys } from 'librechat-data-provider';
 import { useQueryClient } from '@tanstack/react-query';
-import type { QueryClient } from '@tanstack/react-query';
 import type { TSchedule } from 'librechat-data-provider';
-import { trackScheduledRun } from '~/data-provider/Schedules/admission';
+import { trackScheduledRun, releaseScheduledRun } from '~/data-provider/Schedules/admission';
 
 type Occurrences = Pick<TSchedule, 'inFlight' | 'lastRun'>;
 
@@ -21,27 +20,9 @@ const runState = (schedule: Occurrences): string => {
   return `${live}|${lastRun?.conversationId ?? ''}:${lastRun?.status ?? ''}`;
 };
 
-/** What a schedule this client has never seen is compared against. One created
- *  elsewhere that arrives with its first run already settled is news the list
- *  should hear; one that arrives with no run yet is not. */
+/** A schedule that has never run. What a schedule this client has not seen before
+ *  is compared against — and, on the first observation, what every schedule is. */
 const IDLE_STATE = runState({});
-
-/** When the sidebar's lists were last read from the server — the oldest across
- *  the variants, since any one of them could be the one missing a chat. Nothing
- *  cached means nothing stale: a list mounted later is read fresh. */
-const listsReadAt = (queryClient: QueryClient): number => {
-  const lists = queryClient.getQueryCache().findAll([QueryKeys.allConversations], { exact: false });
-  return lists.length === 0 ? Infinity : Math.min(...lists.map((list) => list.state.dataUpdatedAt));
-};
-
-/** Whether a run settled after the sidebar last heard from the server. The first
- *  observation cannot compare against an earlier one, but it can compare against
- *  this: a panel opened long after a run must not refetch a list that has held
- *  that chat all along, and must refetch one that never got the chance to. */
-const settledSince = (schedules: TSchedule[], readAt: number): boolean =>
-  schedules.some(
-    (schedule) => schedule.lastRun != null && Date.parse(schedule.lastRun.firedAt) > readAt,
-  );
 
 /**
  * Puts an automatic occurrence's chat in the sidebar, the same way Run Now does.
@@ -54,22 +35,28 @@ const settledSince = (schedules: TSchedule[], readAt: number): boolean =>
  * than inferred from the schedule. Every one is handed to the admission watch Run
  * Now uses, on every observation: that watch is the one place that decides whether
  * an id is landed, in flight, or — having given up on a delivery deferred past its
- * budget — worth trying again on a later announcement. Only generating runs are
- * ever handed over, so a settled run whose generation never wrote a conversation
- * is never watched, let alone watched again.
+ * budget — worth trying again. When an occurrence leaves the list it is released,
+ * so the watch remembers a run only for as long as this keeps announcing it.
+ *
+ * `observedAt` is what makes "every observation" true. React Query keeps the
+ * previous reference when a refetch is deep-equal, which is exactly what a poll
+ * returns while a run stays in flight, so an effect keyed on the data alone would
+ * never run again — and a watch that gave up would never be asked to try again.
  *
  * When a run's state moves — one settles, its schedule is deleted from under it,
  * or a schedule created elsewhere arrives with a run already behind it — the list
- * is re-read once for the chat, order and title the settlement changed.
- * Because the state includes the generating occurrences, an owner editing the
- * schedule mid-flight (which fences the `lastRun` projection) still cannot hide a
- * settlement. The first observation has no earlier one to compare against, so it
- * compares against the sidebar instead: it re-reads only if a run settled after
- * the lists were last read, which is the one case where they lack its chat.
+ * is re-read once for the chat, order and title the settlement changed. Because
+ * the state includes the generating occurrences, an owner editing the schedule
+ * mid-flight (which fences the `lastRun` projection) still cannot hide a
+ * settlement. The first observation has nothing earlier to compare against, so it
+ * re-reads if any schedule has run at all: the sidebar may have been read before
+ * that run, and nothing here can tell — one refetch on opening the panel is the
+ * honest price of that.
  */
-export default function useRunSync(schedules?: TSchedule[]): void {
+export default function useRunSync(schedules?: TSchedule[], observedAt?: number): void {
   const queryClient = useQueryClient();
   const states = useRef<Map<string, string> | null>(null);
+  const announced = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     if (schedules == null) {
@@ -77,20 +64,28 @@ export default function useRunSync(schedules?: TSchedule[]): void {
     }
     const previous = states.current;
     const current = new Map<string, string>();
+    const live = new Set<string>();
     for (const schedule of schedules) {
       current.set(schedule.id, runState(schedule));
       for (const conversationId of inFlightChats(schedule)) {
+        live.add(conversationId);
         void trackScheduledRun(queryClient, conversationId);
       }
     }
+    for (const conversationId of announced.current) {
+      if (!live.has(conversationId)) {
+        releaseScheduledRun(conversationId);
+      }
+    }
+    announced.current = live;
     states.current = current;
     const moved =
       previous == null
-        ? settledSince(schedules, listsReadAt(queryClient))
+        ? [...current.values()].some((state) => state !== IDLE_STATE)
         : [...previous].some(([id, state]) => current.get(id) !== state) ||
           [...current].some(([id, state]) => !previous.has(id) && state !== IDLE_STATE);
     if (moved) {
       queryClient.invalidateQueries([QueryKeys.allConversations]);
     }
-  }, [schedules, queryClient]);
+  }, [schedules, observedAt, queryClient]);
 }

--- a/client/src/components/SidePanel/Schedules/useRunSync.ts
+++ b/client/src/components/SidePanel/Schedules/useRunSync.ts
@@ -4,23 +4,18 @@ import { useQueryClient } from '@tanstack/react-query';
 import type { TSchedule } from 'librechat-data-provider';
 import { trackScheduledRun } from '~/data-provider/Schedules/admission';
 
-/** The chats a schedule names: those its running occurrences are producing, and
- *  the one its last occurrence produced. A run short enough to start and settle
- *  between two polls is never seen running; it is still seen settled. */
-const namedChats = (schedule: TSchedule): string[] => {
-  const ids = (schedule.activeRuns ?? []).map((run) => run.conversationId);
-  if (schedule.lastRun?.conversationId != null) {
-    ids.push(schedule.lastRun.conversationId);
-  }
-  return ids;
-};
+const inFlightChats = (schedule: TSchedule): string[] =>
+  (schedule.inFlight ?? []).map((run) => run.conversationId);
 
 /** Everything about a schedule's occurrences that should send the list back to
- *  the server when it moves: which runs are live, and how the last one ended. */
+ *  the server when it moves: which runs are generating, and how the last one
+ *  ended. A run short enough to start and settle between two polls is never seen
+ *  generating; it is still seen settled, and the refetch that follows brings its
+ *  chat with the server's own row. */
 const runState = (schedule: TSchedule): string => {
-  const live = (schedule.activeRuns ?? []).map((run) => run.conversationId).sort();
   const { lastRun } = schedule;
-  return `${live.join(',')}|${lastRun?.conversationId ?? ''}:${lastRun?.status ?? ''}`;
+  const live = inFlightChats(schedule).sort().join(',');
+  return `${live}|${lastRun?.conversationId ?? ''}:${lastRun?.status ?? ''}`;
 };
 
 /**
@@ -30,60 +25,42 @@ const runState = (schedule: TSchedule): string => {
  * no submission, stream or event handler ever tells the sidebar its chat exists —
  * and the list's own five-minute staleness leaves it out of a tab that stays
  * focused. This panel's query is already polling for the cards, and it names the
- * chats each schedule is producing and has produced, read from the run rows rather
- * than inferred from the schedule. Every chat it names is handed to the admission
- * watch Run Now uses on every observation: that watch is the one place that
- * decides whether an id is already landed, in flight, or — having given up on a
- * delivery deferred past its budget — worth trying again on a later announcement.
+ * chat each generating occurrence is producing, read from the run's own row rather
+ * than inferred from the schedule. Every one is handed to the admission watch Run
+ * Now uses, on every observation: that watch is the one place that decides whether
+ * an id is landed, in flight, or — having given up on a delivery deferred past its
+ * budget — worth trying again on a later announcement. Only generating runs are
+ * ever handed over, so a settled run whose generation never wrote a conversation
+ * is never watched, let alone watched again.
  *
- * The exception is history. A panel opened long after a run must not go and fetch
- * chats that were listed before it opened, so whatever the first observation names
- * that is not actually generating — the last settled occurrence, and a pause that
- * may sit on its approval indefinitely — is never handed over. A pause resolving
- * later still re-reads the list, below.
- *
- * When a run's state moves — one settles, a pause resolves — the list is re-read
- * once for the order and title its settlement changed. Because the state includes
- * the live occurrences, an owner editing the schedule mid-flight (which fences the
- * `lastRun` projection) still cannot hide a settlement.
+ * When a run's state moves — one settles, or its schedule is deleted from under it
+ * — the list is re-read once for the chat, order and title the settlement changed.
+ * Because the state includes the generating occurrences, an owner editing the
+ * schedule mid-flight (which fences the `lastRun` projection) still cannot hide a
+ * settlement. The first observation is recorded in silence: a panel opened long
+ * after a run must not refetch a list that has held its chat all along.
  */
 export default function useRunSync(schedules?: TSchedule[]): void {
   const queryClient = useQueryClient();
-  const history = useRef<Set<string> | null>(null);
-  const states = useRef<Map<string, string>>(new Map());
+  const states = useRef<Map<string, string> | null>(null);
 
   useEffect(() => {
     if (schedules == null) {
       return;
     }
-    const first = history.current == null;
-    const skip = (history.current ??= new Set());
-    let moved = false;
+    const previous = states.current;
+    const current = new Map<string, string>();
     for (const schedule of schedules) {
-      const state = runState(schedule);
-      const before = states.current.get(schedule.id);
-      states.current.set(schedule.id, state);
-      if (!first && before !== undefined && before !== state) {
-        moved = true;
-      }
-      if (first) {
-        const generating = new Set(
-          (schedule.activeRuns ?? [])
-            .filter((run) => run.status === 'started')
-            .map((run) => run.conversationId),
-        );
-        for (const conversationId of namedChats(schedule)) {
-          if (!generating.has(conversationId)) {
-            skip.add(conversationId);
-          }
-        }
-      }
-      for (const conversationId of namedChats(schedule)) {
-        if (!skip.has(conversationId)) {
-          void trackScheduledRun(queryClient, conversationId);
-        }
+      current.set(schedule.id, runState(schedule));
+      for (const conversationId of inFlightChats(schedule)) {
+        void trackScheduledRun(queryClient, conversationId);
       }
     }
+    states.current = current;
+    if (previous == null) {
+      return;
+    }
+    const moved = [...previous].some(([id, state]) => current.get(id) !== state);
     if (moved) {
       queryClient.invalidateQueries([QueryKeys.allConversations]);
     }

--- a/client/src/data-provider/Schedules/admission.ts
+++ b/client/src/data-provider/Schedules/admission.ts
@@ -55,7 +55,7 @@ const cacheOwner = (queryClient: QueryClient): string | undefined =>
  * evicted: a second watch for a run still being watched is the one thing this
  * exists to prevent.
  */
-const watching = new Set<string>();
+const watching = new Map<string, { retain: boolean }>();
 
 /**
  * Runs already landed, so a later announcement is a no-op. A run is announced for
@@ -80,6 +80,10 @@ export function trackedRunCount(): number {
  *  so nothing can announce it again, and there is nothing left to remember. */
 export function releaseScheduledRun(conversationId: string): void {
   landed.delete(conversationId);
+  const watch = watching.get(conversationId);
+  if (watch) {
+    watch.retain = false;
+  }
 }
 
 /**
@@ -170,6 +174,9 @@ async function admit(queryClient: QueryClient, conversationId: string): Promise<
  * a 200 means the chat is listable now, and carries the server's own row rather
  * than a guess assembled from the client's cached schedule.
  *
+ * `retain` is for a polling owner that will release the id when it stops naming
+ * it. One-shot Run Now calls leave no retained id after admission finishes.
+ *
  * Deliberately detached from the caller: the sidebar has to gain the chat whether
  * or not the panel the run was announced in is still mounted. Bounded, and it
  * writes only what the server returned — a delivery that never admits leaves
@@ -178,14 +185,23 @@ async function admit(queryClient: QueryClient, conversationId: string): Promise<
 export async function trackScheduledRun(
   queryClient: QueryClient,
   conversationId: string,
+  { retain = false }: { retain?: boolean } = {},
 ): Promise<void> {
-  if (!conversationId || watching.has(conversationId) || landed.has(conversationId)) {
+  const existing = watching.get(conversationId);
+  if (existing && retain) {
+    existing.retain = true;
+  }
+  if (!conversationId || existing || landed.has(conversationId)) {
     return;
   }
-  watching.add(conversationId);
-  const admitted = await admit(queryClient, conversationId);
-  watching.delete(conversationId);
-  if (admitted) {
-    landed.add(conversationId);
+  const watch = { retain };
+  watching.set(conversationId, watch);
+  try {
+    const admitted = await admit(queryClient, conversationId);
+    if (admitted && watch.retain) {
+      landed.add(conversationId);
+    }
+  } finally {
+    watching.delete(conversationId);
   }
 }

--- a/client/src/data-provider/Schedules/admission.ts
+++ b/client/src/data-provider/Schedules/admission.ts
@@ -56,9 +56,31 @@ const cacheOwner = (queryClient: QueryClient): string | undefined =>
  */
 const tracked = new Set<string>();
 
-/** @internal Test seam. */
+/**
+ * How many landed runs to remember. A panel that stays mounted sees a new id per
+ * occurrence for as long as schedules keep firing, and a run is only announced
+ * while it is in flight — none is still in flight by the time this many have
+ * started after it — so the oldest entries can go without a watch ever running
+ * twice for the same run.
+ */
+const TRACKED_RUN_LIMIT = 256;
+
+function forgetOldestTracked(): void {
+  while (tracked.size > TRACKED_RUN_LIMIT) {
+    const [oldest] = tracked;
+    if (oldest === undefined) {
+      return;
+    }
+    tracked.delete(oldest);
+  }
+}
+
+/** @internal Test seams. */
 export function resetTrackedRuns(): void {
   tracked.clear();
+}
+export function trackedRunCount(): number {
+  return tracked.size;
 }
 
 /**
@@ -162,6 +184,7 @@ export async function trackScheduledRun(
     return;
   }
   tracked.add(conversationId);
+  forgetOldestTracked();
   const landed = await admit(queryClient, conversationId);
   if (!landed) {
     tracked.delete(conversationId);

--- a/client/src/data-provider/Schedules/admission.ts
+++ b/client/src/data-provider/Schedules/admission.ts
@@ -58,25 +58,14 @@ const cacheOwner = (queryClient: QueryClient): string | undefined =>
 const watching = new Set<string>();
 
 /**
- * Runs already landed, so a later announcement is a no-op. A panel that stays
- * mounted sees a new id per occurrence for as long as schedules keep firing, so
- * only the most recent are kept: a run is announced only while it is in flight,
- * and one that landed is not — a forgotten id would at worst be probed once more
- * and found already present. A watch that gave up is in neither set, so a later
- * announcement of a run admitted after the budget can try again.
+ * Runs already landed, so a later announcement is a no-op. A run is announced for
+ * as long as it is generating, and the announcer releases it when it stops — so
+ * this holds an id exactly as long as something could announce it, and is bounded
+ * by real concurrency rather than by a count that could evict a run still being
+ * announced. A watch that gave up is in neither set, so a later announcement of a
+ * run admitted after the budget can try again.
  */
 const landed = new Set<string>();
-const LANDED_RUN_LIMIT = 256;
-
-function forgetOldestLanded(): void {
-  while (landed.size > LANDED_RUN_LIMIT) {
-    const [oldest] = landed;
-    if (oldest === undefined) {
-      return;
-    }
-    landed.delete(oldest);
-  }
-}
 
 /** @internal Test seams. */
 export function resetTrackedRuns(): void {
@@ -85,6 +74,12 @@ export function resetTrackedRuns(): void {
 }
 export function trackedRunCount(): number {
   return watching.size + landed.size;
+}
+
+/** The announcer no longer names this run — it settled, or its schedule went —
+ *  so nothing can announce it again, and there is nothing left to remember. */
+export function releaseScheduledRun(conversationId: string): void {
+  landed.delete(conversationId);
 }
 
 /**
@@ -192,6 +187,5 @@ export async function trackScheduledRun(
   watching.delete(conversationId);
   if (admitted) {
     landed.add(conversationId);
-    forgetOldestLanded();
   }
 }

--- a/client/src/data-provider/Schedules/admission.ts
+++ b/client/src/data-provider/Schedules/admission.ts
@@ -49,38 +49,42 @@ const cacheOwner = (queryClient: QueryClient): string | undefined =>
   queryClient.getQueryData<TUser>([QueryKeys.user])?.id;
 
 /**
- * Runs with a watch in flight or already landed. A run can be announced twice —
- * by the click that started it, and by the schedules poll that then lists it —
- * and must be watched once. A watch that gave up is forgotten, so a later
- * announcement of a run admitted after the budget can try again.
+ * Runs with a watch in flight. A run can be announced twice — by the click that
+ * started it, and by the schedules poll that then lists it — and must be watched
+ * once. Bounded by however many generations can actually be running, and never
+ * evicted: a second watch for a run still being watched is the one thing this
+ * exists to prevent.
  */
-const tracked = new Set<string>();
+const watching = new Set<string>();
 
 /**
- * How many landed runs to remember. A panel that stays mounted sees a new id per
- * occurrence for as long as schedules keep firing, and a run is only announced
- * while it is in flight — none is still in flight by the time this many have
- * started after it — so the oldest entries can go without a watch ever running
- * twice for the same run.
+ * Runs already landed, so a later announcement is a no-op. A panel that stays
+ * mounted sees a new id per occurrence for as long as schedules keep firing, so
+ * only the most recent are kept: a run is announced only while it is in flight,
+ * and one that landed is not — a forgotten id would at worst be probed once more
+ * and found already present. A watch that gave up is in neither set, so a later
+ * announcement of a run admitted after the budget can try again.
  */
-const TRACKED_RUN_LIMIT = 256;
+const landed = new Set<string>();
+const LANDED_RUN_LIMIT = 256;
 
-function forgetOldestTracked(): void {
-  while (tracked.size > TRACKED_RUN_LIMIT) {
-    const [oldest] = tracked;
+function forgetOldestLanded(): void {
+  while (landed.size > LANDED_RUN_LIMIT) {
+    const [oldest] = landed;
     if (oldest === undefined) {
       return;
     }
-    tracked.delete(oldest);
+    landed.delete(oldest);
   }
 }
 
 /** @internal Test seams. */
 export function resetTrackedRuns(): void {
-  tracked.clear();
+  watching.clear();
+  landed.clear();
 }
 export function trackedRunCount(): number {
-  return tracked.size;
+  return watching.size + landed.size;
 }
 
 /**
@@ -180,13 +184,14 @@ export async function trackScheduledRun(
   queryClient: QueryClient,
   conversationId: string,
 ): Promise<void> {
-  if (!conversationId || tracked.has(conversationId)) {
+  if (!conversationId || watching.has(conversationId) || landed.has(conversationId)) {
     return;
   }
-  tracked.add(conversationId);
-  forgetOldestTracked();
-  const landed = await admit(queryClient, conversationId);
-  if (!landed) {
-    tracked.delete(conversationId);
+  watching.add(conversationId);
+  const admitted = await admit(queryClient, conversationId);
+  watching.delete(conversationId);
+  if (admitted) {
+    landed.add(conversationId);
+    forgetOldestLanded();
   }
 }

--- a/client/src/data-provider/__tests__/scheduleRunNow.test.tsx
+++ b/client/src/data-provider/__tests__/scheduleRunNow.test.tsx
@@ -6,11 +6,16 @@ import type { TConversation, TScheduleRunNowResponse } from 'librechat-data-prov
 import type { InfiniteData } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 import {
+  resetTrackedRuns,
+  trackScheduledRun,
+  trackedRunCount,
+  releaseScheduledRun,
+} from '../Schedules/admission';
+import {
   ACTIVE_JOBS_POLL_MS,
   resetActiveJobsGrace,
   getActiveJobsRefetchInterval,
 } from '../SSE/queries';
-import { resetTrackedRuns, trackScheduledRun, trackedRunCount } from '../Schedules/admission';
 import { useRunScheduleNowMutation } from '../Schedules/mutations';
 import * as sseQueries from '../SSE/queries';
 
@@ -381,48 +386,26 @@ describe('run-now conversation tracking', () => {
     queryClient.clear();
   });
 
-  it('remembers only the most recent landed runs, so a long-lived panel stays bounded', async () => {
+  it('remembers a landed run until it is released, then probes it again if announced', async () => {
     const queryClient = createQueryClient();
     signIn(queryClient, 'user-a');
     seedList(queryClient);
-    mockGetConversationById.mockImplementation(async (id) => ({
-      ...serverConversation(),
-      conversationId: id,
-    }));
+    mockGetConversationById.mockResolvedValue(serverConversation());
 
-    for (let i = 0; i < 300; i += 1) {
-      void trackScheduledRun(queryClient, `run-${i}`);
-    }
+    void trackScheduledRun(queryClient, 'run-convo-1');
+    await settleAdmission();
+    void trackScheduledRun(queryClient, 'run-convo-1');
+    await settleAdmission();
+    expect(mockGetConversationById).toHaveBeenCalledTimes(1);
+    expect(trackedRunCount()).toBe(1);
+
+    releaseScheduledRun('run-convo-1');
+    expect(trackedRunCount()).toBe(0);
+    void trackScheduledRun(queryClient, 'run-convo-1');
     await settleAdmission();
 
-    expect(trackedRunCount()).toBe(256);
-    expect(readList(queryClient)).toHaveLength(301);
-    queryClient.clear();
-  });
-
-  it('never evicts a watch still in flight, however many runs land after it', async () => {
-    const queryClient = createQueryClient();
-    signIn(queryClient, 'user-a');
-    seedList(queryClient);
-    /** One delivery deferred well past the others; three hundred land around it. */
-    mockGetConversationById.mockImplementation(async (id) =>
-      id === 'slow'
-        ? Promise.reject(httpError(404, 'Not Found'))
-        : { ...serverConversation(), conversationId: id },
-    );
-
-    void trackScheduledRun(queryClient, 'slow');
-    for (let i = 0; i < 300; i += 1) {
-      void trackScheduledRun(queryClient, `run-${i}`);
-    }
-    await settleAdmission(3_000);
-    /** Announced again, as the poll would while it is still in flight. Were it
-     *  evicted, this would start a second watch and double the probes. */
-    void trackScheduledRun(queryClient, 'slow');
-    await settleAdmission(3_000);
-
-    const slowProbes = mockGetConversationById.mock.calls.filter(([id]) => id === 'slow').length;
-    expect(slowProbes).toBe(3);
+    expect(mockGetConversationById).toHaveBeenCalledTimes(2);
+    expect(readList(queryClient).filter((c) => c.conversationId === 'run-convo-1')).toHaveLength(1);
     queryClient.clear();
   });
 

--- a/client/src/data-provider/__tests__/scheduleRunNow.test.tsx
+++ b/client/src/data-provider/__tests__/scheduleRunNow.test.tsx
@@ -10,8 +10,8 @@ import {
   resetActiveJobsGrace,
   getActiveJobsRefetchInterval,
 } from '../SSE/queries';
+import { resetTrackedRuns, trackScheduledRun, trackedRunCount } from '../Schedules/admission';
 import { useRunScheduleNowMutation } from '../Schedules/mutations';
-import { resetTrackedRuns } from '../Schedules/admission';
 import * as sseQueries from '../SSE/queries';
 
 const mockRunScheduleNow = jest.fn<Promise<TScheduleRunNowResponse>, [string]>();
@@ -378,6 +378,25 @@ describe('run-now conversation tracking', () => {
 
     expect(mockGetConversationById).toHaveBeenCalledTimes(1);
     expect(readList(queryClient).filter((c) => c.conversationId === 'run-convo-1')).toHaveLength(1);
+    queryClient.clear();
+  });
+
+  it('remembers only the most recent landed runs, so a long-lived panel stays bounded', async () => {
+    const queryClient = createQueryClient();
+    signIn(queryClient, 'user-a');
+    seedList(queryClient);
+    mockGetConversationById.mockImplementation(async (id) => ({
+      ...serverConversation(),
+      conversationId: id,
+    }));
+
+    for (let i = 0; i < 300; i += 1) {
+      void trackScheduledRun(queryClient, `run-${i}`);
+    }
+    await settleAdmission();
+
+    expect(trackedRunCount()).toBe(256);
+    expect(readList(queryClient)).toHaveLength(301);
     queryClient.clear();
   });
 

--- a/client/src/data-provider/__tests__/scheduleRunNow.test.tsx
+++ b/client/src/data-provider/__tests__/scheduleRunNow.test.tsx
@@ -400,6 +400,32 @@ describe('run-now conversation tracking', () => {
     queryClient.clear();
   });
 
+  it('never evicts a watch still in flight, however many runs land after it', async () => {
+    const queryClient = createQueryClient();
+    signIn(queryClient, 'user-a');
+    seedList(queryClient);
+    /** One delivery deferred well past the others; three hundred land around it. */
+    mockGetConversationById.mockImplementation(async (id) =>
+      id === 'slow'
+        ? Promise.reject(httpError(404, 'Not Found'))
+        : { ...serverConversation(), conversationId: id },
+    );
+
+    void trackScheduledRun(queryClient, 'slow');
+    for (let i = 0; i < 300; i += 1) {
+      void trackScheduledRun(queryClient, `run-${i}`);
+    }
+    await settleAdmission(3_000);
+    /** Announced again, as the poll would while it is still in flight. Were it
+     *  evicted, this would start a second watch and double the probes. */
+    void trackScheduledRun(queryClient, 'slow');
+    await settleAdmission(3_000);
+
+    const slowProbes = mockGetConversationById.mock.calls.filter(([id]) => id === 'slow').length;
+    expect(slowProbes).toBe(3);
+    queryClient.clear();
+  });
+
   it('refuses the write when the cache is claimed while the owner is still unknown', async () => {
     const queryClient = createQueryClient();
     seedList(queryClient);

--- a/client/src/data-provider/__tests__/scheduleRunNow.test.tsx
+++ b/client/src/data-provider/__tests__/scheduleRunNow.test.tsx
@@ -386,7 +386,7 @@ describe('run-now conversation tracking', () => {
     queryClient.clear();
   });
 
-  it('remembers a landed run until it is released, then probes it again if announced', async () => {
+  it('does not retain a one-shot admission without a polling owner', async () => {
     const queryClient = createQueryClient();
     signIn(queryClient, 'user-a');
     seedList(queryClient);
@@ -394,14 +394,28 @@ describe('run-now conversation tracking', () => {
 
     void trackScheduledRun(queryClient, 'run-convo-1');
     await settleAdmission();
-    void trackScheduledRun(queryClient, 'run-convo-1');
+
+    expect(readList(queryClient).some((c) => c.conversationId === 'run-convo-1')).toBe(true);
+    expect(trackedRunCount()).toBe(0);
+    queryClient.clear();
+  });
+
+  it('remembers a landed run until it is released, then probes it again if announced', async () => {
+    const queryClient = createQueryClient();
+    signIn(queryClient, 'user-a');
+    seedList(queryClient);
+    mockGetConversationById.mockResolvedValue(serverConversation());
+
+    void trackScheduledRun(queryClient, 'run-convo-1', { retain: true });
+    await settleAdmission();
+    void trackScheduledRun(queryClient, 'run-convo-1', { retain: true });
     await settleAdmission();
     expect(mockGetConversationById).toHaveBeenCalledTimes(1);
     expect(trackedRunCount()).toBe(1);
 
     releaseScheduledRun('run-convo-1');
     expect(trackedRunCount()).toBe(0);
-    void trackScheduledRun(queryClient, 'run-convo-1');
+    void trackScheduledRun(queryClient, 'run-convo-1', { retain: true });
     await settleAdmission();
 
     expect(mockGetConversationById).toHaveBeenCalledTimes(2);

--- a/packages/api/src/schedules/handlers.spec.ts
+++ b/packages/api/src/schedules/handlers.spec.ts
@@ -760,52 +760,73 @@ describe('active run projection', () => {
       { user: { id: 'user-1' } } as unknown as ServerRequest,
       res,
     );
-    return (captured.body as { schedules: Array<{ activeRun?: { conversationId: string } }> })
-      .schedules[0];
+    return (
+      captured.body as { schedules: Array<{ activeRuns?: Array<{ conversationId: string }> }> }
+    ).schedules[0];
   }
 
   it('names the chat a running occurrence is producing', async () => {
     const wire = await listWith([run({ conversationId: 'convo-1' })]);
-    expect(wire.activeRun).toEqual({ conversationId: 'convo-1' });
+    expect(wire.activeRuns).toEqual([{ conversationId: 'convo-1' }]);
   });
 
   it('projects nothing for a reservation that has not been dispatched', async () => {
     const wire = await listWith([run({})]);
-    expect(wire.activeRun).toBeUndefined();
+    expect(wire.activeRuns).toBeUndefined();
   });
 
   it('projects nothing when no occurrence is running', async () => {
     const wire = await listWith([]);
-    expect(wire.activeRun).toBeUndefined();
+    expect(wire.activeRuns).toBeUndefined();
   });
 
-  it('prefers the occurrence that fired last when a pause and a run coexist', async () => {
+  it('keeps every concurrent occurrence: a pause does not block the next run', async () => {
     const wire = await listWith([
-      run({
-        conversationId: 'paused',
-        status: 'requires_action',
-        firedAt: new Date('2026-09-05T09:00:00Z'),
-      }),
-      run({ conversationId: 'running', firedAt: new Date('2026-09-06T09:00:00Z') }),
+      run({ conversationId: 'paused', status: 'requires_action' }),
+      run({ conversationId: 'running' }),
     ]);
-    expect(wire.activeRun).toEqual({ conversationId: 'running' });
+    expect(wire.activeRuns).toEqual([{ conversationId: 'paused' }, { conversationId: 'running' }]);
   });
 
-  it("reads the single-schedule route from that schedule's own rows", async () => {
+  it('files each occurrence under its own schedule', async () => {
+    const deps = makeCreateDeps();
+    (deps.methods.getSchedulesByUser as jest.Mock) = jest.fn(async () => [
+      schedule,
+      { ...schedule, id: 'sched-2' },
+    ]);
+    (deps.methods.getActiveRunsForUser as jest.Mock) = jest.fn(async () => [
+      run({ conversationId: 'convo-2', scheduleId: 'sched-2' }),
+    ]);
+    (deps.methods.getDeletingScheduleIds as jest.Mock) = jest.fn(async () => []);
+    const { res, captured } = makeRes();
+    await createSchedulesHandlers(deps).listSchedules(
+      { user: { id: 'user-1' } } as unknown as ServerRequest,
+      res,
+    );
+    const [first, second] = (
+      captured.body as { schedules: Array<{ activeRuns?: Array<{ conversationId: string }> }> }
+    ).schedules;
+    expect(first.activeRuns).toBeUndefined();
+    expect(second.activeRuns).toEqual([{ conversationId: 'convo-2' }]);
+  });
+
+  it('scopes the single-schedule read to the caller before ownership is known', async () => {
     const deps = makeCreateDeps();
     (deps.methods.getScheduleById as jest.Mock) = jest.fn(async () => schedule);
-    (deps.methods.getActiveRunsForSchedule as jest.Mock) = jest.fn(async () => [
-      run({ conversationId: 'convo-1' }),
+    (deps.methods.getActiveRunsForUser as jest.Mock) = jest.fn(async () => [
+      run({ conversationId: 'mine' }),
+      run({ conversationId: 'other-schedule', scheduleId: 'sched-9' }),
     ]);
     const { res, captured } = makeRes();
     await createSchedulesHandlers(deps).getSchedule(
       { params: { id: 'sched-1' }, user: { id: 'user-1' } } as unknown as ServerRequest,
       res,
     );
-    expect(deps.methods.getActiveRunsForSchedule).toHaveBeenCalledWith('sched-1');
-    expect((captured.body as { activeRun?: unknown }).activeRun).toEqual({
-      conversationId: 'convo-1',
-    });
+    expect(deps.methods.getActiveRunsForUser).toHaveBeenCalledWith('user-1');
+    expect(deps.methods.getActiveRunsForSchedule).not.toHaveBeenCalled();
+    expect((captured.body as { activeRuns?: unknown }).activeRuns).toEqual([
+      { conversationId: 'mine' },
+    ]);
   });
 });
 

--- a/packages/api/src/schedules/handlers.spec.ts
+++ b/packages/api/src/schedules/handlers.spec.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import type { ISchedule } from '@librechat/data-schemas';
+import type { ISchedule, IScheduleRun } from '@librechat/data-schemas';
 import type { Response } from 'express';
 import type { SchedulesHandlersDeps } from './handlers';
 import type { ServerRequest } from '~/types';
@@ -154,6 +154,8 @@ function makeCreateDeps(over: Partial<SchedulesHandlersDeps> = {}): SchedulesHan
     markScheduleDeleting: jest.fn(async () => ({ id: 'sched-1' }) as ISchedule),
     updateScheduleById: jest.fn(async () => ({ id: 'sched-1' }) as ISchedule),
     armSchedule: jest.fn(async () => undefined),
+    getActiveRunsForUser: jest.fn(async () => []),
+    getActiveRunsForSchedule: jest.fn(async () => []),
   };
   return {
     methods: methods as unknown as SchedulesHandlersDeps['methods'],
@@ -734,6 +736,76 @@ describe('deferred deletion retry', () => {
     await new Promise((resolve) => setImmediate(resolve));
 
     expect(captured.body).toEqual(expect.objectContaining({ schedules: [] }));
+  });
+});
+
+describe('active run projection', () => {
+  const schedule = { id: 'sched-1', user: 'user-1', name: 'Digest' } as unknown as ISchedule;
+  const run = (over: Partial<IScheduleRun>): IScheduleRun =>
+    ({
+      scheduleId: 'sched-1',
+      user: 'user-1',
+      scheduledFor: new Date('2026-09-06T09:00:00Z'),
+      status: 'started',
+      ...over,
+    }) as unknown as IScheduleRun;
+
+  async function listWith(runs: IScheduleRun[]) {
+    const deps = makeCreateDeps();
+    (deps.methods.getSchedulesByUser as jest.Mock) = jest.fn(async () => [schedule]);
+    (deps.methods.getActiveRunsForUser as jest.Mock) = jest.fn(async () => runs);
+    (deps.methods.getDeletingScheduleIds as jest.Mock) = jest.fn(async () => []);
+    const { res, captured } = makeRes();
+    await createSchedulesHandlers(deps).listSchedules(
+      { user: { id: 'user-1' } } as unknown as ServerRequest,
+      res,
+    );
+    return (captured.body as { schedules: Array<{ activeRun?: { conversationId: string } }> })
+      .schedules[0];
+  }
+
+  it('names the chat a running occurrence is producing', async () => {
+    const wire = await listWith([run({ conversationId: 'convo-1' })]);
+    expect(wire.activeRun).toEqual({ conversationId: 'convo-1' });
+  });
+
+  it('projects nothing for a reservation that has not been dispatched', async () => {
+    const wire = await listWith([run({})]);
+    expect(wire.activeRun).toBeUndefined();
+  });
+
+  it('projects nothing when no occurrence is running', async () => {
+    const wire = await listWith([]);
+    expect(wire.activeRun).toBeUndefined();
+  });
+
+  it('prefers the occurrence that fired last when a pause and a run coexist', async () => {
+    const wire = await listWith([
+      run({
+        conversationId: 'paused',
+        status: 'requires_action',
+        firedAt: new Date('2026-09-05T09:00:00Z'),
+      }),
+      run({ conversationId: 'running', firedAt: new Date('2026-09-06T09:00:00Z') }),
+    ]);
+    expect(wire.activeRun).toEqual({ conversationId: 'running' });
+  });
+
+  it("reads the single-schedule route from that schedule's own rows", async () => {
+    const deps = makeCreateDeps();
+    (deps.methods.getScheduleById as jest.Mock) = jest.fn(async () => schedule);
+    (deps.methods.getActiveRunsForSchedule as jest.Mock) = jest.fn(async () => [
+      run({ conversationId: 'convo-1' }),
+    ]);
+    const { res, captured } = makeRes();
+    await createSchedulesHandlers(deps).getSchedule(
+      { params: { id: 'sched-1' }, user: { id: 'user-1' } } as unknown as ServerRequest,
+      res,
+    );
+    expect(deps.methods.getActiveRunsForSchedule).toHaveBeenCalledWith('sched-1');
+    expect((captured.body as { activeRun?: unknown }).activeRun).toEqual({
+      conversationId: 'convo-1',
+    });
   });
 });
 

--- a/packages/api/src/schedules/handlers.spec.ts
+++ b/packages/api/src/schedules/handlers.spec.ts
@@ -739,7 +739,7 @@ describe('deferred deletion retry', () => {
   });
 });
 
-describe('active run projection', () => {
+describe('in-flight run projection', () => {
   const schedule = { id: 'sched-1', user: 'user-1', name: 'Digest' } as unknown as ISchedule;
   const run = (over: Partial<IScheduleRun>): IScheduleRun =>
     ({
@@ -749,10 +749,11 @@ describe('active run projection', () => {
       status: 'started',
       ...over,
     }) as unknown as IScheduleRun;
+  type Wire = { inFlight?: Array<{ conversationId: string }> };
 
-  async function listWith(runs: IScheduleRun[]) {
+  async function listWith(runs: IScheduleRun[], schedules: ISchedule[] = [schedule]) {
     const deps = makeCreateDeps();
-    (deps.methods.getSchedulesByUser as jest.Mock) = jest.fn(async () => [schedule]);
+    (deps.methods.getSchedulesByUser as jest.Mock) = jest.fn(async () => schedules);
     (deps.methods.getActiveRunsForUser as jest.Mock) = jest.fn(async () => runs);
     (deps.methods.getDeletingScheduleIds as jest.Mock) = jest.fn(async () => []);
     const { res, captured } = makeRes();
@@ -760,57 +761,38 @@ describe('active run projection', () => {
       { user: { id: 'user-1' } } as unknown as ServerRequest,
       res,
     );
-    return (
-      captured.body as { schedules: Array<{ activeRuns?: Array<{ conversationId: string }> }> }
-    ).schedules[0];
+    return { deps, schedules: (captured.body as { schedules: Wire[] }).schedules };
   }
 
-  it('names the chat a running occurrence is producing', async () => {
-    const wire = await listWith([run({ conversationId: 'convo-1' })]);
-    expect(wire.activeRuns).toEqual([{ conversationId: 'convo-1', status: 'started' }]);
+  it('names the chat a generating occurrence is producing', async () => {
+    const { schedules } = await listWith([run({ conversationId: 'convo-1' })]);
+    expect(schedules[0].inFlight).toEqual([{ conversationId: 'convo-1' }]);
+  });
+
+  it('asks only for generating occurrences, never the parked ones', async () => {
+    // Indexed by status rather than user, and `requires_action` rows accumulate for
+    // as long as approvals wait; `started` rows are bounded by the capacity slots.
+    const { deps } = await listWith([]);
+    expect(deps.methods.getActiveRunsForUser).toHaveBeenCalledWith('user-1', ['started']);
   });
 
   it('projects nothing for a reservation that has not been dispatched', async () => {
-    const wire = await listWith([run({})]);
-    expect(wire.activeRuns).toBeUndefined();
+    const { schedules } = await listWith([run({})]);
+    expect(schedules[0].inFlight).toBeUndefined();
   });
 
-  it('projects nothing when no occurrence is running', async () => {
-    const wire = await listWith([]);
-    expect(wire.activeRuns).toBeUndefined();
-  });
-
-  it('keeps every concurrent occurrence: a pause does not block the next run', async () => {
-    const wire = await listWith([
-      run({ conversationId: 'paused', status: 'requires_action' }),
-      run({ conversationId: 'running' }),
-    ]);
-    expect(wire.activeRuns).toEqual([
-      { conversationId: 'paused', status: 'requires_action' },
-      { conversationId: 'running', status: 'started' },
-    ]);
+  it('projects nothing when no occurrence is generating', async () => {
+    const { schedules } = await listWith([]);
+    expect(schedules[0].inFlight).toBeUndefined();
   });
 
   it('files each occurrence under its own schedule', async () => {
-    const deps = makeCreateDeps();
-    (deps.methods.getSchedulesByUser as jest.Mock) = jest.fn(async () => [
-      schedule,
-      { ...schedule, id: 'sched-2' },
-    ]);
-    (deps.methods.getActiveRunsForUser as jest.Mock) = jest.fn(async () => [
-      run({ conversationId: 'convo-2', scheduleId: 'sched-2' }),
-    ]);
-    (deps.methods.getDeletingScheduleIds as jest.Mock) = jest.fn(async () => []);
-    const { res, captured } = makeRes();
-    await createSchedulesHandlers(deps).listSchedules(
-      { user: { id: 'user-1' } } as unknown as ServerRequest,
-      res,
+    const { schedules } = await listWith(
+      [run({ conversationId: 'convo-2', scheduleId: 'sched-2' })],
+      [schedule, { ...schedule, id: 'sched-2' }],
     );
-    const [first, second] = (
-      captured.body as { schedules: Array<{ activeRuns?: Array<{ conversationId: string }> }> }
-    ).schedules;
-    expect(first.activeRuns).toBeUndefined();
-    expect(second.activeRuns).toEqual([{ conversationId: 'convo-2', status: 'started' }]);
+    expect(schedules[0].inFlight).toBeUndefined();
+    expect(schedules[1].inFlight).toEqual([{ conversationId: 'convo-2' }]);
   });
 
   it('scopes the single-schedule read to the caller before ownership is known', async () => {
@@ -825,11 +807,9 @@ describe('active run projection', () => {
       { params: { id: 'sched-1' }, user: { id: 'user-1' } } as unknown as ServerRequest,
       res,
     );
-    expect(deps.methods.getActiveRunsForUser).toHaveBeenCalledWith('user-1');
+    expect(deps.methods.getActiveRunsForUser).toHaveBeenCalledWith('user-1', ['started']);
     expect(deps.methods.getActiveRunsForSchedule).not.toHaveBeenCalled();
-    expect((captured.body as { activeRuns?: unknown }).activeRuns).toEqual([
-      { conversationId: 'mine', status: 'started' },
-    ]);
+    expect((captured.body as Wire).inFlight).toEqual([{ conversationId: 'mine' }]);
   });
 });
 

--- a/packages/api/src/schedules/handlers.spec.ts
+++ b/packages/api/src/schedules/handlers.spec.ts
@@ -767,7 +767,7 @@ describe('active run projection', () => {
 
   it('names the chat a running occurrence is producing', async () => {
     const wire = await listWith([run({ conversationId: 'convo-1' })]);
-    expect(wire.activeRuns).toEqual([{ conversationId: 'convo-1' }]);
+    expect(wire.activeRuns).toEqual([{ conversationId: 'convo-1', status: 'started' }]);
   });
 
   it('projects nothing for a reservation that has not been dispatched', async () => {
@@ -785,7 +785,10 @@ describe('active run projection', () => {
       run({ conversationId: 'paused', status: 'requires_action' }),
       run({ conversationId: 'running' }),
     ]);
-    expect(wire.activeRuns).toEqual([{ conversationId: 'paused' }, { conversationId: 'running' }]);
+    expect(wire.activeRuns).toEqual([
+      { conversationId: 'paused', status: 'requires_action' },
+      { conversationId: 'running', status: 'started' },
+    ]);
   });
 
   it('files each occurrence under its own schedule', async () => {
@@ -807,7 +810,7 @@ describe('active run projection', () => {
       captured.body as { schedules: Array<{ activeRuns?: Array<{ conversationId: string }> }> }
     ).schedules;
     expect(first.activeRuns).toBeUndefined();
-    expect(second.activeRuns).toEqual([{ conversationId: 'convo-2' }]);
+    expect(second.activeRuns).toEqual([{ conversationId: 'convo-2', status: 'started' }]);
   });
 
   it('scopes the single-schedule read to the caller before ownership is known', async () => {
@@ -825,7 +828,7 @@ describe('active run projection', () => {
     expect(deps.methods.getActiveRunsForUser).toHaveBeenCalledWith('user-1');
     expect(deps.methods.getActiveRunsForSchedule).not.toHaveBeenCalled();
     expect((captured.body as { activeRuns?: unknown }).activeRuns).toEqual([
-      { conversationId: 'mine' },
+      { conversationId: 'mine', status: 'started' },
     ]);
   });
 });

--- a/packages/api/src/schedules/handlers.ts
+++ b/packages/api/src/schedules/handlers.ts
@@ -241,7 +241,7 @@ export type WireSchedule = Pick<
   | 'updatedAt'
 > & {
   /** See `TSchedule.activeRuns`: the running occurrences, from their own run rows. */
-  activeRuns?: Array<{ conversationId: string }>;
+  activeRuns?: Array<{ conversationId: string; status: IScheduleRun['status'] }>;
 };
 
 /**
@@ -251,9 +251,9 @@ export type WireSchedule = Pick<
  */
 export function toWireActiveRuns(
   runs: readonly IScheduleRun[],
-): Array<{ conversationId: string }> | undefined {
+): Array<{ conversationId: string; status: IScheduleRun['status'] }> | undefined {
   const chats = runs.flatMap((run) =>
-    run.conversationId != null ? [{ conversationId: run.conversationId }] : [],
+    run.conversationId != null ? [{ conversationId: run.conversationId, status: run.status }] : [],
   );
   return chats.length > 0 ? chats : undefined;
 }

--- a/packages/api/src/schedules/handlers.ts
+++ b/packages/api/src/schedules/handlers.ts
@@ -6,7 +6,7 @@ import {
   isCronCadence,
 } from 'librechat-data-provider';
 import type { TScheduleCadence, TCreateSchedule, TUpdateSchedule } from 'librechat-data-provider';
-import type { ScheduleMethods, ISchedule } from '@librechat/data-schemas';
+import type { ScheduleMethods, ISchedule, IScheduleRun } from '@librechat/data-schemas';
 import type { Response } from 'express';
 import type {
   ScheduleDeleteResult,
@@ -239,7 +239,51 @@ export type WireSchedule = Pick<
   | 'configRevision'
   | 'createdAt'
   | 'updatedAt'
->;
+> & {
+  /** See `TSchedule.activeRun`: the running occurrence, from its own run row. */
+  activeRun?: { conversationId: string };
+};
+
+/**
+ * The occurrence a client should go looking for. A schedule can hold two active
+ * rows — a `requires_action` pause does not block the next occurrence — so take the
+ * one that fired last. A reservation that has not been dispatched yet carries no
+ * conversation id, and there is nothing to look for until it does.
+ */
+export function pickActiveRun(runs: readonly IScheduleRun[]): IScheduleRun | undefined {
+  let latest: IScheduleRun | undefined;
+  for (const run of runs) {
+    if (run.conversationId == null) {
+      continue;
+    }
+    const firedAt = (run.firedAt ?? run.scheduledFor).getTime();
+    const latestFiredAt = latest ? (latest.firedAt ?? latest.scheduledFor).getTime() : -Infinity;
+    if (firedAt >= latestFiredAt) {
+      latest = run;
+    }
+  }
+  return latest;
+}
+
+function activeRunsBySchedule(runs: readonly IScheduleRun[]): Map<string, IScheduleRun> {
+  const grouped = new Map<string, IScheduleRun[]>();
+  for (const run of runs) {
+    const list = grouped.get(run.scheduleId);
+    if (list) {
+      list.push(run);
+    } else {
+      grouped.set(run.scheduleId, [run]);
+    }
+  }
+  const picked = new Map<string, IScheduleRun>();
+  for (const [scheduleId, list] of grouped) {
+    const run = pickActiveRun(list);
+    if (run) {
+      picked.set(scheduleId, run);
+    }
+  }
+  return picked;
+}
 
 /**
  * Public projection. `limits` is optional only for callers that have none to hand;
@@ -251,6 +295,7 @@ export type WireSchedule = Pick<
 export function toWireSchedule(
   schedule: ISchedule,
   limits?: Pick<ScheduleLimits, 'projectId'>,
+  activeRun?: IScheduleRun,
 ): WireSchedule {
   return {
     id: schedule.id,
@@ -272,6 +317,9 @@ export function toWireSchedule(
     configRevision: schedule.configRevision,
     createdAt: schedule.createdAt,
     updatedAt: schedule.updatedAt,
+    ...(activeRun?.conversationId != null && {
+      activeRun: { conversationId: activeRun.conversationId },
+    }),
   };
 }
 
@@ -477,13 +525,21 @@ export function createSchedulesHandlers(deps: SchedulesHandlersDeps): SchedulesH
   }
 
   async function listSchedules(req: ServerRequest, res: Response): Promise<void> {
-    const [schedules, limits] = await Promise.all([
-      deps.methods.getSchedulesByUser(requestUser(req).id),
-      deps.getLimits(requestUser(req)),
+    const user = requestUser(req);
+    // Three independent, user-scoped reads; the active runs ride alongside so the
+    // list can name the chat each running occurrence is producing without a second
+    // round trip per card.
+    const [schedules, limits, activeRuns] = await Promise.all([
+      deps.methods.getSchedulesByUser(user.id),
+      deps.getLimits(user),
+      deps.methods.getActiveRunsForUser(user.id),
     ]);
-    retryDeferredDeletions(requestUser(req).id);
+    const activeBySchedule = activeRunsBySchedule(activeRuns);
+    retryDeferredDeletions(user.id);
     res.json({
-      schedules: schedules.map((schedule) => toWireSchedule(schedule, limits)),
+      schedules: schedules.map((schedule) =>
+        toWireSchedule(schedule, limits, activeBySchedule.get(schedule.id)),
+      ),
       limits: {
         maxPerUser: limits.maxPerUser,
         // minIntervalMinutes ships with the list so the dialog can refuse a cadence
@@ -498,15 +554,16 @@ export function createSchedulesHandlers(deps: SchedulesHandlersDeps): SchedulesH
   async function getSchedule(req: ServerRequest, res: Response): Promise<void> {
     const { id } = req.params as { id: string };
     const user = requestUser(req);
-    const [schedule, limits] = await Promise.all([
+    const [schedule, limits, activeRuns] = await Promise.all([
       deps.methods.getScheduleById(id, user.id),
       deps.getLimits(user),
+      deps.methods.getActiveRunsForSchedule(id),
     ]);
     if (schedule == null) {
       res.status(404).json({ error: 'Schedule not found' });
       return;
     }
-    res.json(toWireSchedule(schedule, limits));
+    res.json(toWireSchedule(schedule, limits, pickActiveRun(activeRuns)));
   }
 
   async function createSchedule(req: ServerRequest, res: Response): Promise<void> {

--- a/packages/api/src/schedules/handlers.ts
+++ b/packages/api/src/schedules/handlers.ts
@@ -240,32 +240,25 @@ export type WireSchedule = Pick<
   | 'createdAt'
   | 'updatedAt'
 > & {
-  /** See `TSchedule.activeRun`: the running occurrence, from its own run row. */
-  activeRun?: { conversationId: string };
+  /** See `TSchedule.activeRuns`: the running occurrences, from their own run rows. */
+  activeRuns?: Array<{ conversationId: string }>;
 };
 
 /**
- * The occurrence a client should go looking for. A schedule can hold two active
- * rows — a `requires_action` pause does not block the next occurrence — so take the
- * one that fired last. A reservation that has not been dispatched yet carries no
- * conversation id, and there is nothing to look for until it does.
+ * The chats a schedule's running occurrences are producing. A reservation that has
+ * not been dispatched yet carries no conversation id, and there is nothing to look
+ * for until it does.
  */
-export function pickActiveRun(runs: readonly IScheduleRun[]): IScheduleRun | undefined {
-  let latest: IScheduleRun | undefined;
-  for (const run of runs) {
-    if (run.conversationId == null) {
-      continue;
-    }
-    const firedAt = (run.firedAt ?? run.scheduledFor).getTime();
-    const latestFiredAt = latest ? (latest.firedAt ?? latest.scheduledFor).getTime() : -Infinity;
-    if (firedAt >= latestFiredAt) {
-      latest = run;
-    }
-  }
-  return latest;
+export function toWireActiveRuns(
+  runs: readonly IScheduleRun[],
+): Array<{ conversationId: string }> | undefined {
+  const chats = runs.flatMap((run) =>
+    run.conversationId != null ? [{ conversationId: run.conversationId }] : [],
+  );
+  return chats.length > 0 ? chats : undefined;
 }
 
-function activeRunsBySchedule(runs: readonly IScheduleRun[]): Map<string, IScheduleRun> {
+function activeRunsBySchedule(runs: readonly IScheduleRun[]): Map<string, IScheduleRun[]> {
   const grouped = new Map<string, IScheduleRun[]>();
   for (const run of runs) {
     const list = grouped.get(run.scheduleId);
@@ -275,14 +268,7 @@ function activeRunsBySchedule(runs: readonly IScheduleRun[]): Map<string, ISched
       grouped.set(run.scheduleId, [run]);
     }
   }
-  const picked = new Map<string, IScheduleRun>();
-  for (const [scheduleId, list] of grouped) {
-    const run = pickActiveRun(list);
-    if (run) {
-      picked.set(scheduleId, run);
-    }
-  }
-  return picked;
+  return grouped;
 }
 
 /**
@@ -295,7 +281,7 @@ function activeRunsBySchedule(runs: readonly IScheduleRun[]): Map<string, ISched
 export function toWireSchedule(
   schedule: ISchedule,
   limits?: Pick<ScheduleLimits, 'projectId'>,
-  activeRun?: IScheduleRun,
+  activeRuns: readonly IScheduleRun[] = [],
 ): WireSchedule {
   return {
     id: schedule.id,
@@ -317,9 +303,7 @@ export function toWireSchedule(
     configRevision: schedule.configRevision,
     createdAt: schedule.createdAt,
     updatedAt: schedule.updatedAt,
-    ...(activeRun?.conversationId != null && {
-      activeRun: { conversationId: activeRun.conversationId },
-    }),
+    ...(activeRuns.length > 0 && { activeRuns: toWireActiveRuns(activeRuns) }),
   };
 }
 
@@ -554,16 +538,25 @@ export function createSchedulesHandlers(deps: SchedulesHandlersDeps): SchedulesH
   async function getSchedule(req: ServerRequest, res: Response): Promise<void> {
     const { id } = req.params as { id: string };
     const user = requestUser(req);
+    // The run read starts before ownership is established, so it is scoped to the
+    // caller — the same user-bound query the list uses — and narrowed here, rather
+    // than a by-schedule read that would touch rows the caller may not own.
     const [schedule, limits, activeRuns] = await Promise.all([
       deps.methods.getScheduleById(id, user.id),
       deps.getLimits(user),
-      deps.methods.getActiveRunsForSchedule(id),
+      deps.methods.getActiveRunsForUser(user.id),
     ]);
     if (schedule == null) {
       res.status(404).json({ error: 'Schedule not found' });
       return;
     }
-    res.json(toWireSchedule(schedule, limits, pickActiveRun(activeRuns)));
+    res.json(
+      toWireSchedule(
+        schedule,
+        limits,
+        activeRuns.filter((run) => run.scheduleId === id),
+      ),
+    );
   }
 
   async function createSchedule(req: ServerRequest, res: Response): Promise<void> {

--- a/packages/api/src/schedules/handlers.ts
+++ b/packages/api/src/schedules/handlers.ts
@@ -240,25 +240,30 @@ export type WireSchedule = Pick<
   | 'createdAt'
   | 'updatedAt'
 > & {
-  /** See `TSchedule.activeRuns`: the running occurrences, from their own run rows. */
-  activeRuns?: Array<{ conversationId: string; status: IScheduleRun['status'] }>;
+  /** See `TSchedule.inFlight`: the generating occurrences, from their own run rows. */
+  inFlight?: Array<{ conversationId: string }>;
 };
 
+/** Only generating occurrences are read for the list. `ScheduleRun` is indexed by
+ *  status, not by user, and `started` rows are bounded globally by the capacity
+ *  slots; `requires_action` rows accumulate for as long as their approvals wait. */
+export const LISTED_RUN_STATUSES: readonly IScheduleRun['status'][] = ['started'];
+
 /**
- * The chats a schedule's running occurrences are producing. A reservation that has
- * not been dispatched yet carries no conversation id, and there is nothing to look
- * for until it does.
+ * The chats a schedule's generating occurrences are producing. A reservation that
+ * has not been dispatched yet carries no conversation id, and there is nothing to
+ * look for until it does.
  */
-export function toWireActiveRuns(
+export function toWireInFlight(
   runs: readonly IScheduleRun[],
-): Array<{ conversationId: string; status: IScheduleRun['status'] }> | undefined {
+): Array<{ conversationId: string }> | undefined {
   const chats = runs.flatMap((run) =>
-    run.conversationId != null ? [{ conversationId: run.conversationId, status: run.status }] : [],
+    run.conversationId != null ? [{ conversationId: run.conversationId }] : [],
   );
   return chats.length > 0 ? chats : undefined;
 }
 
-function activeRunsBySchedule(runs: readonly IScheduleRun[]): Map<string, IScheduleRun[]> {
+function inFlightBySchedule(runs: readonly IScheduleRun[]): Map<string, IScheduleRun[]> {
   const grouped = new Map<string, IScheduleRun[]>();
   for (const run of runs) {
     const list = grouped.get(run.scheduleId);
@@ -281,7 +286,7 @@ function activeRunsBySchedule(runs: readonly IScheduleRun[]): Map<string, ISched
 export function toWireSchedule(
   schedule: ISchedule,
   limits?: Pick<ScheduleLimits, 'projectId'>,
-  activeRuns: readonly IScheduleRun[] = [],
+  inFlight: readonly IScheduleRun[] = [],
 ): WireSchedule {
   return {
     id: schedule.id,
@@ -303,7 +308,7 @@ export function toWireSchedule(
     configRevision: schedule.configRevision,
     createdAt: schedule.createdAt,
     updatedAt: schedule.updatedAt,
-    ...(activeRuns.length > 0 && { activeRuns: toWireActiveRuns(activeRuns) }),
+    ...(inFlight.length > 0 && { inFlight: toWireInFlight(inFlight) }),
   };
 }
 
@@ -510,19 +515,19 @@ export function createSchedulesHandlers(deps: SchedulesHandlersDeps): SchedulesH
 
   async function listSchedules(req: ServerRequest, res: Response): Promise<void> {
     const user = requestUser(req);
-    // Three independent, user-scoped reads; the active runs ride alongside so the
-    // list can name the chat each running occurrence is producing without a second
-    // round trip per card.
-    const [schedules, limits, activeRuns] = await Promise.all([
+    // Three independent, user-scoped reads; the generating runs ride alongside so
+    // the list can name the chat each one is producing without a second round trip
+    // per card.
+    const [schedules, limits, inFlight] = await Promise.all([
       deps.methods.getSchedulesByUser(user.id),
       deps.getLimits(user),
-      deps.methods.getActiveRunsForUser(user.id),
+      deps.methods.getActiveRunsForUser(user.id, LISTED_RUN_STATUSES),
     ]);
-    const activeBySchedule = activeRunsBySchedule(activeRuns);
+    const inFlightBySchedule_ = inFlightBySchedule(inFlight);
     retryDeferredDeletions(user.id);
     res.json({
       schedules: schedules.map((schedule) =>
-        toWireSchedule(schedule, limits, activeBySchedule.get(schedule.id)),
+        toWireSchedule(schedule, limits, inFlightBySchedule_.get(schedule.id)),
       ),
       limits: {
         maxPerUser: limits.maxPerUser,
@@ -541,10 +546,10 @@ export function createSchedulesHandlers(deps: SchedulesHandlersDeps): SchedulesH
     // The run read starts before ownership is established, so it is scoped to the
     // caller — the same user-bound query the list uses — and narrowed here, rather
     // than a by-schedule read that would touch rows the caller may not own.
-    const [schedule, limits, activeRuns] = await Promise.all([
+    const [schedule, limits, inFlight] = await Promise.all([
       deps.methods.getScheduleById(id, user.id),
       deps.getLimits(user),
-      deps.methods.getActiveRunsForUser(user.id),
+      deps.methods.getActiveRunsForUser(user.id, LISTED_RUN_STATUSES),
     ]);
     if (schedule == null) {
       res.status(404).json({ error: 'Schedule not found' });
@@ -554,7 +559,7 @@ export function createSchedulesHandlers(deps: SchedulesHandlersDeps): SchedulesH
       toWireSchedule(
         schedule,
         limits,
-        activeRuns.filter((run) => run.scheduleId === id),
+        inFlight.filter((run) => run.scheduleId === id),
       ),
     );
   }

--- a/packages/data-provider/src/types/schedules.ts
+++ b/packages/data-provider/src/types/schedules.ts
@@ -136,13 +136,13 @@ export type TSchedule = {
   nextRunAt?: string;
   lastRun?: TScheduleLastRun;
   /**
-   * The occurrence running right now, when one is. Read from its own run row, not
-   * from `lastRun` — which is projected only when a run settles, pauses or skips,
-   * and is deliberately withheld from a run whose schedule was edited mid-flight.
-   * This is the one signal a client has that a chat is on its way, and the id it
-   * needs to go and fetch it.
+   * The occurrences running right now — a `requires_action` pause does not block
+   * the next one, so there can be two. Read from their own run rows, not from
+   * `lastRun`, which is projected only when a run settles, pauses or skips and is
+   * deliberately withheld from a run whose schedule was edited mid-flight. This is
+   * the signal a client has that a chat is on its way, and the id to fetch it by.
    */
-  activeRun?: { conversationId: string };
+  activeRuns?: Array<{ conversationId: string }>;
   runCount: number;
   failureCount: number;
   configRevision?: number;

--- a/packages/data-provider/src/types/schedules.ts
+++ b/packages/data-provider/src/types/schedules.ts
@@ -142,7 +142,12 @@ export type TSchedule = {
    * deliberately withheld from a run whose schedule was edited mid-flight. This is
    * the signal a client has that a chat is on its way, and the id to fetch it by.
    */
-  activeRuns?: Array<{ conversationId: string }>;
+  activeRuns?: Array<{
+    conversationId: string;
+    /** `started` is generating; `requires_action` is paused on an approval and may
+     *  stay that way indefinitely, so only the former is "in flight" to a client. */
+    status: ScheduleRunStatus;
+  }>;
   runCount: number;
   failureCount: number;
   configRevision?: number;

--- a/packages/data-provider/src/types/schedules.ts
+++ b/packages/data-provider/src/types/schedules.ts
@@ -135,6 +135,14 @@ export type TSchedule = {
   disabledReason?: ScheduleDisabledReason;
   nextRunAt?: string;
   lastRun?: TScheduleLastRun;
+  /**
+   * The occurrence running right now, when one is. Read from its own run row, not
+   * from `lastRun` — which is projected only when a run settles, pauses or skips,
+   * and is deliberately withheld from a run whose schedule was edited mid-flight.
+   * This is the one signal a client has that a chat is on its way, and the id it
+   * needs to go and fetch it.
+   */
+  activeRun?: { conversationId: string };
   runCount: number;
   failureCount: number;
   configRevision?: number;

--- a/packages/data-provider/src/types/schedules.ts
+++ b/packages/data-provider/src/types/schedules.ts
@@ -136,18 +136,14 @@ export type TSchedule = {
   nextRunAt?: string;
   lastRun?: TScheduleLastRun;
   /**
-   * The occurrences running right now — a `requires_action` pause does not block
-   * the next one, so there can be two. Read from their own run rows, not from
+   * The occurrences generating right now. Read from their own run rows, not from
    * `lastRun`, which is projected only when a run settles, pauses or skips and is
    * deliberately withheld from a run whose schedule was edited mid-flight. This is
    * the signal a client has that a chat is on its way, and the id to fetch it by.
+   * A run parked on an approval is not here: its chat was listed long ago, and the
+   * rows can accumulate for as long as approvals wait.
    */
-  activeRuns?: Array<{
-    conversationId: string;
-    /** `started` is generating; `requires_action` is paused on an approval and may
-     *  stay that way indefinitely, so only the former is "in flight" to a client. */
-    status: ScheduleRunStatus;
-  }>;
+  inFlight?: Array<{ conversationId: string }>;
   runCount: number;
   failureCount: number;
   configRevision?: number;

--- a/packages/data-schemas/src/methods/schedule.methods.spec.ts
+++ b/packages/data-schemas/src/methods/schedule.methods.spec.ts
@@ -228,6 +228,26 @@ describe('getScheduleRunProject (occurrence scope, recorded vs unknown)', () => 
    * if that ever stopped holding, a deliberately unscoped run would silently start
    * being validated against the schedule's current project instead.
    */
+  it("narrows the user's in-flight runs to the statuses asked for", async () => {
+    const schedule = await methods.createSchedule(scheduleData());
+    const generating = new Date('2026-07-22T12:00:00Z');
+    const paused = new Date('2026-07-23T12:00:00Z');
+    await methods.reserveStartedRun(runData(schedule, { scheduledFor: paused }));
+    await methods.recordRunOutcome({
+      scheduleId: schedule.id,
+      scheduledFor: paused,
+      status: 'requires_action',
+      autoDisableAfterFailures: 5,
+    });
+    await methods.reserveStartedRun(runData(schedule, { scheduledFor: generating }));
+
+    const all = await methods.getActiveRunsForUser(schedule.user);
+    const started = await methods.getActiveRunsForUser(schedule.user, ['started']);
+
+    expect(all.map((run) => run.status).sort()).toEqual(['requires_action', 'started']);
+    expect(started.map((run) => run.scheduledFor)).toEqual([generating]);
+  });
+
   it('reports a recorded null apart from a field that was never written', async () => {
     const schedule = await methods.createSchedule(scheduleData());
     const scoped = new Date('2026-07-20T12:00:00Z');

--- a/packages/data-schemas/src/methods/schedule.ts
+++ b/packages/data-schemas/src/methods/schedule.ts
@@ -289,7 +289,10 @@ export type ScheduleMethods = {
   ) => Promise<void>;
   markScheduleDeleting: (id: string, userId: string | Types.ObjectId) => Promise<ISchedule | null>;
   getActiveRunsForSchedule: (scheduleId: string) => Promise<IScheduleRun[]>;
-  getActiveRunsForUser: (userId: string | Types.ObjectId) => Promise<IScheduleRun[]>;
+  getActiveRunsForUser: (
+    userId: string | Types.ObjectId,
+    statuses?: readonly ScheduleRunStatus[],
+  ) => Promise<IScheduleRun[]>;
   suspendUserSchedulesForDeletion: (
     userId: string | Types.ObjectId,
     token: string,
@@ -1756,10 +1759,19 @@ export function createScheduleMethods(mongoose: typeof import('mongoose')): Sche
       .lean<IScheduleRun[]>();
   }
 
-  /** In-flight runs across all of a user's schedules — for account-deletion quiescing. */
-  async function getActiveRunsForUser(userId: string | Types.ObjectId): Promise<IScheduleRun[]> {
+  /**
+   * In-flight runs across all of a user's schedules — for account-deletion quiescing,
+   * and, narrowed to `started`, for the schedules list. The narrowing matters there:
+   * this collection is indexed by status, not by user, and `started` rows are bounded
+   * globally by the capacity slots while `requires_action` rows can accumulate for as
+   * long as an approval waits.
+   */
+  async function getActiveRunsForUser(
+    userId: string | Types.ObjectId,
+    statuses: readonly ScheduleRunStatus[] = ACTIVE_RUN_STATUSES,
+  ): Promise<IScheduleRun[]> {
     return ScheduleRun()
-      .find({ user: userId, status: { $in: ACTIVE_RUN_STATUSES } })
+      .find({ user: userId, status: { $in: statuses } })
       .lean<IScheduleRun[]>();
   }
 


### PR DESCRIPTION
> Follows #15630 (merged as `e1f2298cb8`), which this builds on: the automatic half of the same bug, sharing that PR's admission watch.

## Problem

The automatic half of the same bug: a scheduled occurrence is the one generation nothing in the client starts, so nothing tells the sidebar its chat exists, and the list's five-minute `staleTime` leaves it out of a tab that stays focused.

## Why the first three versions were wrong

Each review round found a new way the schedule projection diverges from the run it stands in for: `lastRun` is not written at fire (only at settlement, pause or skip); `nextRunAt` advances at enqueue, *before* the conversation exists; an owner editing the schedule mid-flight bumps `configRevision`, the terminal write is revision-fenced, and `lastRun` deliberately never changes. Nothing on a schedule document means "this run's chat is listable now", so every signal read from one was too early or too late. That is a design error presenting as a bug list, and patching it a fourth time would have produced a fifth.

## Fix: stop inferring

**Server.** `listSchedules` already reads the user's schedules and limits in parallel; it now reads their active run rows alongside (`getActiveRunsForUser`, one user-scoped query, joined by schedule id) and projects each generating occurrence's conversation id as `inFlight` on `TSchedule`. Only `started` rows are read — `ScheduleRun` is indexed by status, not by user, `started` rows are bounded globally by the capacity slots, and `requires_action` rows accumulate for as long as their approvals wait — through an optional status narrowing on the existing `getActiveRunsForUser`. They come from the run rows, so the configRevision fence cannot hide them, and are absent until dispatch has actually reserved a conversation. A pause resolving is still seen through `lastRun`. `getSchedule` uses the same user-bound query narrowed to the schedule: its read starts before ownership is established, so it must stay scoped to the caller.

**Client.** A run short enough to start and settle between two polls is never seen running, and most scheduled chats are short — so the panel fetches every chat the list names that it has not seen, `activeRuns` *and* `lastRun.conversationId`, to `trackScheduledRun` on every observation — the same admission watch Run Now uses (#15630), which probes until the server has the chat and adds the server's own row, warms the chat-route cache, queues the title, re-arms the active-job poll and refreshes the project rows. It is the one place that decides whether an id is landed, in flight, or — having given up on a delivery deferred past its budget — worth trying again. One mechanism for both paths, detached from the panel. Only generating runs are ever handed over: a settled run is covered by the list re-read its settlement triggers, which brings the server's own row, so a run that failed before writing a conversation (a 404 for good) is never probed. When an occurrence leaves the list the hook releases it, so the watch remembers a run exactly as long as something can announce it — bounded by real concurrency, no count cap. The effect is keyed on the poll's timestamp as well as its data, because a deep-equal refetch hands back the same array and a watch that gave up would otherwise never be asked again. The first observation has nothing earlier to compare against and cannot tell when the sidebar was last read from the server, so it re-reads if any schedule has run at all: one refetch on opening the panel. When a run's state moves — one settles, its schedule is deleted from under it, or a schedule created elsewhere arrives with a run already behind it — the list is re-read once for the chat, order and title the settlement changed. A run short enough to start and settle between two polls is never seen generating; it is still seen settled, and that re-read is what brings it. 

## Tests

- `packages/data-schemas/src/methods/schedule.methods.spec.ts` — real Mongo: the status narrowing returns the generating run and not the paused one.
- `packages/api/src/schedules/handlers.spec.ts` — 6 projection cases: names the generating chat; **asks only for `started`**; nothing for an undispatched reservation; nothing when idle; each filed under its own schedule; the single-schedule read scoped to the caller. 314/314 in `src/schedules`.
- `client/src/components/SidePanel/Schedules/__tests__/useRunSync.spec.tsx` — 15 cases with the real admission watch under fake timers: the chat lands; watched once across polls; settlement re-reads; settlement seen through a mid-flight edit; a run that started and settled between polls triggers a re-read **without being probed**; every generating occurrence fetched; **a deleted schedule's run counts as a settlement**; **a schedule created elsewhere arriving already settled counts too**, and one arriving idle does not; a run whose watch gave up is announced again; first observation re-reads when anything has run and stays silent when nothing has; **a watch that gave up is announced again on a deep-equal poll**; a run is released once it leaves the list; unrelated edits ignored; undefined data ignored. Each load-bearing cell fails against its removal. The watch keeps in-flight ids in their own set and remembers landed ones until the hook releases them, so nothing is capped and nothing still announced can be evicted.
- ESLint, Prettier, `sort-imports`, and `tsc --noEmit` clean in `client`, `packages/api` and `packages/data-provider`.

## Scope

Covers a run that fires **while the schedules panel is open**, where the cards already updated and the sidebar did not. Two things resolve on the next window-focus refetch rather than here: a run that fires with the panel closed (closing that means mounting the schedules query app-wide, a request-volume decision for every deployment), and a run that starts, is *edited*, and settles all inside one poll — the edit fences `lastRun` and the run was never seen live; closing that needs the server to project recently settled rows for a third-order case.
