### PR TITLE
🫠 fix: Surface Bedrock Content Filter Refusals

### DIFF
--- a/api/server/controllers/agents/__tests__/modelEndHandler.spec.js
+++ b/api/server/controllers/agents/__tests__/modelEndHandler.spec.js
@@ -1,12 +1,16 @@
 jest.mock('@librechat/data-schemas', () => ({
   logger: { error: jest.fn(), debug: jest.fn() },
 }));
-jest.mock('@librechat/api', () => ({
-  sendEvent: jest.fn(),
-  emitEvent: jest.fn(),
-  createToolExecuteHandler: jest.fn(),
-  markSummarizationUsage: (usage) => usage,
-}));
+jest.mock('@librechat/api', () => {
+  const { getModelRefusalInfo } = jest.requireActual('@librechat/api');
+  return {
+    sendEvent: jest.fn(),
+    emitEvent: jest.fn(),
+    createToolExecuteHandler: jest.fn(),
+    markSummarizationUsage: (usage) => usage,
+    getModelRefusalInfo,
+  };
+});
 jest.mock('~/server/services/Files/Citations', () => ({
   processFileCitations: jest.fn(),
 }));

--- a/api/server/controllers/agents/callbacks.js
+++ b/api/server/controllers/agents/callbacks.js
@@ -132,8 +132,14 @@ class ModelEndHandler {
     let errorMessage;
     try {
       const agentContext = graph.getAgentContext(metadata);
-      if (data?.output?.additional_kwargs?.stop_reason === 'refusal') {
-        const info = { ...data.output.additional_kwargs };
+      const responseMetadata = data?.output?.response_metadata;
+      const bedrockStopReason =
+        responseMetadata?.messageStop?.stopReason ?? responseMetadata?.stopReason;
+      const isBedrockContentFiltered = bedrockStopReason === 'content_filtered';
+      if (data?.output?.additional_kwargs?.stop_reason === 'refusal' || isBedrockContentFiltered) {
+        const info = isBedrockContentFiltered
+          ? { stop_reason: bedrockStopReason }
+          : { ...data.output.additional_kwargs };
         errorMessage = JSON.stringify({
           type: ErrorTypes.REFUSAL,
           info,
@@ -148,7 +154,7 @@ class ModelEndHandler {
 
       const usage = data?.output?.usage_metadata;
       if (!usage) {
-        return this.finalize(errorMessage);
+        return;
       }
       let taggedUsage = contextualizeModelUsage(usage, metadata, agentContext);
       /** Hidden intermediate sequential-agent calls are billed but never shown.
@@ -229,7 +235,8 @@ class ModelEndHandler {
       }
     } catch (error) {
       logger.error('Error handling model end event:', error);
-      return this.finalize(errorMessage);
+    } finally {
+      this.finalize(errorMessage);
     }
   }
 }

--- a/api/server/controllers/agents/callbacks.js
+++ b/api/server/controllers/agents/callbacks.js
@@ -26,6 +26,7 @@ const {
   createBackgroundCodeResultHandler: createCodeHarvestHandler,
   HOST_FILE_AUTHORING_ARTIFACT_KEY,
   isCodeSessionToolName,
+  getModelRefusalInfo,
   shouldSignalSandboxStart,
   getToolInputValidationDetails,
 } = require('@librechat/api');
@@ -132,20 +133,14 @@ class ModelEndHandler {
     let errorMessage;
     try {
       const agentContext = graph.getAgentContext(metadata);
-      const responseMetadata = data?.output?.response_metadata;
-      const bedrockStopReason =
-        responseMetadata?.messageStop?.stopReason ?? responseMetadata?.stopReason;
-      const isBedrockContentFiltered = bedrockStopReason === 'content_filtered';
-      if (data?.output?.additional_kwargs?.stop_reason === 'refusal' || isBedrockContentFiltered) {
-        const info = isBedrockContentFiltered
-          ? { stop_reason: bedrockStopReason }
-          : { ...data.output.additional_kwargs };
+      const refusalInfo = getModelRefusalInfo(data?.output);
+      if (refusalInfo) {
         errorMessage = JSON.stringify({
           type: ErrorTypes.REFUSAL,
-          info,
+          info: refusalInfo,
         });
         logger.debug(`[ModelEndHandler] Model refused to respond`, {
-          ...info,
+          ...refusalInfo,
           userId: metadata.user_id,
           messageId: metadata.run_id,
           conversationId: metadata.thread_id,

--- a/packages/api/src/agents/index.ts
+++ b/packages/api/src/agents/index.ts
@@ -75,6 +75,7 @@ export * from './activityPhases';
 export * from './subagentDelivery';
 export * from './view';
 export * from './reasoningLabels';
+export * from './refusal';
 export * from './toolValidation';
 export * from './remote';
 export * from './queuedTurns';

--- a/packages/api/src/agents/refusal.spec.ts
+++ b/packages/api/src/agents/refusal.spec.ts
@@ -1,0 +1,25 @@
+import { getModelRefusalInfo } from './refusal';
+
+describe('getModelRefusalInfo', () => {
+  it.each([
+    { response_metadata: { messageStop: { stopReason: 'content_filtered' } } },
+    { response_metadata: { stopReason: 'content_filtered' } },
+  ])('normalizes Bedrock content filtering', (output) => {
+    expect(getModelRefusalInfo(output)).toEqual({ stop_reason: 'content_filtered' });
+  });
+
+  it('preserves Anthropic refusal metadata', () => {
+    expect(
+      getModelRefusalInfo({ additional_kwargs: { stop_reason: 'refusal', reason: 'safety' } }),
+    ).toEqual({ stop_reason: 'refusal', reason: 'safety' });
+  });
+
+  it('ignores normal completions', () => {
+    expect(
+      getModelRefusalInfo({
+        additional_kwargs: { stop_reason: 'end_turn' },
+        response_metadata: { stopReason: 'end_turn' },
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/api/src/agents/refusal.ts
+++ b/packages/api/src/agents/refusal.ts
@@ -1,0 +1,26 @@
+export interface ModelResponseMetadata {
+  messageStop?: {
+    stopReason?: string;
+  };
+  stopReason?: string;
+}
+
+export interface ModelOutputWithRefusal<TAdditional extends { stop_reason?: string }> {
+  additional_kwargs?: TAdditional;
+  response_metadata?: ModelResponseMetadata;
+}
+
+/** Normalizes provider-specific model refusal metadata for downstream handlers. */
+export function getModelRefusalInfo<TAdditional extends { stop_reason?: string }>(
+  output?: ModelOutputWithRefusal<TAdditional>,
+): TAdditional | { stop_reason: string } | undefined {
+  const bedrockStopReason =
+    output?.response_metadata?.messageStop?.stopReason ?? output?.response_metadata?.stopReason;
+  if (bedrockStopReason === 'content_filtered') {
+    return { stop_reason: bedrockStopReason };
+  }
+  if (output?.additional_kwargs?.stop_reason === 'refusal') {
+    return { ...output.additional_kwargs };
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary

Bedrock Converse can stop with `content_filtered` after emitting partial text. The agent adapter preserves that status in response metadata, but `ModelEndHandler` only recognizes Anthropic's `additional_kwargs.stop_reason === 'refusal'`, so the user gets an empty or partial answer without refusal feedback.

Recognize Bedrock's streaming `response_metadata.messageStop.stopReason` and non-streaming `response_metadata.stopReason`, and use the existing localized refusal error. Run refusal finalization after usage collection; previously, a response with usage metadata skipped finalization, including recognized Anthropic refusals. Token accounting and streamed content are preserved.

This changes one existing handler, with no new dependencies, configuration, or provider filtering policy.

## Change Type

- [x] Bug fix

## Reproduction

Use a Bedrock model request that the provider content filter stops. The exact trigger is provider/model dependent; the relevant ConverseStream events are:

```json
[
  { "messageStop": { "stopReason": "content_filtered" } },
  { "metadata": { "usage": { "inputTokens": 10, "outputTokens": 2, "totalTokens": 12 } } }
]
```

The adapter returns a message with `response_metadata.messageStop.stopReason` and `usage_metadata`. Before this change, the handler returns normally. Afterward, it records usage and throws the existing `refusal` payload, which the agent client renders through its error content path. Bedrock documents this status in [MessageStopEvent](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_MessageStopEvent.html).

## Testing

- Built `data-provider`, `data-schemas`, and `api` with Node 24.16.0.
- Existing `api/server/controllers/agents/__tests__/modelEndHandler.spec.js`: 11 tests passed.
- Affected ESLint, Prettier, import-order, package validation, and circular-dependency checks passed through `npm run static-checks -- api/server/controllers/agents/callbacks.js`.
- Manual before/after handler replay using actual upstream dependencies: streaming and non-streaming filtering, missing usage, normal completion, and Anthropic refusal with usage. Filtered/refused responses now fail visibly through the existing typed-error contract; normal completion and usage accounting remain unchanged.

The replay verifies handler behavior. A full browser/server persistence test of this patch has not been run.

## Checklist

- [x] Follows the project's code style.
- [x] Self-reviewed the change and its error-path consumers.
- [x] Existing focused tests pass.
