### PR TITLE
🕹 fix: Keep Composer Focus Off Clicked Controls So Menus Can Close

### DIFF
--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -162,7 +162,15 @@ const ChatForm = memo(function ChatForm({
     [requiresKey, invalidAssistant],
   );
 
-  const handleContainerClick = useCallback(() => {
+  const handleContainerClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    if (
+      event.target instanceof Element &&
+      event.target.closest(
+        'button, a, input, select, textarea, [role="button"], [role="menuitem"], [role="menu"]',
+      )
+    ) {
+      return;
+    }
     /** Check if the device is a touchscreen */
     if (window.matchMedia?.('(pointer: coarse)').matches) {
       return;

--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -165,19 +165,35 @@ const ChatForm = memo(function ChatForm({
     [requiresKey, invalidAssistant],
   );
 
-  const handleContainerClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
-    /** Check if the device is a touchscreen */
+  /** Skipped on touchscreens so a tap does not raise the keyboard. */
+  const focusTextArea = useCallback(() => {
     if (window.matchMedia?.('(pointer: coarse)').matches) {
-      return;
-    }
-    /** Ariakit records `document.activeElement` at open time as a menu's disclosure. Stealing
-     * focus from a clicked control makes the textarea that disclosure, so the menu can never
-     * close on textarea interaction (#15624). Only empty composer space focuses the textarea. */
-    if (event.target instanceof Element && event.target.closest(interactiveTargetSelector)) {
       return;
     }
     textAreaRef.current?.focus();
   }, []);
+
+  /** Ariakit records `document.activeElement` at open time as a menu's disclosure. Stealing
+   * focus from a clicked control makes the textarea that disclosure, so the menu can never
+   * close on textarea interaction (#15624). Only empty composer space focuses the textarea;
+   * controls that finish a composer action (send, steer, stop) restore it themselves. */
+  const handleContainerClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (event.target instanceof Element && event.target.closest(interactiveTargetSelector)) {
+        return;
+      }
+      focusTextArea();
+    },
+    [focusTextArea],
+  );
+
+  const handleStop = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      handleStopGenerating(event);
+      focusTextArea();
+    },
+    [handleStopGenerating, focusTextArea],
+  );
 
   const handleFocusOrClick = useCallback(() => {
     if (isCollapsed) {
@@ -507,13 +523,16 @@ const ChatForm = memo(function ChatForm({
           control={methods.control}
           steering={steering}
           getText={() => methods.getValues('text')}
-          onConsumed={() => methods.reset()}
+          onConsumed={() => {
+            methods.reset();
+            focusTextArea();
+          }}
           disabled={filesLoading}
         />
       );
     }
     if (showStopButton) {
-      return <StopButton stop={handleStopGenerating} setShowStopButton={setShowStopButton} />;
+      return <StopButton stop={handleStop} setShowStopButton={setShowStopButton} />;
     }
     return null;
   })();
@@ -531,6 +550,7 @@ const ChatForm = memo(function ChatForm({
   return (
     <form
       onSubmit={methods.handleSubmit((data) => {
+        focusTextArea();
         // Answer mode: composer text answers the paused run instead of
         // starting a new turn (submitText resets the composer itself).
         // Dismissing the popover — or collapsing a batch, which answers in its
@@ -762,7 +782,10 @@ const ChatForm = memo(function ChatForm({
                       <InterruptSteerButton
                         steering={steering}
                         getText={() => methods.getValues('text')}
-                        onConsumed={() => methods.reset()}
+                        onConsumed={() => {
+                          methods.reset();
+                          focusTextArea();
+                        }}
                         disabled={filesLoading}
                       />
                     </div>

--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -179,23 +179,37 @@ const ChatForm = memo(function ChatForm({
     [requiresKey, invalidAssistant],
   );
 
+  /** Skipped on touchscreens so a tap does not raise the keyboard. */
+  const focusTextArea = useCallback(() => {
+    if (window.matchMedia?.('(pointer: coarse)').matches) {
+      return;
+    }
+    textAreaRef.current?.focus();
+  }, []);
+
   /** The surface returns focus to the textarea after any click (send, stop, badge
    * toggles), except when the target owns focus itself or opens a popup. Ariakit
    * records `document.activeElement` at open time as a menu's disclosure, so
    * refocusing the textarea behind a menu button made the textarea the disclosure
    * and the menu could never close on textarea interaction (#15624). */
-  const handleContainerClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
-    /** Check if the device is a touchscreen */
-    if (window.matchMedia?.('(pointer: coarse)').matches) {
-      return;
-    }
-    const owner =
-      event.target instanceof Element ? event.target.closest(focusOwningTargetSelector) : null;
-    if (owner && !owner.contains(event.currentTarget)) {
-      return;
-    }
-    textAreaRef.current?.focus();
-  }, []);
+  const handleContainerClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      const owner =
+        event.target instanceof Element ? event.target.closest(focusOwningTargetSelector) : null;
+      if (owner && !owner.contains(event.currentTarget)) {
+        return;
+      }
+      focusTextArea();
+    },
+    [focusTextArea],
+  );
+
+  /** Actions that consume the composer from inside a popup (the during-run
+   * hovercard) sit in exempted popup content, so they restore focus themselves. */
+  const consumeComposer = useCallback(() => {
+    methods.reset();
+    focusTextArea();
+  }, [methods, focusTextArea]);
 
   const handleFocusOrClick = useCallback(() => {
     if (isCollapsed) {
@@ -525,7 +539,7 @@ const ChatForm = memo(function ChatForm({
           control={methods.control}
           steering={steering}
           getText={() => methods.getValues('text')}
-          onConsumed={() => methods.reset()}
+          onConsumed={consumeComposer}
           disabled={filesLoading}
         />
       );
@@ -780,7 +794,7 @@ const ChatForm = memo(function ChatForm({
                       <InterruptSteerButton
                         steering={steering}
                         getText={() => methods.getValues('text')}
-                        onConsumed={() => methods.reset()}
+                        onConsumed={consumeComposer}
                         disabled={filesLoading}
                       />
                     </div>

--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -77,6 +77,9 @@ interface ChatFormProps {
   stopGenerating: () => void;
 }
 
+const interactiveTargetSelector =
+  'button, a, input, select, textarea, label, [role="button"], [role="menu"], [role="menuitem"]';
+
 const ChatForm = memo(function ChatForm({
   index,
   placeholder,
@@ -163,16 +166,14 @@ const ChatForm = memo(function ChatForm({
   );
 
   const handleContainerClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
-    if (
-      event.target instanceof Element &&
-      event.target.closest(
-        'button, a, input, select, textarea, [role="button"], [role="menuitem"], [role="menu"]',
-      )
-    ) {
-      return;
-    }
     /** Check if the device is a touchscreen */
     if (window.matchMedia?.('(pointer: coarse)').matches) {
+      return;
+    }
+    /** Ariakit records `document.activeElement` at open time as a menu's disclosure. Stealing
+     * focus from a clicked control makes the textarea that disclosure, so the menu can never
+     * close on textarea interaction (#15624). Only empty composer space focuses the textarea. */
+    if (event.target instanceof Element && event.target.closest(interactiveTargetSelector)) {
       return;
     }
     textAreaRef.current?.focus();
@@ -600,6 +601,7 @@ const ChatForm = memo(function ChatForm({
               agentId={conversation?.agent_id}
             />
             <div
+              data-testid="composer-surface"
               onClick={handleContainerClick}
               className={cn(
                 'relative flex w-full flex-grow flex-col overflow-hidden rounded-t-3xl pb-4 sm:rounded-3xl sm:pb-0',

--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -77,8 +77,22 @@ interface ChatFormProps {
   stopGenerating: () => void;
 }
 
-const interactiveTargetSelector =
-  'button, a, input, select, textarea, label, [role="button"], [role="menu"], [role="menuitem"]';
+/** Targets that own focus themselves: form fields and links, popup disclosures
+ * (Ariakit and Radix both emit `aria-haspopup`), and popup content, which React
+ * bubbles through portals. */
+const focusOwningTargetSelector = [
+  'a',
+  'input',
+  'select',
+  'textarea',
+  'label',
+  '[aria-haspopup]:not([aria-haspopup="false"])',
+  '[role="combobox"]',
+  '[role="menu"]',
+  '[role="listbox"]',
+  '[role="dialog"]',
+  '[role="alertdialog"]',
+].join(', ');
 
 const ChatForm = memo(function ChatForm({
   index,
@@ -165,35 +179,23 @@ const ChatForm = memo(function ChatForm({
     [requiresKey, invalidAssistant],
   );
 
-  /** Skipped on touchscreens so a tap does not raise the keyboard. */
-  const focusTextArea = useCallback(() => {
+  /** The surface returns focus to the textarea after any click (send, stop, badge
+   * toggles), except when the target owns focus itself or opens a popup. Ariakit
+   * records `document.activeElement` at open time as a menu's disclosure, so
+   * refocusing the textarea behind a menu button made the textarea the disclosure
+   * and the menu could never close on textarea interaction (#15624). */
+  const handleContainerClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    /** Check if the device is a touchscreen */
     if (window.matchMedia?.('(pointer: coarse)').matches) {
+      return;
+    }
+    const owner =
+      event.target instanceof Element ? event.target.closest(focusOwningTargetSelector) : null;
+    if (owner && !owner.contains(event.currentTarget)) {
       return;
     }
     textAreaRef.current?.focus();
   }, []);
-
-  /** Ariakit records `document.activeElement` at open time as a menu's disclosure. Stealing
-   * focus from a clicked control makes the textarea that disclosure, so the menu can never
-   * close on textarea interaction (#15624). Only empty composer space focuses the textarea;
-   * controls that finish a composer action (send, steer, stop) restore it themselves. */
-  const handleContainerClick = useCallback(
-    (event: React.MouseEvent<HTMLDivElement>) => {
-      if (event.target instanceof Element && event.target.closest(interactiveTargetSelector)) {
-        return;
-      }
-      focusTextArea();
-    },
-    [focusTextArea],
-  );
-
-  const handleStop = useCallback(
-    (event: React.MouseEvent<HTMLButtonElement>) => {
-      handleStopGenerating(event);
-      focusTextArea();
-    },
-    [handleStopGenerating, focusTextArea],
-  );
 
   const handleFocusOrClick = useCallback(() => {
     if (isCollapsed) {
@@ -523,16 +525,13 @@ const ChatForm = memo(function ChatForm({
           control={methods.control}
           steering={steering}
           getText={() => methods.getValues('text')}
-          onConsumed={() => {
-            methods.reset();
-            focusTextArea();
-          }}
+          onConsumed={() => methods.reset()}
           disabled={filesLoading}
         />
       );
     }
     if (showStopButton) {
-      return <StopButton stop={handleStop} setShowStopButton={setShowStopButton} />;
+      return <StopButton stop={handleStopGenerating} setShowStopButton={setShowStopButton} />;
     }
     return null;
   })();
@@ -550,7 +549,6 @@ const ChatForm = memo(function ChatForm({
   return (
     <form
       onSubmit={methods.handleSubmit((data) => {
-        focusTextArea();
         // Answer mode: composer text answers the paused run instead of
         // starting a new turn (submitText resets the composer itself).
         // Dismissing the popover — or collapsing a batch, which answers in its
@@ -782,10 +780,7 @@ const ChatForm = memo(function ChatForm({
                       <InterruptSteerButton
                         steering={steering}
                         getText={() => methods.getValues('text')}
-                        onConsumed={() => {
-                          methods.reset();
-                          focusTextArea();
-                        }}
+                        onConsumed={() => methods.reset()}
                         disabled={filesLoading}
                       />
                     </div>

--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -656,7 +656,7 @@ const ChatForm = memo(function ChatForm({
               <TextareaHeader addedConvo={addedConvo} setAddedConvo={setAddedConvo} />
               <PendingManualSkillsChips conversationId={conversationId} />
               {quotesEnabled && (
-                <PendingQuoteChips conversationId={conversationId} textAreaRef={textAreaRef} />
+                <PendingQuoteChips conversationId={conversationId} focusComposer={focusTextArea} />
               )}
               {steering.enabled && (
                 <PendingSteerChips

--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -655,7 +655,9 @@ const ChatForm = memo(function ChatForm({
               {project ? <ProjectLandingChip project={project} /> : null}
               <TextareaHeader addedConvo={addedConvo} setAddedConvo={setAddedConvo} />
               <PendingManualSkillsChips conversationId={conversationId} />
-              {quotesEnabled && <PendingQuoteChips conversationId={conversationId} />}
+              {quotesEnabled && (
+                <PendingQuoteChips conversationId={conversationId} textAreaRef={textAreaRef} />
+              )}
               {steering.enabled && (
                 <PendingSteerChips
                   conversationId={conversationId}

--- a/client/src/components/Chat/Input/PendingQuoteChips.tsx
+++ b/client/src/components/Chat/Input/PendingQuoteChips.tsx
@@ -41,10 +41,11 @@ const CLOSE_DELAY_MS = 120;
  */
 function PendingQuoteChips({
   conversationId,
-  textAreaRef,
+  focusComposer,
 }: {
   conversationId: string;
-  textAreaRef?: React.RefObject<HTMLTextAreaElement>;
+  /** The composer's guarded refocus, which skips touchscreens. */
+  focusComposer?: () => void;
 }) {
   const localize = useLocalize();
   const quotes = useRecoilValue(store.pendingQuotesByConvoId(conversationId));
@@ -81,18 +82,32 @@ function PendingQuoteChips({
   const clearAll = useCallback(() => setQuotes([]), [setQuotes]);
   /** The clicked remove button unmounts with its row, and the composer surface
    * does not refocus the textarea for clicks inside popup content, so restore
-   * focus here: to the textarea once the popup collapses, otherwise to the popup
-   * so keyboard users stay inside it. */
+   * focus here: to the composer once the popup collapses, otherwise to the
+   * remove button now at the same row (or the last one) once React has
+   * re-rendered the list. */
+  const pendingFocusIndexRef = useRef<number | null>(null);
+  useEffect(() => {
+    const index = pendingFocusIndexRef.current;
+    if (index == null) {
+      return;
+    }
+    pendingFocusIndexRef.current = null;
+    const buttons = popover.getState().contentElement?.querySelectorAll('button');
+    if (!buttons?.length) {
+      return;
+    }
+    buttons[Math.min(index, buttons.length - 1)].focus();
+  }, [quotes, popover]);
   const removeAt = useCallback(
     (index: number) => {
       setQuotes((prev) => prev.filter((_, i) => i !== index));
       if (quotes.length <= 2) {
-        textAreaRef?.current?.focus();
+        focusComposer?.();
         return;
       }
-      popover.getState().contentElement?.focus();
+      pendingFocusIndexRef.current = index;
     },
-    [setQuotes, quotes.length, popover, textAreaRef],
+    [setQuotes, quotes.length, focusComposer],
   );
 
   if (quotes.length === 0) {

--- a/client/src/components/Chat/Input/PendingQuoteChips.tsx
+++ b/client/src/components/Chat/Input/PendingQuoteChips.tsx
@@ -39,7 +39,13 @@ const CLOSE_DELAY_MS = 120;
  * once the message is sent (the excerpts then re-render as `MessageQuotes` on
  * the user bubble, or inside the steer bubble for a mid-run injection).
  */
-function PendingQuoteChips({ conversationId }: { conversationId: string }) {
+function PendingQuoteChips({
+  conversationId,
+  textAreaRef,
+}: {
+  conversationId: string;
+  textAreaRef?: React.RefObject<HTMLTextAreaElement>;
+}) {
   const localize = useLocalize();
   const quotes = useRecoilValue(store.pendingQuotesByConvoId(conversationId));
   const setQuotes = useSetRecoilState(store.pendingQuotesByConvoId(conversationId));
@@ -73,9 +79,20 @@ function PendingQuoteChips({ conversationId }: { conversationId: string }) {
   useEffect(() => cancelClose, [cancelClose]);
 
   const clearAll = useCallback(() => setQuotes([]), [setQuotes]);
+  /** The clicked remove button unmounts with its row, and the composer surface
+   * does not refocus the textarea for clicks inside popup content, so restore
+   * focus here: to the textarea once the popup collapses, otherwise to the popup
+   * so keyboard users stay inside it. */
   const removeAt = useCallback(
-    (index: number) => setQuotes((prev) => prev.filter((_, i) => i !== index)),
-    [setQuotes],
+    (index: number) => {
+      setQuotes((prev) => prev.filter((_, i) => i !== index));
+      if (quotes.length <= 2) {
+        textAreaRef?.current?.focus();
+        return;
+      }
+      popover.getState().contentElement?.focus();
+    },
+    [setQuotes, quotes.length, popover, textAreaRef],
   );
 
   if (quotes.length === 0) {

--- a/client/src/components/Chat/Input/__tests__/ChatForm.attachments.spec.tsx
+++ b/client/src/components/Chat/Input/__tests__/ChatForm.attachments.spec.tsx
@@ -6,8 +6,8 @@ import { RecoilRoot, useRecoilState } from 'recoil';
 import userEvent from '@testing-library/user-event';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { QueryKeys, FileSources, EModelEndpoint } from 'librechat-data-provider';
 import type { TFile, TFileUpload, TConversation } from 'librechat-data-provider';
 import type { ChatFormValues } from '~/common';
@@ -172,6 +172,34 @@ describe('ChatForm attachments', () => {
 
     await waitFor(() => expect(sendButton()).toBeEnabled());
     expect(textarea).toHaveValue('hi');
+  }, 20000);
+
+  test('does not steal focus when clicking the nested attachment icon', async () => {
+    renderComposer();
+    const textarea = await screen.findByTestId('text-input');
+    const trigger = screen.getByRole('button', { name: 'Attach File Options' });
+    expect(trigger).toBeEnabled();
+    const icon = trigger.querySelector('svg');
+    expect(icon).not.toBeNull();
+    const focus = jest.spyOn(textarea, 'focus');
+
+    await userEvent.click(icon as SVGElement);
+
+    expect(focus).not.toHaveBeenCalled();
+    expect(await screen.findByRole('menu', { name: 'Attach File Options' })).toBeInTheDocument();
+  }, 20000);
+
+  test('focuses the textarea when clicking empty composer space', async () => {
+    renderComposer();
+    const textarea = await screen.findByTestId('text-input');
+    const surface = textarea.closest('.rounded-t-3xl');
+    expect(surface).not.toBeNull();
+    const focus = jest.spyOn(textarea, 'focus');
+
+    fireEvent.click(surface as HTMLElement);
+
+    expect(focus).toHaveBeenCalledTimes(1);
+    expect(textarea).toHaveFocus();
   }, 20000);
 
   test('enables send for an attachment with no composer text', async () => {

--- a/client/src/components/Chat/Input/__tests__/ChatForm.attachments.spec.tsx
+++ b/client/src/components/Chat/Input/__tests__/ChatForm.attachments.spec.tsx
@@ -255,8 +255,11 @@ describe('ChatForm attachments', () => {
   test('returns focus to the textarea when removing a quote collapses the popup', async () => {
     renderComposer({ quotes: ['alpha', 'beta'] });
     const textarea = await screen.findByTestId('text-input');
-    await userEvent.click(screen.getByRole('button', { name: '2 selections' }));
-    const popup = await screen.findByTestId('quote-selections-popup');
+    // Hover opens this disclosure too; test the click path without a synthetic hover toggle.
+    await userEvent.click(screen.getByRole('button', { name: '2 selections' }), {
+      skipHover: true,
+    });
+    const popup = await screen.findByRole('dialog');
 
     await userEvent.click(within(popup).getAllByRole('button', { name: 'Remove quote' })[0]);
 
@@ -268,8 +271,11 @@ describe('ChatForm attachments', () => {
   test('keeps focus inside the popup when removing a quote leaves several', async () => {
     renderComposer({ quotes: ['alpha', 'beta', 'gamma'] });
     await screen.findByTestId('text-input');
-    await userEvent.click(screen.getByRole('button', { name: '3 selections' }));
-    const popup = await screen.findByTestId('quote-selections-popup');
+    // Hover opens this disclosure too; test the click path without a synthetic hover toggle.
+    await userEvent.click(screen.getByRole('button', { name: '3 selections' }), {
+      skipHover: true,
+    });
+    const popup = await screen.findByRole('dialog');
 
     await userEvent.click(within(popup).getAllByRole('button', { name: 'Remove quote' })[0]);
 
@@ -285,8 +291,11 @@ describe('ChatForm attachments', () => {
     try {
       renderComposer({ quotes: ['alpha', 'beta'] });
       const textarea = await screen.findByTestId('text-input');
-      await userEvent.click(screen.getByRole('button', { name: '2 selections' }));
-      const popup = await screen.findByTestId('quote-selections-popup');
+      // Hover opens this disclosure too; test the click path without a synthetic hover toggle.
+      await userEvent.click(screen.getByRole('button', { name: '2 selections' }), {
+        skipHover: true,
+      });
+      const popup = await screen.findByRole('dialog');
 
       await userEvent.click(within(popup).getAllByRole('button', { name: 'Remove quote' })[0]);
 

--- a/client/src/components/Chat/Input/__tests__/ChatForm.attachments.spec.tsx
+++ b/client/src/components/Chat/Input/__tests__/ChatForm.attachments.spec.tsx
@@ -274,7 +274,27 @@ describe('ChatForm attachments', () => {
     await userEvent.click(within(popup).getAllByRole('button', { name: 'Remove quote' })[0]);
 
     await waitFor(() => expect(within(popup).getAllByRole('button')).toHaveLength(2));
-    expect(popup).toHaveFocus();
+    expect(within(popup).getAllByRole('button', { name: 'Remove quote' })[0]).toHaveFocus();
+  }, 20000);
+
+  test('does not raise the keyboard when a quote removal collapses the popup on touch', async () => {
+    const matchMedia = window.matchMedia;
+    window.matchMedia = jest
+      .fn()
+      .mockReturnValue({ matches: true }) as unknown as typeof matchMedia;
+    try {
+      renderComposer({ quotes: ['alpha', 'beta'] });
+      const textarea = await screen.findByTestId('text-input');
+      await userEvent.click(screen.getByRole('button', { name: '2 selections' }));
+      const popup = await screen.findByTestId('quote-selections-popup');
+
+      await userEvent.click(within(popup).getAllByRole('button', { name: 'Remove quote' })[0]);
+
+      await waitFor(() => expect(screen.queryByTestId('quote-selections-popup')).toBeNull());
+      expect(textarea).not.toHaveFocus();
+    } finally {
+      window.matchMedia = matchMedia;
+    }
   }, 20000);
 
   test('focuses the textarea when clicking empty composer space', async () => {

--- a/client/src/components/Chat/Input/__tests__/ChatForm.attachments.spec.tsx
+++ b/client/src/components/Chat/Input/__tests__/ChatForm.attachments.spec.tsx
@@ -7,8 +7,8 @@ import userEvent from '@testing-library/user-event';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { QueryKeys, FileSources, EModelEndpoint } from 'librechat-data-provider';
+import { render, screen, within, waitFor, fireEvent } from '@testing-library/react';
 import type { TFile, TFileUpload, TConversation } from 'librechat-data-provider';
 import type { ChatFormValues } from '~/common';
 import { ChatContext, ChatFormProvider } from '~/Providers';
@@ -117,7 +117,7 @@ function Harness() {
   );
 }
 
-function renderComposer() {
+function renderComposer({ submitting = false }: { submitting?: boolean } = {}) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
@@ -127,7 +127,7 @@ function renderComposer() {
 
   return render(
     <QueryClientProvider client={queryClient}>
-      <RecoilRoot>
+      <RecoilRoot initializeState={({ set }) => set(store.isSubmittingFamily(0), submitting)}>
         <Router>
           <AuthContextProvider authConfig={{ loginRedirect: '', test: true }}>
             <DndProvider backend={HTML5Backend}>
@@ -211,6 +211,25 @@ describe('ChatForm attachments', () => {
 
     await userEvent.click(sendButton());
 
+    expect(textarea).toHaveFocus();
+  }, 20000);
+
+  test('returns focus to the textarea after a during-run hovercard action', async () => {
+    renderComposer({ submitting: true });
+    const textarea = await screen.findByTestId('text-input');
+    await userEvent.type(textarea, 'later');
+    /** Ariakit shows a hovercard only after the pointer has travelled, and a
+     *  keydown resets that, so the hover needs real screen-coordinate movement. */
+    const anchor = await screen.findByTestId('during-run-send-button');
+    fireEvent.mouseMove(anchor, { screenX: 10, screenY: 10 });
+    fireEvent.mouseMove(anchor, { screenX: 20, screenY: 20 });
+    const hovercard = await screen.findByRole('dialog');
+    const queue = within(hovercard).getByRole('button', { name: /^Queue\b/ });
+    expect(queue).toBeEnabled();
+
+    await userEvent.click(queue);
+
+    await waitFor(() => expect(textarea).toHaveValue(''));
     expect(textarea).toHaveFocus();
   }, 20000);
 

--- a/client/src/components/Chat/Input/__tests__/ChatForm.attachments.spec.tsx
+++ b/client/src/components/Chat/Input/__tests__/ChatForm.attachments.spec.tsx
@@ -117,7 +117,10 @@ function Harness() {
   );
 }
 
-function renderComposer({ submitting = false }: { submitting?: boolean } = {}) {
+function renderComposer({
+  submitting = false,
+  quotes = [],
+}: { submitting?: boolean; quotes?: string[] } = {}) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
@@ -127,7 +130,12 @@ function renderComposer({ submitting = false }: { submitting?: boolean } = {}) {
 
   return render(
     <QueryClientProvider client={queryClient}>
-      <RecoilRoot initializeState={({ set }) => set(store.isSubmittingFamily(0), submitting)}>
+      <RecoilRoot
+        initializeState={({ set }) => {
+          set(store.isSubmittingFamily(0), submitting);
+          set(store.pendingQuotesByConvoId(conversation.conversationId ?? ''), quotes);
+        }}
+      >
         <Router>
           <AuthContextProvider authConfig={{ loginRedirect: '', test: true }}>
             <DndProvider backend={HTML5Backend}>
@@ -231,6 +239,42 @@ describe('ChatForm attachments', () => {
 
     await waitFor(() => expect(textarea).toHaveValue(''));
     expect(textarea).toHaveFocus();
+  }, 20000);
+
+  test('returns focus to the textarea after the primary during-run submit', async () => {
+    renderComposer({ submitting: true });
+    const textarea = await screen.findByTestId('text-input');
+    await userEvent.type(textarea, 'later');
+
+    await userEvent.click(await screen.findByTestId('during-run-send-button'));
+
+    await waitFor(() => expect(textarea).toHaveValue(''));
+    expect(textarea).toHaveFocus();
+  }, 20000);
+
+  test('returns focus to the textarea when removing a quote collapses the popup', async () => {
+    renderComposer({ quotes: ['alpha', 'beta'] });
+    const textarea = await screen.findByTestId('text-input');
+    await userEvent.click(screen.getByRole('button', { name: '2 selections' }));
+    const popup = await screen.findByTestId('quote-selections-popup');
+
+    await userEvent.click(within(popup).getAllByRole('button', { name: 'Remove quote' })[0]);
+
+    await waitFor(() => expect(screen.queryByTestId('quote-selections-popup')).toBeNull());
+    expect(screen.getByText('beta')).toBeInTheDocument();
+    expect(textarea).toHaveFocus();
+  }, 20000);
+
+  test('keeps focus inside the popup when removing a quote leaves several', async () => {
+    renderComposer({ quotes: ['alpha', 'beta', 'gamma'] });
+    await screen.findByTestId('text-input');
+    await userEvent.click(screen.getByRole('button', { name: '3 selections' }));
+    const popup = await screen.findByTestId('quote-selections-popup');
+
+    await userEvent.click(within(popup).getAllByRole('button', { name: 'Remove quote' })[0]);
+
+    await waitFor(() => expect(within(popup).getAllByRole('button')).toHaveLength(2));
+    expect(popup).toHaveFocus();
   }, 20000);
 
   test('focuses the textarea when clicking empty composer space', async () => {

--- a/client/src/components/Chat/Input/__tests__/ChatForm.attachments.spec.tsx
+++ b/client/src/components/Chat/Input/__tests__/ChatForm.attachments.spec.tsx
@@ -203,6 +203,17 @@ describe('ChatForm attachments', () => {
     expect(textarea).toHaveFocus();
   }, 20000);
 
+  test('returns focus to the textarea after a mouse click on send', async () => {
+    renderComposer();
+    const textarea = await screen.findByTestId('text-input');
+    await userEvent.type(textarea, 'hi');
+    expect(sendButton()).toBeEnabled();
+
+    await userEvent.click(sendButton());
+
+    expect(textarea).toHaveFocus();
+  }, 20000);
+
   test('focuses the textarea when clicking empty composer space', async () => {
     renderComposer();
     const textarea = await screen.findByTestId('text-input');

--- a/client/src/components/Chat/Input/__tests__/ChatForm.attachments.spec.tsx
+++ b/client/src/components/Chat/Input/__tests__/ChatForm.attachments.spec.tsx
@@ -189,14 +189,27 @@ describe('ChatForm attachments', () => {
     expect(await screen.findByRole('menu', { name: 'Attach File Options' })).toBeInTheDocument();
   }, 20000);
 
+  test('closes an open menu when the textarea is clicked', async () => {
+    renderComposer();
+    const textarea = await screen.findByTestId('text-input');
+    await userEvent.click(screen.getByRole('button', { name: 'Attach File Options' }));
+    expect(await screen.findByRole('menu', { name: 'Attach File Options' })).toBeInTheDocument();
+
+    await userEvent.click(textarea);
+
+    await waitFor(() =>
+      expect(screen.queryByRole('menu', { name: 'Attach File Options' })).not.toBeInTheDocument(),
+    );
+    expect(textarea).toHaveFocus();
+  }, 20000);
+
   test('focuses the textarea when clicking empty composer space', async () => {
     renderComposer();
     const textarea = await screen.findByTestId('text-input');
-    const surface = textarea.closest('.rounded-t-3xl');
-    expect(surface).not.toBeNull();
+    const surface = screen.getByTestId('composer-surface');
     const focus = jest.spyOn(textarea, 'focus');
 
-    fireEvent.click(surface as HTMLElement);
+    fireEvent.click(surface);
 
     expect(focus).toHaveBeenCalledTimes(1);
     expect(textarea).toHaveFocus();

--- a/client/src/components/Chat/Input/__tests__/ChatForm.attachments.spec.tsx
+++ b/client/src/components/Chat/Input/__tests__/ChatForm.attachments.spec.tsx
@@ -203,7 +203,7 @@ describe('ChatForm attachments', () => {
     expect(textarea).toHaveFocus();
   }, 20000);
 
-  test('returns focus to the textarea after a mouse click on send', async () => {
+  test('still returns focus to the textarea after a plain control click', async () => {
     renderComposer();
     const textarea = await screen.findByTestId('text-input');
     await userEvent.type(textarea, 'hi');

--- a/e2e/specs/mock/quotes.spec.ts
+++ b/e2e/specs/mock/quotes.spec.ts
@@ -581,11 +581,12 @@ test.describe('quote references', () => {
     // Opening via keyboard moves focus into the popup (first excerpt's remove ×).
     await expect(popup.getByRole('button').first()).toBeFocused();
 
-    // Escape closes it and returns focus to the composer (NOT the page top, the
-    // bug this guards against). `document.activeElement` must be a real control.
+    // Escape closes it and returns focus to the pill that opened it (NOT the
+    // page top, the bug this guards against). `document.activeElement` must be
+    // a real control.
     await page.keyboard.press('Escape');
     await expect(popup).toBeHidden();
-    await expect(page.getByRole('textbox', { name: 'Message input' })).toBeFocused();
+    await expect(trigger).toBeFocused();
     const focusTag = await page.evaluate(() => document.activeElement?.tagName ?? 'NONE');
     expect(focusTag).not.toBe('BODY');
   });


### PR DESCRIPTION
## Summary

Closes #15624. Supersedes #15635 and carries @jacksonriding's commit for credit.

The Tools and attach menus in the composer stayed open after clicking the textarea, typing, or sending. Reported on Safari, but it reproduces in Chromium and Firefox: it is not a WebKit bug.

## Root cause

Ariakit's `useDialog` records `document.activeElement` at open time as the menu's disclosure element. The composer surface focused the textarea on every bubbled click, including the click that opened a menu. React flushes the open state after the whole dispatch, so by the time the layout effect ran, the active element was the textarea, and the textarea became the menu's "disclosure". `useHideOnInteractOutside` ignores interaction on the disclosure, and `markTreeOutside` walked from the textarea instead of the button, so nothing in the textarea's subtree was ever marked outside. Clicks elsewhere in the chat still closed the menu; textarea clicks, focus, and typing never did.

## Why it regressed in v0.8.8-rc2

`handleContainerClick` has behaved this way since before v0.8.6, so the disclosure was always mis-recorded. #14979 (first shipped in v0.8.8-rc2) switched the Tools dropdown from `modal={true}` to `modal={false}` to fix axe violations. The modal backdrop had been catching outside clicks and trapping focus, which hid the underlying bug. Once the backdrop went away, dismissal depended on the disclosure bookkeeping, which was wrong.

## The rule

The surface has always returned focus to the textarea after any click inside it, and plain controls (send, stop, steer, badge toggles, chip removal) rely on that: a mouse user clicks send and keeps typing. Exempting every `button` from the refocus, as the first pass did, silently inverted that for every control and turned each one into its own follow-up finding. So the exemption is stated the other way round: the surface refocuses the textarea after any click **except** on a target that owns focus itself or opens or belongs to a popup.

- **Owns focus:** `a`, `input`, `select`, `textarea`, `label`.
- **Opens a popup:** `[aria-haspopup]` (Ariakit and Radix both emit it on menu, dialog, and listbox disclosures) and `[role="combobox"]`.
- **Is popup content:** `menu`, `listbox`, `dialog`, `alertdialog` roles. React bubbles clicks through portals, so a menu item click reaches the surface; refocusing then would close a `hideOnClick: false` item's menu.
- A match that contains the surface itself is ignored, so a host that renders the composer inside a dialog can never switch the refocus off.
- **Actions inside exempt popup content that consume the composer or unmount their own control** cannot rely on the bubbled refocus, so they restore it themselves. Today that is the during-run hovercard (Steer, Queue, Interrupt), through a shared consume callback, and the selections popup's remove buttons, which go through the composer's guarded refocus when the popup collapses (so a touchscreen tap never raises the keyboard) and otherwise land on the remove button now at the same row once the list re-renders. The primary during-run submit is not in this set: Ariakit's hovercard anchor carries no popup attributes, so it bubbles like any plain button, and a test pins that.

Safari note for reviewers: Ariakit already gives buttons `tabIndex=0` on Safari so they take focus on mousedown, sets the disclosure in the button's own `onClick`, and falls back to the last mousedown target when the active element is `body`. The only way the textarea became the disclosure was the bubbled refocus removed here.

## Behavior note

One e2e expectation changed. `quotes.spec.ts` asserted that Escape on the "N selections" popover focuses the textarea. That only ever held through this bug: Enter on the pill fired a click that bubbled to the surface, the textarea took focus mid-open and was recorded as the popover's disclosure, so Ariakit "restored" focus to it on hide. With the surface no longer stealing focus from a popup disclosure, the pill is the disclosure and Escape returns focus to it, which is what `PendingQuoteChips` documents and what ARIA expects. The assertion now expects the pill; the guard against focus landing on `body` is unchanged. Ariakit skips that restore in jsdom (its `isFocusable` needs layout), so the e2e remains the test for it.

## Scope

Codex asked for `pendingQuotesByConvoId` to move from Recoil to Jotai because this PR touches the quote chip. Declined here: the change does not alter the quote state's shape or write path, and the atom is drained by `useChatFunctions.ask` and three `useSteering` paths and written by `QuoteButton`, so that migration is a cross-cutting change for its own PR rather than an rc regression fix.

## Tests

Ten tests in `ChatForm.attachments.spec.tsx`, each proven against its failure mode:

- clicking the nested attach icon does not focus the textarea (fails with no exemption)
- opening a menu and then clicking the textarea closes the menu (fails with no exemption)
- a mouse click on send still returns focus to the textarea (fails with a blanket `button` exemption)
- choosing Queue from the real during-run hovercard leaves the textarea focused (fails without the consume refocus; the hovercard is driven with screen-coordinate mouse travel because Ariakit only opens it after real pointer movement)
- the primary during-run submit still returns focus to the textarea through the surface
- removing the second-to-last quote from the selections popup focuses the textarea (fails without the chip's refocus), and not on a coarse pointer (fails without the guard)
- removing one of three quotes focuses the remove button now at that row (fails without the re-render effect)
- clicking empty composer space focuses the textarea, via a `composer-surface` test id rather than a utility class

Codegraph selected five client specs for the change (`ChatForm.attachments`, `ChatForm.pasteUpload`, `ChatView`, `ChatView.subagent`, `skillsRoutes`); all pass locally. ESLint and import order are clean on the two changed files. Client `tsc` reports no errors in `Chat/Input`.
