### PR TITLE
🫸 fix: Stop OAuth Sign-In After Binding Failure

### DIFF
--- a/client/src/components/Chat/Messages/Content/ToolCall.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCall.tsx
@@ -53,6 +53,7 @@ export default function ToolCall({
   runStepDurationMs?: PartMetadata['runStepDurationMs'];
 }) {
   const localize = useLocalize();
+  const [oauthError, setOAuthError] = useState<string | null>(null);
   const autoExpand = useRecoilValue(store.autoExpandTools);
   const hasOutput = (output?.length ?? 0) > 0;
   const [showInfo, setShowInfo] = useState(() => autoExpand && hasOutput);
@@ -142,6 +143,7 @@ export default function ToolCall({
     if (!auth) {
       return;
     }
+    setOAuthError(null);
     try {
       if (isMCPToolCall && mcpServerName) {
         await dataService.bindMCPOAuth(mcpServerName);
@@ -150,9 +152,11 @@ export default function ToolCall({
       }
     } catch (e) {
       logger.error('Failed to bind OAuth CSRF cookie', e);
+      setOAuthError(localize('com_ui_oauth_error_generic'));
+      return;
     }
     window.open(auth, '_blank', 'noopener,noreferrer');
-  }, [auth, isMCPToolCall, mcpServerName, actionId]);
+  }, [auth, isMCPToolCall, mcpServerName, actionId, localize]);
 
   const hasError = (typeof output === 'string' && isError(output)) || runStepStatus === 'failed';
   /**
@@ -337,6 +341,11 @@ export default function ToolCall({
               {localize('com_ui_sign_in_to_domain', { 0: authDomain })}
             </Button>
           </div>
+          {oauthError && (
+            <p role="alert" className="text-sm text-text-destructive">
+              {oauthError}
+            </p>
+          )}
           <ToolAuthWarning />
         </div>
       )}


### PR DESCRIPTION
## Summary

The inline tool sign-in button opens the authorization URL even when binding the OAuth security cookie fails. The user proceeds into an authorization attempt that cannot complete that binding step.

Stop on a failed MCP or action bind and show the existing localized authentication error beside the sign-in button. Clicking again clears the error and retries. Successful binding and the existing authorization-window behavior are unchanged.

Related: #12269 and #12418 addressed identifying the correct MCP binding target. This fixes the remaining error path after the binding request itself rejects.

## Change Type

- [x] Bug fix

## Testing

Node 24.16.0:

- Existing `ToolCall.test.tsx` passes (29 tests).
- Client typecheck and scoped static checks pass.
- Executed the actual click callback for MCP and action calls. A synthetic bind rejection produced feedback without opening the authorization URL; a subsequent successful bind cleared the feedback and opened it.

A live OAuth provider/browser round trip was not run. To verify, make the appropriate bind endpoint fail, click Sign in, confirm an inline error and no authorization navigation, restore the endpoint, and retry.

## Checklist

- [x] Followed project style and reviewed the complete diff.
- [x] Relevant existing checks pass.
