### PR TITLE
🔏 feat: Promote Safe Tool Metadata to Langfuse

### DIFF
--- a/api/server/controllers/auth/oauth.js
+++ b/api/server/controllers/auth/oauth.js
@@ -83,6 +83,7 @@ function createOAuthHandler(redirectUri = domains.client) {
           existingRefreshToken: req.user.tokenset.refresh_token,
           openidSubject: req.user.openidId,
           openidIssuer: req.user.openidIssuer,
+          discardSessionTokens: true,
           req,
           res,
         });

--- a/api/server/controllers/auth/oauth.spec.js
+++ b/api/server/controllers/auth/oauth.spec.js
@@ -169,6 +169,7 @@ describe('createOAuthHandler', () => {
       existingRefreshToken: 'openid-refresh-token',
       openidSubject: undefined,
       openidIssuer: undefined,
+      discardSessionTokens: true,
       req,
       res,
     });

--- a/packages/api/src/auth/openid/recovery.spec.ts
+++ b/packages/api/src/auth/openid/recovery.spec.ts
@@ -104,4 +104,49 @@ describe('OpenID authentication publication settlement', () => {
     expect(deps.completeOpenIDRefreshFlight).toHaveBeenCalledTimes(1);
     expect(deps.failOpenIDRefreshFlight).not.toHaveBeenCalled();
   });
+
+  describe('with a stale token set left in the Express session', () => {
+    function buildStaleSession() {
+      return {
+        accessToken: 'stale-access',
+        idToken: 'stale-id',
+        refreshToken: 'stale-refresh',
+        accessTokenExpiresAt: Math.floor(Date.now() / 1000) - 120,
+      };
+    }
+
+    it('publishes the IdP token set at login instead of the stale session set', async () => {
+      const { deps, service, input } = setup();
+      const req = { session: { openidTokens: buildStaleSession() } };
+      await expect(
+        service.sendOpenIDAuthResponse({ ...input, req, discardSessionTokens: true }),
+      ).resolves.toBe('app-token');
+      expect(req.session.openidTokens).toBeUndefined();
+      expect(deps.completeOpenIDRefreshFlight).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tokens: expect.objectContaining({
+            tokenset: expect.objectContaining({ access_token: 'access', refresh_token: 'refresh' }),
+          }),
+        }),
+      );
+      expect(deps.setOpenIDAuthTokens).toHaveBeenCalledWith(
+        expect.objectContaining({ access_token: 'access', refresh_token: 'refresh' }),
+        req,
+        input.res,
+        expect.objectContaining({ userId: 'user', existingRefreshToken: 'refresh' }),
+      );
+    });
+
+    it('keeps adopting an advanced session on the refresh path', async () => {
+      const { deps, service, input } = setup();
+      const req = { session: { openidTokens: buildStaleSession() } };
+      await expect(service.sendOpenIDAuthResponse({ ...input, req })).resolves.toBe('app-token');
+      expect(deps.setOpenIDAuthTokens).toHaveBeenCalledWith(
+        expect.objectContaining({ access_token: 'stale-access', refresh_token: 'stale-refresh' }),
+        req,
+        input.res,
+        expect.objectContaining({ existingRefreshToken: 'stale-refresh' }),
+      );
+    });
+  });
 });

--- a/packages/api/src/auth/openid/recovery.ts
+++ b/packages/api/src/auth/openid/recovery.ts
@@ -100,6 +100,12 @@ interface SendOpenIDAuthResponseInput {
     },
   ) => Promise<void>;
   preparePublication?: boolean;
+  /**
+   * A fresh authorization-code login supersedes whatever token set the Express session still
+   * holds from an earlier authentication. The advanced-session comparison exists for refresh
+   * races and must not republish that stale set in place of the tokens the IdP just issued.
+   */
+  discardSessionTokens?: boolean;
 }
 
 export interface OpenIDRefreshRecoveryService {
@@ -679,6 +685,7 @@ export function createOpenIDRefreshRecoveryService(
     publicationGeneration,
     commitPublication,
     preparePublication = true,
+    discardSessionTokens = false,
   }: SendOpenIDAuthResponseInput): Promise<string | undefined> {
     const userId = user._id.toString();
     const publicationIdentity = predecessorIdentity ?? {
@@ -720,6 +727,7 @@ export function createOpenIDRefreshRecoveryService(
             publicationGeneration: sharedGeneration,
             commitPublication: async () => {},
             preparePublication: false,
+            discardSessionTokens,
           });
         }
         let completionStarted = false;
@@ -745,6 +753,7 @@ export function createOpenIDRefreshRecoveryService(
                   ? new Date(flight.flight.createdAt).getTime()
                   : Date.now(),
               },
+              discardSessionTokens,
               commitPublication: async (appAuthToken, publishedTokenset, metadata) => {
                 const completed = await completeOpenIDRefreshFlight({
                   key,
@@ -796,6 +805,9 @@ export function createOpenIDRefreshRecoveryService(
       await new Promise<void>((resolve, reject) => {
         reload((error?: Error | null) => (error ? reject(error) : resolve()));
       });
+    }
+    if (discardSessionTokens && req?.session?.openidTokens) {
+      delete req.session.openidTokens;
     }
     let effectiveTokenset = tokenset;
     let effectiveExistingRefreshToken = existingRefreshToken;


### PR DESCRIPTION
## Summary

Fixes #15648 (v0.8.8-rc2, `OPENID_REUSE_TOKENS=true`): every OIDC login failed with `OpenID refresh result is no longer available for publication` while a stale token set lived in the Express session.

## Mechanism

- Passport runs the OpenID callback with `session: false`, so the Express session is never regenerated at login. A token set written by an earlier authentication or refresh survives in `req.session.openidTokens` for the session cookie's lifetime.
- `sendOpenIDAuthResponse` compares the incoming token set with the session's. At login the session's refresh token differs from the one the IdP just issued, which the advanced-session check reads as "a concurrent refresh already advanced the session". The fresh IdP tokens are discarded and the stale set is republished.
- If that stale access token has already expired, `completeOpenIDRefreshFlight` clamps the completed flight's TTL to 1ms, `findOpenIDRefreshFlight` no longer sees it, and the post-completion availability assertion throws the reported message. Same second as `login success`, 100% reproducible, and only rc2 writes `accessTokenExpiresAt` into the session, which is why 0.8.7 is unaffected.

Even when the stale token is still valid this path silently publishes the wrong token set, so the login was wrong before it was loud.

## Change

- `packages/api/src/auth/openid/recovery.ts`: new `discardSessionTokens` option on `sendOpenIDAuthResponse`. When set, the session's token set is dropped after the service's own session reload (so the store cannot resurrect it) and before the advanced-session comparison. The option is threaded through both recursive publication calls.
- `api/server/controllers/auth/oauth.js`: the OpenID login passes `discardSessionTokens: true`. Refresh callers are unchanged and keep the advanced-session behaviour.

The flight TTL clamp is left as is: the expiry module deliberately treats an elapsed lifetime as dead, and with login no longer adopting session tokens nothing reaches the clamp with an expired token.

## Tests

- `recovery.spec.ts`: login with a stale session set publishes the IdP tokens and clears the session (fails without the fix, verified by removing the `delete`), plus a contrasting test that the refresh path still adopts an advanced session.
- `oauth.spec.js`: the login call carries the new flag.

Focused runs (selected with codegraph): `recovery.spec.ts`, `flight.spec.ts`, `oauth.spec.js`, `routes/oauth.test.js`, `routes/admin/auth.refresh.test.js` all green; eslint clean on the changed files.
