### PR TITLE
🫳 fix: Let the Composer Column Shrink Below a Queued Row's Text

### DIFF
--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -550,7 +550,7 @@ const ChatForm = memo(function ChatForm({
           : 'sm:mb-10',
       )}
     >
-      <div className="relative flex h-full flex-1 items-stretch md:flex-col">
+      <div className="relative flex h-full min-w-0 flex-1 items-stretch md:flex-col">
         {/* Primary composer owns the selection popup so split-view doesn't double it. */}
         {index === 0 && quotesEnabled && <QuoteButton conversationId={conversationId} />}
         {/* `relative` anchors the in-flight steer overlay, which floats above

--- a/e2e/specs/mock/steering.spec.ts
+++ b/e2e/specs/mock/steering.spec.ts
@@ -21,6 +21,11 @@ const MCP_SERVER_TITLE = 'E2E Memory';
 /** Last chunk streamed by the fake model's slow replies (160 chunks, 0-indexed). */
 const SLOW_REPLY_LAST_CHUNK = 'chunk-159';
 const SLOW_REPLY_CONTINUATION_TEXT = 'E2E slow reply continued';
+/** A pasted paragraph wider than the composer at any desktop viewport. */
+const LONG_PASTE = Array.from(
+  { length: 6 },
+  (_, index) => `pasted line ${index + 1}: a follow-up long enough to overflow the composer`,
+).join(' ');
 
 const uniqueLabel = (prefix: string) =>
   `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1e4)}`;
@@ -508,7 +513,9 @@ test.describe('mid-run steering and queuing', () => {
   }) => {
     test.setTimeout(120000);
     const label = uniqueLabel('queue');
-    const queueText = `Queued follow-up ${label}`;
+    /** Wider than the composer at every desktop width: the row must truncate
+     *  the text rather than widen the composer column to fit it. */
+    const queueText = `Queued follow-up ${label} ${LONG_PASTE}`;
 
     await page.goto(NEW_CHAT_PATH, { timeout: 10000 });
     await selectMockEndpoint(page, MOCK_ENDPOINTS[0]);
@@ -524,6 +531,20 @@ test.describe('mid-run steering and queuing', () => {
     await expect(row).toBeVisible({ timeout: 10000 });
     // Queued means NOT injected into the live thread.
     await expect(inFlightSteers(page)).toHaveCount(0);
+
+    // The queued text's natural width must not leak into the composer's size:
+    // the row ends where the form ends and its controls stay on screen.
+    const overflow = await row.evaluate((element) => {
+      const form = element.closest('form');
+      if (form == null) {
+        return Number.POSITIVE_INFINITY;
+      }
+      return element.getBoundingClientRect().right - form.getBoundingClientRect().right;
+    });
+    expect(overflow).toBeLessThanOrEqual(0);
+    await expect(row.getByRole('button', { name: 'Remove message' })).toBeInViewport({
+      ratio: 1,
+    });
 
     // Clean completion drains exactly one queued message as a new user turn.
     await expect(row).toHaveCount(0, { timeout: 60000 });


### PR DESCRIPTION
## Summary

A queued follow-up (or failed steer) row longer than the composer widened the whole composer column to the text's own length instead of truncating. The row's controls ended up off-screen, the composer ran under the side panel, and the chat pane grew a horizontal scrollbar.

The row's text is `nowrap` with `min-w-0 flex-1 truncate`, which is correct in isolation. What it lacks is a width cap, so its min-content width is the full text width, and that intrinsic size propagates straight up: chip row → chips column → composer surface → composer column → the form's `flex-1` child. That child is a flex item with `min-width: auto`, so its automatic minimum is its content's min-content width and the form cannot shrink it. The quote and skill chips beside it never trigger this only because each carries a fixed `max-w-[16rem]` / `max-w-[12rem]`.

`overflow-hidden` on the composer surface (already there) and on the row (tried) do not help: overflow only changes a flex item's own automatic minimum, not the min-content contribution it hands its parent.

## Change

- `ChatForm`: `min-w-0` on the form's `flex-1` column wrapper, the one flex item on the path whose `min-width: auto` let the composer exceed the form. Every child below it is already `w-full` or `overflow-hidden`, so the text truncates where it was always meant to. This closes the same hole for anything else rendered inside the composer surface (headers, file cards, future chips).
- `steering.spec.ts`: the Cmd/Ctrl+Enter queue test now queues a paragraph wider than the composer and asserts the row ends no further right than the form and that its remove button is fully in the viewport.

## Verification

Static harness (real Tailwind output for the exact ancestor chain, measured in Chromium):

| Viewport | Form right edge | Composer column right edge (before) | After |
|---|---|---|---|
| 1400px | 988 | 2264 | 980 |
| 900px | 580 | 2172 | 572 |
| 390px | 390 | 2164 | 390 |

Horizontal scroll on the chat pane went from 1184 / 1592 / 1774px to 0 at each width. Adding `overflow-hidden` to the row instead changed nothing.

Mock e2e (`steering.spec.ts`, "queues with Cmd/Ctrl+Enter…") against a client build without the fix fails the new assertion with the row 2119px past the form; the same test passes on the fixed build.
