### PR TITLE
🏠 fix: Route Standalone File Writes to BYOM Workers

### DIFF
--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -49,6 +49,8 @@ const {
   createGitIdentityProgrammaticBashTool,
   resolveCodeExecutionContext,
   resolveCallerCapabilityProjectionSnapshot,
+  CREATE_FILE_TOOL_NAME,
+  EDIT_FILE_TOOL_NAME,
   LIST_WORKSPACE_FILES_TOOL_NAME,
   SEARCH_WORKSPACE_TOOL_NAME,
   getTransactionsConfig,
@@ -2013,7 +2015,7 @@ async function loadToolsForExecution({
     isWorkspaceListRequested;
   const isSkillToolRequested = toolNames.includes(AgentConstants.SKILL_TOOL);
   const isSandboxFileToolRequested = toolNames.some((name) =>
-    [AgentConstants.READ_FILE, AgentConstants.CREATE_FILE, AgentConstants.EDIT_FILE].includes(name),
+    [AgentConstants.READ_FILE, CREATE_FILE_TOOL_NAME, EDIT_FILE_TOOL_NAME].includes(name),
   );
 
   let enabledCapabilities;

--- a/api/server/services/__tests__/ToolService.spec.js
+++ b/api/server/services/__tests__/ToolService.spec.js
@@ -2529,43 +2529,96 @@ describe('ToolService - Action Capability Gating', () => {
       }
     });
 
-    it('resolves stateful routing for host file tools with the controller conversation ID', async () => {
-      const capabilities = [
-        AgentCapabilities.tools,
-        AgentCapabilities.execute_code,
-        AgentCapabilities.stateful_code_sessions,
-      ];
-      const req = createMockReq(capabilities);
-      req.body = {};
-      mockGetEndpointsConfig.mockResolvedValue(createEndpointsConfig(capabilities));
-      process.env.LIBRECHAT_CODE_BASEURL_STATEFUL = 'http://code-stateful.test/v1';
+    it.each(['read_file', 'create_file', 'edit_file'])(
+      'resolves stateful routing for standalone %s with the controller conversation ID',
+      async (toolName) => {
+        const capabilities = [
+          AgentCapabilities.tools,
+          AgentCapabilities.execute_code,
+          AgentCapabilities.stateful_code_sessions,
+        ];
+        const req = createMockReq(capabilities);
+        req.body = {};
+        mockGetEndpointsConfig.mockResolvedValue(createEndpointsConfig(capabilities));
+        process.env.LIBRECHAT_CODE_BASEURL_STATEFUL = 'http://code-stateful.test/v1';
 
-      try {
+        try {
+          const result = await loadToolsForExecution({
+            req,
+            res: {},
+            conversationId: 'resolved-api-conversation',
+            agent: {
+              id: 'stateful-agent',
+              tools: [Tools.execute_code],
+              stateful_code_sessions: true,
+              stateful_code_environment: 'conversation',
+            },
+            toolNames: [toolName],
+            actionsEnabled: false,
+          });
+
+          expect(result.configurable.codeExecutionContext.executionProfile).toBe('stateful');
+          expect(mockResolveCodeExecutionContext).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              statefulSessions: true,
+              conversationId: 'resolved-api-conversation',
+            }),
+          );
+        } finally {
+          delete process.env.LIBRECHAT_CODE_BASEURL_STATEFUL;
+        }
+      },
+    );
+
+    it.each(['read_file', 'create_file', 'edit_file'])(
+      'keeps standalone %s on the selected attached worker',
+      async (toolName) => {
+        const capabilities = [
+          AgentCapabilities.tools,
+          AgentCapabilities.execute_code,
+          AgentCapabilities.stateful_code_sessions,
+        ];
+        const req = createMockReq(capabilities);
+        req.config.endpoints.agents.statefulCodeSessions = {
+          environments: [
+            {
+              id: 'personal-machine',
+              type: 'attached',
+              baseURL: 'https://attached-code.test/v1',
+              workerId: 'worker-personal',
+            },
+          ],
+        };
+        mockGetEndpointsConfig.mockResolvedValue(createEndpointsConfig(capabilities));
+        mockResolveCodeExecutionContext.mockImplementationOnce(
+          jest.requireActual('@librechat/api').resolveCodeExecutionContext,
+        );
+
         const result = await loadToolsForExecution({
           req,
           res: {},
           conversationId: 'resolved-api-conversation',
           agent: {
-            id: 'stateful-agent',
+            id: 'attached-agent',
             tools: [Tools.execute_code],
             stateful_code_sessions: true,
-            stateful_code_environment: 'conversation',
+            code_environment_id: 'personal-machine',
           },
-          toolNames: [AgentConstants.READ_FILE],
+          toolNames: [toolName],
           actionsEnabled: false,
         });
 
-        expect(result.configurable.codeExecutionContext.executionProfile).toBe('stateful');
-        expect(mockResolveCodeExecutionContext).toHaveBeenLastCalledWith(
+        expect(result.configurable.codeExecutionContext).toEqual(
           expect.objectContaining({
-            statefulSessions: true,
-            conversationId: 'resolved-api-conversation',
+            baseUrl: 'https://attached-code.test/v1',
+            executionProfile: 'stateful',
+            environmentType: 'attached',
+            environmentId: 'personal-machine',
+            bridgeWorkerId: 'worker-personal',
           }),
         );
-      } finally {
-        delete process.env.LIBRECHAT_CODE_BASEURL_STATEFUL;
-      }
-    });
+      },
+    );
 
     it('preserves attached routing when workspace search is the only requested tool', async () => {
       const capabilities = [


### PR DESCRIPTION
## Summary

I fixed standalone `create_file` calls losing their selected BYOM environment and reporting success after writing to the default hosted sandbox instead of the attached machine.

- Use the canonical host-owned create/edit tool names from `@librechat/api` when deciding whether to resolve code execution capabilities; the SDK has no `Constants.CREATE_FILE`.
- Preserve the selected endpoint, stateful profile, and worker identity when creation is the only requested tool and action capability resolution was already completed.
- Cover standalone read/create/edit routing, controller conversation identity, and attached worker selection using the real execution-context resolver.

No SDK, Code API, worker, configuration, or database migration is required. Deploy the LibreChat fix, then repeat an approved create/read on the attached machine. Approval and sandbox policies remain unchanged.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Reproduced on a live native macOS BYOM worker: an approved `create_file` reported success, the file was absent, and immediate `read_file` failed. Temporary worker tracing observed the read but no write request. Removed the tracing afterward.
- Verified the installed worker's local write implementation independently creates and reads a fixture successfully.
- Reproduced a failing regression before the fix: standalone `create_file` selected `default` instead of `stateful`.
- Passed six focused tests: `node node_modules/jest/bin/jest.js --config api/jest.config.js --runInBand --verbose=false --runTestsByPath api/server/services/__tests__/ToolService.spec.js -t 'standalone'`.
- Passed ESLint for both changed files, formatting, and `git diff --check`.
- Used the codegraph skill's source-based fallback for test selection because its authenticated selector credential was unavailable. Full suites are left to CI.
- Pending deployment acceptance: approve creation of a new small file, verify it physically exists on the selected machine, and read it back through LibreChat. This has not yet been claimed as passing with the deployed fix.

### Test Configuration

Agent with Run Code, stateful sessions, an attached environment, and ask-every-time file approvals. Invoke `create_file` by itself (not alongside a read or command).

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
