### PR TITLE
🩹 fix: Restore the Client Build by Parsing Single-Dollar Math via Micromark

### DIFF
--- a/client/src/utils/richtext.spec.ts
+++ b/client/src/utils/richtext.spec.ts
@@ -113,14 +113,14 @@ describe('markdownToHtml', () => {
     );
   });
 
-  it('renders single-dollar math when the renderer preprocesses LaTeX', () => {
+  it('renders single-dollar math when the renderer parses LaTeX', () => {
     expect(markdownToHtml('Energy is $E=mc^2$ inline.', { variant: 'full', latex: true })).toBe(
       '<p>Energy is E=mc^2 inline.</p>',
     );
     expect(markdownToHtml('Energy is $E=mc^2$ inline.')).toBe('<p>Energy is $E=mc^2$ inline.</p>');
   });
 
-  it('still leaves currency alone with LaTeX preprocessing on', () => {
+  it('still leaves currency alone with LaTeX parsing on', () => {
     expect(markdownToHtml('Costs rose from $5 to $10.', { variant: 'full', latex: true })).toBe(
       '<p>Costs rose from $5 to $10.</p>',
     );

--- a/client/src/utils/richtext.ts
+++ b/client/src/utils/richtext.ts
@@ -20,7 +20,7 @@ import type {
 import type { Extension as MicromarkExtension } from 'micromark-util-types';
 import { mcpUIResourcePlugin } from '~/components/MCPUIResource/plugin';
 import { remarkApproxTilde } from './tilde';
-import { preprocessLaTeX } from './latex';
+import { singleDollarMath } from './latex';
 
 /**
  * Which message renderer this copy has to match. `Markdown` (assistant turns)
@@ -404,10 +404,11 @@ function serializeChildren(nodes: readonly SerializableNode[], context: Serializ
  * the clipboard as `text/html`. Paste targets that ignore Markdown (Teams,
  * Outlook, Word) strip stylesheets, so every visual cue has to be inline.
  *
- * Parsing mirrors the message renderers: the same LaTeX preprocessing, the same
- * micromark extensions with `singleDollarTextMath` off so currency such as
- * `$5 to $10` stays currency, then the same `remarkApproxTilde` and
- * `remark-supersub` transforms they apply to the parsed tree.
+ * Parsing mirrors the message renderers: the same currency-safe single-dollar
+ * math extension, the same `micromark-extension-math` with `singleDollarTextMath`
+ * off so currency such as `$5 to $10` stays currency, then the same
+ * `remarkApproxTilde` and `remark-supersub` transforms they apply to the parsed
+ * tree.
  */
 export function markdownToHtml(
   markdown: string,
@@ -417,10 +418,11 @@ export function markdownToHtml(
   if (mode.variant === 'full') {
     extensions.push(directive());
   }
+  if (mode.latex) {
+    extensions.push(singleDollarMath);
+  }
 
-  const source = mode.latex ? preprocessLaTeX(markdown) : markdown;
-
-  const tree = fromMarkdown(source, {
+  const tree = fromMarkdown(markdown, {
     extensions,
     mdastExtensions: [gfmFromMarkdown(), directiveFromMarkdown(), mathFromMarkdown()],
   });


### PR DESCRIPTION
## Summary

`dev` does not typecheck or build. `markdownToHtml` (added by #15087, `client/src/utils/richtext.ts:23`) imports `preprocessLaTeX` from `client/src/utils/latex.ts`, but #15181 replaced that preprocessing pass with the currency-safe `singleDollarMath` micromark construct and deleted the function. The symbol exists nowhere in the repo — `git grep preprocessLaTeX` on `dev` returns only those two `richtext.ts` lines plus two prose mentions in `packages/api/src/utils/latex.ts`.

Consequences on `dev` and on every open pull request (CI builds `refs/pull/N/merge`, so each PR inherits it):

- `TypeScript type checks (client)` — `src/utils/richtext.ts(23,10): error TS2305: Module '"./latex"' has no exported member 'preprocessLaTeX'.`
- `Vite build verification` — `[MISSING_EXPORT] "preprocessLaTeX" is not exported by "src/utils/latex.ts"`
- Everything downstream of the client build fails in well under a minute: all `e2e` shards, `e2e (redis transport)`, `MCP list_changed`, `API runtime smoke`, `bombadil`, `Tests: Ubuntu (shard 2/2)`.

## Fix

Register `singleDollarMath` in the micromark extension list when `mode.latex` is set, instead of preprocessing the source string.

That is what the message renderers do: `markdownConfig.ts:46` adds `remarkSingleDollarMath` only when `latexParsing` is on, and that plugin does nothing but push `singleDollarMath` into `micromarkExtensions`. `markdownToHtml` parses with `fromMarkdown` directly rather than through unified, so the extension array is the equivalent seam. Clipboard HTML therefore keeps mirroring the rendered message, which is the parity this helper is built around.

The two existing specs already pinned the intended behavior and pass unchanged — `$E=mc^2$` becomes inline math under `latex: true`, `$5 to $10` stays currency. Their titles claimed the renderer "preprocesses" LaTeX, which no longer names a mechanism that exists, so they now say "parses".

## Verification

- `client`: `npx tsc --noEmit` → 0 errors (was 1)
- `client`: `npm run build:ci` → `✓ built` (was `MISSING_EXPORT`)
- `client`: `richtext.spec.ts` + `latex.spec.ts` → 72 passed, 0 failed