### PR TITLE
🥅 chore: Block DB Model APIs That Bypass Isolation

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -374,7 +374,9 @@ export default [
     },
   },
   {
-    // **Data-schemas — ban raw bulkWrite/collection.* in production code**
+    // **Data-schemas — ban model APIs that bypass tenant isolation in production code**
+    // Mongoose middleware is the only enforcement point for the tenant-isolation plugin,
+    // so every API that skips it is banned here rather than guarded downstream.
     // Tests and the tenantSafeBulkWrite wrapper itself are excluded.
     files: ['./packages/data-schemas/**/*.ts'],
     ignores: ['**/*.spec.ts', '**/*.test.ts', '**/utils/tenantBulkWrite.ts'],
@@ -390,6 +392,21 @@ export default [
           selector: "MemberExpression[property.name='collection'][parent.type='MemberExpression']",
           message:
             'Avoid Model.collection.* — raw driver calls bypass all Mongoose middleware including tenant isolation. Use Mongoose model methods or tenantSafeBulkWrite() instead.',
+        },
+        {
+          selector: "CallExpression[callee.property.name='bulkSave']",
+          message:
+            'Avoid Model.bulkSave() — it derives writes and delegates to bulkWrite() without running save or query middleware, so the tenant isolation plugin can neither stamp nor scope them. Use create()/insertMany() or tenantSafeBulkWrite() instead.',
+        },
+        {
+          selector: "CallExpression[callee.property.name='watch']",
+          message:
+            "Avoid Model.watch() — a change stream opens outside query middleware, so the tenant isolation plugin cannot scope it and it emits every tenant's events. Open one only under runAsSystem() with an explicit $match on tenantId.",
+        },
+        {
+          selector: "CallExpression[callee.property.name='estimatedDocumentCount']",
+          message:
+            'Avoid Model.estimatedDocumentCount() — it reads collection metadata and takes no filter, so it always returns the count across every tenant. Use countDocuments() for a tenant-scoped count.',
         },
       ],
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,24 @@ const compat = new FlatCompat({
   allConfig: js.configs.all,
 });
 
+const tenantModelRestrictions = [
+  {
+    selector: "CallExpression[callee.property.name='bulkSave']",
+    message:
+      'Avoid Model.bulkSave() — it derives writes and delegates to bulkWrite() after running save hooks, but without query middleware to scope the generated write filters. Use create()/insertMany() or tenantSafeBulkWrite() instead.',
+  },
+  {
+    selector: "CallExpression[callee.property.name='watch']",
+    message:
+      "Avoid Model.watch() — a change stream opens outside query middleware, so the tenant isolation plugin cannot scope it and it emits every tenant's events. A change stream requires a justified inline exemption documenting its system context and explicit tenantId $match guard.",
+  },
+  {
+    selector: "CallExpression[callee.property.name='estimatedDocumentCount']",
+    message:
+      'Avoid Model.estimatedDocumentCount() — it reads collection metadata and takes no filter, so it always returns the count across every tenant. Use countDocuments() for a tenant-scoped count.',
+  },
+];
+
 export default [
   {
     ignores: [
@@ -374,9 +392,15 @@ export default [
     },
   },
   {
+    files: ['packages/api/**/*.{ts,js}', 'api/**/*.{ts,js}'],
+    ignores: ['**/*.spec.{ts,js}', '**/*.test.{ts,js}'],
+    rules: {
+      'no-restricted-syntax': ['error', ...tenantModelRestrictions],
+    },
+  },
+  {
     // **Data-schemas — ban model APIs that bypass tenant isolation in production code**
-    // Mongoose middleware is the only enforcement point for the tenant-isolation plugin,
-    // so every API that skips it is banned here rather than guarded downstream.
+    // Raw driver calls bypass the plugin; bulkSave also bypasses query filter scoping.
     // Tests and the tenantSafeBulkWrite wrapper itself are excluded.
     files: ['./packages/data-schemas/**/*.ts'],
     ignores: ['**/*.spec.ts', '**/*.test.ts', '**/utils/tenantBulkWrite.ts'],
@@ -393,21 +417,7 @@ export default [
           message:
             'Avoid Model.collection.* — raw driver calls bypass all Mongoose middleware including tenant isolation. Use Mongoose model methods or tenantSafeBulkWrite() instead.',
         },
-        {
-          selector: "CallExpression[callee.property.name='bulkSave']",
-          message:
-            'Avoid Model.bulkSave() — it derives writes and delegates to bulkWrite() without running save or query middleware, so the tenant isolation plugin can neither stamp nor scope them. Use create()/insertMany() or tenantSafeBulkWrite() instead.',
-        },
-        {
-          selector: "CallExpression[callee.property.name='watch']",
-          message:
-            "Avoid Model.watch() — a change stream opens outside query middleware, so the tenant isolation plugin cannot scope it and it emits every tenant's events. Open one only under runAsSystem() with an explicit $match on tenantId.",
-        },
-        {
-          selector: "CallExpression[callee.property.name='estimatedDocumentCount']",
-          message:
-            'Avoid Model.estimatedDocumentCount() — it reads collection metadata and takes no filter, so it always returns the count across every tenant. Use countDocuments() for a tenant-scoped count.',
-        },
+        ...tenantModelRestrictions,
       ],
     },
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -392,7 +392,7 @@ export default [
     },
   },
   {
-    files: ['packages/api/**/*.{ts,js}', 'api/**/*.{ts,js}'],
+    files: ['packages/data-schemas/**/*.ts', 'packages/api/**/*.{ts,js}', 'api/**/*.{ts,js}'],
     ignores: ['**/*.spec.{ts,js}', '**/*.test.{ts,js}'],
     rules: {
       'no-restricted-syntax': ['error', ...tenantModelRestrictions],

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -478,6 +478,7 @@ const createMeiliMongooseModel = ({
       );
 
       // Get approximate total count for raw estimation, the sync should not overcome this number
+      // eslint-disable-next-line no-restricted-syntax -- a collection-wide estimate is the quantity wanted here: it bounds a full-index sync and only feeds a progress log, so a tenant-scoped count would be wrong, not just unnecessary.
       const approxTotalCount = await this.estimatedDocumentCount();
       logger.info(
         `[syncWithMeili] Approximate total number of all ${collectionName}: ${approxTotalCount}`,


### PR DESCRIPTION
Follow-up from the #15578 review. Config-only plus one inline exemption; no
runtime behaviour changes.

## Why

Mongoose middleware is the only enforcement point for the tenant-isolation
plugin, and `eslint.config.mjs` already bans the two model APIs known to skip
it — `Model.bulkWrite()` and `Model.collection.*` — precisely because a
downstream guard cannot see them. The driver-level probe review surfaced three
more in the same class:

| API | Why it bypasses the plugin |
|---|---|
| `Model.bulkSave()` | runs save hooks, then delegates to `bulkWrite()` without query middleware to scope the generated write filters |
| `Model.watch()` | opens a change stream outside query middleware — it emits every tenant's events |
| `Model.estimatedDocumentCount()` | reads collection metadata and takes no filter — always the count across every tenant |

`bulkSave()` and `watch()` have **zero call sites** today. Banning them at lint
time across `packages/data-schemas`, `packages/api`, and legacy `api` closes the class preventively rather than detecting adoption after the
fact, and does it without the replica-set harness a runtime test for `watch()`
would need. This is the better answer to two of the open findings on #15578
than probe coverage would have been.

## The one existing caller

`estimatedDocumentCount()` is called exactly once, in `syncWithMeili`, where a
collection-wide estimate is the quantity wanted: it bounds a full-index sync
and only feeds a progress log, and it runs from `indexSync()` at boot outside
any tenant context. That call carries an inline disable stating the reason, in
the same form as the existing `no-restricted-syntax` exemptions in `role.ts`
and `mongoMeili.ts`.

The exemption has to land in this PR rather than separately: the ESLint config
regression sweep fails a config change that produces any *new*
`(file, rule, severity)` diagnostic, so the selector and its single legitimate
hit must arrive together.

## Verification

- A throwaway fixture calling all three plus `bulkWrite()` as a control
  produced exactly 4 `no-restricted-syntax` errors with the intended messages,
  then was deleted.
- `packages/data-schemas` lints clean under the new config.
- `npm run static-checks -- --against origin/dev`: ESLint, Prettier, import
  sorting, ESLint config validation and circular-deps all pass.

## Review follow-up

- Apply the three restrictions to backend TS/JS callers as well as data-schemas, using shared selectors.
- Preserve the existing data-schemas bulkWrite/collection restrictions and test exemptions.
- Correct the bulkSave diagnostic: save hooks run, but query middleware does not scope its generated bulk-write filters.
- Require a justified inline exemption documenting system context and tenant filtering for a change stream.
- Verify all three bans using ESLint fixtures in four backend path/language combinations, plus test-exemption and existing-rule controls. All assertions pass.
