### PR TITLE
🎟️ fix: Preserve OpenID Logout Token Hints

### DIFF
--- a/api/server/controllers/auth/LogoutController.js
+++ b/api/server/controllers/auth/LogoutController.js
@@ -36,7 +36,10 @@ const logoutController = async (req, res) => {
   }
   /** Both can name distinct durable sessions when an older browser request races rotation. */
   refreshToken = parsedCookies.refreshToken || sessionRefreshToken;
-  idToken = idToken || parsedCookies.openid_id_token;
+  idToken =
+    idToken ||
+    (isOpenIdUser ? req.session?.openidLogoutIdToken : undefined) ||
+    parsedCookies.openid_id_token;
   const logoutTokens = isOpenIdUser
     ? [...new Set([parsedCookies.refreshToken, sessionRefreshToken].filter(Boolean))]
     : [refreshToken];
@@ -63,8 +66,9 @@ const logoutController = async (req, res) => {
         userId,
         tenantId: req.user?.tenantId,
       });
-      if (req.session?.openidTokens) {
+      if (req.session) {
         delete req.session.openidTokens;
+        delete req.session.openidLogoutIdToken;
       }
     }
     if (logoutTokens.length === 0) {
@@ -158,7 +162,7 @@ const logoutController = async (req, res) => {
             } else {
               logger.warn(
                 '[logoutController] Neither id_token_hint nor OPENID_CLIENT_ID is available. ' +
-                  'To enable id_token_hint, set OPENID_REUSE_TOKENS=true. ' +
+                  'Sign in again to establish an OpenID session with an ID token. ' +
                   'The OIDC end-session request may be rejected by the identity provider.',
               );
             }

--- a/api/server/controllers/auth/oauth.js
+++ b/api/server/controllers/auth/oauth.js
@@ -88,6 +88,12 @@ function createOAuthHandler(redirectUri = domains.client) {
         });
       } else {
         await setAuthTokens(req.user._id, res, null, req);
+        if (
+          req.user.provider === 'openid' &&
+          isEnabled(process.env.OPENID_USE_END_SESSION_ENDPOINT)
+        ) {
+          req.session.openidLogoutIdToken = req.user.tokenset?.id_token;
+        }
       }
       res.redirect(redirectUri);
     } catch (err) {


### PR DESCRIPTION
## Summary

With `OPENID_REUSE_TOKENS=false`, the standard OpenID login handler issues LibreChat tokens but discards the provider ID token. Logout therefore cannot supply the available `id_token_hint` to the configured end-session endpoint.

When end-session logout is enabled, retain that ID token in a separate field of the existing server session, read it before logout cleanup, and remove it with the session's OpenID data. Authentication mode, cookie sizes, session lifetimes, refresh revocation, and the existing missing/oversized-token handling are unchanged. The hint remains available only while that server session exists.

Related: #12997 / #12999 preserve a logout hint when an OpenID refresh response omits a new ID token. This covers the separate login path with token reuse disabled. The [RP-Initiated Logout specification](https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout) recommends the previously issued ID token as the logout hint.

## Change Type

- [x] Bug fix

## Testing

Node 24.16.0:

- Existing OAuth controller, logout controller, and auth-service suites pass (107 tests), including reuse, revocation, and oversized-token handling.
- Scoped static checks pass.
- Exercised the actual login and logout controllers over local HTTP with a real Express session store and synthetic identity/auth-service dependencies. With reuse disabled, the end-session redirect contained the supplied ID token; with end-session logout disabled, no redirect was returned. LibreChat token mode was retained and logout removed the server session in both cases.

A live identity-provider round trip was not run. Verify with token reuse disabled and end-session logout enabled: sign in, log out while the server session is present, and confirm the provider receives its ID token hint and completes the registered post-logout redirect.

## Checklist

- [x] Followed project style and reviewed the complete diff.
- [x] Relevant existing checks pass.
