### PR TITLE
📐 fix: Keep the Live Slot Under a Phase Card One Row Tall

### DIFF
--- a/client/src/components/Chat/Messages/Content/ActivityPhaseGroup.tsx
+++ b/client/src/components/Chat/Messages/Content/ActivityPhaseGroup.tsx
@@ -13,7 +13,7 @@ import {
 import useSmoothStreaming from '~/hooks/Messages/useSmoothStreaming';
 import { getActivityLabelText } from '~/utils/activityLabels';
 import { AttachmentGroup, EmptyText } from './Parts';
-import Container from './Container';
+import { TOOL_ROW_CLASSES } from './rows';
 import { cn } from '~/utils';
 
 /** Matches `EXPAND_TRANSITION` so the panel and the label ticker resolve on
@@ -269,10 +269,18 @@ export default function ActivityPhaseGroup({
     };
   }, [foldsIn, isSettled]);
 
+  /** The live slot under a collapsed card alternates between this cursor and
+   *  the next call's row for the rest of the run: a label fills, the row it
+   *  headed folds into the card and the cursor takes its place; the next call
+   *  starts and the cursor gives way to a row again. A cursor in a bare
+   *  `Container` (20px, no margins) was 12px shorter than the tool row
+   *  (`my-1.5 h-5`), so everything beneath the card stepped up on every
+   *  absorb and back down on every call. The cursor takes the row's exact box
+   *  and a 2px inset centers the 12px dot on the 16px glyph rail. */
   const cursor = showCursor ? (
-    <Container>
+    <div className={cn(TOOL_ROW_CLASSES, 'ps-0.5')} data-testid="activity-phase-cursor">
       <EmptyText />
-    </Container>
+    </div>
   ) : null;
   const media =
     attachments != null && attachments.length > 0 ? (

--- a/client/src/components/Chat/Messages/Content/AskUserQuestionCall.tsx
+++ b/client/src/components/Chat/Messages/Content/AskUserQuestionCall.tsx
@@ -11,6 +11,7 @@ import AskUserQuestionProgress from './AskUserQuestionProgress';
 import { useLocalize, useExpandCollapse } from '~/hooks';
 import ProgressText from './ProgressText';
 import EmptyText from './Parts/EmptyText';
+import { TOOL_ROW_CLASSES } from './rows';
 import Container from './Container';
 import store from '~/store';
 
@@ -147,10 +148,7 @@ export default function AskUserQuestionCall({
 
   return (
     <>
-      <div
-        className="relative my-1.5 flex h-5 shrink-0 items-center gap-2.5"
-        data-testid="ask-user-question-call"
-      >
+      <div className={TOOL_ROW_CLASSES} data-testid="ask-user-question-call">
         <ProgressText
           phase="completed"
           onClick={toggleExpanded}

--- a/client/src/components/Chat/Messages/Content/Parts/BashCall.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/BashCall.tsx
@@ -14,6 +14,7 @@ import useFollowScroll from './useFollowScroll';
 import { ERROR_PATTERNS } from './ExecuteCode';
 import { AttachmentGroup } from './Attachment';
 import { useToolCallIntent } from './intent';
+import { TOOL_ROW_CLASSES } from '../rows';
 import PtcToolTrace from './PtcToolTrace';
 import { useLocalize } from '~/hooks';
 import { cn } from '~/utils';
@@ -121,7 +122,7 @@ export default function BashCall({
 
   return (
     <>
-      <div className="relative my-1.5 flex h-5 shrink-0 items-center gap-2.5">
+      <div className={TOOL_ROW_CLASSES}>
         <ProgressText
           phase={phase}
           onClick={toggleCode}

--- a/client/src/components/Chat/Messages/Content/Parts/ExecuteCode.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/ExecuteCode.tsx
@@ -11,6 +11,7 @@ import CodeWindowHeader from './CodeWindowHeader';
 import useFollowScroll from './useFollowScroll';
 import { AttachmentGroup } from './Attachment';
 import { useToolCallIntent } from './intent';
+import { TOOL_ROW_CLASSES } from '../rows';
 import PtcToolTrace from './PtcToolTrace';
 import { useLocalize } from '~/hooks';
 import Stdout from './Stdout';
@@ -130,7 +131,7 @@ export default function ExecuteCode({
 
   return (
     <>
-      <div className="relative my-1.5 flex h-5 shrink-0 items-center gap-2.5">
+      <div className={TOOL_ROW_CLASSES}>
         <ProgressText
           phase={phase}
           onClick={toggleCode}

--- a/client/src/components/Chat/Messages/Content/Parts/FileAuthoringCall.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/FileAuthoringCall.tsx
@@ -10,6 +10,7 @@ import useFollowScroll from './useFollowScroll';
 import { AttachmentGroup } from './Attachment';
 import { langFromPath } from './ReadFileCall';
 import { useToolCallIntent } from './intent';
+import { TOOL_ROW_CLASSES } from '../rows';
 import { useLocalize } from '~/hooks';
 import { cn } from '~/utils';
 
@@ -176,7 +177,7 @@ export default function FileAuthoringCall({
 
   return (
     <>
-      <div className="relative my-1.5 flex h-5 shrink-0 items-center gap-2.5">
+      <div className={TOOL_ROW_CLASSES}>
         <ProgressText
           phase={phase}
           onClick={toggleCode}

--- a/client/src/components/Chat/Messages/Content/Parts/PendingSkillCall.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/PendingSkillCall.tsx
@@ -1,4 +1,5 @@
 import { ScrollText } from 'lucide-react';
+import { TOOL_ROW_CLASSES } from '../rows';
 import { useLocalize } from '~/hooks';
 import { cn } from '~/utils';
 
@@ -33,7 +34,7 @@ export default function PendingSkillCall({
     : localize('com_ui_skill_running', { 0: skillName });
 
   return (
-    <div className="relative my-1.5 flex h-5 shrink-0 items-center gap-2.5">
+    <div className={TOOL_ROW_CLASSES}>
       <div className="progress-text-wrapper text-token-text-secondary relative -mt-[0.75px] h-5 w-full leading-5">
         <div
           className="progress-text-content absolute left-0 top-0 max-w-full overflow-visible whitespace-nowrap"

--- a/client/src/components/Chat/Messages/Content/Parts/ReadFileCall.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/ReadFileCall.tsx
@@ -8,6 +8,7 @@ import CodeWindowHeader from './CodeWindowHeader';
 import { AttachmentGroup } from './Attachment';
 import parseJsonField from './parseJsonField';
 import { useToolCallIntent } from './intent';
+import { TOOL_ROW_CLASSES } from '../rows';
 import { useLocalize } from '~/hooks';
 import { cn } from '~/utils';
 
@@ -102,7 +103,7 @@ export default function ReadFileCall({
 
   return (
     <>
-      <div className="relative my-1.5 flex h-5 shrink-0 items-center gap-2.5">
+      <div className={TOOL_ROW_CLASSES}>
         <ProgressText
           phase={phase}
           onClick={toggleCode}

--- a/client/src/components/Chat/Messages/Content/Parts/SkillCall.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/SkillCall.tsx
@@ -6,6 +6,7 @@ import useToolCallState from './useToolCallState';
 import { AttachmentGroup } from './Attachment';
 import parseJsonField from './parseJsonField';
 import { useToolCallIntent } from './intent';
+import { TOOL_ROW_CLASSES } from '../rows';
 import { useLocalize } from '~/hooks';
 import Stdout from './Stdout';
 import { cn } from '~/utils';
@@ -46,7 +47,7 @@ export default function SkillCall({
 
   return (
     <>
-      <div className="relative my-1.5 flex h-5 shrink-0 items-center gap-2.5">
+      <div className={TOOL_ROW_CLASSES}>
         <ProgressText
           phase={phase}
           onClick={toggleCode}

--- a/client/src/components/Chat/Messages/Content/ToolCall.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCall.tsx
@@ -18,6 +18,7 @@ import { useToolCallIntent } from './Parts/intent';
 import { AttachmentGroup } from './Parts';
 import ToolCallInfo from './ToolCallInfo';
 import ProgressText from './ProgressText';
+import { TOOL_ROW_CLASSES } from './rows';
 import { logger } from '~/utils';
 import store from '~/store';
 
@@ -274,11 +275,7 @@ export default function ToolCall({
           return getFinishedText();
         })()}
       </span>
-      <div
-        className="relative my-1.5 flex h-5 shrink-0 items-center gap-2.5"
-        data-testid="tool-call"
-        data-tool-call-id={toolCallId}
-      >
+      <div className={TOOL_ROW_CLASSES} data-testid="tool-call" data-tool-call-id={toolCallId}>
         <ProgressText
           phase={phase}
           onClick={handleToggleInfo}

--- a/client/src/components/Chat/Messages/Content/__tests__/ActivityPhaseGroup.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ActivityPhaseGroup.test.tsx
@@ -2,6 +2,7 @@ import { ContentTypes } from 'librechat-data-provider';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import type { TMessageContentParts } from 'librechat-data-provider';
 import ActivityPhaseGroup from '../ActivityPhaseGroup';
+import { TOOL_ROW_CLASSES } from '../rows';
 
 const mockUseSmoothStreaming = jest.fn(() => true);
 const mockScheduleLayoutReconcile = jest.fn((_target: HTMLElement | null) => jest.fn());
@@ -97,6 +98,23 @@ describe('ActivityPhaseGroup', () => {
     );
 
     expect(container.querySelector('.result-thinking')).toBeInTheDocument();
+  });
+
+  test('the cursor occupies exactly a tool row box', () => {
+    render(
+      <ActivityPhaseGroup labelPart={labelPart} hasContent showCursor>
+        <div data-testid="phase-content" />
+      </ActivityPhaseGroup>,
+    );
+
+    /** The cursor and the next call's row trade places under the card for the
+     *  rest of the run. Any difference between their boxes moves everything
+     *  beneath the card on every swap. */
+    const cursor = screen.getByTestId('activity-phase-cursor');
+    for (const token of TOOL_ROW_CLASSES.split(' ')) {
+      expect(cursor).toHaveClass(token);
+    }
+    expect(cursor.querySelector('.result-thinking')).toBeInTheDocument();
   });
 
   test('opens the summary on the same glyph rail as the rows it replaces', () => {

--- a/client/src/components/Chat/Messages/Content/rows.ts
+++ b/client/src/components/Chat/Messages/Content/rows.ts
@@ -1,0 +1,8 @@
+/**
+ * The vertical box of a live tool row: a 20px line with 6px margins above and
+ * below, shared by every call card header and by the streaming cursor a
+ * collapsed phase card renders beneath itself. The two trade places on every
+ * absorb → next-call cycle of a run, so they must occupy the same height or
+ * everything under the card moves on each swap.
+ */
+export const TOOL_ROW_CLASSES = 'relative my-1.5 flex h-5 shrink-0 items-center gap-2.5';


### PR DESCRIPTION
## The bug

During an agent run, with nothing touched, the layout under a collapsed phase card steps **up** and then back **down** every few seconds — visible as the elapsed timestamp jumping. Nothing visible changes at the moment of the jump, which reads as "room being made for nested tool calls that never appear".

## Cause

Replaying the content stream of a real export through `ContentParts` step by step (running → output → blank label reservation → label fill, per block) shows what the slot beneath a synthesized phase card holds over a run:

| moment | slot contents | box |
|---|---|---|
| label fills, row folds into the card | streaming cursor in a bare `Container` | **20px**, no margins |
| next call starts | the call's header row (`my-1.5 h-5`) | **32px** |

So every absorb shrinks the column and every new call grows it again. Measured in Chromium with the app's generated CSS: 60px vs 66px for the two states (the row's bottom margin adds more in the live column, where the flex parent stops it collapsing).

## Fix

- The cursor now takes the exact box of the row it stands in for, so the swap is height-neutral (re-measured: **0px** delta). A 2px inset centers the 12px dot on the 16px glyph rail.
- That row box was the same literal in 8 call cards; it is now `TOOL_ROW_CLASSES` in `rows.ts` (separate, output-identical commit) so the cursor and every card share one definition rather than a comment promising they match.

## Verification

- New test asserts the cursor carries every token of `TOOL_ROW_CLASSES` — confirmed it fails against the previous `Container`.
- 1084/1084 across `client/src/components/Chat/Messages`; changed files typecheck clean; `static-checks` green.

Not in scope: a THINK part streaming between calls still renders taller than the cursor (a real "Thinking" row appearing), and the card's ticker re-title is unchanged.