### PR TITLE
🐛 fix: improve sidebar title clarity and hover scrolling

### DIFF
--- a/client/src/components/Conversations/Convo.tsx
+++ b/client/src/components/Conversations/Convo.tsx
@@ -48,6 +48,7 @@ function Conversation({
   const [titleInput, setTitleInput] = useState(title || '');
   const [renaming, setRenaming] = useState(false);
   const [isPopoverActive, setIsPopoverActive] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
   // Lazy-load ConvoOptions to avoid running heavy hooks for all conversations
   const [hasInteracted, setHasInteracted] = useState(false);
 
@@ -222,6 +223,13 @@ function Conversation({
           ? 'bg-surface-active-alt before:absolute before:bottom-1 before:left-0 before:top-1 before:w-0.5 before:rounded-full before:bg-text-primary'
           : 'hover:bg-surface-active-alt',
       )}
+      onPointerEnter={(event) => {
+        if (event.pointerType === 'mouse') {
+          setIsHovered(true);
+        }
+      }}
+      onPointerLeave={() => setIsHovered(false)}
+      onPointerCancel={() => setIsHovered(false)}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       onFocus={handleMouseEnter}
@@ -249,6 +257,7 @@ function Conversation({
         <ConvoLink
           isActiveConvo={isActiveConvo}
           isPopoverActive={isPopoverActive}
+          isHovered={isHovered}
           isSharedBadgeVisible={isSharedBadgeVisible}
           title={title}
           onRename={handleRename}

--- a/client/src/components/Conversations/ConvoLink.tsx
+++ b/client/src/components/Conversations/ConvoLink.tsx
@@ -1,20 +1,24 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import type { TOptions } from 'i18next';
+import type { TranslationKeys } from '~/hooks/useLocalize';
 import { cn } from '~/utils';
 
 interface ConvoLinkProps {
   isActiveConvo: boolean;
   isPopoverActive: boolean;
+  isHovered: boolean;
   isSharedBadgeVisible: boolean;
   title: string | null;
   onRename: () => void;
   isSmallScreen: boolean;
-  localize: (key: any, options?: any) => string;
+  localize: (key: TranslationKeys, options?: TOptions) => string;
   children: React.ReactNode;
 }
 
 const ConvoLink: React.FC<ConvoLinkProps> = ({
   isActiveConvo,
   isPopoverActive,
+  isHovered,
   isSharedBadgeVisible,
   title,
   onRename,
@@ -22,14 +26,87 @@ const ConvoLink: React.FC<ConvoLinkProps> = ({
   localize,
   children,
 }) => {
+  const [isOverflowing, setIsOverflowing] = useState(false);
+  const titleRef = useRef<HTMLSpanElement>(null);
+  const textRef = useRef<HTMLSpanElement>(null);
+  const displayTitle = title || localize('com_ui_untitled');
+
+  useEffect(() => {
+    const viewport = titleRef.current;
+    const text = textRef.current;
+    if (!viewport || !text) {
+      return;
+    }
+
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+    let animation: Animation | undefined;
+    let fadeAnimation: Animation | undefined;
+
+    const start = () => {
+      animation?.cancel();
+      fadeAnimation?.cancel();
+      const overflow = text.getBoundingClientRect().width - viewport.getBoundingClientRect().width;
+      setIsOverflowing(overflow > 0);
+      if (!isHovered || isSmallScreen || reducedMotion.matches || overflow <= 0) {
+        return;
+      }
+
+      const style = getComputedStyle(viewport);
+      const direction = style.direction === 'rtl' ? 1 : -1;
+      const fadeWidth = parseFloat(style.getPropertyValue('--convo-title-fade-width'));
+      const travelDuration = (overflow / 30) * 1000;
+      const duration = travelDuration + 2000;
+      const end = `translateX(${direction * overflow}px)`;
+      const timing = { duration, delay: 600, iterations: Infinity, easing: 'linear' };
+
+      animation = text.animate(
+        [
+          { transform: 'translateX(0)' },
+          { transform: end, offset: travelDuration / duration },
+          { transform: end },
+        ],
+        timing,
+      );
+
+      /** Reveal the final characters by moving the fade, not by overscrolling the text. */
+      const fullMask = `calc(100% + ${fadeWidth}px) 100%`;
+      fadeAnimation = viewport.animate(
+        [
+          { maskSize: '100% 100%' },
+          {
+            maskSize: '100% 100%',
+            offset: (Math.max(0, (overflow - fadeWidth) / 30) * 1000) / duration,
+          },
+          { maskSize: fullMask, offset: travelDuration / duration },
+          { maskSize: fullMask },
+        ],
+        timing,
+      );
+    };
+
+    const observer = new ResizeObserver(start);
+    observer.observe(viewport);
+    observer.observe(text);
+    if (isHovered) {
+      reducedMotion.addEventListener('change', start);
+    }
+    start();
+
+    return () => {
+      observer.disconnect();
+      reducedMotion.removeEventListener('change', start);
+      animation?.cancel();
+      fadeAnimation?.cancel();
+    };
+  }, [isHovered, isSmallScreen, displayTitle]);
+
   return (
     <button
       type="button"
       className={cn(
-        'flex min-w-0 grow cursor-pointer items-center gap-2 overflow-hidden rounded-lg px-2 text-left outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-text-primary',
+        'flex w-full min-w-0 grow cursor-pointer items-center gap-2 overflow-hidden rounded-lg px-2 text-left outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-text-primary',
         isActiveConvo || isPopoverActive ? 'bg-surface-active-alt' : '',
       )}
-      title={title ?? undefined}
       aria-current={isActiveConvo ? 'page' : undefined}
       aria-label={
         isSharedBadgeVisible
@@ -40,12 +117,15 @@ const ConvoLink: React.FC<ConvoLinkProps> = ({
               title: title || localize('com_ui_untitled'),
             })
       }
-      style={{ width: '100%' }}
     >
       {children}
-      <div
-        className="relative flex-1 grow overflow-hidden whitespace-nowrap"
-        style={{ textOverflow: 'clip' }}
+      <span
+        ref={titleRef}
+        className={cn(
+          'min-w-0 flex-1 overflow-hidden whitespace-nowrap [--convo-title-fade-width:24px] [mask-position:left] [mask-repeat:no-repeat] [text-align:start] [&:dir(rtl)]:[mask-position:right]',
+          isOverflowing &&
+            '[mask-image:linear-gradient(to_right,currentColor_calc(100%_-_var(--convo-title-fade-width)),transparent)] [&:dir(rtl)]:[mask-image:linear-gradient(to_left,currentColor_calc(100%_-_var(--convo-title-fade-width)),transparent)]',
+        )}
         onDoubleClick={(e) => {
           if (isSmallScreen) {
             return;
@@ -55,17 +135,10 @@ const ConvoLink: React.FC<ConvoLinkProps> = ({
           onRename();
         }}
       >
-        {title || localize('com_ui_untitled')}
-        <div
-          className={cn(
-            'pointer-events-none absolute bottom-0 right-0 top-0 w-20 bg-gradient-to-l',
-            isActiveConvo || isPopoverActive
-              ? 'from-surface-active-alt'
-              : 'from-surface-primary-alt from-0% to-transparent group-hover:from-surface-active-alt group-hover:from-0%',
-          )}
-          aria-hidden="true"
-        />
-      </div>
+        <span ref={textRef} className="inline-block">
+          {displayTitle}
+        </span>
+      </span>
     </button>
   );
 };

--- a/client/src/components/Conversations/ConvoLink.tsx
+++ b/client/src/components/Conversations/ConvoLink.tsx
@@ -15,6 +15,21 @@ interface ConvoLinkProps {
   children: React.ReactNode;
 }
 
+const TITLE_SPEED_PX_PER_SECOND = 30;
+const TITLE_START_DELAY_MS = 600;
+const TITLE_HOLD_MS = 2000;
+
+/** Legacy engines expose only `addListener` on MediaQueryList. */
+const observeMediaQuery = (query: MediaQueryList, onChange: () => void) => {
+  if (typeof query.addEventListener === 'function') {
+    query.addEventListener('change', onChange);
+    return () => query.removeEventListener('change', onChange);
+  }
+
+  query.addListener(onChange);
+  return () => query.removeListener(onChange);
+};
+
 const ConvoLink: React.FC<ConvoLinkProps> = ({
   isActiveConvo,
   isPopoverActive,
@@ -40,11 +55,12 @@ const ConvoLink: React.FC<ConvoLinkProps> = ({
 
     const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
     let animation: Animation | undefined;
-    let fadeAnimation: Animation | undefined;
+    let frame = 0;
 
     const start = () => {
       animation?.cancel();
-      fadeAnimation?.cancel();
+      cancelAnimationFrame(frame);
+      delete viewport.dataset.titleRevealed;
       const overflow = text.getBoundingClientRect().width - viewport.getBoundingClientRect().width;
       setIsOverflowing(overflow > 0);
       if (!isHovered || isSmallScreen || reducedMotion.matches || overflow <= 0) {
@@ -53,11 +69,10 @@ const ConvoLink: React.FC<ConvoLinkProps> = ({
 
       const style = getComputedStyle(viewport);
       const direction = style.direction === 'rtl' ? 1 : -1;
-      const fadeWidth = parseFloat(style.getPropertyValue('--convo-title-fade-width'));
-      const travelDuration = (overflow / 30) * 1000;
-      const duration = travelDuration + 2000;
+      const revealDuration = parseFloat(style.getPropertyValue('--convo-title-reveal-duration'));
+      const travelDuration = (overflow / TITLE_SPEED_PX_PER_SECOND) * 1000;
+      const duration = travelDuration + TITLE_HOLD_MS;
       const end = `translateX(${direction * overflow}px)`;
-      const timing = { duration, delay: 600, iterations: Infinity, easing: 'linear' };
 
       animation = text.animate(
         [
@@ -65,38 +80,41 @@ const ConvoLink: React.FC<ConvoLinkProps> = ({
           { transform: end, offset: travelDuration / duration },
           { transform: end },
         ],
-        timing,
+        {
+          duration,
+          delay: TITLE_START_DELAY_MS,
+          iterations: Infinity,
+          easing: 'linear',
+        },
       );
 
-      /** Reveal the final characters by moving the fade, not by overscrolling the text. */
-      const fullMask = `calc(100% + ${fadeWidth}px) 100%`;
-      fadeAnimation = viewport.animate(
-        [
-          { maskSize: '100% 100%' },
-          {
-            maskSize: '100% 100%',
-            offset: (Math.max(0, (overflow - fadeWidth) / 30) * 1000) / duration,
-          },
-          { maskSize: fullMask, offset: travelDuration / duration },
-          { maskSize: fullMask },
-        ],
-        timing,
-      );
+      /** The fade retreats as the ending arrives, so the last characters read
+       * clearly without the text overscrolling past the available width. CSS owns
+       * the mask because Web Animations cannot carry the `-webkit-` fallback that
+       * older WebKit needs. */
+      const revealFrom = Math.max(0, travelDuration - revealDuration);
+      const tick = () => {
+        const currentTime = typeof animation?.currentTime === 'number' ? animation.currentTime : 0;
+        const elapsed = currentTime - TITLE_START_DELAY_MS;
+        viewport.dataset.titleRevealed = String(elapsed > 0 && elapsed % duration >= revealFrom);
+        frame = requestAnimationFrame(tick);
+      };
+
+      tick();
     };
 
     const observer = new ResizeObserver(start);
     observer.observe(viewport);
     observer.observe(text);
-    if (isHovered) {
-      reducedMotion.addEventListener('change', start);
-    }
+    const unobserveMediaQuery = observeMediaQuery(reducedMotion, start);
     start();
 
     return () => {
       observer.disconnect();
-      reducedMotion.removeEventListener('change', start);
+      unobserveMediaQuery();
       animation?.cancel();
-      fadeAnimation?.cancel();
+      cancelAnimationFrame(frame);
+      delete viewport.dataset.titleRevealed;
     };
   }, [isHovered, isSmallScreen, displayTitle]);
 
@@ -122,9 +140,10 @@ const ConvoLink: React.FC<ConvoLinkProps> = ({
       <span
         ref={titleRef}
         className={cn(
-          'min-w-0 flex-1 overflow-hidden whitespace-nowrap [--convo-title-fade-width:24px] [mask-position:left] [mask-repeat:no-repeat] [text-align:start] [&:dir(rtl)]:[mask-position:right]',
+          'min-w-0 flex-1 overflow-hidden whitespace-nowrap [--convo-title-fade-width:24px] [--convo-title-reveal-duration:800ms] [mask-position:left] [mask-repeat:no-repeat] [mask-size:100%_100%] [text-align:start] [transition-duration:0ms] [transition-property:mask-size] [transition-timing-function:linear] [&:dir(rtl)]:[mask-position:right]',
           isOverflowing &&
             '[mask-image:linear-gradient(to_right,currentColor_calc(100%_-_var(--convo-title-fade-width)),transparent)] [&:dir(rtl)]:[mask-image:linear-gradient(to_left,currentColor_calc(100%_-_var(--convo-title-fade-width)),transparent)]',
+          'data-[title-revealed=true]:[mask-size:calc(100%_+_var(--convo-title-fade-width))_100%] data-[title-revealed=true]:[transition-duration:var(--convo-title-reveal-duration)]',
         )}
         onDoubleClick={(e) => {
           if (isSmallScreen) {


### PR DESCRIPTION
## Summary

Fixes #15637.

- Replace the background-colored title overlay with a direction-aware alpha fade so selected and hovered titles are not obscured by the row background.
- Scroll overflowing titles smoothly when hovering anywhere on a conversation row, including its action area. Fitting titles remain stationary.
- Hold the ending for two seconds, reset to the beginning, and repeat until hover ends. Move the fade out of the way near the end instead of overscrolling the text and leaving trailing space.
- Keep conversation titles as native buttons without hover tooltips, preserving accessible names, focus indicators, double-click rename, and reduced-motion behavior.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

- Passed frontend typechecking: `npm run typecheck --workspace=@librechat/frontend`.
- Passed frontend production build: `npm run build:client`.
- Passed PR-scoped static checks: `npm run static-checks -- --against origin/dev` (ESLint, Prettier, import sorting, and package.json validation).
- Browser smoke checks in the full LibreChat app covered row hover, fitting titles, sidebar resizing, smooth scrolling, the two-second end hold and repeat, immediate reset on hover leave, tooltip removal, and reduced motion.
- Verified the final text edge has no extra trailing gap in both LTR and RTL layouts.

The production build retains the pre-existing Tailwind warning about the ambiguous `ease-[…]` class.

### Test Configuration

Local LibreChat with an isolated MongoDB database and sample conversations, exercised in Chromium. No provider key is needed to test this sidebar behavior.

### Manual reproduction

1. Open LibreChat with both short and overflowing conversation titles in the sidebar.
2. Confirm idle and active titles have a transparent ending rather than an opaque overlay or ellipsis.
3. Hover the title, endpoint icon, or action area of an overflowing conversation row. Confirm scrolling continues while the pointer stays inside the row.
4. At the end, confirm the final characters are fully visible without extra trailing space; the title pauses for two seconds, resets, and repeats.
5. Leave the row and confirm the title immediately returns to its starting position with no tooltip.
6. Resize the sidebar, try an RTL layout, and enable reduced motion. Fitting titles and reduced-motion users should not animate.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code

No configuration, dependency, localization, or documentation changes are required.
