### PR TITLE
🚮 fix: Require Sign-In After Missing OpenID Sessions

### DIFF
--- a/api/server/controllers/AuthController.js
+++ b/api/server/controllers/AuthController.js
@@ -8,6 +8,7 @@ const {
   createAuthIdentityContext,
   createOpenIDRefreshOwnershipError,
   isOpenIDRefreshOwnershipError,
+  isOpenIDSessionMissingError,
   isOpenIDSessionIdentityMatch,
   OPENID_EXPIRY_BUFFER_SECONDS,
 } = require('@librechat/api');
@@ -517,13 +518,17 @@ const refreshController = async (req, res) => {
         );
       });
     } catch (error) {
-      if (isOpenIDRefreshOwnershipError(error)) {
+      if (isOpenIDRefreshOwnershipError(error) || isOpenIDSessionMissingError(error)) {
         clearOpenIDAuthTokens(
           req,
           res,
           req.session?.openidTokens?.appUserId,
           req.session?.openidTokens?.tenantId,
         );
+      }
+      if (isOpenIDSessionMissingError(error)) {
+        logger.warn('[refreshController] OpenID session missing; sign-in required');
+        return res.status(401).send({ code: 'OPENID_SESSION_MISSING' });
       }
       logger.error('[refreshController] OpenID token refresh error', error);
 

--- a/api/server/controllers/AuthController.spec.js
+++ b/api/server/controllers/AuthController.spec.js
@@ -856,6 +856,29 @@ describe('refreshController – OpenID path', () => {
     expect(res.status).toHaveBeenCalledWith(403);
   });
 
+  it('requires sign-in without publishing tokens when the persisted session disappeared', async () => {
+    req.session.reload = jest.fn((callback) => callback(new Error('failed to load session')));
+
+    await refreshController(req, res);
+
+    expect(clearOpenIDAuthTokens).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.send).toHaveBeenCalledWith({ code: 'OPENID_SESSION_MISSING' });
+    expect(setOpenIDAuthTokens).not.toHaveBeenCalled();
+    expect(storeOpenIDSession).not.toHaveBeenCalled();
+    expect(getRefreshTokenBridge).not.toHaveBeenCalled();
+  });
+
+  it('does not classify a session store outage as a missing session', async () => {
+    req.session.reload = jest.fn((callback) => callback(new Error('connection unavailable')));
+
+    await refreshController(req, res);
+
+    expect(clearOpenIDAuthTokens).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(setOpenIDAuthTokens).not.toHaveBeenCalled();
+  });
+
   it('uses a reloaded advanced session instead of publishing a stale flight result', async () => {
     req.session.reload = jest.fn((callback) => {
       req.session.openidTokens = {

--- a/packages/api/src/auth/openid/errors.spec.ts
+++ b/packages/api/src/auth/openid/errors.spec.ts
@@ -1,0 +1,16 @@
+import { isOpenIDSessionMissingError } from './errors';
+
+describe('isOpenIDSessionMissingError', () => {
+  it('recognizes the express-session missing record error', () => {
+    expect(isOpenIDSessionMissingError(new Error('failed to load session'))).toBe(true);
+  });
+
+  it.each([
+    new Error('connection unavailable'),
+    new Error('session unavailable'),
+    null,
+    'failed to load session',
+  ])('does not interpret other failures as permission to clear credentials: %s', (error) =>
+    expect(isOpenIDSessionMissingError(error)).toBe(false),
+  );
+});

--- a/packages/api/src/auth/openid/errors.ts
+++ b/packages/api/src/auth/openid/errors.ts
@@ -2,6 +2,11 @@ import type { LogArgument } from './types';
 
 export const OPENID_REFRESH_OWNERSHIP_LOST = 'OPENID_REFRESH_OWNERSHIP_LOST';
 
+/** Express-session uses this exact error when reload cannot find the persisted session. */
+export function isOpenIDSessionMissingError(error: unknown): boolean {
+  return error instanceof Error && error.message === 'failed to load session';
+}
+
 export function toOpenIDLogArgument(error: unknown): LogArgument {
   return error instanceof Error ? error : String(error);
 }

--- a/packages/data-provider/specs/request-interceptor.spec.ts
+++ b/packages/data-provider/specs/request-interceptor.spec.ts
@@ -615,6 +615,41 @@ describe('axios 401 interceptor — Authorization header guard', () => {
     expect(hrefWrites[0]).toBe('/login?redirect_to=%2Fc%2Frace');
   });
 
+  it('settles concurrent idle-tab requests and preserves the deep link when the session is gone', async () => {
+    setTokenHeader('expired-token');
+    const hrefWrites = setTrackedWindowLocation({
+      href: 'http://localhost/c/resume?view=chat',
+      pathname: '/c/resume',
+      search: '?view=chat',
+      hash: '',
+    });
+    const events: string[] = [];
+    const listener = (event: Event) => events.push((event as CustomEvent).detail.state);
+    window.addEventListener('authRecovery', listener);
+    mockAdapter.mockImplementation((config: InternalAxiosRequestConfig) => {
+      if (config.url?.includes('/api/auth/refresh') === true) {
+        return Promise.reject({
+          response: { status: 401, data: { code: 'OPENID_SESSION_MISSING' } },
+          config,
+        });
+      }
+      return create401Error(config);
+    });
+    try {
+      const results = await Promise.allSettled([
+        axios.get('/api/messages'),
+        axios.get('/api/convos'),
+        axios.get('/api/files'),
+      ]);
+      expect(results.every((result) => result.status === 'rejected')).toBe(true);
+      expect(getCallsForUrl('/api/auth/refresh')).toHaveLength(1);
+      expect(hrefWrites).toEqual(['/login?redirect_to=%2Fc%2Fresume%3Fview%3Dchat']);
+      expect(events).toEqual(['started', 'finished']);
+    } finally {
+      window.removeEventListener('authRecovery', listener);
+    }
+  });
+
   it('keeps redirect deduping when the storage timestamp is corrupted', async () => {
     expect.assertions(2);
     setTokenHeader('expired-token');


### PR DESCRIPTION
## Summary
- Treat express-session's specific `failed to load session` refresh failure as requiring a new sign-in.
- Clear unusable OpenID refresh cookies/session tokens, return a structured 401, and do not attempt token publication or bridge recovery for a missing session.
- Preserve existing behavior for unrelated store failures and retain the publication-flight settlement protection from #15641.

This deliberately does not resurrect a missing session or treat every reload error as permission to skip session validation. It addresses recovery after the failure, not every possible reason a session record disappeared.

## Verification
- 22 request-interceptor tests pass, including concurrent idle-tab requests: one refresh, one redirect with the conversation URL intact, and recovery loading state settled.
- 10 OpenID error/publication tests pass.
- Added controller regressions for missing sessions and store outages. All three API test shards pass in CI against rebuilt packages (local compiled exports were stale).
- Focused ESLint and diff checks pass.
- Backend and frontend TypeScript checks pass in CI. Local workspace typechecks were blocked by stale dependency/export errors.
