### PR TITLE
📏 style: Put the Grouped Thought on the Row Rail

### DIFF
--- a/client/src/components/Chat/Messages/Content/Parts/Reasoning.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Reasoning.tsx
@@ -366,13 +366,6 @@ export const ReasoningCompact = memo(
             aria-controls={contentId}
             className="group/disclosure h-auto min-w-0 flex-1 justify-start gap-2 rounded-none p-0 font-normal text-text-secondary hover:bg-transparent"
           >
-            {/* The one row this feature adds under a message header, so it
-                takes the same 24px glyph slot as the tool cards, the group
-                header, the phase check and `ThinkingLabel` — the projection
-                marker that stands in for this very row. Bare, its bulb sat
-                on the pre-rail axis and its label 8px left of every
-                neighbour, including an unavailable thought in the same
-                group. */}
             <span className={ROW_GLYPH_SLOT} aria-hidden="true">
               <Lightbulb className="size-4 shrink-0 text-text-secondary" />
             </span>

--- a/client/src/components/Chat/Messages/Content/Parts/Reasoning.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Reasoning.tsx
@@ -18,6 +18,7 @@ import CopyButton from '~/components/Messages/Content/CopyButton';
 import { showThinkingAtom } from '~/store/showThinking';
 import { fontSizeAtom } from '~/store/fontSize';
 import { useMessageContext } from '~/Providers';
+import { ROW_GLYPH_SLOT } from '../rows';
 import { cn } from '~/utils';
 
 const stripThinkTags = (reasoning: string): string =>
@@ -365,7 +366,16 @@ export const ReasoningCompact = memo(
             aria-controls={contentId}
             className="group/disclosure h-auto min-w-0 flex-1 justify-start gap-2 rounded-none p-0 font-normal text-text-secondary hover:bg-transparent"
           >
-            <Lightbulb className="size-4 shrink-0 text-text-secondary" aria-hidden="true" />
+            {/* The one row this feature adds under a message header, so it
+                takes the same 24px glyph slot as the tool cards, the group
+                header, the phase check and `ThinkingLabel` — the projection
+                marker that stands in for this very row. Bare, its bulb sat
+                on the pre-rail axis and its label 8px left of every
+                neighbour, including an unavailable thought in the same
+                group. */}
+            <span className={ROW_GLYPH_SLOT} aria-hidden="true">
+              <Lightbulb className="size-4 shrink-0 text-text-secondary" />
+            </span>
             <span className="tool-status-text font-medium">{label}</span>
             <ChevronDown
               className={cn(

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/ReasoningCompact.test.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/ReasoningCompact.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { ReasoningCompact } from '../Reasoning';
+import { ROW_GLYPH_SLOT } from '../../rows';
 
 jest.mock('~/hooks', () => ({
   useLocalize: () => (key: string) => key,
@@ -52,6 +53,22 @@ describe('ReasoningCompact', () => {
     );
     expect(chevron).toHaveClass('transition-transform');
     expect(chevron.className).not.toContain('transition-opacity');
+  });
+
+  it('takes the shared glyph slot so it lands on the row rail', () => {
+    /** Every other row under a message header centers its glyph in the 24px
+     *  slot, including the `ThinkingLabel` marker that stands in for this
+     *  exact row when a projection has no text. Bare, the bulb sat on the
+     *  pre-rail axis and the label 8px left of its neighbours. */
+    render(<ReasoningCompact reasoning="A useful thought" label="Thoughts" showThinking={false} />);
+
+    const slot = screen.getByTestId('thoughts-icon').parentElement;
+    for (const token of ROW_GLYPH_SLOT.split(' ')) {
+      expect(slot).toHaveClass(token);
+    }
+    /** 24px slot plus the row's 8px gap is what puts the label where the
+     *  header's name starts. */
+    expect(screen.getByRole('button', { name: 'Thoughts' })).toHaveClass('gap-2');
   });
 
   it('removes the extra top margin when Thoughts follows a tool', () => {


### PR DESCRIPTION
Follow-up to #14546, which merged while the audit below was still running.

`ROW_GLYPH_SLOT` (#15643) is the one definition of a row's leading glyph under a
message header: a 24px slot — the header avatar's width — that centers a 16px
tool icon, the 14px phase check and the 12px cursor dot on the avatar's axis, so
with the row's 8px gap every row's text starts where the name does.

Auditing every label row against that rail left exactly one outlier, and it is
the row #14546 added:

| Row | Glyph |
| --- | --- |
| Phase label — `ActivityPhaseGroup` → `PhaseGlyph` | slot |
| Activity label — `ToolCallGroup` header, both glyph branches | slot |
| Reasoning label — standalone `Reasoning` → `ThinkingButton` | slot |
| Reasoning label — unavailable projection → `ReasoningMarker` → `ThinkingLabel` | slot |
| Author re-attribution — `AgentUpdate`, `AgentHandoff` | 24px avatar |
| **Reasoning label — grouped `ReasoningCompact`** | **bare 16px `Lightbulb`** |

So a thought interleaved with tool calls drew its bulb on the pre-rail axis with
its label 8px left of every row around it. Most visibly, `ReasoningMarker` — the
marker that stands in for this exact row when a detached-subagent projection has
no text — renders inside the same group body and is on the rail, so an available
thought and an unavailable one sat on two different left edges.

The bulb takes `ROW_GLYPH_SLOT`. Nothing else changes: the button already carried
the row's 8px gap.

## Verification

- `ReasoningCompact.test.tsx` gains `takes the shared glyph slot so it lands on the row rail`; it fails against the pre-fix component.
- `npx tsc --noEmit` clean in `client`.
- `client/src/components/Chat/Messages/Content`: 67 suites / 935 tests pass.