### PR TITLE
📫 fix: Surface Sandbox Artifact Delivery Failures

### DIFF
--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -34,6 +34,7 @@ const {
   CODE_OUTPUT_PREFLIGHT_MAX_BYTES,
   CODE_OUTPUT_PREFLIGHT_MAX_COUNT,
   sortCodeFilesByDestinationPriority,
+  normalizeArtifactDeliveryFailure,
 } = require('@librechat/api');
 const {
   Tools,
@@ -2057,7 +2058,7 @@ async function execSandboxImageChunk({
  * @param {string} [params.session_id] - Sandbox session id from the seeded context.
  * @param {Array<{id: string, name: string, session_id?: string}>} [params.files] - File refs to mount.
  * @param {ServerRequest} [params.req] - Current authenticated request, used to mint Code API auth.
- * @returns {Promise<{stdout?: string, stderr?: string, session_id?: string, files?: Array<Object>} | null>}
+ * @returns {Promise<{stdout?: string, stderr?: string, session_id?: string, files?: Array<Object>, artifact_delivery?: {code: 'artifact_delivery_failed', status: 'partial' | 'failed', attempted: number, delivered: number, failed: number}} | null>}
  */
 async function writeSandboxFile({
   file_path,
@@ -2138,6 +2139,7 @@ async function writeSandboxFile({
       stderr: result.stderr == null ? undefined : String(result.stderr),
       session_id: result.session_id,
       files: result.files,
+      artifact_delivery: normalizeArtifactDeliveryFailure(result.artifact_delivery),
     };
   } catch (error) {
     logAxiosError({

--- a/api/server/services/Files/Code/process.spec.js
+++ b/api/server/services/Files/Code/process.spec.js
@@ -77,6 +77,16 @@ jest.mock('@librechat/api', () => {
     sanitizeArtifactPath: jest.fn((name) => name),
     flattenArtifactPath: jest.fn((name) => name.replace(/\//g, '__')),
     createAxiosInstance: jest.fn(() => mockAxios),
+    normalizeArtifactDeliveryFailure: (value) =>
+      value?.code === 'artifact_delivery_failed'
+        ? {
+            code: value.code,
+            status: value.status,
+            attempted: value.attempted,
+            delivered: value.delivered,
+            failed: value.failed,
+          }
+        : undefined,
     executeWorkspaceTool: (...args) => mockExecuteWorkspaceTool(...args),
     getCodeApiAuthHeaders: jest.fn(async () => ({})),
     /* Windowing, sizing and rate-limit policy are real code in
@@ -2457,6 +2467,38 @@ describe('Code Process', () => {
         session_id: 'sess-new',
         files: [{ id: 'file-new', name: 'new.txt' }],
       });
+    });
+
+    it('forwards only a valid bounded artifact delivery failure', async () => {
+      mockAxios.mockResolvedValueOnce({
+        data: {
+          stdout: 'WROTE 1 bytes to /mnt/data/new.txt\n',
+          session_id: 'sess-new',
+          files: [],
+          artifact_delivery: {
+            code: 'artifact_delivery_failed',
+            status: 'failed',
+            attempted: 1,
+            delivered: 0,
+            failed: 1,
+            detail: 'private object storage failure',
+          },
+        },
+      });
+
+      const result = await writeSandboxFile({
+        file_path: '/mnt/data/new.txt',
+        content: 'x',
+      });
+
+      expect(result.artifact_delivery).toEqual({
+        code: 'artifact_delivery_failed',
+        status: 'failed',
+        attempted: 1,
+        delivered: 0,
+        failed: 1,
+      });
+      expect(JSON.stringify(result)).not.toContain('private object storage failure');
     });
 
     it('encodes path and content in a base64 JSON payload instead of shell-interpolating them', async () => {

--- a/packages/api/src/agents/handlers.spec.ts
+++ b/packages/api/src/agents/handlers.spec.ts
@@ -3923,6 +3923,45 @@ describe('createToolExecuteHandler', () => {
       });
     });
 
+    it('does not report a sandbox write as durable when artifact delivery failed', async () => {
+      const readSandboxFile = jest.fn(async () => {
+        throw new Error('cat: /mnt/data/new.txt: No such file or directory');
+      });
+      const writeSandboxFile = jest.fn(async () => ({
+        stdout: 'WROTE 11 bytes to /mnt/data/new.txt\n',
+        session_id: 'sess-new',
+        files: [],
+        artifact_delivery: {
+          code: 'artifact_delivery_failed' as const,
+          status: 'failed' as const,
+          attempted: 1,
+          delivered: 0,
+          failed: 1,
+        },
+      }));
+      const handler = makeSandboxAuthoringHandler({
+        readSandboxFile,
+        writeSandboxFile,
+      });
+
+      const [result] = await invokeHandler(handler, [
+        {
+          id: 'call_create_sandbox_delivery_failure',
+          name: 'create_file',
+          args: {
+            path: '/mnt/data/new.txt',
+            content: 'hello world',
+          },
+        } as unknown as ToolCallRequest,
+      ]);
+
+      expect(result.status).toBe('error');
+      expect(result.errorMessage).toContain('could not be persisted');
+      expect(result.errorMessage).toContain('do not retry automatically');
+      expect(result.errorMessage).not.toContain('storage');
+      expect(result.artifact).toBeUndefined();
+    });
+
     it('carries whole file refs into the next authoring call on the same path', async () => {
       /**
        * Regression: the batch-local sandbox context rebuilt each ref from

--- a/packages/api/src/agents/handlers.ts
+++ b/packages/api/src/agents/handlers.ts
@@ -34,6 +34,7 @@ import type {
 import type { SkillFileRecord, PrimeSkillFilesResult } from './skillFiles';
 import type { BackgroundToolResultState } from './harvest';
 import type { CodeExecutionContext } from './execution';
+import type { ArtifactDeliveryFailure } from '~/files/code';
 import type { TextContentFragment } from '~/protection';
 import type { ServerRequest } from '~/types';
 import {
@@ -603,6 +604,7 @@ export interface ToolExecuteOptions {
     stderr?: string;
     session_id?: string;
     files?: SandboxFileRef[];
+    artifact_delivery?: ArtifactDeliveryFailure;
   } | null>;
 }
 
@@ -2805,6 +2807,13 @@ async function writeSandboxTextForAuthoring({
   }
   if (!writeResult) {
     return errorResult(tc, `Failed to write "${filePath}" to the code-execution sandbox.`);
+  }
+  if (writeResult.artifact_delivery) {
+    const { attempted, failed } = writeResult.artifact_delivery;
+    return errorResult(
+      tc,
+      `Wrote "${filePath}" in the sandbox, but ${failed} of ${attempted} generated files could not be persisted. The file is not guaranteed to be available to later calls or downloadable. The execution may have had side effects; do not retry automatically.`,
+    );
   }
 
   const action = created ? 'Created' : 'Updated';

--- a/packages/api/src/agents/handlers.ts
+++ b/packages/api/src/agents/handlers.ts
@@ -32,9 +32,9 @@ import type {
   BackgroundToolWakeupRegistration,
 } from './backgroundCompletion';
 import type { SkillFileRecord, PrimeSkillFilesResult } from './skillFiles';
+import type { ArtifactDeliveryFailure } from '~/files/code';
 import type { BackgroundToolResultState } from './harvest';
 import type { CodeExecutionContext } from './execution';
-import type { ArtifactDeliveryFailure } from '~/files/code';
 import type { TextContentFragment } from '~/protection';
 import type { ServerRequest } from '~/types';
 import {

--- a/packages/api/src/files/code/artifactDelivery.spec.ts
+++ b/packages/api/src/files/code/artifactDelivery.spec.ts
@@ -1,0 +1,31 @@
+import { normalizeArtifactDeliveryFailure } from './artifactDelivery';
+
+describe('normalizeArtifactDeliveryFailure', () => {
+  it('retains only the bounded public contract', () => {
+    expect(
+      normalizeArtifactDeliveryFailure({
+        code: 'artifact_delivery_failed',
+        status: 'partial',
+        attempted: 3,
+        delivered: 2,
+        failed: 1,
+        detail: 'private storage failure',
+      }),
+    ).toEqual({
+      code: 'artifact_delivery_failed',
+      status: 'partial',
+      attempted: 3,
+      delivered: 2,
+      failed: 1,
+    });
+  });
+
+  it.each([
+    null,
+    { code: 'storage_error', status: 'failed', attempted: 1, delivered: 0, failed: 1 },
+    { code: 'artifact_delivery_failed', status: 'failed', attempted: 2, delivered: 1, failed: 1 },
+    { code: 'artifact_delivery_failed', status: 'partial', attempted: 1, delivered: 0, failed: 1 },
+  ])('rejects malformed external values', (value) => {
+    expect(normalizeArtifactDeliveryFailure(value)).toBeUndefined();
+  });
+});

--- a/packages/api/src/files/code/artifactDelivery.ts
+++ b/packages/api/src/files/code/artifactDelivery.ts
@@ -1,0 +1,43 @@
+export type ArtifactDeliveryFailure = {
+  code: 'artifact_delivery_failed';
+  status: 'partial' | 'failed';
+  attempted: number;
+  delivered: number;
+  failed: number;
+};
+
+export function normalizeArtifactDeliveryFailure(
+  value: unknown,
+): ArtifactDeliveryFailure | undefined {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const candidate = value as Partial<ArtifactDeliveryFailure>;
+  if (
+    candidate.code !== 'artifact_delivery_failed' ||
+    (candidate.status !== 'partial' && candidate.status !== 'failed') ||
+    !Number.isSafeInteger(candidate.attempted) ||
+    !Number.isSafeInteger(candidate.delivered) ||
+    !Number.isSafeInteger(candidate.failed) ||
+    candidate.attempted == null ||
+    candidate.delivered == null ||
+    candidate.failed == null ||
+    candidate.attempted < 1 ||
+    candidate.delivered < 0 ||
+    candidate.failed < 1 ||
+    candidate.attempted !== candidate.delivered + candidate.failed ||
+    (candidate.status === 'failed' && candidate.delivered !== 0) ||
+    (candidate.status === 'partial' && candidate.delivered === 0)
+  ) {
+    return undefined;
+  }
+
+  return {
+    code: candidate.code,
+    status: candidate.status,
+    attempted: candidate.attempted,
+    delivered: candidate.delivered,
+    failed: candidate.failed,
+  };
+}

--- a/packages/api/src/files/code/index.ts
+++ b/packages/api/src/files/code/index.ts
@@ -1,4 +1,5 @@
 export * from './classify';
+export * from './artifactDelivery';
 export * from './destinations';
 export * from './errors';
 export * from './extract';


### PR DESCRIPTION
## Summary

I prevented sandbox file-authoring tools from claiming durable success when Code API execution succeeded but generated-file persistence failed.

- Add a portable TypeScript artifact-delivery contract and strict normalizer in packages/api with no Express or Mongo dependency.
- Strip unexpected response fields before delivery status crosses the Code API adapter boundary.
- Forward the bounded status through writeSandboxFile.
- Return an explicit create_file or edit_file error when the authored file is not guaranteed durable or downloadable.
- Preserve the side-effect warning so the model does not automatically rerun a successful writer process.
- Pair with LibreChat-AI/code-interpreter#119 and danny-avila/agents#515 to address #15659 end to end.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran the Code file-process suite: 146 passing.
- Ran the packages/api agent-handler and artifact-delivery suites: 184 passing.
- Ran ESLint on every changed source and test file with no findings.
- Confirmed the changed handlers have no TypeScript diagnostics. The broad linked-worktree typecheck remains unsuitable because its generated sibling-package declarations predate current dev.

### **Test Configuration**:

- macOS local worktree
- Existing LibreChat dependency workspace linked read-only for focused checks

## Checklist

- [x] My code adheres to this project style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.