### PR TITLE
🫙 fix: Surface Document Extraction Failures

### DIFF
--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -889,6 +889,7 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
           `[processAgentFileUpload] Document parser failed for ${extractionFileLabel}:`,
           errorMetadata,
         );
+        throw err;
       }
     };
 

--- a/api/server/services/Files/process.spec.js
+++ b/api/server/services/Files/process.spec.js
@@ -622,7 +622,7 @@ describe('processAgentFileUpload', () => {
 
       await expect(
         processAgentFileUpload({ req, res: mockRes, metadata: makeMetadata() }),
-      ).rejects.toThrow(/image-based and requires an OCR service/);
+      ).rejects.toThrow('No text found in document');
 
       expect(parseText).not.toHaveBeenCalled();
     });
@@ -632,8 +632,11 @@ describe('processAgentFileUpload', () => {
         handleFileUpload: jest.fn().mockRejectedValue(new Error('PRIVATE parser failure')),
       });
       extractInspectableFileText.mockImplementationOnce(async ({ extract }) => {
-        await extract();
-        throw makeUninspectableExtractedTextError();
+        try {
+          await extract();
+        } catch {
+          throw makeUninspectableExtractedTextError();
+        }
       });
       const req = makeReq({
         mimetype: PDF_MIME,
@@ -771,7 +774,7 @@ describe('processAgentFileUpload', () => {
 
       await expect(
         processAgentFileUpload({ req, res: mockRes, metadata: makeMetadata() }),
-      ).rejects.toThrow(/image-based and requires an OCR service/);
+      ).rejects.toThrow('failure');
 
       expect(parseText).not.toHaveBeenCalled();
     });
@@ -862,8 +865,11 @@ describe('processAgentFileUpload', () => {
         handleFileUpload: jest.fn().mockRejectedValue(new Error('PRIVATE parser failure')),
       });
       extractInspectableFileText.mockImplementationOnce(async ({ extract }) => {
-        await extract();
-        throw makeUninspectableExtractedTextError();
+        try {
+          await extract();
+        } catch {
+          throw makeUninspectableExtractedTextError();
+        }
       });
       const req = makeReq({
         mimetype: DOCX_MIME,

--- a/packages/api/src/utils/files.ts
+++ b/packages/api/src/utils/files.ts
@@ -7,6 +7,12 @@ const USER_FACING_UPLOAD_ERRORS = [
   ['Invalid file format', 'Invalid file format'],
   ['exceeds token limit', 'File content exceeds token limit'],
   ['Unable to extract text from', 'Unable to extract text from file'],
+  ['No text found in document', 'No text found in document'],
+  ['MB document parser limit', 'File exceeds the document parser size limit'],
+  ['MB per-entry decompressed cap', 'Document entry exceeds the decompressed size limit'],
+  ['total decompressed size exceeds the', 'Document exceeds the total decompressed size limit'],
+  ['MB decompressed limit', 'Document exceeds the decompressed size limit'],
+  ['MB storage limit', 'Extracted text exceeds the storage size limit'],
 ] as const;
 
 const ASCII_FILENAME_SAFE_PATTERN = /^[a-zA-Z0-9._-]$/;


### PR DESCRIPTION
## Summary

The last document-parser failure in agent context uploads is logged and swallowed. A size-limit error then becomes an unrelated message saying the document may require OCR. Known parser/storage errors that do reach the upload route also lose their reason.

Rethrow the terminal parser error and add its known user-actionable messages to the existing upload-error mapping, including redacted variants. Configured OCR fallback, extraction routes, limits, and content-protection behavior stay intact. Existing assertions and extraction-policy mocks are adjusted to the corrected propagation; no test cases are added.

Related: #14701 changes parser engines/routing and introduces coded refusal handling. This correction targets the existing terminal parser path on `dev`, including empty-document and extracted-text storage errors; it does not introduce those engines or routing changes. The terminal-error hunk will need reconciliation if #14701 lands first.

## Change Type

- [x] Bug fix

## Testing

Node 24.16.0:

- Existing upload-processing, file utilities, document parsing, ZIP safety, and extracted-text policy suites pass (182 tests).
- API package build, API TypeScript check (`tsc --noEmit -p tsconfig.build.json`), and scoped static checks pass.
- Parsed a generated XLSX with the real document parser through the extracted upload callback. A separate size-metadata boundary probe preserved the parser-limit message and its redacted form.

Full browser upload/persistence validation was not run. To verify: upload an empty document and a document over the existing parser limit as agent context, confirm the specific reason, then upload a valid document. With content protection enabled, confirm private filenames and parser details are not included in the response.

## Checklist

- [x] Followed project style and reviewed the complete diff.
- [x] Relevant existing checks pass.
