### PR TITLE
🎖️ perf: Promote Flat Thread Rendering to Default

### DIFF
--- a/client/src/components/Chat/Messages/Thread/flag.ts
+++ b/client/src/components/Chat/Messages/Thread/flag.ts
@@ -1,12 +1,13 @@
 /**
- * Prototype switch for the flat thread renderer, read once per page load.
- * `LC_FLAT_THREAD` in localStorage wins; `VITE_FLAT_THREAD` sets the default.
+ * Renderer switch for the message thread, read once per page load. The flat
+ * renderer is the default; `VITE_FLAT_THREAD=false` at build time or
+ * `LC_FLAT_THREAD=false` in localStorage falls back to the recursive one.
  */
 function readFlag(): boolean {
-  const fallback = import.meta.env.VITE_FLAT_THREAD === 'true';
+  const fallback = import.meta.env.VITE_FLAT_THREAD !== 'false';
   try {
     const stored = localStorage.getItem('LC_FLAT_THREAD');
-    return stored == null ? fallback : stored === 'true';
+    return stored == null ? fallback : stored !== 'false';
   } catch {
     return fallback;
   }

--- a/e2e/benchmarks-tree/flatenv.ts
+++ b/e2e/benchmarks-tree/flatenv.ts
@@ -1,2 +1,2 @@
-/** Side-effect module: defaults the flat thread renderer ON for the parity config. */
+/** Side-effect module: pins the flat thread renderer ON for the parity config, whatever the default. */
 process.env.VITE_FLAT_THREAD = process.env.VITE_FLAT_THREAD ?? 'true';

--- a/e2e/playwright.config.tree-parity.ts
+++ b/e2e/playwright.config.tree-parity.ts
@@ -6,7 +6,7 @@ import treePerfConfig from './playwright.config.tree-perf';
 
 /**
  * Runs the branch-sensitive mock specs against the vite dev server with the
- * flat thread renderer defaulted ON, so the prototype is checked against the
+ * flat thread renderer pinned ON, so the flat path is checked against the
  * same scenarios the recursive renderer passes.
  */
 

--- a/e2e/playwright.config.tree-perf-prod.ts
+++ b/e2e/playwright.config.tree-perf-prod.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from '@playwright/test';
+import mockConfig from './playwright.config.mock';
+
+/**
+ * Message-tree benchmark against the BUILT client (`client/dist`, served by
+ * the mock app server): production-minified numbers. react-scan's
+ * per-component names are mangled here, so run it with TREE_PERF_SCAN=0 and
+ * read the CDP and resource lines.
+ */
+export default defineConfig({
+  ...mockConfig,
+  testDir: 'benchmarks-tree',
+  outputDir: 'benchmarks-tree/.test-results',
+  timeout: 10 * 60 * 1000,
+  retries: 0,
+  reporter: [['line']],
+});

--- a/e2e/specs/mock/thread-renderers.spec.ts
+++ b/e2e/specs/mock/thread-renderers.spec.ts
@@ -1,0 +1,257 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import type { AgentDetail } from './agents.helpers';
+import { cleanupAgent, openAgentBuilder, uniqueAgentName } from './agents.helpers';
+import {
+  MOCK_ENDPOINTS,
+  NEW_CHAT_PATH,
+  getAccessToken,
+  isAgentsStream,
+  messagesView,
+  requestJson,
+  selectMockEndpoint,
+  sendMessage,
+  sendMessageAndWaitForCompletion,
+} from './helpers';
+
+/**
+ * Differential check of the two message-thread renderers. One conversation is
+ * built through the real pipeline with the content shapes the seeded
+ * benchmarks never produce (a regenerated branch, reasoning, markdown with a
+ * table and code, provider attachments, and detached subagent activity), then
+ * rendered by the flat list and by the recursive tree in turn. Both must
+ * produce the same transcript, sibling counters, and activity groups, before
+ * and after cycling a branch.
+ */
+
+type Transcript = {
+  rows: string[];
+  siblingCounters: string[];
+  attachments: string[];
+  activityGroups: number;
+};
+
+const uniqueLabel = (name: string) => `${name}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+const countedPrompt = (label: string) => `E2E_COUNTED_REPLY:${label}`;
+const countedReplyText = (label: string, count: number) => `E2E counted reply ${label} #${count}`;
+const thinkPrompt = (label: string) => `E2E_THINK_REPLY:${label}`;
+const thinkReplyText = (label: string) => `E2E reply ${label}`;
+const PARAGRAPHS_PROMPT = 'E2E_PARAGRAPHS_REPLY';
+const CLOSING_PARAGRAPH = 'E2E closing paragraph';
+const SUBAGENT_ACTIVITY_MARKER = 'E2E_SUBAGENT_ACTIVITY:';
+
+const textFixture = {
+  name: 'renderer-context.txt',
+  mimeType: 'text/plain',
+  buffer: Buffer.from('This text attachment rides the message into both renderers.\n'),
+};
+
+const messageRender = (page: Page, text: string) =>
+  page.locator('.message-render').filter({ hasText: text }).last();
+
+async function setRenderer(page: Page, flat: boolean) {
+  await page.evaluate((value) => {
+    localStorage.setItem('LC_FLAT_THREAD', value ? 'true' : 'false');
+  }, flat);
+  await page.reload({ timeout: 15_000 });
+}
+
+/** Text a viewer sees, with clocks, relative ages and whitespace normalized so time passing between captures cannot differ. */
+async function captureTranscript(page: Page, settledText: string): Promise<Transcript> {
+  await expect(messagesView(page).getByText(settledText)).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByRole('button', { name: 'Stop generating' })).toBeHidden();
+  await page.waitForTimeout(500);
+  return page.evaluate(() => {
+    const normalize = (value: string) =>
+      value
+        .replace(/\b\d{1,2}:\d{2}(:\d{2})?\s*(AM|PM)?\b/gi, '')
+        .replace(/(\d+|\ban?)\s+(second|minute|hour|day)s?\s+ago\b/gi, '')
+        .replace(/\bjust now\b/gi, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+    const view = document.querySelector('[data-testid="messages-view"]');
+    if (!view) {
+      throw new Error('messages view missing');
+    }
+    const rows = Array.from(view.querySelectorAll('.message-render')).map((row) =>
+      normalize((row as HTMLElement).innerText),
+    );
+    const siblingCounters = Array.from(view.querySelectorAll('nav [role="status"]')).map((node) =>
+      normalize((node as HTMLElement).innerText),
+    );
+    const attachments = Array.from(view.querySelectorAll('button'))
+      .map((button) => button.getAttribute('aria-label') ?? button.textContent ?? '')
+      .filter((name) => /\.(txt|png)$/i.test(name.trim()))
+      .map((name) => name.trim());
+    const activityGroups = Array.from(view.querySelectorAll('button')).filter((button) =>
+      /^Ran \d+ agents?$/.test(button.textContent?.trim() ?? ''),
+    ).length;
+    return { rows, siblingCounters, attachments, activityGroups };
+  });
+}
+
+async function clickMessageTitleButton(page: Page, text: string, title: string) {
+  const render = messageRender(page, text);
+  await render.scrollIntoViewIfNeeded();
+  await render.hover();
+  await render.getByRole('button', { name: title, exact: true }).last().click();
+}
+
+async function clickSibling(page: Page, text: string, direction: 'Previous' | 'Next') {
+  const render = messageRender(page, text);
+  await render.scrollIntoViewIfNeeded();
+  await render.hover();
+  await render.getByRole('button', { name: `${direction} sibling message` }).click();
+}
+
+async function sendAndExpectReply(page: Page, prompt: string, expectedReply: string) {
+  const response = await sendMessage(page, prompt);
+  expect(response.ok()).toBeTruthy();
+  await expect(messagesView(page).getByText(expectedReply)).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByRole('button', { name: 'Stop generating' })).toBeHidden({
+    timeout: 30_000,
+  });
+}
+
+async function uploadProviderFile(page: Page) {
+  await page.getByRole('button', { name: 'Attach File Options' }).click();
+  await expect(page.getByText('Upload to Provider')).toBeVisible();
+  const fileChooserPromise = page.waitForEvent('filechooser');
+  await page.getByText('Upload to Provider').click();
+  const fileChooser = await fileChooserPromise;
+  const uploadResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/files') &&
+      response.request().method() === 'POST' &&
+      response.status() === 200,
+    { timeout: 30_000 },
+  );
+  await fileChooser.setFiles(textFixture);
+  expect((await uploadResponse).ok()).toBeTruthy();
+  await page.waitForTimeout(350);
+}
+
+async function createAgent(
+  page: Page,
+  token: string,
+  name: string,
+  subagents?: AgentDetail['subagents'],
+): Promise<AgentDetail> {
+  return requestJson<AgentDetail>(page, {
+    path: '/api/agents',
+    token,
+    method: 'POST',
+    body: {
+      name,
+      description: 'Playwright renderer parity: detached child activity.',
+      instructions: 'Follow the deterministic end-to-end request exactly.',
+      provider: MOCK_ENDPOINTS[0].label,
+      model: MOCK_ENDPOINTS[0].model,
+      subagents,
+    },
+  });
+}
+
+async function selectAgent(page: Page, name: string): Promise<void> {
+  const form = await openAgentBuilder(page);
+  await form.getByRole('combobox', { name: 'Agent', exact: true }).click();
+  await page.getByRole('option', { name }).click();
+  await expect(form.getByLabel('Agent name')).toHaveValue(name);
+  await form.getByRole('button', { name: 'Select Agent' }).click();
+}
+
+test.describe('thread renderers', () => {
+  test('flat and recursive renderers agree on a branched, rich conversation', async ({ page }) => {
+    test.setTimeout(240_000);
+    const label = uniqueLabel('renderers');
+    const firstReply = countedReplyText(label, 1);
+    const regeneratedReply = countedReplyText(label, 2);
+    const fileReply = `E2E provider file assertion passed: ${textFixture.name}`;
+
+    await page.goto(NEW_CHAT_PATH, { timeout: 10_000 });
+    await selectMockEndpoint(page, MOCK_ENDPOINTS[0]);
+    await sendAndExpectReply(page, countedPrompt(label), firstReply);
+    const [regenerate] = await Promise.all([
+      page.waitForResponse(isAgentsStream, { timeout: 30_000 }),
+      clickMessageTitleButton(page, firstReply, 'Regenerate'),
+    ]);
+    expect(regenerate.ok()).toBeTruthy();
+    await expect(messagesView(page).getByText(regeneratedReply)).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByRole('button', { name: 'Stop generating' })).toBeHidden({
+      timeout: 30_000,
+    });
+    await sendAndExpectReply(page, thinkPrompt(label), thinkReplyText(label));
+    await sendAndExpectReply(page, PARAGRAPHS_PROMPT, CLOSING_PARAGRAPH);
+    await uploadProviderFile(page);
+    await sendAndExpectReply(page, `E2E_ASSERT_PROVIDER_FILE:${textFixture.name}`, fileReply);
+
+    await setRenderer(page, false);
+    const tree = await captureTranscript(page, fileReply);
+    await clickSibling(page, regeneratedReply, 'Previous');
+    const treeOlderBranch = await captureTranscript(page, firstReply);
+
+    await setRenderer(page, true);
+    const flat = await captureTranscript(page, fileReply);
+    await clickSibling(page, regeneratedReply, 'Previous');
+    const flatOlderBranch = await captureTranscript(page, firstReply);
+    await clickSibling(page, firstReply, 'Next');
+    await expect(messagesView(page).getByText(regeneratedReply)).toBeVisible();
+
+    expect(tree.rows.length).toBeGreaterThanOrEqual(8);
+    expect(tree.siblingCounters).toEqual(['2 / 2']);
+    expect(tree.attachments).toContain(textFixture.name);
+    expect(treeOlderBranch.rows.length).toBe(2);
+    expect(treeOlderBranch.siblingCounters).toEqual(['1 / 2']);
+    expect(flat).toEqual(tree);
+    expect(flatOlderBranch).toEqual(treeOlderBranch);
+  });
+
+  test('flat and recursive renderers agree on detached subagent activity', async ({ page }) => {
+    test.setTimeout(240_000);
+    const label = `renderers-${Date.now().toString(36)}`;
+    const createdAgentIds: string[] = [];
+    try {
+      await page.goto(NEW_CHAT_PATH, { timeout: 10_000 });
+      const token = await getAccessToken(page);
+      const children: AgentDetail[] = [];
+      for (const childName of [
+        uniqueAgentName('E2E Renderer Child A'),
+        uniqueAgentName('E2E Renderer Child B'),
+      ]) {
+        const child = await createAgent(page, token, childName);
+        children.push(child);
+        createdAgentIds.push(child.id);
+      }
+      const parentName = uniqueAgentName('E2E Renderer Parent');
+      const parent = await createAgent(page, token, parentName, {
+        enabled: true,
+        allowSelf: false,
+        agent_ids: children.map((child) => child.id),
+      });
+      createdAgentIds.push(parent.id);
+      await selectAgent(page, parentName);
+
+      const response = await sendMessageAndWaitForCompletion(
+        page,
+        `${SUBAGENT_ACTIVITY_MARKER}${children.map((child) => child.id).join(',')}:${label}`,
+      );
+      expect(response.ok()).toBeTruthy();
+      const groupButton = page.getByRole('button', { name: 'Ran 2 agents' });
+      await expect(groupButton).toBeVisible({ timeout: 30_000 });
+      const settledText = await groupButton.textContent();
+      expect(settledText).toBeTruthy();
+
+      await setRenderer(page, false);
+      const tree = await captureTranscript(page, settledText as string);
+      await setRenderer(page, true);
+      const flat = await captureTranscript(page, settledText as string);
+
+      expect(tree.activityGroups).toBe(1);
+      expect(flat).toEqual(tree);
+    } finally {
+      for (const agentId of createdAgentIds) {
+        await cleanupAgent(page, agentId);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Stacked on #15633. Flips the message-thread renderer default to the flat index-and-path renderer that #15633 introduced behind a flag. The recursive `MultiMessage` path stays reachable as an escape hatch with `VITE_FLAT_THREAD=false` at build time or `LC_FLAT_THREAD=false` in localStorage, and is meant to be deleted once this has shipped in a release.

### Why

From the #15633 measurements (CDP, react-scan off, dev build), the flat path is equal or better on every axis:

- Zero `MultiMessage` and activity-group re-renders per streamed delta, versus one per level (122 plus 61 on a 240-row thread).
- About 21% less renderer CPU during a stream at 240 rows in the dev build. In the production build at 240 rows the two are within noise (script 2.7 s versus 2.5 s, CPU and retained heap equal), so the win at that size is structural rather than felt.
- Identical retained heap, but the recursive path's per-flush copies generate nearly twice the transient garbage at 800 rows (1,168 MB versus 639 MB peak before GC), enough to crash a tab in one run.
- Sibling reconciliation is one central, unit-tested function instead of an effect duplicated per level.

### Evidence

- **Full mock e2e suite** in this PR's CI runs with the flat renderer as the default: every shard, the redis transport and both MCP list-changed jobs passed.
- **Differential spec** (`e2e/specs/mock/thread-renderers.spec.ts`, added here and part of the mock suite from now on): builds a conversation through the real pipeline with a regenerated branch, reasoning, markdown with a table and code, and a provider attachment, plus a second one with detached subagent activity from API-created agents, then renders each with the flat list and the recursive tree in turn. Both must produce the same transcript, sibling counters, attachments and activity groups, before and after cycling a branch. It passes.
- **Bombadil** (randomized exploration of the core chat, branching, parallel-response, reload and sidebar flows) against the built client: over six three-minute runs per build, the recursive build violated `sidebarNavigationEventuallySelectsTarget` (bursts of four sidebar clicks in half a second) in 5 of 6 runs and the flat build in 4 of 6, and one flat run violated `assistantReplyEventuallyAppears` after the harness clicked away from the conversation 200 ms after pressing Enter. Both are harness-level navigation races that exist on the current renderer; the `.message-render` DOM the properties read is identical between the two. Exact trace replays diverge on both builds, so equal-budget campaigns were used instead of replays.
- Locally, the four branch-sensitive mock spec files pass on the real default path (25 passed), and the full client jest suite passes with the default flipped (503 suites, 6,372 tests).

### After this

Delete `MultiMessage` and the flag, move the share view's own recursive renderer over, then the chat-context fan-out fix and virtualization on top of the row list.
