### PR TITLE
Harden early stream buffer recovery

### DIFF
--- a/packages/api/src/app/metrics.spec.ts
+++ b/packages/api/src/app/metrics.spec.ts
@@ -11,6 +11,9 @@ import {
   recordAgentStartupMilestone,
   recordAgentStartupResult,
   recordGenerationJob,
+  recordGenerationStreamAttachment,
+  recordGenerationStreamEarlyBufferOverflow,
+  recordGenerationStreamRecovery,
   recordGenerationStreamResumePendingEvents,
   recordGenerationStreamSubscription,
   recordOpenIDUserLookup,
@@ -527,6 +530,9 @@ describe('createMetrics', () => {
     recordGenerationStreamSubscription('redis', 'resume', 'not_found');
     recordGenerationStreamSubscription('redis', 'resume_state', 'missing');
     recordGenerationStreamResumePendingEvents('memory', 3);
+    recordGenerationStreamEarlyBufferOverflow('redis');
+    recordGenerationStreamRecovery('redis', 'redis', 'success', 'none', 0.125, 5001, 2);
+    recordGenerationStreamAttachment('redis', 'bootstrap_slow', 1.5);
 
     const response = await request(app)
       .get('/metrics')
@@ -543,6 +549,21 @@ describe('createMetrics', () => {
     );
     expect(response.text).toMatch(
       /generation_stream_resume_pending_events_total\{store="memory"\} 3/,
+    );
+    expect(response.text).toMatch(
+      /generation_stream_early_buffer_overflows_total\{store="redis"\} 1/,
+    );
+    expect(response.text).toMatch(
+      /generation_stream_early_buffer_recoveries_total\{store="redis",source="redis",outcome="success",reason="none"\} 1/,
+    );
+    expect(response.text).toMatch(
+      /generation_stream_early_buffer_reconstructed_events_total\{store="redis",source="redis",outcome="success"\} 5001/,
+    );
+    expect(response.text).toMatch(
+      /generation_stream_attachment_outcomes_total\{store="redis",result="bootstrap_slow"\} 1/,
+    );
+    expect(response.text).toMatch(
+      /generation_stream_first_attachment_duration_seconds_count\{store="redis",result="bootstrap_slow"\} 1/,
     );
   });
 

--- a/packages/api/src/app/metrics.ts
+++ b/packages/api/src/app/metrics.ts
@@ -157,6 +157,20 @@ export type GenerationStreamSubscriptionResult =
   | 'error'
   | 'found'
   | 'missing';
+export type GenerationStreamRecoverySource = 'redis' | 'snapshot';
+export type GenerationStreamRecoveryOutcome = 'success' | 'failure' | 'not_attempted';
+export type GenerationStreamRecoveryFailureReason =
+  | 'none'
+  | 'durable_frontier_gap'
+  | 'durable_state_missing'
+  | 'snapshot_missing'
+  | 'subscriber_never_attached'
+  | 'reconstruction_error';
+export type GenerationStreamAttachmentResult =
+  | 'attached'
+  | 'bootstrap_slow'
+  | 'disconnected'
+  | 'never_attached';
 export type RumProxyEndpoint = 'traces' | 'logs' | 'unknown';
 export type RumProxyResult =
   | 'success'
@@ -206,6 +220,20 @@ type GenerationJobMetrics = {
   ) => void;
   recordResumePendingEvents: (store: GenerationJobStore, count: number) => void;
   recordEarlyBufferOverflow: (store: GenerationJobStore) => void;
+  recordRecovery: (
+    store: GenerationJobStore,
+    source: GenerationStreamRecoverySource,
+    outcome: GenerationStreamRecoveryOutcome,
+    reason: GenerationStreamRecoveryFailureReason,
+    durationSeconds: number,
+    eventCount: number,
+    contentCount: number,
+  ) => void;
+  recordAttachment: (
+    store: GenerationJobStore,
+    result: GenerationStreamAttachmentResult,
+    durationSeconds: number,
+  ) => void;
 };
 
 let generationJobMetrics: GenerationJobMetrics = {
@@ -214,6 +242,8 @@ let generationJobMetrics: GenerationJobMetrics = {
   recordSubscription: () => undefined,
   recordResumePendingEvents: () => undefined,
   recordEarlyBufferOverflow: () => undefined,
+  recordRecovery: () => undefined,
+  recordAttachment: () => undefined,
 };
 
 type AgentStartupMetrics = {
@@ -272,6 +302,8 @@ const resetMetricRecorders = (): void => {
     recordSubscription: () => undefined,
     recordResumePendingEvents: () => undefined,
     recordEarlyBufferOverflow: () => undefined,
+    recordRecovery: () => undefined,
+    recordAttachment: () => undefined,
   };
   agentStartupMetrics = {
     recordMilestone: () => undefined,
@@ -314,6 +346,34 @@ export function recordGenerationStreamResumePendingEvents(
 
 export function recordGenerationStreamEarlyBufferOverflow(store: GenerationJobStore): void {
   generationJobMetrics.recordEarlyBufferOverflow(store);
+}
+
+export function recordGenerationStreamRecovery(
+  store: GenerationJobStore,
+  source: GenerationStreamRecoverySource,
+  outcome: GenerationStreamRecoveryOutcome,
+  reason: GenerationStreamRecoveryFailureReason,
+  durationSeconds: number,
+  eventCount: number,
+  contentCount: number,
+): void {
+  generationJobMetrics.recordRecovery(
+    store,
+    source,
+    outcome,
+    reason,
+    durationSeconds,
+    eventCount,
+    contentCount,
+  );
+}
+
+export function recordGenerationStreamAttachment(
+  store: GenerationJobStore,
+  result: GenerationStreamAttachmentResult,
+  durationSeconds: number,
+): void {
+  generationJobMetrics.recordAttachment(store, result, durationSeconds);
 }
 
 export function recordAgentStartupMilestone(
@@ -641,6 +701,50 @@ export function createMetrics(options: MetricsOptions = {}): PrometheusMetrics {
     registers: [registry],
   });
 
+  const generationStreamRecoveries = new Counter({
+    name: 'generation_stream_early_buffer_recoveries_total',
+    help: 'Early-buffer recovery outcomes; success divided by overflows is the recovery ratio',
+    labelNames: ['store', 'source', 'outcome', 'reason'] as const,
+    registers: [registry],
+  });
+
+  const generationStreamRecoveryDuration = new Histogram({
+    name: 'generation_stream_early_buffer_recovery_duration_seconds',
+    help: 'Early-buffer recovery duration by bounded source and outcome',
+    labelNames: ['store', 'source', 'outcome'] as const,
+    buckets: [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30],
+    registers: [registry],
+  });
+
+  const generationStreamRecoveryEvents = new Counter({
+    name: 'generation_stream_early_buffer_reconstructed_events_total',
+    help: 'Events observed in early-buffer reconstruction attempts',
+    labelNames: ['store', 'source', 'outcome'] as const,
+    registers: [registry],
+  });
+
+  const generationStreamRecoveryContent = new Counter({
+    name: 'generation_stream_early_buffer_reconstructed_content_total',
+    help: 'Content parts observed in early-buffer reconstruction attempts',
+    labelNames: ['store', 'source', 'outcome'] as const,
+    registers: [registry],
+  });
+
+  const generationStreamAttachments = new Counter({
+    name: 'generation_stream_attachment_outcomes_total',
+    help: 'Generation attachment lifecycle outcomes',
+    labelNames: ['store', 'result'] as const,
+    registers: [registry],
+  });
+
+  const generationStreamFirstAttachmentDuration = new Histogram({
+    name: 'generation_stream_first_attachment_duration_seconds',
+    help: 'Time from generation creation to its first subscriber attachment',
+    labelNames: ['store', 'result'] as const,
+    buckets: [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300],
+    registers: [registry],
+  });
+
   const agentStartupMilestoneDuration = new Histogram({
     name: 'agent_startup_milestone_duration_seconds',
     help: 'Cumulative agent chat startup latency from request ingress to each milestone',
@@ -765,6 +869,19 @@ export function createMetrics(options: MetricsOptions = {}): PrometheusMetrics {
     recordResumePendingEvents: (store, count) =>
       generationStreamResumePendingEvents.inc({ store }, count),
     recordEarlyBufferOverflow: (store) => generationStreamEarlyBufferOverflows.inc({ store }),
+    recordRecovery: (store, source, outcome, reason, durationSeconds, eventCount, contentCount) => {
+      const labels = { store, source, outcome };
+      generationStreamRecoveries.inc({ ...labels, reason });
+      generationStreamRecoveryDuration.observe(labels, durationSeconds);
+      generationStreamRecoveryEvents.inc(labels, eventCount);
+      generationStreamRecoveryContent.inc(labels, contentCount);
+    },
+    recordAttachment: (store, result, durationSeconds) => {
+      generationStreamAttachments.inc({ store, result });
+      if (result === 'attached' || result === 'bootstrap_slow') {
+        generationStreamFirstAttachmentDuration.observe({ store, result }, durationSeconds);
+      }
+    },
   };
 
   agentStartupMetrics = {

--- a/packages/api/src/app/metrics.ts
+++ b/packages/api/src/app/metrics.ts
@@ -163,6 +163,7 @@ export type GenerationStreamRecoveryFailureReason =
   | 'none'
   | 'durable_frontier_gap'
   | 'durable_state_missing'
+  | 'overflow_marker_persistence_failed'
   | 'snapshot_missing'
   | 'subscriber_never_attached'
   | 'reconstruction_error';

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -3964,6 +3964,7 @@ class GenerationJobManagerClass {
         : undefined;
     let cleanupError: unknown;
     let retainTerminalHostEvidence = false;
+    let retainPendingRecoveryEvidence = false;
 
     /** Account for an overflow before successful completion can remove its
      * durable job record. A concurrently attached replica claims the durable
@@ -4038,16 +4039,16 @@ class GenerationJobManagerClass {
         // durable final whose DONE publish failed is retained for reconnect
         // replay even though its pending marker is already clear.
         const terminalJob = await this.jobStore.getJob(streamId);
+        retainPendingRecoveryEvidence =
+          terminalJob?.firstSubscriberAttachedAt != null &&
+          terminalJob.earlyBufferRecovery != null &&
+          terminalJob.earlyBufferRecovery.outcome == null;
         if (
           !retainForTerminalReplay &&
           terminalJob?.providerDrained !== false &&
           terminalJob?.preserveForScheduleReconcile !== true &&
           terminalJob?.terminalHostActionPending !== true &&
-          !(
-            terminalJob?.firstSubscriberAttachedAt != null &&
-            terminalJob.earlyBufferRecovery != null &&
-            terminalJob.earlyBufferRecovery.outcome == null
-          ) &&
+          !retainPendingRecoveryEvidence &&
           (terminalJob?.createdAt !== createdAt || terminalJob.terminalPersistencePending !== true)
         ) {
           // A same-stream replacement created after the claim makes this a safe
@@ -4070,7 +4071,7 @@ class GenerationJobManagerClass {
           runtime.startupTelemetry?.end('completed_without_delta');
         }
         runtime.startupTelemetry = undefined;
-        if (!retainTerminalHostEvidence) {
+        if (!retainTerminalHostEvidence && !retainPendingRecoveryEvidence) {
           this.jobStore.clearContentState(streamId, createdAt);
           this.runStepBuffers?.delete(streamId);
         }

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -33,6 +33,8 @@ import type {
   DetachedAgentEventActionStoreMode,
   EarlyBufferRecoveryState,
   EarlyBufferRecoveryFailureReason,
+  ContentPartsReadOptions,
+  RecoveryEventStats,
 } from './interfaces/IJobStore';
 import type { AgentStartupTelemetry } from '~/agents/startup';
 import type { RecoveredSteerPayload } from './SteerRecovery';
@@ -161,6 +163,10 @@ const EARLY_EVENT_BUFFER_MAX_EVENTS = 5_000;
 const EARLY_EVENT_BUFFER_MAX_BYTES = 8 * 1024 * 1024;
 const ATTACHMENT_BOOTSTRAP_SLOW_MS = 1_000;
 export const GENERATION_RECOVERY_FAILED_ERROR = 'generation_recovery_failed';
+const RECOVERY_STATS = Symbol('generation-recovery-stats');
+type ResumeStateWithRecoveryStats = t.ResumeState & {
+  [RECOVERY_STATS]?: RecoveryEventStats;
+};
 const CLIENT_REQUEST_ID_PATTERN = /^[A-Za-z0-9:_-]{1,128}$/;
 type TokenIdempotencyClaim = IdempotencyClaimValue & {
   claimedAt: number;
@@ -696,6 +702,8 @@ interface RuntimeJobState {
   outstandingCoalescedReceipts?: number;
   hasSubscriber: boolean;
   everHadSubscriber: boolean;
+  /** Durable first-attachment claim acquired before overflow reconstruction. */
+  firstAttachmentClaimedAt?: number;
   /** Advances whenever every local SSE subscriber for one attachment generation leaves. */
   attachmentGeneration: number;
   /** Attachment generation whose partial-response disconnect cleanup was most recently started. */
@@ -3673,6 +3681,12 @@ class GenerationJobManagerClass {
       throw new Error('A failed pause-persistence claim must be a non-pending error terminal');
     }
     const observedRuntime = this.runtimeState.get(streamId);
+    if (status === 'complete' && observedRuntime?.earlyBufferRecoveryWrite) {
+      await observedRuntime.earlyBufferRecoveryWrite;
+      if (observedRuntime.earlyBufferRecoveryPersistenceFailed) {
+        return null;
+      }
+    }
     const targetCreatedAt = expectedCreatedAt ?? observedRuntime?.createdAt;
     let jobData = await this.jobStore.getJob(streamId);
     if (!jobData || (targetCreatedAt != null && jobData.createdAt !== targetCreatedAt)) {
@@ -4966,7 +4980,8 @@ class GenerationJobManagerClass {
 
     const isFirst = this.eventTransport.isFirstSubscriber(streamId);
 
-    const isFirstAttachment = !runtime.everHadSubscriber;
+    const isFirstAttachment =
+      runtime.firstAttachmentClaimedAt != null || !runtime.everHadSubscriber;
     if (!runtime.hasSubscriber) {
       runtime.hasSubscriber = true;
       runtime.everHadSubscriber = true;
@@ -5104,14 +5119,15 @@ class GenerationJobManagerClass {
 
     if (isFirstAttachment) {
       const attachedAt = Date.now();
-      let claimedFirstAttachment = true;
+      let claimedFirstAttachment = runtime.firstAttachmentClaimedAt != null;
       try {
-        claimedFirstAttachment =
-          (await this.jobStore.claimFirstSubscriberAttachment?.(
+        if (!claimedFirstAttachment) {
+          claimedFirstAttachment = await this.jobStore.claimFirstSubscriberAttachment(
             streamId,
             runtime.createdAt,
             attachedAt,
-          )) ?? true;
+          );
+        }
       } catch (err) {
         claimedFirstAttachment = false;
         logger.warn(
@@ -5120,6 +5136,7 @@ class GenerationJobManagerClass {
         );
       }
       if (claimedFirstAttachment) {
+        runtime.firstAttachmentClaimedAt = undefined;
         const bootstrapDurationMs = attachedAt - attachmentStartedAt;
         recordGenerationStreamAttachment(
           this.storeLabel,
@@ -5448,23 +5465,14 @@ class GenerationJobManagerClass {
       ...(failureReason && { failureReason }),
     };
     try {
-      const settlement = this.jobStore.settleEarlyBufferRecovery
-        ? await this.jobStore.settleEarlyBufferRecovery(
-            streamId,
-            runtime.createdAt,
-            recovery.correlationId,
-            settled,
-          )
-        : { recovery: settled, committed: true };
+      const settlement = await this.jobStore.settleEarlyBufferRecovery(
+        streamId,
+        runtime.createdAt,
+        recovery.correlationId,
+        settled,
+      );
       if (settlement == null) {
         return undefined;
-      }
-      if (!this.jobStore.settleEarlyBufferRecovery) {
-        await this.jobStore.updateJob(
-          streamId,
-          { earlyBufferRecovery: settled },
-          runtime.createdAt,
-        );
       }
       runtime.earlyBufferRecovery = settlement.recovery;
       if (!settlement.committed) {
@@ -5638,6 +5646,31 @@ class GenerationJobManagerClass {
       return { subscription: null, resumeState: null, pendingEvents: [] };
     }
 
+    const pendingOverflowAtEntry =
+      runtime.earlyBufferRecovery?.outcome == null ? runtime.earlyBufferRecovery : undefined;
+    if (pendingOverflowAtEntry && !runtime.everHadSubscriber) {
+      const claimedAt = Date.now();
+      try {
+        const claimed = await this.jobStore.claimFirstSubscriberAttachment(
+          streamId,
+          runtime.createdAt,
+          claimedAt,
+        );
+        if (claimed) {
+          runtime.firstAttachmentClaimedAt = claimedAt;
+          runtime.everHadSubscriber = true;
+        } else {
+          const durableJob = await this.jobStore.getJob(streamId);
+          runtime.everHadSubscriber = durableJob?.firstSubscriberAttachedAt != null;
+        }
+      } catch (error) {
+        logger.warn('[GenerationRecovery] Failed to claim recovery attachment', {
+          correlationId: pendingOverflowAtEntry.correlationId,
+          error,
+        });
+      }
+    }
+
     await runtime.earlyBufferRecoveryWrite;
     if (runtime.earlyBufferRecoveryPersistenceFailed) {
       recordGenerationStreamSubscription(this.storeLabel, 'resume', 'error');
@@ -5660,6 +5693,23 @@ class GenerationJobManagerClass {
       });
     }
     const activeOverflowRecovery = overflowRecovery?.outcome == null ? overflowRecovery : undefined;
+
+    if (activeOverflowRecovery && !runtime.everHadSubscriber) {
+      const durableOutcome = await this.settleEarlyBufferRecovery(
+        streamId,
+        runtime,
+        activeOverflowRecovery,
+        'failure',
+        'reconstruction_error',
+        0,
+        0,
+      );
+      if (durableOutcome?.outcome !== 'success') {
+        await this.completeJob(streamId, GENERATION_RECOVERY_FAILED_ERROR, runtime.createdAt);
+        onError?.(GENERATION_RECOVERY_FAILED_ERROR);
+        return { subscription: null, resumeState: null, pendingEvents: [] };
+      }
+    }
 
     const capturedPendingEvents: t.ServerSentEvent[] = [];
     const pendingEvents: t.ServerSentEvent[] = [];
@@ -5767,7 +5817,9 @@ class GenerationJobManagerClass {
         }
       } else {
         [resumeState, jobData] = await Promise.all([
-          this.getResumeState(streamId, options?.expectedCreatedAt),
+          this.getResumeState(streamId, options?.expectedCreatedAt, {
+            includeRecoveryStats: activeOverflowRecovery != null,
+          }),
           this.jobStore.getJob(streamId),
         ]);
       }
@@ -6019,7 +6071,7 @@ class GenerationJobManagerClass {
           if (resumeState == null) {
             failureReason = this._isRedis ? 'durable_state_missing' : 'snapshot_missing';
           } else if (this._isRedis) {
-            const stats = await this.jobStore.getRecoveryEventStats?.(streamId, runtime.createdAt);
+            const stats = (resumeState as ResumeStateWithRecoveryStats)[RECOVERY_STATS];
             reconstructedEventCount = stats?.eventCount ?? 0;
             if (stats == null) {
               failureReason = 'durable_state_missing';
@@ -8055,6 +8107,7 @@ class GenerationJobManagerClass {
   async getResumeState(
     streamId: string,
     expectedCreatedAt?: number,
+    options?: ContentPartsReadOptions,
   ): Promise<t.ResumeState | null> {
     const jobData = await this.jobStore.getJob(streamId);
     if (!jobData || (expectedCreatedAt != null && jobData.createdAt !== expectedCreatedAt)) {
@@ -8065,7 +8118,7 @@ class GenerationJobManagerClass {
      *  Safe despite readCachedGraph's cache-drop side effect — each call catches its own
      *  unusable-graph throw and falls back to reconstruction, so ordering cannot change the result. */
     const [result, runSteps, queuedSteers, claimedSteers] = await Promise.all([
-      this.jobStore.getContentParts(streamId, jobData.createdAt),
+      this.jobStore.getContentParts(streamId, jobData.createdAt, options),
       this.jobStore.getRunSteps(streamId, jobData.createdAt),
       this.jobStore.peekSteers(streamId, jobData.createdAt),
       this.jobStore.peekClaimedSteers(streamId, jobData.createdAt),
@@ -8149,7 +8202,7 @@ class GenerationJobManagerClass {
       collectedUsageLength: collectedUsage?.length ?? 0,
     });
 
-    return {
+    const resumeState = {
       runSteps: effectiveRunSteps,
       aggregatedContent,
       userMessage: jobData.userMessage,
@@ -8173,6 +8226,10 @@ class GenerationJobManagerClass {
           : undefined,
       pendingSteers: pendingSteers.length > 0 ? pendingSteers : undefined,
     } satisfies t.ResumeState;
+    if (result?.recoveryStats) {
+      Object.defineProperty(resumeState, RECOVERY_STATS, { value: result.recoveryStats });
+    }
+    return resumeState;
   }
 
   /**

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -4988,6 +4988,43 @@ class GenerationJobManagerClass {
 
     const isFirstAttachment =
       runtime.firstAttachmentClaimedAt != null || !runtime.everHadSubscriber;
+
+    /** An overflow attachment depends on durable reconstruction. Fence terminal
+     * cleanup before any bootstrap wait or local observed-state mutation so a
+     * concurrent completion cannot remove the job and chunk log underneath it. */
+    if (
+      isFirstAttachment &&
+      runtime.firstAttachmentClaimedAt == null &&
+      runtime.earlyEventBufferOverflowed === true
+    ) {
+      const claimedAt = Date.now();
+      try {
+        const claimed = await this.jobStore.claimFirstSubscriberAttachment(
+          streamId,
+          runtime.createdAt,
+          claimedAt,
+        );
+        if (claimed) {
+          runtime.firstAttachmentClaimedAt = claimedAt;
+        } else {
+          const durableJob = await this.jobStore.getJob(streamId);
+          if (
+            durableJob?.createdAt !== runtime.createdAt ||
+            durableJob.firstSubscriberAttachedAt == null
+          ) {
+            subscription.unsubscribe();
+            recordGenerationStreamSubscription(this.storeLabel, subscriptionType, 'error');
+            return null;
+          }
+        }
+      } catch (err) {
+        subscription.unsubscribe();
+        recordGenerationStreamSubscription(this.storeLabel, subscriptionType, 'error');
+        logger.warn('[GenerationJobManager] Failed to fence overflow attachment:', err);
+        return null;
+      }
+    }
+
     if (!runtime.hasSubscriber) {
       runtime.hasSubscriber = true;
       runtime.everHadSubscriber = true;

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -672,6 +672,7 @@ interface RuntimeJobState {
   earlyEventBufferOverflowed?: true;
   earlyBufferRecovery?: EarlyBufferRecoveryState;
   earlyBufferRecoveryWrite?: Promise<void>;
+  earlyBufferRecoveryPersistenceFailed?: true;
   /** Recovery-only sequence for events persisted in the Redis chunk log. */
   durableReplaySequence: number;
   /** Pre-attachment append receipts used to prove the overflow frontier was durable. */
@@ -3954,6 +3955,7 @@ class GenerationJobManagerClass {
      * first-subscriber field before reconstructing, so only a genuinely
      * never-attached generation can win the not-attempted outcome. */
     if (runtime && this.runtimeState.get(streamId) === runtime && !runtime.everHadSubscriber) {
+      await runtime.earlyBufferRecoveryWrite;
       const durableJob = await this.jobStore.getJob(streamId).catch(() => null);
       if (durableJob != null && durableJob.firstSubscriberAttachedAt == null) {
         recordGenerationStreamAttachment(this.storeLabel, 'never_attached', 0);
@@ -5345,13 +5347,72 @@ class GenerationJobManagerClass {
     runtime.earlyEventBufferClosed = true;
     runtime.earlyEventBufferOverflowed = true;
     runtime.earlyBufferRecoveryWrite = (async () => {
-      await Promise.all(appendReceipts);
+      const appendResults = await Promise.all(appendReceipts);
+      if (appendResults.some((appended) => !appended)) {
+        throw new Error('One or more pre-overflow chunk appends were not committed');
+      }
       await this.jobStore.flushPendingAppends?.(streamId);
       await this.jobStore.updateJob(streamId, { earlyBufferRecovery: recovery }, runtime.createdAt);
     })().catch((error) => {
+      runtime.earlyBufferRecoveryPersistenceFailed = true;
       logger.error('[GenerationRecovery] Failed to persist overflow marker', {
         correlationId: recovery.correlationId,
         error,
+      });
+      setImmediate(() => {
+        void (async () => {
+          const failureReason = 'overflow_marker_persistence_failed' as const;
+          const durableOutcome = await this.settleEarlyBufferRecovery(
+            streamId,
+            runtime,
+            recovery,
+            'failure',
+            failureReason,
+            0,
+            0,
+          );
+          if (durableOutcome?.outcome === 'success') {
+            return;
+          }
+          if (durableOutcome == null) {
+            const completedAt = Date.now();
+            runtime.earlyBufferRecovery = {
+              ...recovery,
+              source: this._isRedis ? 'redis' : 'snapshot',
+              startedAt: recovery.overflowedAt,
+              outcome: 'failure',
+              failureReason,
+              completedAt,
+              durationMs: Math.max(0, completedAt - recovery.overflowedAt),
+              reconstructedEventCount: 0,
+              reconstructedContentCount: 0,
+            };
+            recordGenerationStreamRecovery(
+              this.storeLabel,
+              this._isRedis ? 'redis' : 'snapshot',
+              'failure',
+              failureReason,
+              Math.max(0, completedAt - recovery.overflowedAt) / 1000,
+              0,
+              0,
+            );
+            logger.info('[GenerationRecovery] Recovery outcome', {
+              correlationId: recovery.correlationId,
+              source: this._isRedis ? 'redis' : 'snapshot',
+              outcome: 'failure',
+              failureReason,
+              durationMs: Math.max(0, completedAt - recovery.overflowedAt),
+              reconstructedEventCount: 0,
+              reconstructedContentCount: 0,
+            });
+          }
+          await this.completeJob(streamId, GENERATION_RECOVERY_FAILED_ERROR, runtime.createdAt);
+        })().catch((terminalError) => {
+          logger.error('[GenerationRecovery] Failed to terminalize overflow marker error', {
+            correlationId: recovery.correlationId,
+            error: terminalError,
+          });
+        });
       });
     });
     recordGenerationStreamEarlyBufferOverflow(this.storeLabel);
@@ -5372,9 +5433,9 @@ class GenerationJobManagerClass {
     failureReason: EarlyBufferRecoveryFailureReason | undefined,
     reconstructedEventCount: number,
     reconstructedContentCount: number,
-  ): Promise<void> {
+  ): Promise<EarlyBufferRecoveryState | undefined> {
     if (recovery.outcome != null || runtime.earlyBufferRecovery?.outcome != null) {
-      return;
+      return runtime.earlyBufferRecovery;
     }
     const completedAt = Date.now();
     const settled: EarlyBufferRecoveryState = {
@@ -5387,18 +5448,16 @@ class GenerationJobManagerClass {
       ...(failureReason && { failureReason }),
     };
     try {
-      const committed = this.jobStore.settleEarlyBufferRecovery
+      const settlement = this.jobStore.settleEarlyBufferRecovery
         ? await this.jobStore.settleEarlyBufferRecovery(
             streamId,
             runtime.createdAt,
             recovery.correlationId,
             settled,
           )
-        : true;
-      if (!committed) {
-        runtime.earlyBufferRecovery =
-          (await this.jobStore.getJob(streamId))?.earlyBufferRecovery ?? recovery;
-        return;
+        : { recovery: settled, committed: true };
+      if (settlement == null) {
+        return undefined;
       }
       if (!this.jobStore.settleEarlyBufferRecovery) {
         await this.jobStore.updateJob(
@@ -5407,13 +5466,16 @@ class GenerationJobManagerClass {
           runtime.createdAt,
         );
       }
-      runtime.earlyBufferRecovery = settled;
+      runtime.earlyBufferRecovery = settlement.recovery;
+      if (!settlement.committed) {
+        return settlement.recovery;
+      }
     } catch (error) {
       logger.error('[GenerationRecovery] Failed to persist recovery outcome', {
         correlationId: recovery.correlationId,
         error,
       });
-      return;
+      return undefined;
     }
     const source = settled.source ?? (this._isRedis ? 'redis' : 'snapshot');
     recordGenerationStreamRecovery(
@@ -5434,6 +5496,7 @@ class GenerationJobManagerClass {
       reconstructedContentCount,
       ...(failureReason && { failureReason }),
     });
+    return settled;
   }
 
   private recoveryFrontierHasNoGaps(sequences: readonly number[], frontier: number): boolean {
@@ -5576,6 +5639,11 @@ class GenerationJobManagerClass {
     }
 
     await runtime.earlyBufferRecoveryWrite;
+    if (runtime.earlyBufferRecoveryPersistenceFailed) {
+      recordGenerationStreamSubscription(this.storeLabel, 'resume', 'error');
+      onError?.(GENERATION_RECOVERY_FAILED_ERROR);
+      return { subscription: null, resumeState: null, pendingEvents: [] };
+    }
     let overflowRecovery = runtime.earlyBufferRecovery;
     if (overflowRecovery && overflowRecovery.outcome == null) {
       const startedRecovery: EarlyBufferRecoveryState = {
@@ -5969,7 +6037,7 @@ class GenerationJobManagerClass {
         }
 
         if (failureReason) {
-          await this.settleEarlyBufferRecovery(
+          const durableOutcome = await this.settleEarlyBufferRecovery(
             streamId,
             runtime,
             activeOverflowRecovery,
@@ -5978,9 +6046,11 @@ class GenerationJobManagerClass {
             reconstructedEventCount,
             reconstructedContentCount,
           );
-          runtime.abortController.abort();
-          await this.completeJob(streamId, GENERATION_RECOVERY_FAILED_ERROR, runtime.createdAt);
-          return cancelResumeSubscription();
+          if (durableOutcome?.outcome !== 'success') {
+            runtime.abortController.abort();
+            await this.completeJob(streamId, GENERATION_RECOVERY_FAILED_ERROR, runtime.createdAt);
+            return cancelResumeSubscription();
+          }
         }
 
         await this.settleEarlyBufferRecovery(

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -6048,8 +6048,10 @@ class GenerationJobManagerClass {
           );
           if (durableOutcome?.outcome !== 'success') {
             runtime.abortController.abort();
+            const canceled = cancelResumeSubscription();
             await this.completeJob(streamId, GENERATION_RECOVERY_FAILED_ERROR, runtime.createdAt);
-            return cancelResumeSubscription();
+            onError?.(GENERATION_RECOVERY_FAILED_ERROR);
+            return canceled;
           }
         }
 

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -31,12 +31,23 @@ import type {
   PreemptMessage,
   SteerQueueItem,
   DetachedAgentEventActionStoreMode,
+  EarlyBufferRecoveryState,
+  EarlyBufferRecoveryFailureReason,
 } from './interfaces/IJobStore';
 import type { AgentStartupTelemetry } from '~/agents/startup';
 import type { RecoveredSteerPayload } from './SteerRecovery';
 import type { SteerContentView } from './SteeringLifecycle';
 import type { GenerationJobStore } from '~/app/metrics';
 import type * as t from '~/types';
+import {
+  recordGenerationStreamEarlyBufferOverflow,
+  recordGenerationStreamAttachment,
+  recordGenerationStreamRecovery,
+  recordGenerationStreamResumePendingEvents,
+  recordGenerationStreamSubscription,
+  setGenerationJobsInFlight,
+  recordGenerationJob,
+} from '~/app/metrics';
 import {
   GenerationPublicationFencedError,
   JobCreationSupersededError,
@@ -47,13 +58,6 @@ import {
   PROVIDER_DRAIN_TIMEOUT_MS,
   STEER_QUEUE_MAX_DEPTH,
 } from './interfaces/IJobStore';
-import {
-  recordGenerationStreamEarlyBufferOverflow,
-  recordGenerationStreamResumePendingEvents,
-  recordGenerationStreamSubscription,
-  setGenerationJobsInFlight,
-  recordGenerationJob,
-} from '~/app/metrics';
 import { isRecoveredSteerPayload, RecoveredSteerPayloadMismatchError } from './SteerRecovery';
 import { assertJobStoreV2 } from './jobStoreCapabilities';
 
@@ -155,6 +159,8 @@ const TERMINAL_PERSISTENCE_TIMEOUT_MS = 30_000;
  * durable chunk log, in-memory reconnects recover from the resume snapshot. */
 const EARLY_EVENT_BUFFER_MAX_EVENTS = 5_000;
 const EARLY_EVENT_BUFFER_MAX_BYTES = 8 * 1024 * 1024;
+const ATTACHMENT_BOOTSTRAP_SLOW_MS = 1_000;
+export const GENERATION_RECOVERY_FAILED_ERROR = 'generation_recovery_failed';
 const CLIENT_REQUEST_ID_PATTERN = /^[A-Za-z0-9:_-]{1,128}$/;
 type TokenIdempotencyClaim = IdempotencyClaimValue & {
   claimedAt: number;
@@ -664,6 +670,12 @@ interface RuntimeJobState {
    * consumed it. Non-resume attachments are redirected to the resume path,
    * which reconstructs the discarded output from durable/snapshot state. */
   earlyEventBufferOverflowed?: true;
+  earlyBufferRecovery?: EarlyBufferRecoveryState;
+  earlyBufferRecoveryWrite?: Promise<void>;
+  /** Recovery-only sequence for events persisted in the Redis chunk log. */
+  durableReplaySequence: number;
+  /** Pre-attachment append receipts used to prove the overflow frontier was durable. */
+  earlyDurableAppendPromises: Array<Promise<boolean>>;
   earlyEventSequencePromises: Array<Promise<void | number>>;
   /** Initial subscribers eligible to receive the local pre-attachment replay. */
   earlyReplayHandlers: Set<t.ChunkHandler>;
@@ -682,6 +694,7 @@ interface RuntimeJobState {
   /** Coalesced delta publications emitted but not yet settled by a window flush. */
   outstandingCoalescedReceipts?: number;
   hasSubscriber: boolean;
+  everHadSubscriber: boolean;
   /** Advances whenever every local SSE subscriber for one attachment generation leaves. */
   attachmentGeneration: number;
   /** Attachment generation whose partial-response disconnect cleanup was most recently started. */
@@ -1607,6 +1620,7 @@ class GenerationJobManagerClass {
         return;
       }
 
+      recordGenerationStreamAttachment(this.storeLabel, 'disconnected', 0);
       const cleanup = this.persistSubscriberCleanup(streamId, runtime);
       this.subscriberCleanupPromises.add(cleanup);
       void cleanup.then(
@@ -2606,13 +2620,20 @@ class GenerationJobManagerClass {
       earlyEventBuffer: [],
       earlyEventBufferBytes: 0,
       earlyEventBufferClosed: false,
+      earlyEventBufferOverflowed:
+        jobData.earlyBufferRecovery?.outcome == null && jobData.earlyBufferRecovery != null
+          ? true
+          : undefined,
       earlyEventSequencePromises: [],
+      durableReplaySequence: 0,
+      earlyDurableAppendPromises: [],
       earlyReplayHandlers: new Set(),
       resumeCaptureHandlers: new Set(),
       localErrorHandlers: new Set(),
       emissionSequence: 0,
       inFlightSnapshotEmissions: new Map(),
       hasSubscriber: false,
+      everHadSubscriber: jobData.firstSubscriberAttachedAt != null,
       attachmentGeneration: 0,
     };
     this.runtimeState.set(streamId, runtime);
@@ -2908,13 +2929,21 @@ class GenerationJobManagerClass {
       earlyEventBuffer: [],
       earlyEventBufferBytes: 0,
       earlyEventBufferClosed: false,
+      earlyEventBufferOverflowed:
+        jobData.earlyBufferRecovery?.outcome == null && jobData.earlyBufferRecovery != null
+          ? true
+          : undefined,
       earlyEventSequencePromises: [],
+      earlyBufferRecovery: jobData.earlyBufferRecovery,
+      durableReplaySequence: jobData.earlyBufferRecovery?.durableFrontier ?? 0,
+      earlyDurableAppendPromises: [],
       earlyReplayHandlers: new Set(),
       resumeCaptureHandlers: new Set(),
       localErrorHandlers: new Set(),
       emissionSequence: 0,
       inFlightSnapshotEmissions: new Map(),
       hasSubscriber: false,
+      everHadSubscriber: jobData.firstSubscriberAttachedAt != null,
       attachmentGeneration: 0,
       finalEvent,
       errorEvent: jobData.error,
@@ -3920,6 +3949,29 @@ class GenerationJobManagerClass {
     let cleanupError: unknown;
     let retainTerminalHostEvidence = false;
 
+    /** Account for an overflow before successful completion can remove its
+     * durable job record. A concurrently attached replica claims the durable
+     * first-subscriber field before reconstructing, so only a genuinely
+     * never-attached generation can win the not-attempted outcome. */
+    if (runtime && this.runtimeState.get(streamId) === runtime && !runtime.everHadSubscriber) {
+      const durableJob = await this.jobStore.getJob(streamId).catch(() => null);
+      if (durableJob != null && durableJob.firstSubscriberAttachedAt == null) {
+        recordGenerationStreamAttachment(this.storeLabel, 'never_attached', 0);
+        const pendingRecovery = runtime.earlyBufferRecovery;
+        if (pendingRecovery && pendingRecovery.outcome == null) {
+          await this.settleEarlyBufferRecovery(
+            streamId,
+            runtime,
+            pendingRecovery,
+            'not_attempted',
+            'subscriber_never_attached',
+            0,
+            0,
+          );
+        }
+      }
+    }
+
     // Error jobs stay durable long enough for late subscribers to receive the
     // stored error. A publication failure must never bypass the finally cleanup.
     try {
@@ -4583,6 +4635,7 @@ class GenerationJobManagerClass {
     options?: t.SubscribeOptions,
     prepared?: PreparedSubscription,
   ): Promise<(t.StreamSubscription & { activate?: () => void }) | null> {
+    const attachmentStartedAt = Date.now();
     const subscriptionType = options?.skipBufferReplay ? 'resume' : 'initial';
     if (options?.signal?.aborted) {
       recordGenerationStreamSubscription(this.storeLabel, subscriptionType, 'error');
@@ -4911,8 +4964,10 @@ class GenerationJobManagerClass {
 
     const isFirst = this.eventTransport.isFirstSubscriber(streamId);
 
+    const isFirstAttachment = !runtime.everHadSubscriber;
     if (!runtime.hasSubscriber) {
       runtime.hasSubscriber = true;
+      runtime.everHadSubscriber = true;
       const attachmentGeneration = runtime.attachmentGeneration;
       const earlyPublicationFence = this.waitForEarlyEventPublications(runtime);
       if (!(await waitWhileAttached(earlyPublicationFence))) {
@@ -5044,6 +5099,33 @@ class GenerationJobManagerClass {
     }
 
     recordGenerationStreamSubscription(this.storeLabel, subscriptionType, 'success');
+
+    if (isFirstAttachment) {
+      const attachedAt = Date.now();
+      let claimedFirstAttachment = true;
+      try {
+        claimedFirstAttachment =
+          (await this.jobStore.claimFirstSubscriberAttachment?.(
+            streamId,
+            runtime.createdAt,
+            attachedAt,
+          )) ?? true;
+      } catch (err) {
+        claimedFirstAttachment = false;
+        logger.warn(
+          '[GenerationJobManager] Failed to claim first subscriber attachment telemetry:',
+          err,
+        );
+      }
+      if (claimedFirstAttachment) {
+        const bootstrapDurationMs = attachedAt - attachmentStartedAt;
+        recordGenerationStreamAttachment(
+          this.storeLabel,
+          bootstrapDurationMs >= ATTACHMENT_BOOTSTRAP_SLOW_MS ? 'bootstrap_slow' : 'attached',
+          Math.max(0, attachedAt - runtime.createdAt) / 1000,
+        );
+      }
+    }
 
     if (isFirst) {
       runtime.resolveReady();
@@ -5201,16 +5283,16 @@ class GenerationJobManagerClass {
    */
   private async waitForEarlyEventPublications(runtime: RuntimeJobState): Promise<void> {
     const pending = [...runtime.earlyEventSequencePromises];
-    if (pending.length === 0) {
-      return;
-    }
-
-    await Promise.all(pending);
+    await Promise.all([
+      ...(pending.length > 0 ? pending : []),
+      ...(runtime.earlyBufferRecoveryWrite ? [runtime.earlyBufferRecoveryWrite] : []),
+    ]);
   }
 
   private resetEarlyEventBuffer(runtime: RuntimeJobState): void {
     runtime.earlyEventBuffer = [];
     runtime.earlyEventSequencePromises = [];
+    runtime.earlyDurableAppendPromises = [];
     runtime.earlyEventBufferBytes = 0;
   }
 
@@ -5247,17 +5329,124 @@ class GenerationJobManagerClass {
   }
 
   private overflowEarlyEventBuffer(streamId: string, runtime: RuntimeJobState): void {
+    if (runtime.earlyBufferRecovery != null) {
+      return;
+    }
     const droppedEvents = runtime.earlyEventBuffer.length;
     const droppedBytes = runtime.earlyEventBufferBytes;
+    const recovery: EarlyBufferRecoveryState = {
+      correlationId: randomUUID(),
+      overflowedAt: Date.now(),
+      durableFrontier: runtime.durableReplaySequence,
+    };
+    const appendReceipts = [...runtime.earlyDurableAppendPromises];
+    runtime.earlyBufferRecovery = recovery;
     this.resetEarlyEventBuffer(runtime);
     runtime.earlyEventBufferClosed = true;
     runtime.earlyEventBufferOverflowed = true;
+    runtime.earlyBufferRecoveryWrite = (async () => {
+      await Promise.all(appendReceipts);
+      await this.jobStore.flushPendingAppends?.(streamId);
+      await this.jobStore.updateJob(streamId, { earlyBufferRecovery: recovery }, runtime.createdAt);
+    })().catch((error) => {
+      logger.error('[GenerationRecovery] Failed to persist overflow marker', {
+        correlationId: recovery.correlationId,
+        error,
+      });
+    });
     recordGenerationStreamEarlyBufferOverflow(this.storeLabel);
-    logger.warn(
-      `[GenerationJobManager] Early event buffer overflow for ${streamId}; ` +
-        `discarded ${droppedEvents} buffered events (~${droppedBytes} bytes); ` +
-        'late subscribers will recover from durable/resume state',
+    logger.warn('[GenerationRecovery] Early event buffer overflow', {
+      correlationId: recovery.correlationId,
+      store: this.storeLabel,
+      droppedEvents,
+      droppedBytes,
+      durableFrontier: recovery.durableFrontier,
+    });
+  }
+
+  private async settleEarlyBufferRecovery(
+    streamId: string,
+    runtime: RuntimeJobState,
+    recovery: EarlyBufferRecoveryState,
+    outcome: 'success' | 'failure' | 'not_attempted',
+    failureReason: EarlyBufferRecoveryFailureReason | undefined,
+    reconstructedEventCount: number,
+    reconstructedContentCount: number,
+  ): Promise<void> {
+    if (recovery.outcome != null || runtime.earlyBufferRecovery?.outcome != null) {
+      return;
+    }
+    const completedAt = Date.now();
+    const settled: EarlyBufferRecoveryState = {
+      ...recovery,
+      outcome,
+      completedAt,
+      durationMs: Math.max(0, completedAt - (recovery.startedAt ?? recovery.overflowedAt)),
+      reconstructedEventCount,
+      reconstructedContentCount,
+      ...(failureReason && { failureReason }),
+    };
+    try {
+      const committed = this.jobStore.settleEarlyBufferRecovery
+        ? await this.jobStore.settleEarlyBufferRecovery(
+            streamId,
+            runtime.createdAt,
+            recovery.correlationId,
+            settled,
+          )
+        : true;
+      if (!committed) {
+        runtime.earlyBufferRecovery =
+          (await this.jobStore.getJob(streamId))?.earlyBufferRecovery ?? recovery;
+        return;
+      }
+      if (!this.jobStore.settleEarlyBufferRecovery) {
+        await this.jobStore.updateJob(
+          streamId,
+          { earlyBufferRecovery: settled },
+          runtime.createdAt,
+        );
+      }
+      runtime.earlyBufferRecovery = settled;
+    } catch (error) {
+      logger.error('[GenerationRecovery] Failed to persist recovery outcome', {
+        correlationId: recovery.correlationId,
+        error,
+      });
+      return;
+    }
+    const source = settled.source ?? (this._isRedis ? 'redis' : 'snapshot');
+    recordGenerationStreamRecovery(
+      this.storeLabel,
+      source,
+      outcome,
+      failureReason ?? 'none',
+      settled.durationMs! / 1000,
+      reconstructedEventCount,
+      reconstructedContentCount,
     );
+    logger.info('[GenerationRecovery] Recovery outcome', {
+      correlationId: recovery.correlationId,
+      source,
+      outcome,
+      durationMs: settled.durationMs,
+      reconstructedEventCount,
+      reconstructedContentCount,
+      ...(failureReason && { failureReason }),
+    });
+  }
+
+  private recoveryFrontierHasNoGaps(sequences: readonly number[], frontier: number): boolean {
+    if (frontier === 0) {
+      return true;
+    }
+    const observed = new Set(sequences);
+    for (let sequence = 1; sequence <= frontier; sequence++) {
+      if (!observed.has(sequence)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**
@@ -5385,6 +5574,24 @@ class GenerationJobManagerClass {
       recordGenerationStreamSubscription(this.storeLabel, 'resume', 'not_found');
       return { subscription: null, resumeState: null, pendingEvents: [] };
     }
+
+    await runtime.earlyBufferRecoveryWrite;
+    let overflowRecovery = runtime.earlyBufferRecovery;
+    if (overflowRecovery && overflowRecovery.outcome == null) {
+      const startedRecovery: EarlyBufferRecoveryState = {
+        ...overflowRecovery,
+        source: this._isRedis ? 'redis' : 'snapshot',
+        startedAt: Date.now(),
+      };
+      overflowRecovery = startedRecovery;
+      runtime.earlyBufferRecovery = startedRecovery;
+      logger.info('[GenerationRecovery] Recovery started', {
+        correlationId: startedRecovery.correlationId,
+        source: startedRecovery.source,
+        durableFrontier: startedRecovery.durableFrontier,
+      });
+    }
+    const activeOverflowRecovery = overflowRecovery?.outcome == null ? overflowRecovery : undefined;
 
     const capturedPendingEvents: t.ServerSentEvent[] = [];
     const pendingEvents: t.ServerSentEvent[] = [];
@@ -5736,6 +5943,57 @@ class GenerationJobManagerClass {
         }
       }
 
+      if (activeOverflowRecovery) {
+        let failureReason: EarlyBufferRecoveryFailureReason | undefined;
+        let reconstructedEventCount = runtime.emissionSequence;
+        const reconstructedContentCount = resumeState?.aggregatedContent?.length ?? 0;
+        try {
+          if (resumeState == null) {
+            failureReason = this._isRedis ? 'durable_state_missing' : 'snapshot_missing';
+          } else if (this._isRedis) {
+            const stats = await this.jobStore.getRecoveryEventStats?.(streamId, runtime.createdAt);
+            reconstructedEventCount = stats?.eventCount ?? 0;
+            if (stats == null) {
+              failureReason = 'durable_state_missing';
+            } else if (
+              !this.recoveryFrontierHasNoGaps(
+                stats.recoverySequences,
+                activeOverflowRecovery.durableFrontier,
+              )
+            ) {
+              failureReason = 'durable_frontier_gap';
+            }
+          }
+        } catch {
+          failureReason = 'reconstruction_error';
+        }
+
+        if (failureReason) {
+          await this.settleEarlyBufferRecovery(
+            streamId,
+            runtime,
+            activeOverflowRecovery,
+            'failure',
+            failureReason,
+            reconstructedEventCount,
+            reconstructedContentCount,
+          );
+          runtime.abortController.abort();
+          await this.completeJob(streamId, GENERATION_RECOVERY_FAILED_ERROR, runtime.createdAt);
+          return cancelResumeSubscription();
+        }
+
+        await this.settleEarlyBufferRecovery(
+          streamId,
+          runtime,
+          activeOverflowRecovery,
+          'success',
+          undefined,
+          reconstructedEventCount,
+          reconstructedContentCount,
+        );
+      }
+
       // Reconciliation is complete. Events that arrive after this point already belong to the
       // paused transport subscription and must remain there for activation rather than being
       // appended to a pending-events array the caller may already be serializing.
@@ -6009,14 +6267,30 @@ class GenerationJobManagerClass {
       // The SSE event structure is { event: string, data: unknown, ... }
       // The aggregator expects { event: string, data: unknown } where data is the payload
       if (eventType && eventData !== undefined) {
+        const trackRecoverySequence = !runtime.hasSubscriber && runtime.earlyBufferRecovery == null;
+        const recoverySequence = trackRecoverySequence
+          ? ++runtime.durableReplaySequence
+          : undefined;
         // Store in format expected by aggregateContent: { event, data }
         const appendPromise = this.jobStore.appendChunk(
           streamId,
-          { event: eventType, data: eventData },
+          {
+            event: eventType,
+            data: eventData,
+            ...(recoverySequence != null && { recoverySequence }),
+          },
           runtime.createdAt,
           options?.deliveredSteer,
           coalescableDelta ? { coalesce: true } : undefined,
         );
+        if (trackRecoverySequence) {
+          runtime.earlyDurableAppendPromises.push(
+            appendPromise.then(
+              (appended) => appended !== false,
+              () => false,
+            ),
+          );
+        }
 
         if (options?.durable === true) {
           let appended: boolean;

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -5760,6 +5760,33 @@ class GenerationJobManagerClass {
     }
     const activeOverflowRecovery = overflowRecovery?.outcome == null ? overflowRecovery : undefined;
 
+    /** The marker may have been installed while the barrier above was pending.
+     * Claim that newly observed recovery before deciding it was unattached. */
+    if (activeOverflowRecovery && !runtime.everHadSubscriber) {
+      const claimedAt = Date.now();
+      try {
+        const claimed = await this.jobStore.claimFirstSubscriberAttachment(
+          streamId,
+          runtime.createdAt,
+          claimedAt,
+        );
+        if (claimed) {
+          runtime.firstAttachmentClaimedAt = claimedAt;
+          runtime.everHadSubscriber = true;
+        } else {
+          const durableJob = await this.jobStore.getJob(streamId);
+          runtime.everHadSubscriber = durableJob?.firstSubscriberAttachedAt != null;
+        }
+      } catch (error) {
+        logger.warn('[GenerationRecovery] Failed to claim newly observed recovery attachment', {
+          correlationId: activeOverflowRecovery.correlationId,
+          error,
+        });
+        recordGenerationStreamSubscription(this.storeLabel, 'resume', 'error');
+        return { subscription: null, resumeState: null, pendingEvents: [] };
+      }
+    }
+
     if (activeOverflowRecovery && !runtime.everHadSubscriber) {
       const durableOutcome = await this.settleEarlyBufferRecovery(
         streamId,
@@ -6467,7 +6494,10 @@ class GenerationJobManagerClass {
       // The SSE event structure is { event: string, data: unknown, ... }
       // The aggregator expects { event: string, data: unknown } where data is the payload
       if (eventType && eventData !== undefined) {
-        const trackRecoverySequence = !runtime.hasSubscriber && runtime.earlyBufferRecovery == null;
+        const trackRecoverySequence =
+          !runtime.everHadSubscriber &&
+          !runtime.hasSubscriber &&
+          runtime.earlyBufferRecovery == null;
         const recoverySequence = trackRecoverySequence
           ? ++runtime.durableReplaySequence
           : undefined;

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -34,6 +34,7 @@ import type {
   EarlyBufferRecoveryState,
   EarlyBufferRecoveryFailureReason,
   ContentPartsReadOptions,
+  ContentPartsRecoveryReadOptions,
   RecoveryEventStats,
 } from './interfaces/IJobStore';
 import type { AgentStartupTelemetry } from '~/agents/startup';
@@ -4042,6 +4043,11 @@ class GenerationJobManagerClass {
           terminalJob?.providerDrained !== false &&
           terminalJob?.preserveForScheduleReconcile !== true &&
           terminalJob?.terminalHostActionPending !== true &&
+          !(
+            terminalJob?.firstSubscriberAttachedAt != null &&
+            terminalJob.earlyBufferRecovery != null &&
+            terminalJob.earlyBufferRecovery.outcome == null
+          ) &&
           (terminalJob?.createdAt !== createdAt || terminalJob.terminalPersistencePending !== true)
         ) {
           // A same-stream replacement created after the claim makes this a safe
@@ -5423,6 +5429,7 @@ class GenerationJobManagerClass {
               reconstructedContentCount: 0,
             });
           }
+          this.abortRecoveryGeneration(streamId, runtime, recovery);
           await this.completeJob(streamId, GENERATION_RECOVERY_FAILED_ERROR, runtime.createdAt);
         })().catch((terminalError) => {
           logger.error('[GenerationRecovery] Failed to terminalize overflow marker error', {
@@ -5505,6 +5512,26 @@ class GenerationJobManagerClass {
       ...(failureReason && { failureReason }),
     });
     return settled;
+  }
+
+  /** Stop the provider-owning replica as soon as durable recovery becomes terminal. */
+  private abortRecoveryGeneration(
+    streamId: string,
+    runtime: RuntimeJobState,
+    recovery: EarlyBufferRecoveryState,
+  ): void {
+    try {
+      this.eventTransport.emitAbort?.(streamId, runtime.createdAt);
+    } catch (error) {
+      logger.error('[GenerationRecovery] Failed to publish recovery abort', {
+        correlationId: recovery.correlationId,
+        error,
+      });
+    }
+    if (this.runtimeState.get(streamId) === runtime) {
+      this.releaseAbortSubscription(runtime);
+    }
+    runtime.abortController.abort();
   }
 
   private recoveryFrontierHasNoGaps(sequences: readonly number[], frontier: number): boolean {
@@ -5668,6 +5695,8 @@ class GenerationJobManagerClass {
           correlationId: pendingOverflowAtEntry.correlationId,
           error,
         });
+        recordGenerationStreamSubscription(this.storeLabel, 'resume', 'error');
+        return { subscription: null, resumeState: null, pendingEvents: [] };
       }
     }
 
@@ -5705,6 +5734,7 @@ class GenerationJobManagerClass {
         0,
       );
       if (durableOutcome?.outcome !== 'success') {
+        this.abortRecoveryGeneration(streamId, runtime, activeOverflowRecovery);
         await this.completeJob(streamId, GENERATION_RECOVERY_FAILED_ERROR, runtime.createdAt);
         onError?.(GENERATION_RECOVERY_FAILED_ERROR);
         return { subscription: null, resumeState: null, pendingEvents: [] };
@@ -5817,9 +5847,11 @@ class GenerationJobManagerClass {
         }
       } else {
         [resumeState, jobData] = await Promise.all([
-          this.getResumeState(streamId, options?.expectedCreatedAt, {
-            includeRecoveryStats: activeOverflowRecovery != null,
-          }),
+          activeOverflowRecovery != null
+            ? this.getResumeState(streamId, options?.expectedCreatedAt, {
+                includeRecoveryStats: true,
+              })
+            : this.getResumeState(streamId, options?.expectedCreatedAt),
           this.jobStore.getJob(streamId),
         ]);
       }
@@ -6099,15 +6131,15 @@ class GenerationJobManagerClass {
             reconstructedContentCount,
           );
           if (durableOutcome?.outcome !== 'success') {
-            runtime.abortController.abort();
             const canceled = cancelResumeSubscription();
+            this.abortRecoveryGeneration(streamId, runtime, activeOverflowRecovery);
             await this.completeJob(streamId, GENERATION_RECOVERY_FAILED_ERROR, runtime.createdAt);
             onError?.(GENERATION_RECOVERY_FAILED_ERROR);
             return canceled;
           }
         }
 
-        await this.settleEarlyBufferRecovery(
+        const durableOutcome = await this.settleEarlyBufferRecovery(
           streamId,
           runtime,
           activeOverflowRecovery,
@@ -6116,6 +6148,13 @@ class GenerationJobManagerClass {
           reconstructedEventCount,
           reconstructedContentCount,
         );
+        if (durableOutcome?.outcome !== 'success') {
+          const canceled = cancelResumeSubscription();
+          this.abortRecoveryGeneration(streamId, runtime, activeOverflowRecovery);
+          await this.completeJob(streamId, GENERATION_RECOVERY_FAILED_ERROR, runtime.createdAt);
+          onError?.(GENERATION_RECOVERY_FAILED_ERROR);
+          return canceled;
+        }
       }
 
       // Reconciliation is complete. Events that arrive after this point already belong to the
@@ -8107,7 +8146,7 @@ class GenerationJobManagerClass {
   async getResumeState(
     streamId: string,
     expectedCreatedAt?: number,
-    options?: ContentPartsReadOptions,
+    options?: ContentPartsReadOptions | ContentPartsRecoveryReadOptions,
   ): Promise<t.ResumeState | null> {
     const jobData = await this.jobStore.getJob(streamId);
     if (!jobData || (expectedCreatedAt != null && jobData.createdAt !== expectedCreatedAt)) {
@@ -8117,8 +8156,11 @@ class GenerationJobManagerClass {
     /** Independent reads (streamId-only): parallel to collapse 3 Redis round trips into 1.
      *  Safe despite readCachedGraph's cache-drop side effect — each call catches its own
      *  unusable-graph throw and falls back to reconstruction, so ordering cannot change the result. */
+    const contentPartsRead = options?.includeRecoveryStats
+      ? this.jobStore.getContentParts(streamId, jobData.createdAt, { includeRecoveryStats: true })
+      : this.jobStore.getContentParts(streamId, jobData.createdAt);
     const [result, runSteps, queuedSteers, claimedSteers] = await Promise.all([
-      this.jobStore.getContentParts(streamId, jobData.createdAt, options),
+      contentPartsRead,
       this.jobStore.getRunSteps(streamId, jobData.createdAt),
       this.jobStore.peekSteers(streamId, jobData.createdAt),
       this.jobStore.peekClaimedSteers(streamId, jobData.createdAt),
@@ -8226,7 +8268,7 @@ class GenerationJobManagerClass {
           : undefined,
       pendingSteers: pendingSteers.length > 0 ? pendingSteers : undefined,
     } satisfies t.ResumeState;
-    if (result?.recoveryStats) {
+    if (result && 'recoveryStats' in result) {
       Object.defineProperty(resumeState, RECOVERY_STATS, { value: result.recoveryStats });
     }
     return resumeState;

--- a/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
+++ b/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
@@ -1832,6 +1832,147 @@ describe('GenerationJobManager Integration Tests', () => {
       },
     );
 
+    testRedis(
+      'retains a completed job while an attached overflow recovery is pending',
+      async () => {
+        const manager = createRedisManager();
+        const streamId = `overflow-terminal-race-${Date.now()}`;
+        const job = await manager.createJob(streamId, 'user-1');
+        const overflowedAt = Date.now();
+
+        await manager.getJobStore().updateJob(
+          streamId,
+          {
+            firstSubscriberAttachedAt: overflowedAt,
+            earlyBufferRecovery: {
+              correlationId: 'terminal-race-correlation',
+              overflowedAt,
+              durableFrontier: 0,
+            },
+          },
+          job.createdAt,
+        );
+
+        await expect(manager.completeJob(streamId, undefined, job.createdAt)).resolves.toBe(true);
+        expect(await manager.getJobStore().getJob(streamId)).toMatchObject({
+          status: 'complete',
+          firstSubscriberAttachedAt: overflowedAt,
+          earlyBufferRecovery: { correlationId: 'terminal-race-correlation' },
+        });
+
+        await manager.destroy();
+      },
+    );
+
+    testRedis('keeps a transient recovery attachment claim failure retryable', async () => {
+      const owner = createRedisManager();
+      const recoveryReplica = createRedisManager();
+      const streamId = `overflow-claim-retry-${Date.now()}`;
+      const job = await owner.createJob(streamId, 'user-1');
+      await owner.emitChunk(streamId, {
+        event: 'on_run_step',
+        data: {
+          id: 'step-1',
+          runId: 'run-1',
+          index: 0,
+          stepDetails: { type: 'message_creation' },
+        },
+      });
+      await owner.getJobStore().updateJob(
+        streamId,
+        {
+          earlyBufferRecovery: {
+            correlationId: 'claim-retry-correlation',
+            overflowedAt: Date.now(),
+            durableFrontier: 0,
+          },
+        },
+        job.createdAt,
+      );
+
+      const claim = jest
+        .spyOn(recoveryReplica.getJobStore(), 'claimFirstSubscriberAttachment')
+        .mockRejectedValueOnce(new Error('transient claim timeout'));
+      const first = await recoveryReplica.subscribeWithResume(streamId, () => {});
+      expect(first.subscription).toBeNull();
+      expect(await recoveryReplica.getJobStore().getJob(streamId)).toMatchObject({
+        status: 'running',
+        earlyBufferRecovery: { outcome: undefined },
+      });
+
+      const retried = await recoveryReplica.subscribeWithResume(streamId, () => {});
+      expect(retried.subscription).not.toBeNull();
+      expect(await recoveryReplica.getJobStore().getJob(streamId)).toMatchObject({
+        earlyBufferRecovery: { outcome: 'success' },
+      });
+      expect(claim).toHaveBeenCalledTimes(2);
+
+      retried.subscription?.unsubscribe();
+      await recoveryReplica.destroy();
+      await owner.destroy();
+    });
+
+    testRedis('rejects and aborts when another replica wins recovery with failure', async () => {
+      const owner = createRedisManager();
+      const services = createStreamServices({ useRedis: true, redisClient: ioredisClient! });
+      const recoveryReplica = new GenerationJobManagerClass();
+      recoveryReplica.configure(services);
+      recoveryReplica.initialize();
+      const streamId = `overflow-settlement-race-${Date.now()}`;
+      const job = await owner.createJob(streamId, 'user-1');
+      await owner.emitChunk(streamId, {
+        event: 'on_run_step',
+        data: {
+          id: 'step-1',
+          runId: 'run-1',
+          index: 0,
+          stepDetails: { type: 'message_creation' },
+        },
+      });
+      await owner.getJobStore().updateJob(
+        streamId,
+        {
+          earlyBufferRecovery: {
+            correlationId: 'settlement-race-correlation',
+            overflowedAt: Date.now(),
+            durableFrontier: 0,
+          },
+        },
+        job.createdAt,
+      );
+
+      const store = recoveryReplica.getJobStore();
+      const settle = store.settleEarlyBufferRecovery.bind(store);
+      jest
+        .spyOn(store, 'settleEarlyBufferRecovery')
+        .mockImplementationOnce(async (id, createdAt, correlationId, recovery) => {
+          await settle(id, createdAt, correlationId, {
+            ...recovery,
+            outcome: 'failure',
+            failureReason: 'reconstruction_error',
+          });
+          return settle(id, createdAt, correlationId, recovery);
+        });
+      const abort = jest.spyOn(services.eventTransport, 'emitAbort');
+      const errors: string[] = [];
+      const recovered = await recoveryReplica.subscribeWithResume(
+        streamId,
+        () => {},
+        undefined,
+        (error) => errors.push(error),
+      );
+
+      expect(recovered.subscription).toBeNull();
+      expect(errors).toEqual([GENERATION_RECOVERY_FAILED_ERROR]);
+      expect(abort).toHaveBeenCalledWith(streamId, job.createdAt);
+      expect(await store.getJob(streamId)).toMatchObject({
+        earlyBufferRecovery: { outcome: 'failure' },
+      });
+
+      await recoveryReplica.destroy();
+      await owner.destroy();
+    });
+
     test('buffers detached events until the cap in in-memory mode', async () => {
       const manager = createInMemoryManager();
       const streamId = `buf-below-cap-${Date.now()}`;

--- a/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
+++ b/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
@@ -1789,6 +1789,43 @@ describe('GenerationJobManager Integration Tests', () => {
     );
 
     testRedis(
+      'fences terminal cleanup before an overflow attachment waits on bootstrap',
+      async () => {
+        const services = createStreamServices({ useRedis: true, redisClient: ioredisClient! });
+        const manager = new GenerationJobManagerClass();
+        manager.configure(services);
+        manager.initialize();
+        const streamId = `overflow-bootstrap-race-${Date.now()}`;
+        const job = await manager.createJob(streamId, 'user-1');
+
+        const bigText = 'q'.repeat(2 * 1024 * 1024);
+        for (let i = 0; i < 5; i++) {
+          await manager.emitChunk(streamId, {
+            event: 'on_message_delta',
+            data: { id: 'step-1', delta: { content: { type: 'text', text: bigText } } },
+          });
+        }
+
+        jest
+          .spyOn(services.eventTransport, 'syncReorderBuffer')
+          .mockImplementationOnce(async () => {
+            await manager.completeJob(streamId, undefined, job.createdAt);
+          });
+        await manager.subscribe(streamId, () => {});
+
+        const retained = await manager.getJobStore().getJob(streamId);
+        expect(retained).toMatchObject({
+          status: 'complete',
+          firstSubscriberAttachedAt: expect.any(Number),
+        });
+        expect(retained?.earlyBufferRecovery?.outcome).toBeUndefined();
+
+        await manager.destroy();
+      },
+      30_000,
+    );
+
+    testRedis(
       'terminally fails overflow recovery when the durable chunk log is missing',
       async () => {
         const manager = createRedisManager();

--- a/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
+++ b/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
@@ -1683,6 +1683,12 @@ describe('GenerationJobManager Integration Tests', () => {
         const stats = manager.getRuntimeStats();
         expect(stats.earlyBufferedEvents).toBe(0);
         expect(stats.earlyBufferedBytes).toBe(0);
+        const runtime = (
+          manager as unknown as {
+            runtimeState: Map<string, { earlyDurableAppendPromises: Promise<boolean>[] }>;
+          }
+        ).runtimeState.get(streamId);
+        expect(runtime?.earlyDurableAppendPromises).toHaveLength(0);
 
         await manager.destroy();
       },
@@ -1819,6 +1825,11 @@ describe('GenerationJobManager Integration Tests', () => {
           firstSubscriberAttachedAt: expect.any(Number),
         });
         expect(retained?.earlyBufferRecovery?.outcome).toBeUndefined();
+        await expect(
+          manager
+            .getJobStore()
+            .getContentParts(streamId, job.createdAt, { includeRecoveryStats: true }),
+        ).resolves.toMatchObject({ recoveryStats: { eventCount: 5 } });
 
         await manager.destroy();
       },

--- a/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
+++ b/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
@@ -2,14 +2,15 @@
 import type { Redis, Cluster } from 'ioredis';
 import type { ServerSentEvent, StreamEvent, CreatedEvent } from '~/types';
 import {
+  GenerationJobManagerClass,
+  GENERATION_RECOVERY_FAILED_ERROR,
+  TERMINAL_PUBLICATION_RECONNECT_ERROR,
+} from '~/stream/GenerationJobManager';
+import {
   ioredisClient as staticRedisClient,
   keyvRedisClient as staticKeyvClient,
   keyvRedisClientReady,
 } from '~/cache/redisClients';
-import {
-  GenerationJobManagerClass,
-  TERMINAL_PUBLICATION_RECONNECT_ERROR,
-} from '~/stream/GenerationJobManager';
 import { InMemoryEventTransport } from '~/stream/implementations/InMemoryEventTransport';
 import { RedisEventTransport } from '~/stream/implementations/RedisEventTransport';
 import { InMemoryJobStore } from '~/stream/implementations/InMemoryJobStore';
@@ -1730,48 +1731,106 @@ describe('GenerationJobManager Integration Tests', () => {
       await manager.destroy();
     });
 
-    testRedis('redirects a post-overflow first attachment to resume recovery (Redis)', async () => {
-      const manager = createRedisManager();
-      const streamId = `overflow-redirect-${Date.now()}`;
-      await manager.createJob(streamId, 'user-1');
+    testRedis(
+      'reconstructs over 5,000 pre-attachment events from Redis',
+      async () => {
+        const owner = createRedisManager();
+        const streamId = `overflow-redirect-${Date.now()}`;
+        await owner.createJob(streamId, 'user-1');
 
-      await manager.emitChunk(streamId, {
-        event: 'on_run_step',
-        data: {
-          id: 'step-1',
-          runId: 'run-1',
-          index: 0,
-          stepDetails: { type: 'message_creation' },
-        },
-      });
-      const bigText = 'y'.repeat(2 * 1024 * 1024);
-      for (let i = 0; i < 5; i++) {
-        await manager.emitChunk(streamId, {
-          event: 'on_message_delta',
-          data: { id: 'step-1', delta: { content: { type: 'text', text: bigText } } },
+        await owner.emitChunk(streamId, {
+          event: 'on_run_step',
+          data: {
+            id: 'step-1',
+            runId: 'run-1',
+            index: 0,
+            stepDetails: { type: 'message_creation' },
+          },
         });
-      }
-      expect(manager.getRuntimeStats().earlyBufferedEvents).toBe(0);
+        for (let i = 0; i < 5_001; i++) {
+          await owner.emitChunk(streamId, {
+            event: 'on_message_delta',
+            data: { id: 'step-1', delta: { content: { type: 'text', text: 'y' } } },
+          });
+        }
+        expect(owner.getRuntimeStats().earlyBufferedEvents).toBe(0);
 
-      const errors: string[] = [];
-      const sub = await manager.subscribe(
-        streamId,
-        () => {},
-        undefined,
-        (error) => errors.push(error),
-      );
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      expect(errors).toEqual([TERMINAL_PUBLICATION_RECONNECT_ERROR]);
-      sub?.unsubscribe();
-      await new Promise((resolve) => setTimeout(resolve, 100));
+        const errors: string[] = [];
+        const sub = await owner.subscribe(
+          streamId,
+          () => {},
+          undefined,
+          (error) => errors.push(error),
+        );
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        expect(errors).toEqual([TERMINAL_PUBLICATION_RECONNECT_ERROR]);
+        sub?.unsubscribe();
+        await new Promise((resolve) => setTimeout(resolve, 100));
 
-      /** The resume path the client falls back to reconstructs the
-       * discarded output from the durable chunk log. */
-      const resumeState = await manager.getResumeState(streamId);
-      expect(JSON.stringify(resumeState?.aggregatedContent ?? [])).toContain('yyyy');
+        /** The resume path the client falls back to reconstructs the
+         * discarded output from the durable chunk log. */
+        const recoveryReplica = createRedisManager();
+        const recovered = await recoveryReplica.subscribeWithResume(streamId, () => {});
+        const { resumeState } = recovered;
+        expect(JSON.stringify(resumeState?.aggregatedContent ?? [])).toContain('yyyy');
+        expect(
+          (await recoveryReplica.getJobStore().getJob(streamId))?.earlyBufferRecovery,
+        ).toMatchObject({
+          source: 'redis',
+          outcome: 'success',
+          reconstructedEventCount: 5_002,
+        });
+        recovered.subscription?.unsubscribe();
 
-      await manager.destroy();
-    });
+        await recoveryReplica.destroy();
+        await owner.destroy();
+      },
+      60_000,
+    );
+
+    testRedis(
+      'terminally fails overflow recovery when the durable chunk log is missing',
+      async () => {
+        const manager = createRedisManager();
+        const streamId = `overflow-missing-${Date.now()}`;
+        const job = await manager.createJob(streamId, 'user-1');
+
+        const bigText = 'z'.repeat(2 * 1024 * 1024);
+        for (let i = 0; i < 5; i++) {
+          await manager.emitChunk(streamId, {
+            event: 'on_message_delta',
+            data: { id: 'step-1', delta: { content: { type: 'text', text: bigText } } },
+          });
+        }
+
+        const initial = await manager.subscribe(streamId, () => {});
+        initial?.unsubscribe();
+        await ioredisClient!.del(`stream:{${streamId}}:chunks`);
+
+        const errors: string[] = [];
+        const recovered = await manager.subscribeWithResume(
+          streamId,
+          () => {},
+          undefined,
+          (error) => errors.push(error),
+          { expectedCreatedAt: job.createdAt },
+        );
+
+        expect(recovered.subscription).toBeNull();
+        expect(await manager.getJob(streamId)).toMatchObject({
+          status: 'error',
+          error: GENERATION_RECOVERY_FAILED_ERROR,
+          earlyBufferRecovery: {
+            source: 'redis',
+            outcome: 'failure',
+            failureReason: 'durable_state_missing',
+          },
+        });
+        expect(errors).toContain(GENERATION_RECOVERY_FAILED_ERROR);
+
+        await manager.destroy();
+      },
+    );
 
     test('buffers detached events until the cap in in-memory mode', async () => {
       const manager = createInMemoryManager();

--- a/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
+++ b/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
@@ -1817,7 +1817,7 @@ describe('GenerationJobManager Integration Tests', () => {
         );
 
         expect(recovered.subscription).toBeNull();
-        expect(await manager.getJob(streamId)).toMatchObject({
+        expect(await manager.getJobStore().getJob(streamId)).toMatchObject({
           status: 'error',
           error: GENERATION_RECOVERY_FAILED_ERROR,
           earlyBufferRecovery: {

--- a/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
+++ b/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
@@ -1895,10 +1895,9 @@ describe('GenerationJobManager Integration Tests', () => {
         .mockRejectedValueOnce(new Error('transient claim timeout'));
       const first = await recoveryReplica.subscribeWithResume(streamId, () => {});
       expect(first.subscription).toBeNull();
-      expect(await recoveryReplica.getJobStore().getJob(streamId)).toMatchObject({
-        status: 'running',
-        earlyBufferRecovery: { outcome: undefined },
-      });
+      const retryableJob = await recoveryReplica.getJobStore().getJob(streamId);
+      expect(retryableJob).toMatchObject({ status: 'running' });
+      expect(retryableJob?.earlyBufferRecovery?.outcome).toBeUndefined();
 
       const retried = await recoveryReplica.subscribeWithResume(streamId, () => {});
       expect(retried.subscription).not.toBeNull();

--- a/packages/api/src/stream/implementations/InMemoryJobStore.ts
+++ b/packages/api/src/stream/implementations/InMemoryJobStore.ts
@@ -21,6 +21,7 @@ import type {
   JobStatusTransition,
   IdempotencyClaimValue,
   IdempotencyClaimResult,
+  ContentPartsReadOptions,
   ParkedSteerClaim,
   EarlyBufferRecoveryState,
   EarlyBufferRecoverySettlement,
@@ -1522,6 +1523,7 @@ export class InMemoryJobStore implements IJobStoreV2 {
   async getContentParts(
     streamId: string,
     expectedCreatedAt?: number,
+    _options?: ContentPartsReadOptions,
   ): Promise<{
     content: Agents.MessageContentComplex[];
   } | null> {

--- a/packages/api/src/stream/implementations/InMemoryJobStore.ts
+++ b/packages/api/src/stream/implementations/InMemoryJobStore.ts
@@ -23,6 +23,7 @@ import type {
   IdempotencyClaimResult,
   ParkedSteerClaim,
   EarlyBufferRecoveryState,
+  EarlyBufferRecoverySettlement,
 } from '~/stream/interfaces/IJobStore';
 import type { RecoveredSteerPayload } from '~/stream/SteerRecovery';
 import {
@@ -719,17 +720,19 @@ export class InMemoryJobStore implements IJobStoreV2 {
     expectedCreatedAt: number,
     correlationId: string,
     recovery: EarlyBufferRecoveryState,
-  ): Promise<boolean> {
+  ): Promise<EarlyBufferRecoverySettlement | null> {
     const job = this.jobs.get(streamId);
     if (
       job?.createdAt !== expectedCreatedAt ||
-      job.earlyBufferRecovery?.correlationId !== correlationId ||
-      job.earlyBufferRecovery.outcome != null
+      job.earlyBufferRecovery?.correlationId !== correlationId
     ) {
-      return false;
+      return null;
+    }
+    if (job.earlyBufferRecovery.outcome != null) {
+      return { recovery: job.earlyBufferRecovery, committed: false };
     }
     job.earlyBufferRecovery = recovery;
-    return true;
+    return { recovery, committed: true };
   }
 
   async claimFirstSubscriberAttachment(

--- a/packages/api/src/stream/implementations/InMemoryJobStore.ts
+++ b/packages/api/src/stream/implementations/InMemoryJobStore.ts
@@ -22,6 +22,7 @@ import type {
   IdempotencyClaimValue,
   IdempotencyClaimResult,
   ParkedSteerClaim,
+  EarlyBufferRecoveryState,
 } from '~/stream/interfaces/IJobStore';
 import type { RecoveredSteerPayload } from '~/stream/SteerRecovery';
 import {
@@ -711,6 +712,37 @@ export class InMemoryJobStore implements IJobStoreV2 {
     // Plain field writer. Membership-aware status transitions
     // (running ⇄ requires_action) go solely through transitionStatus.
     Object.assign(job, updates);
+  }
+
+  async settleEarlyBufferRecovery(
+    streamId: string,
+    expectedCreatedAt: number,
+    correlationId: string,
+    recovery: EarlyBufferRecoveryState,
+  ): Promise<boolean> {
+    const job = this.jobs.get(streamId);
+    if (
+      job?.createdAt !== expectedCreatedAt ||
+      job.earlyBufferRecovery?.correlationId !== correlationId ||
+      job.earlyBufferRecovery.outcome != null
+    ) {
+      return false;
+    }
+    job.earlyBufferRecovery = recovery;
+    return true;
+  }
+
+  async claimFirstSubscriberAttachment(
+    streamId: string,
+    expectedCreatedAt: number,
+    attachedAt: number,
+  ): Promise<boolean> {
+    const job = this.jobs.get(streamId);
+    if (job?.createdAt !== expectedCreatedAt || job.firstSubscriberAttachedAt != null) {
+      return false;
+    }
+    job.firstSubscriberAttachedAt = attachedAt;
+    return true;
   }
 
   async markProviderExecutionDrained(

--- a/packages/api/src/stream/implementations/InMemoryJobStore.ts
+++ b/packages/api/src/stream/implementations/InMemoryJobStore.ts
@@ -22,6 +22,9 @@ import type {
   IdempotencyClaimValue,
   IdempotencyClaimResult,
   ContentPartsReadOptions,
+  ContentPartsRecoveryReadOptions,
+  ContentPartsRecoveryResult,
+  ContentPartsResult,
   ParkedSteerClaim,
   EarlyBufferRecoveryState,
   EarlyBufferRecoverySettlement,
@@ -1523,10 +1526,20 @@ export class InMemoryJobStore implements IJobStoreV2 {
   async getContentParts(
     streamId: string,
     expectedCreatedAt?: number,
-    _options?: ContentPartsReadOptions,
-  ): Promise<{
-    content: Agents.MessageContentComplex[];
-  } | null> {
+    options?: ContentPartsReadOptions,
+  ): Promise<ContentPartsResult | null>;
+
+  async getContentParts(
+    streamId: string,
+    expectedCreatedAt: number | undefined,
+    options: ContentPartsRecoveryReadOptions,
+  ): Promise<ContentPartsRecoveryResult | null>;
+
+  async getContentParts(
+    streamId: string,
+    expectedCreatedAt?: number,
+    options?: ContentPartsReadOptions | ContentPartsRecoveryReadOptions,
+  ): Promise<ContentPartsResult | ContentPartsRecoveryResult | null> {
     if (expectedCreatedAt != null && this.jobs.get(streamId)?.createdAt !== expectedCreatedAt) {
       return null;
     }
@@ -1536,6 +1549,9 @@ export class InMemoryJobStore implements IJobStoreV2 {
     }
     return {
       content: state.contentParts,
+      ...(options?.includeRecoveryStats && {
+        recoveryStats: { eventCount: 0, recoverySequences: [] },
+      }),
     };
   }
 

--- a/packages/api/src/stream/implementations/InMemoryJobStore.ts
+++ b/packages/api/src/stream/implementations/InMemoryJobStore.ts
@@ -1525,15 +1525,15 @@ export class InMemoryJobStore implements IJobStoreV2 {
    */
   async getContentParts(
     streamId: string,
-    expectedCreatedAt?: number,
-    options?: ContentPartsReadOptions,
-  ): Promise<ContentPartsResult | null>;
-
-  async getContentParts(
-    streamId: string,
     expectedCreatedAt: number | undefined,
     options: ContentPartsRecoveryReadOptions,
   ): Promise<ContentPartsRecoveryResult | null>;
+
+  async getContentParts(
+    streamId: string,
+    expectedCreatedAt?: number,
+    options?: ContentPartsReadOptions,
+  ): Promise<ContentPartsResult | null>;
 
   async getContentParts(
     streamId: string,

--- a/packages/api/src/stream/implementations/RedisJobStore.ts
+++ b/packages/api/src/stream/implementations/RedisJobStore.ts
@@ -25,6 +25,9 @@ import type {
   SteerReceipt,
   SteerReceiptInput,
   ContentPartsReadOptions,
+  ContentPartsRecoveryReadOptions,
+  ContentPartsRecoveryResult,
+  ContentPartsResult,
   ParkedSteerClaim,
   EarlyBufferRecoveryState,
   EarlyBufferRecoverySettlement,
@@ -3784,9 +3787,19 @@ export class RedisJobStore implements IJobStoreV2 {
     streamId: string,
     expectedCreatedAt?: number,
     options?: ContentPartsReadOptions,
-  ): Promise<{
-    content: Agents.MessageContentComplex[];
-  } | null> {
+  ): Promise<ContentPartsResult | null>;
+
+  async getContentParts(
+    streamId: string,
+    expectedCreatedAt: number | undefined,
+    options: ContentPartsRecoveryReadOptions,
+  ): Promise<ContentPartsRecoveryResult | null>;
+
+  async getContentParts(
+    streamId: string,
+    expectedCreatedAt?: number,
+    options?: ContentPartsReadOptions | ContentPartsRecoveryReadOptions,
+  ): Promise<ContentPartsResult | ContentPartsRecoveryResult | null> {
     // 1. Prefer the HOST content array (same-instance fast path): it already
     // contains host-authored steer parts the SDK graph never sees.
     const hostEntry = options?.includeRecoveryStats

--- a/packages/api/src/stream/implementations/RedisJobStore.ts
+++ b/packages/api/src/stream/implementations/RedisJobStore.ts
@@ -25,6 +25,7 @@ import type {
   SteerReceipt,
   SteerReceiptInput,
   ParkedSteerClaim,
+  EarlyBufferRecoveryState,
 } from '~/stream/interfaces/IJobStore';
 import type { ResolvedAskUserQuestion } from '~/agents/hitl/resume';
 import type { RecoveredSteerPayload } from '~/stream/SteerRecovery';
@@ -616,6 +617,17 @@ const JOB_UPDATE_LUA =
   'if runStepsTtl == 0 then redis.call("DEL", KEYS[3]) else redis.call("EXPIRE", KEYS[3], runStepsTtl) end ' +
   'end ' +
   'return 1';
+
+const EARLY_BUFFER_RECOVERY_SETTLE_LUA =
+  'if redis.call("HGET", KEYS[1], "createdAt") ~= ARGV[1] then return 0 end ' +
+  'local raw = redis.call("HGET", KEYS[1], "earlyBufferRecovery") if not raw then return 0 end ' +
+  'local ok, current = pcall(cjson.decode, raw) ' +
+  'if not ok or current.correlationId ~= ARGV[2] or current.outcome then return 0 end ' +
+  'redis.call("HSET", KEYS[1], "earlyBufferRecovery", ARGV[3]) return 1';
+
+const FIRST_SUBSCRIBER_CLAIM_LUA =
+  'if redis.call("HGET", KEYS[1], "createdAt") ~= ARGV[1] then return 0 end ' +
+  'return redis.call("HSETNX", KEYS[1], "firstSubscriberAttachedAt", ARGV[2])';
 
 /** Exact provider-segment completion fence. A paused segment finishing after a
  * resume cannot mark the resumed provider drained because its opaque id differs. */
@@ -2284,6 +2296,44 @@ export class RedisJobStore implements IJobStoreV2 {
         expectedCreatedAt ?? observedJob?.createdAt,
       );
     }
+  }
+
+  async settleEarlyBufferRecovery(
+    streamId: string,
+    expectedCreatedAt: number,
+    correlationId: string,
+    recovery: EarlyBufferRecoveryState,
+  ): Promise<boolean> {
+    return (
+      Number(
+        await this.redis.eval(
+          EARLY_BUFFER_RECOVERY_SETTLE_LUA,
+          1,
+          KEYS.job(streamId),
+          String(expectedCreatedAt),
+          correlationId,
+          JSON.stringify(recovery),
+        ),
+      ) === 1
+    );
+  }
+
+  async claimFirstSubscriberAttachment(
+    streamId: string,
+    expectedCreatedAt: number,
+    attachedAt: number,
+  ): Promise<boolean> {
+    return (
+      Number(
+        await this.redis.eval(
+          FIRST_SUBSCRIBER_CLAIM_LUA,
+          1,
+          KEYS.job(streamId),
+          String(expectedCreatedAt),
+          String(attachedAt),
+        ),
+      ) === 1
+    );
   }
 
   async markProviderExecutionDrained(
@@ -4658,6 +4708,24 @@ export class RedisJobStore implements IJobStoreV2 {
       .filter(Boolean);
   }
 
+  async getRecoveryEventStats(
+    streamId: string,
+    expectedCreatedAt?: number,
+  ): Promise<{ eventCount: number; recoverySequences: number[] } | null> {
+    const chunks = await this.getChunks(streamId, expectedCreatedAt);
+    if (chunks.length === 0) {
+      return null;
+    }
+    const recoverySequences: number[] = [];
+    for (const chunk of chunks) {
+      const sequence = (chunk as { recoverySequence?: unknown }).recoverySequence;
+      if (typeof sequence === 'number' && Number.isSafeInteger(sequence) && sequence > 0) {
+        recoverySequences.push(sequence);
+      }
+    }
+    return { eventCount: chunks.length, recoverySequences };
+  }
+
   /**
    * Save run steps for resume state. Uses the paused-window TTL script so a run-step save
    * landing at/after a HITL pause extends to the approval window instead of resetting the
@@ -4916,6 +4984,12 @@ export class RedisJobStore implements IJobStoreV2 {
       completedAt: data.completedAt ? parseInt(data.completedAt, 10) : undefined,
       conversationId: data.conversationId || undefined,
       error: data.error || undefined,
+      earlyBufferRecovery: data.earlyBufferRecovery
+        ? JSON.parse(data.earlyBufferRecovery)
+        : undefined,
+      firstSubscriberAttachedAt: data.firstSubscriberAttachedAt
+        ? parseInt(data.firstSubscriberAttachedAt, 10)
+        : undefined,
       idempotencyClientRequestId: data.idempotencyClientRequestId || undefined,
       recoveredSteerId: data.recoveredSteerId || undefined,
       userMessage: data.userMessage ? JSON.parse(data.userMessage) : undefined,

--- a/packages/api/src/stream/implementations/RedisJobStore.ts
+++ b/packages/api/src/stream/implementations/RedisJobStore.ts
@@ -140,6 +140,11 @@ const JOB_CAS_LUA =
   'local currentCreatedAt = redis.call("HGET", KEYS[1], "createdAt") ' +
   'local ttl = tonumber(ARGV[5]) ' +
   'local terminal = ARGV[6] == "1" ' +
+  'local preserveRecoverySources = false ' +
+  'if terminal and redis.call("HGET", KEYS[1], "firstSubscriberAttachedAt") then ' +
+  'local recoveryRaw = redis.call("HGET", KEYS[1], "earlyBufferRecovery") ' +
+  'if recoveryRaw then local recoveryOk, recovery = pcall(cjson.decode, recoveryRaw) ' +
+  'preserveRecoverySources = not recoveryOk or type(recovery) ~= "table" or recovery.outcome == nil end end ' +
   'local chunksTtl = tonumber(ARGV[7]) ' +
   'local runStepsTtl = tonumber(ARGV[8]) ' +
   'local parkedTtl = tonumber(ARGV[9]) ' +
@@ -238,8 +243,10 @@ const JOB_CAS_LUA =
   'redis.call("SET", KEYS[7], cjson.encode(parked), "EX", parkedTtl) ' +
   'end ' +
   'redis.call("DEL", KEYS[5], KEYS[6]) ' +
-  'if chunksTtl == 0 then redis.call("DEL", KEYS[3]) else redis.call("EXPIRE", KEYS[3], chunksTtl) end ' +
-  'if runStepsTtl == 0 then redis.call("DEL", KEYS[4]) else redis.call("EXPIRE", KEYS[4], runStepsTtl) end ' +
+  'if preserveRecoverySources then redis.call("EXPIRE", KEYS[3], ttl) ' +
+  'elseif chunksTtl == 0 then redis.call("DEL", KEYS[3]) else redis.call("EXPIRE", KEYS[3], chunksTtl) end ' +
+  'if preserveRecoverySources then redis.call("EXPIRE", KEYS[4], ttl) ' +
+  'elseif runStepsTtl == 0 then redis.call("DEL", KEYS[4]) else redis.call("EXPIRE", KEYS[4], runStepsTtl) end ' +
   'if ARGV[12] == "1" then if #items == 0 then return "[]" end return cjson.encode(items) end ' +
   'else ' +
   'redis.call("EXPIRE", KEYS[3], ttl) ' +

--- a/packages/api/src/stream/implementations/RedisJobStore.ts
+++ b/packages/api/src/stream/implementations/RedisJobStore.ts
@@ -3785,15 +3785,15 @@ export class RedisJobStore implements IJobStoreV2 {
 
   async getContentParts(
     streamId: string,
-    expectedCreatedAt?: number,
-    options?: ContentPartsReadOptions,
-  ): Promise<ContentPartsResult | null>;
-
-  async getContentParts(
-    streamId: string,
     expectedCreatedAt: number | undefined,
     options: ContentPartsRecoveryReadOptions,
   ): Promise<ContentPartsRecoveryResult | null>;
+
+  async getContentParts(
+    streamId: string,
+    expectedCreatedAt?: number,
+    options?: ContentPartsReadOptions,
+  ): Promise<ContentPartsResult | null>;
 
   async getContentParts(
     streamId: string,

--- a/packages/api/src/stream/implementations/RedisJobStore.ts
+++ b/packages/api/src/stream/implementations/RedisJobStore.ts
@@ -24,6 +24,7 @@ import type {
   TerminalSteerAdmissionResult,
   SteerReceipt,
   SteerReceiptInput,
+  ContentPartsReadOptions,
   ParkedSteerClaim,
   EarlyBufferRecoveryState,
   EarlyBufferRecoverySettlement,
@@ -3782,12 +3783,15 @@ export class RedisJobStore implements IJobStoreV2 {
   async getContentParts(
     streamId: string,
     expectedCreatedAt?: number,
+    options?: ContentPartsReadOptions,
   ): Promise<{
     content: Agents.MessageContentComplex[];
   } | null> {
     // 1. Prefer the HOST content array (same-instance fast path): it already
     // contains host-authored steer parts the SDK graph never sees.
-    const hostEntry = this.getLocalEntry(this.localContentParts, streamId, expectedCreatedAt);
+    const hostEntry = options?.includeRecoveryStats
+      ? undefined
+      : this.getLocalEntry(this.localContentParts, streamId, expectedCreatedAt);
     if (hostEntry) {
       const hostParts = hostEntry.value.deref();
       if (hostParts && hostParts.length > 0) {
@@ -3802,7 +3806,9 @@ export class RedisJobStore implements IJobStoreV2 {
     // lacks host-authored steer parts, so overlay them from the chunk log —
     // insert (not assign): the graph array is UNSHIFTED, while recorded steer
     // indices are host-view positions that already account for prior steers.
-    const graphEntry = this.getLocalEntry(this.localGraphCache, streamId, expectedCreatedAt);
+    const graphEntry = options?.includeRecoveryStats
+      ? undefined
+      : this.getLocalEntry(this.localGraphCache, streamId, expectedCreatedAt);
     if (graphEntry) {
       const graph = graphEntry.value.deref();
       if (graph) {
@@ -4032,6 +4038,17 @@ export class RedisJobStore implements IJobStoreV2 {
 
     return {
       content: filtered,
+      ...(options?.includeRecoveryStats && {
+        recoveryStats: {
+          eventCount: chunks.length,
+          recoverySequences: chunks.flatMap((chunk) => {
+            const sequence = (chunk as { recoverySequence?: number }).recoverySequence;
+            return typeof sequence === 'number' && Number.isSafeInteger(sequence) && sequence > 0
+              ? [sequence]
+              : [];
+          }),
+        },
+      }),
     };
   }
 
@@ -4711,24 +4728,6 @@ export class RedisJobStore implements IJobStoreV2 {
         return null;
       })
       .filter(Boolean);
-  }
-
-  async getRecoveryEventStats(
-    streamId: string,
-    expectedCreatedAt?: number,
-  ): Promise<{ eventCount: number; recoverySequences: number[] } | null> {
-    const chunks = await this.getChunks(streamId, expectedCreatedAt);
-    if (chunks.length === 0) {
-      return null;
-    }
-    const recoverySequences: number[] = [];
-    for (const chunk of chunks) {
-      const sequence = (chunk as { recoverySequence?: number }).recoverySequence;
-      if (typeof sequence === 'number' && Number.isSafeInteger(sequence) && sequence > 0) {
-        recoverySequences.push(sequence);
-      }
-    }
-    return { eventCount: chunks.length, recoverySequences };
   }
 
   /**

--- a/packages/api/src/stream/implementations/RedisJobStore.ts
+++ b/packages/api/src/stream/implementations/RedisJobStore.ts
@@ -26,6 +26,7 @@ import type {
   SteerReceiptInput,
   ParkedSteerClaim,
   EarlyBufferRecoveryState,
+  EarlyBufferRecoverySettlement,
 } from '~/stream/interfaces/IJobStore';
 import type { ResolvedAskUserQuestion } from '~/agents/hitl/resume';
 import type { RecoveredSteerPayload } from '~/stream/SteerRecovery';
@@ -619,11 +620,12 @@ const JOB_UPDATE_LUA =
   'return 1';
 
 const EARLY_BUFFER_RECOVERY_SETTLE_LUA =
-  'if redis.call("HGET", KEYS[1], "createdAt") ~= ARGV[1] then return 0 end ' +
-  'local raw = redis.call("HGET", KEYS[1], "earlyBufferRecovery") if not raw then return 0 end ' +
+  'if redis.call("HGET", KEYS[1], "createdAt") ~= ARGV[1] then return nil end ' +
+  'local raw = redis.call("HGET", KEYS[1], "earlyBufferRecovery") if not raw then return nil end ' +
   'local ok, current = pcall(cjson.decode, raw) ' +
-  'if not ok or current.correlationId ~= ARGV[2] or current.outcome then return 0 end ' +
-  'redis.call("HSET", KEYS[1], "earlyBufferRecovery", ARGV[3]) return 1';
+  'if not ok or current.correlationId ~= ARGV[2] then return nil end ' +
+  'if current.outcome then return {raw, "0"} end ' +
+  'redis.call("HSET", KEYS[1], "earlyBufferRecovery", ARGV[3]) return {ARGV[3], "1"}';
 
 const FIRST_SUBSCRIBER_CLAIM_LUA =
   'if redis.call("HGET", KEYS[1], "createdAt") ~= ARGV[1] then return 0 end ' +
@@ -2303,19 +2305,22 @@ export class RedisJobStore implements IJobStoreV2 {
     expectedCreatedAt: number,
     correlationId: string,
     recovery: EarlyBufferRecoveryState,
-  ): Promise<boolean> {
-    return (
-      Number(
-        await this.redis.eval(
-          EARLY_BUFFER_RECOVERY_SETTLE_LUA,
-          1,
-          KEYS.job(streamId),
-          String(expectedCreatedAt),
-          correlationId,
-          JSON.stringify(recovery),
-        ),
-      ) === 1
+  ): Promise<EarlyBufferRecoverySettlement | null> {
+    const settled = await this.redis.eval(
+      EARLY_BUFFER_RECOVERY_SETTLE_LUA,
+      1,
+      KEYS.job(streamId),
+      String(expectedCreatedAt),
+      correlationId,
+      JSON.stringify(recovery),
     );
+    if (!Array.isArray(settled) || typeof settled[0] !== 'string') {
+      return null;
+    }
+    return {
+      recovery: JSON.parse(settled[0]) as EarlyBufferRecoveryState,
+      committed: String(settled[1]) === '1',
+    };
   }
 
   async claimFirstSubscriberAttachment(
@@ -4718,7 +4723,7 @@ export class RedisJobStore implements IJobStoreV2 {
     }
     const recoverySequences: number[] = [];
     for (const chunk of chunks) {
-      const sequence = (chunk as { recoverySequence?: unknown }).recoverySequence;
+      const sequence = (chunk as { recoverySequence?: number }).recoverySequence;
       if (typeof sequence === 'number' && Number.isSafeInteger(sequence) && sequence > 0) {
         recoverySequences.push(sequence);
       }

--- a/packages/api/src/stream/interfaces/IJobStore.ts
+++ b/packages/api/src/stream/interfaces/IJobStore.ts
@@ -107,6 +107,7 @@ export type EarlyBufferRecoveryOutcome = 'success' | 'failure' | 'not_attempted'
 export type EarlyBufferRecoveryFailureReason =
   | 'durable_frontier_gap'
   | 'durable_state_missing'
+  | 'overflow_marker_persistence_failed'
   | 'snapshot_missing'
   | 'subscriber_never_attached'
   | 'reconstruction_error';
@@ -125,6 +126,12 @@ export interface EarlyBufferRecoveryState {
   reconstructedEventCount?: number;
   reconstructedContentCount?: number;
   failureReason?: EarlyBufferRecoveryFailureReason;
+}
+
+export interface EarlyBufferRecoverySettlement {
+  recovery: EarlyBufferRecoveryState;
+  /** True only for the replica that recorded the terminal outcome. */
+  committed: boolean;
 }
 
 /**
@@ -991,7 +998,7 @@ export interface IJobStore {
     expectedCreatedAt: number,
     correlationId: string,
     recovery: EarlyBufferRecoveryState,
-  ): Promise<boolean>;
+  ): Promise<EarlyBufferRecoverySettlement | null>;
   /** Claims first attachment once across replicas. */
   claimFirstSubscriberAttachment?(
     streamId: string,

--- a/packages/api/src/stream/interfaces/IJobStore.ts
+++ b/packages/api/src/stream/interfaces/IJobStore.ts
@@ -134,6 +134,21 @@ export interface EarlyBufferRecoverySettlement {
   committed: boolean;
 }
 
+export interface RecoveryEventStats {
+  eventCount: number;
+  recoverySequences: number[];
+}
+
+export interface ContentPartsReadOptions {
+  /** Force durable reconstruction and return its validation frontier in the same read. */
+  includeRecoveryStats?: boolean;
+}
+
+export interface ContentPartsResult {
+  content: Agents.MessageContentComplex[];
+  recoveryStats?: RecoveryEventStats;
+}
+
 /**
  * Serializable job data - no object references, suitable for Redis/external storage
  */
@@ -933,6 +948,7 @@ export interface IJobStore {
     updates: Partial<SerializableJobData>,
     expectedCreatedAt?: number,
   ): Promise<void>;
+
   transitionStatus(streamId: string, args: JobStatusTransition): Promise<boolean>;
 
   claimIdempotencyKey(
@@ -986,12 +1002,8 @@ export interface IJobStore {
   getContentParts(
     streamId: string,
     expectedCreatedAt?: number,
-  ): Promise<{ content: Agents.MessageContentComplex[] } | null>;
-  /** Rare-path validation metadata for early-buffer recovery. */
-  getRecoveryEventStats?(
-    streamId: string,
-    expectedCreatedAt?: number,
-  ): Promise<{ eventCount: number; recoverySequences: number[] } | null>;
+    options?: ContentPartsReadOptions,
+  ): Promise<ContentPartsResult | null>;
   /** Atomically records the one terminal outcome for an overflow correlation id. */
   settleEarlyBufferRecovery?(
     streamId: string,
@@ -1093,6 +1105,21 @@ export interface IJobStoreV2 extends IJobStore {
     updates: Partial<SerializableJobData>,
     expectedCreatedAt?: number,
   ): Promise<void>;
+
+  /** Atomically records or returns the existing terminal recovery outcome. */
+  settleEarlyBufferRecovery(
+    streamId: string,
+    expectedCreatedAt: number,
+    correlationId: string,
+    recovery: EarlyBufferRecoveryState,
+  ): Promise<EarlyBufferRecoverySettlement | null>;
+
+  /** Claims first attachment once across replicas. */
+  claimFirstSubscriberAttachment(
+    streamId: string,
+    expectedCreatedAt: number,
+    attachedAt: number,
+  ): Promise<boolean>;
 
   /** Atomically marks only the exact provider segment as fully unwound. */
   markProviderExecutionDrained(
@@ -1323,9 +1350,8 @@ export interface IJobStoreV2 extends IJobStore {
   getContentParts(
     streamId: string,
     expectedCreatedAt?: number,
-  ): Promise<{
-    content: Agents.MessageContentComplex[];
-  } | null>;
+    options?: ContentPartsReadOptions,
+  ): Promise<ContentPartsResult | null>;
 
   /**
    * Get run steps for a job (for resume state).

--- a/packages/api/src/stream/interfaces/IJobStore.ts
+++ b/packages/api/src/stream/interfaces/IJobStore.ts
@@ -1008,14 +1008,14 @@ export interface IJobStore {
   ): void;
   getContentParts(
     streamId: string,
-    expectedCreatedAt?: number,
-    options?: ContentPartsReadOptions,
-  ): Promise<ContentPartsResult | null>;
-  getContentParts(
-    streamId: string,
     expectedCreatedAt: number | undefined,
     options: ContentPartsRecoveryReadOptions,
   ): Promise<ContentPartsRecoveryResult | null>;
+  getContentParts(
+    streamId: string,
+    expectedCreatedAt?: number,
+    options?: ContentPartsReadOptions,
+  ): Promise<ContentPartsResult | null>;
   /** Atomically records the one terminal outcome for an overflow correlation id. */
   settleEarlyBufferRecovery?(
     streamId: string,
@@ -1361,14 +1361,14 @@ export interface IJobStoreV2 extends IJobStore {
    */
   getContentParts(
     streamId: string,
-    expectedCreatedAt?: number,
-    options?: ContentPartsReadOptions,
-  ): Promise<ContentPartsResult | null>;
-  getContentParts(
-    streamId: string,
     expectedCreatedAt: number | undefined,
     options: ContentPartsRecoveryReadOptions,
   ): Promise<ContentPartsRecoveryResult | null>;
+  getContentParts(
+    streamId: string,
+    expectedCreatedAt?: number,
+    options?: ContentPartsReadOptions,
+  ): Promise<ContentPartsResult | null>;
 
   /**
    * Get run steps for a job (for resume state).

--- a/packages/api/src/stream/interfaces/IJobStore.ts
+++ b/packages/api/src/stream/interfaces/IJobStore.ts
@@ -102,6 +102,31 @@ export type JobStatus = 'running' | 'complete' | 'error' | 'aborted' | 'requires
  * Missing markers on pre-rollout records are interpreted as protocol v1. */
 export type GenerationProtocolVersion = 1 | 2;
 
+export type EarlyBufferRecoverySource = 'redis' | 'snapshot';
+export type EarlyBufferRecoveryOutcome = 'success' | 'failure' | 'not_attempted';
+export type EarlyBufferRecoveryFailureReason =
+  | 'durable_frontier_gap'
+  | 'durable_state_missing'
+  | 'snapshot_missing'
+  | 'subscriber_never_attached'
+  | 'reconstruction_error';
+
+export interface EarlyBufferRecoveryState {
+  /** Random, non-sensitive identifier used to join overflow and recovery telemetry. */
+  correlationId: string;
+  overflowedAt: number;
+  /** Number of reconstructable events emitted through this runtime at overflow. */
+  durableFrontier: number;
+  source?: EarlyBufferRecoverySource;
+  startedAt?: number;
+  outcome?: EarlyBufferRecoveryOutcome;
+  completedAt?: number;
+  durationMs?: number;
+  reconstructedEventCount?: number;
+  reconstructedContentCount?: number;
+  failureReason?: EarlyBufferRecoveryFailureReason;
+}
+
 /**
  * Serializable job data - no object references, suitable for Redis/external storage
  */
@@ -120,6 +145,10 @@ export interface SerializableJobData {
   completedAt?: number;
   conversationId?: string;
   error?: string;
+  /** Durable accounting for an early-event buffer overflow and its single recovery outcome. */
+  earlyBufferRecovery?: EarlyBufferRecoveryState;
+  /** First subscriber attachment across all replicas. */
+  firstSubscriberAttachedAt?: number;
 
   /** Stable identity of the HTTP submission that created this generation.
    * Internal-only: lets an expired idempotency lease recognize the same live
@@ -951,6 +980,24 @@ export interface IJobStore {
     streamId: string,
     expectedCreatedAt?: number,
   ): Promise<{ content: Agents.MessageContentComplex[] } | null>;
+  /** Rare-path validation metadata for early-buffer recovery. */
+  getRecoveryEventStats?(
+    streamId: string,
+    expectedCreatedAt?: number,
+  ): Promise<{ eventCount: number; recoverySequences: number[] } | null>;
+  /** Atomically records the one terminal outcome for an overflow correlation id. */
+  settleEarlyBufferRecovery?(
+    streamId: string,
+    expectedCreatedAt: number,
+    correlationId: string,
+    recovery: EarlyBufferRecoveryState,
+  ): Promise<boolean>;
+  /** Claims first attachment once across replicas. */
+  claimFirstSubscriberAttachment?(
+    streamId: string,
+    expectedCreatedAt: number,
+    attachedAt: number,
+  ): Promise<boolean>;
   getRunSteps(streamId: string, expectedCreatedAt?: number): Promise<Agents.RunStep[]>;
 
   /** Legacy stores returned `void`; v2 stores return whether the epoch-fenced

--- a/packages/api/src/stream/interfaces/IJobStore.ts
+++ b/packages/api/src/stream/interfaces/IJobStore.ts
@@ -140,13 +140,20 @@ export interface RecoveryEventStats {
 }
 
 export interface ContentPartsReadOptions {
+  includeRecoveryStats?: false;
+}
+
+export interface ContentPartsRecoveryReadOptions {
   /** Force durable reconstruction and return its validation frontier in the same read. */
-  includeRecoveryStats?: boolean;
+  includeRecoveryStats: true;
 }
 
 export interface ContentPartsResult {
   content: Agents.MessageContentComplex[];
-  recoveryStats?: RecoveryEventStats;
+}
+
+export interface ContentPartsRecoveryResult extends ContentPartsResult {
+  recoveryStats: RecoveryEventStats;
 }
 
 /**
@@ -1004,6 +1011,11 @@ export interface IJobStore {
     expectedCreatedAt?: number,
     options?: ContentPartsReadOptions,
   ): Promise<ContentPartsResult | null>;
+  getContentParts(
+    streamId: string,
+    expectedCreatedAt: number | undefined,
+    options: ContentPartsRecoveryReadOptions,
+  ): Promise<ContentPartsRecoveryResult | null>;
   /** Atomically records the one terminal outcome for an overflow correlation id. */
   settleEarlyBufferRecovery?(
     streamId: string,
@@ -1352,6 +1364,11 @@ export interface IJobStoreV2 extends IJobStore {
     expectedCreatedAt?: number,
     options?: ContentPartsReadOptions,
   ): Promise<ContentPartsResult | null>;
+  getContentParts(
+    streamId: string,
+    expectedCreatedAt: number | undefined,
+    options: ContentPartsRecoveryReadOptions,
+  ): Promise<ContentPartsRecoveryResult | null>;
 
   /**
    * Get run steps for a job (for resume state).

--- a/packages/api/src/stream/jobStoreCapabilities.ts
+++ b/packages/api/src/stream/jobStoreCapabilities.ts
@@ -10,6 +10,8 @@ import type { IJobStore, IJobStoreV2 } from './interfaces/IJobStore';
  */
 export const JOB_STORE_V2_REQUIRED_METHODS = [
   'acknowledgeReplacedJobs',
+  'settleEarlyBufferRecovery',
+  'claimFirstSubscriberAttachment',
   'markProviderExecutionDrained',
   'beginProviderExecution',
   'getCleanupBlockingJobIdsByUser',
@@ -37,7 +39,13 @@ export type JobStoreV2RequiredMethod = (typeof JOB_STORE_V2_REQUIRED_METHODS)[nu
 type MethodKeys<T> = {
   [Key in keyof T]-?: NonNullable<T[Key]> extends (...args: never[]) => unknown ? Key : never;
 }[keyof T];
-type V2OnlyMethod = Exclude<MethodKeys<IJobStoreV2>, keyof IJobStore>;
+type RequiredKeys<T> = {
+  [Key in keyof T]-?: object extends Pick<T, Key> ? never : Key;
+}[keyof T];
+type RequiredMethodKeys<T> = Extract<MethodKeys<T>, RequiredKeys<T>>;
+type V2OnlyMethod =
+  | Exclude<MethodKeys<IJobStoreV2>, keyof IJobStore>
+  | Exclude<RequiredMethodKeys<IJobStoreV2>, RequiredMethodKeys<IJobStore>>;
 type SameUnion<Left, Right> = [Left] extends [Right]
   ? [Right] extends [Left]
     ? true


### PR DESCRIPTION
## Summary
- persist a non-sensitive overflow correlation marker and validate the durable recovery frontier before reconnect
- emit one atomic recovery outcome with explicit generation_recovery_failed terminal handling for missing or incomplete durable state
- add bounded recovery and attachment metrics plus focused Redis integration coverage above 5,000 buffered events and across replicas

## Dashboard query
Recovery success ratio:

```promql
sum(rate(generation_stream_early_buffer_recoveries_total{outcome="success"}[5m])) / sum(rate(generation_stream_early_buffer_overflows_total[5m]))
```

## Validation
- focused ESLint on 7 touched files
- focused Prettier check on 7 touched files
- import sorting on 7 touched files
- git diff --check
- scoped TypeScript diagnostics: no errors in touched stream/metrics files
- Redis integration tests deferred to CI because the existing local dependency tree is missing required runtime packages
- full suites deferred to CI by design