### PR TITLE
🧺 fix: Contain Conversation Import and Upload Failures

### DIFF
--- a/api/server/routes/__test-utils__/convos-route-mocks.js
+++ b/api/server/routes/__test-utils__/convos-route-mocks.js
@@ -106,6 +106,7 @@ module.exports = {
     deleteConvoSharedLinksWithCleanup: jest.fn(),
     deleteAllSharedLinksWithCleanup: jest.fn(),
     deleteAgentCheckpoints: jest.fn(),
+    isConversationImportError: jest.fn((error) => error?.name === 'ConversationImportError'),
     ...overrides,
   }),
 

--- a/api/server/routes/__tests__/convos.spec.js
+++ b/api/server/routes/__tests__/convos.spec.js
@@ -271,6 +271,36 @@ describe('Convos Routes', () => {
       const { logger } = require('@librechat/data-schemas');
       expect(logger.error).not.toHaveBeenCalled();
     });
+
+    it('returns an actionable client error for an oversized imported record', async () => {
+      const message = 'Each imported conversation or message must be at most 16711680 bytes';
+      const error = Object.assign(new Error(message), {
+        name: 'ConversationImportError',
+        code: 'invalid_request',
+        statusCode: 413,
+        body: { error: 'invalid_request', message },
+      });
+      importConversations.mockRejectedValue(error);
+
+      const response = await request(app).post('/api/convos/import');
+
+      expect(response.status).toBe(413);
+      expect(response.body).toEqual(error.body);
+      const { logger } = require('@librechat/data-schemas');
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it('preserves the generic server error contract for other import failures', async () => {
+      const error = new Error('invalid JSON');
+      importConversations.mockRejectedValue(error);
+
+      const response = await request(app).post('/api/convos/import');
+
+      expect(response.status).toBe(500);
+      expect(response.text).toBe('Error processing file');
+      const { logger } = require('@librechat/data-schemas');
+      expect(logger.error).toHaveBeenCalledWith('Error processing file', error);
+    });
   });
 
   describe('POST /fork', () => {

--- a/api/server/routes/__tests__/convos.spec.js
+++ b/api/server/routes/__tests__/convos.spec.js
@@ -357,6 +357,27 @@ describe('Convos Routes', () => {
       expect(response.body).toEqual(error.body);
       expect(JSON.stringify(response.body)).not.toContain('PRIVATE-SENTINEL');
     });
+
+    it('returns an actionable client error when a cloned record is oversized', async () => {
+      const message = 'Each imported conversation or message must be at most 16711680 bytes';
+      const error = Object.assign(new Error(message), {
+        name: 'ConversationImportError',
+        code: 'invalid_request',
+        statusCode: 413,
+        body: { error: 'invalid_request', message },
+      });
+      forkConversation.mockRejectedValue(error);
+
+      const response = await request(app).post('/api/convos/fork').send({
+        conversationId: 'source-convo',
+        messageId: 'source-message',
+      });
+
+      expect(response.status).toBe(413);
+      expect(response.body).toEqual(error.body);
+      const { logger } = require('@librechat/data-schemas');
+      expect(logger.error).not.toHaveBeenCalled();
+    });
   });
 
   describe('POST /duplicate', () => {
@@ -411,6 +432,26 @@ describe('Convos Routes', () => {
       expect(response.status).toBe(400);
       expect(response.body).toEqual(error.body);
       expect(JSON.stringify(response.body)).not.toContain('PRIVATE-SENTINEL');
+    });
+
+    it('returns an actionable client error when a cloned record is oversized', async () => {
+      const message = 'Each imported conversation or message must be at most 16711680 bytes';
+      const error = Object.assign(new Error(message), {
+        name: 'ConversationImportError',
+        code: 'invalid_request',
+        statusCode: 413,
+        body: { error: 'invalid_request', message },
+      });
+      duplicateConversation.mockRejectedValue(error);
+
+      const response = await request(app)
+        .post('/api/convos/duplicate')
+        .send({ conversationId: 'source-convo' });
+
+      expect(response.status).toBe(413);
+      expect(response.body).toEqual(error.body);
+      const { logger } = require('@librechat/data-schemas');
+      expect(logger.error).not.toHaveBeenCalled();
     });
   });
 

--- a/api/server/routes/__tests__/share.spec.js
+++ b/api/server/routes/__tests__/share.spec.js
@@ -112,6 +112,7 @@ jest.mock('@librechat/api', () => ({
     (error) =>
       error?.code === 'content_filter_block' || error?.code === 'content_filter_uninspectable',
   ),
+  isConversationImportError: jest.fn((error) => error?.name === 'ConversationImportError'),
 }));
 
 jest.mock('@librechat/data-schemas', () => ({
@@ -1527,6 +1528,23 @@ describe('share fork route', () => {
     const response = await request(buildApp()).post('/api/share/share-123/fork');
 
     expect(response.status).toBe(500);
+  });
+
+  it('returns an actionable client error when a cloned record is oversized', async () => {
+    const message = 'Each imported conversation or message must be at most 16711680 bytes';
+    const error = Object.assign(new Error(message), {
+      name: 'ConversationImportError',
+      code: 'invalid_request',
+      statusCode: 413,
+      body: { error: 'invalid_request', message },
+    });
+    forkSharedConversation.mockRejectedValue(error);
+
+    const response = await request(buildApp()).post('/api/share/share-123/fork');
+
+    expect(response.status).toBe(413);
+    expect(response.body).toEqual(error.body);
+    expect(logger.error).not.toHaveBeenCalled();
   });
 
   it('answers 409 when the viewer forks a payload the owner has republished', async () => {

--- a/api/server/routes/convos.js
+++ b/api/server/routes/convos.js
@@ -782,6 +782,9 @@ router.post('/fork', forkIpLimiter, forkUserLimiter, configMiddleware, async (re
     if (isContentFilterError(error)) {
       return res.status(error.statusCode).json(error.body);
     }
+    if (isConversationImportError(error)) {
+      return res.status(error.statusCode).json(error.body);
+    }
     logger.error('Error forking conversation:', error);
     res.status(500).send('Error forking conversation');
   }
@@ -809,6 +812,9 @@ router.post(
       res.status(201).json(result);
     } catch (error) {
       if (isContentFilterError(error)) {
+        return res.status(error.statusCode).json(error.body);
+      }
+      if (isConversationImportError(error)) {
         return res.status(error.statusCode).json(error.body);
       }
       logger.error('Error duplicating conversation:', error);

--- a/api/server/routes/convos.js
+++ b/api/server/routes/convos.js
@@ -19,6 +19,7 @@ const {
   inspectContent,
   createContentFilter,
   isContentFilterError,
+  isConversationImportError,
   contentFilterBlockResponse,
   extractConversationTitleContent,
   extractStoredMessageContent,
@@ -739,6 +740,9 @@ router.post(
       res.status(201).json({ message: 'Conversation(s) imported successfully' });
     } catch (error) {
       if (isContentFilterError(error)) {
+        return res.status(error.statusCode).json(error.body);
+      }
+      if (isConversationImportError(error)) {
         return res.status(error.statusCode).json(error.body);
       }
       logger.error('Error processing file', error);

--- a/api/server/routes/files/multer.js
+++ b/api/server/routes/files/multer.js
@@ -3,6 +3,7 @@ const path = require('path');
 const crypto = require('crypto');
 const multer = require('multer');
 const { sanitizeFilename, createCustomError } = require('@librechat/api');
+const { logger } = require('@librechat/data-schemas');
 const {
   mergeFileConfig,
   inferMimeType,
@@ -20,8 +21,13 @@ const createStorage = ({ uniqueTempPath = false } = {}) =>
         if (!fs.existsSync(outputPath)) {
           fs.mkdirSync(outputPath, { recursive: true });
         }
-      } catch {
-        return cb(createCustomError(500, 'Failed to prepare upload directory'));
+      } catch (error) {
+        logger.error(
+          `Failed to prepare upload directory: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        const uploadError = createCustomError(500, 'Failed to prepare upload directory');
+        uploadError.cause = error;
+        return cb(uploadError);
       }
       cb(null, outputPath);
     },

--- a/api/server/routes/files/multer.js
+++ b/api/server/routes/files/multer.js
@@ -16,14 +16,22 @@ const createStorage = ({ uniqueTempPath = false } = {}) =>
     destination: function (req, file, cb) {
       const appConfig = req.config;
       const outputPath = path.join(appConfig.paths.uploads, 'temp', req.user.id);
-      if (!fs.existsSync(outputPath)) {
-        fs.mkdirSync(outputPath, { recursive: true });
+      try {
+        if (!fs.existsSync(outputPath)) {
+          fs.mkdirSync(outputPath, { recursive: true });
+        }
+      } catch {
+        return cb(createCustomError(500, 'Failed to prepare upload directory'));
       }
       cb(null, outputPath);
     },
     filename: function (req, file, cb) {
       req.file_id = crypto.randomUUID();
-      file.originalname = decodeURIComponent(file.originalname);
+      try {
+        file.originalname = decodeURIComponent(file.originalname);
+      } catch {
+        return cb(createCustomError(400, 'Invalid filename encoding'));
+      }
       const sanitizedFilename = sanitizeFilename(file.originalname);
       const stagedFilename = uniqueTempPath
         ? sanitizeFilename(`${req.file_id}-${sanitizedFilename}`)

--- a/api/server/routes/files/multer.spec.js
+++ b/api/server/routes/files/multer.spec.js
@@ -8,6 +8,7 @@ const multer = require('multer');
 const express = require('express');
 const request = require('supertest');
 const { ErrorController } = require('@librechat/api');
+const { logger } = require('@librechat/data-schemas');
 const {
   createMulterInstance,
   createStorage,
@@ -591,17 +592,24 @@ describe('Multer Configuration', () => {
     });
 
     it('should report file system errors through the storage callback', (done) => {
+      const loggerError = jest.spyOn(logger, 'error').mockImplementation();
+      const filesystemError = new Error('permission denied');
       const mkdir = jest.spyOn(fs, 'mkdirSync').mockImplementationOnce(() => {
-        throw new Error('permission denied');
+        throw filesystemError;
       });
 
       storage.getDestination(mockReq, mockFile, (err, destination) => {
         expect(err).toMatchObject({
           statusCode: 500,
           body: { message: 'Failed to prepare upload directory' },
+          cause: filesystemError,
         });
         expect(destination).toBeUndefined();
+        expect(loggerError).toHaveBeenCalledWith(
+          'Failed to prepare upload directory: permission denied',
+        );
         mkdir.mockRestore();
+        loggerError.mockRestore();
         done();
       });
     });

--- a/api/server/routes/files/multer.spec.js
+++ b/api/server/routes/files/multer.spec.js
@@ -4,6 +4,10 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const crypto = require('crypto');
+const multer = require('multer');
+const express = require('express');
+const request = require('supertest');
+const { ErrorController } = require('@librechat/api');
 const {
   createMulterInstance,
   createStorage,
@@ -119,6 +123,19 @@ describe('Multer Configuration', () => {
         });
 
         storage.getFilename(mockReq, encodedFile, cb);
+      });
+
+      it('returns a controlled error for malformed URI encoding', (done) => {
+        const malformedFile = { ...mockFile, originalname: '%.json' };
+
+        storage.getFilename(mockReq, malformedFile, (err, filename) => {
+          expect(err).toMatchObject({
+            statusCode: 400,
+            body: { message: 'Invalid filename encoding' },
+          });
+          expect(filename).toBeUndefined();
+          done();
+        });
       });
 
       it('should call real sanitizeFilename with properly encoded filename', (done) => {
@@ -573,15 +590,56 @@ describe('Multer Configuration', () => {
       }).not.toThrow();
     });
 
-    it('should handle file system errors when directory creation fails', () => {
-      // Test with a non-existent parent directory to simulate fs issues
-      const invalidPath = '/nonexistent/path/that/should/not/exist';
-      mockReq.config.paths.uploads = invalidPath;
+    it('should report file system errors through the storage callback', (done) => {
+      const mkdir = jest.spyOn(fs, 'mkdirSync').mockImplementationOnce(() => {
+        throw new Error('permission denied');
+      });
 
-      // The current implementation doesn't catch errors, so they're thrown synchronously
-      expect(() => {
-        storage.getDestination(mockReq, mockFile, jest.fn());
-      }).toThrow();
+      storage.getDestination(mockReq, mockFile, (err, destination) => {
+        expect(err).toMatchObject({
+          statusCode: 500,
+          body: { message: 'Failed to prepare upload directory' },
+        });
+        expect(destination).toBeUndefined();
+        mkdir.mockRestore();
+        done();
+      });
+    });
+
+    it('keeps the upload server alive after rejecting a malformed filename', async () => {
+      const app = express();
+      const upload = multer({ storage });
+      app.use((req, res, next) => {
+        req.user = mockReq.user;
+        req.config = mockReq.config;
+        next();
+      });
+      app.post('/upload', upload.single('file'), (req, res) => {
+        res.status(201).json({
+          originalname: req.file.originalname,
+          filename: req.file.filename,
+        });
+      });
+      app.use(ErrorController);
+
+      const malformed = await request(app).post('/upload').attach('file', Buffer.from('{}'), {
+        filename: '%.json',
+        contentType: 'application/json',
+      });
+
+      expect(malformed.status).toBe(400);
+      expect(malformed.body).toEqual({ message: 'Invalid filename encoding' });
+      const outputPath = path.join(tempDir, 'temp', 'test-user-123');
+      expect(fs.readdirSync(outputPath)).toEqual([]);
+
+      const healthy = await request(app).post('/upload').attach('file', Buffer.from('{}'), {
+        filename: 'healthy%20upload.json',
+        contentType: 'application/json',
+      });
+
+      expect(healthy.status).toBe(201);
+      expect(healthy.body.originalname).toBe('healthy upload.json');
+      expect(fs.existsSync(path.join(outputPath, healthy.body.filename))).toBe(true);
     });
 
     it('should handle malformed filenames with real sanitization', (done) => {

--- a/api/server/routes/share.js
+++ b/api/server/routes/share.js
@@ -5,6 +5,7 @@ const {
   createShareContentPreflight,
   isEnabled,
   isContentFilterError,
+  isConversationImportError,
   generateCheckAccess,
   grantCreationPermissions,
   ensureLinkPermissions,
@@ -437,6 +438,9 @@ if (allowSharedLinks) {
         return res.status(201).json(result);
       } catch (error) {
         if (isContentFilterError(error)) {
+          return res.status(error.statusCode).json(error.body);
+        }
+        if (isConversationImportError(error)) {
           return res.status(error.statusCode).json(error.body);
         }
         if (error?.code !== 'SHARE_REVISION_MISMATCH') {

--- a/api/server/utils/import/importBatchBuilder.js
+++ b/api/server/utils/import/importBatchBuilder.js
@@ -222,9 +222,10 @@ class ImportBatchBuilder {
         updateTagCounts: () => bulkIncrementTagCounts(this.requestUserId, tags),
         deleteMessages: () => deleteImportedMessages(cleanupScope),
         deleteConversations: () => deleteImportedConversations(cleanupScope),
-        onTagCountError: (error) => logger.error('Error updating imported tag counts', error),
+        onTagCountError: (error) =>
+          logger.error(`Error updating imported tag counts: ${error.message}`),
         onCleanupError: (error, resource) =>
-          logger.error(`Error cleaning imported ${resource}`, error),
+          logger.error(`Error cleaning imported ${resource}: ${error.message}`),
       });
       logger.debug(
         `user: ${this.requestUserId} | Added ${this.conversations.length} conversations and ${this.messages.length} messages to the DB.`,

--- a/api/server/utils/import/importBatchBuilder.js
+++ b/api/server/utils/import/importBatchBuilder.js
@@ -1,9 +1,12 @@
 const { v4: uuidv4 } = require('uuid');
 const {
+  assertConversationImportWriteSize,
   assertModelBoundContent,
   assertConversationImportContentAllowed,
+  executeConversationImportWrites,
 } = require('@librechat/api');
 const {
+  getTenantId,
   logger,
   createFallbackRetentionDate,
   createTempChatExpirationDate,
@@ -14,7 +17,14 @@ const {
   RetentionMode,
   openAISettings,
 } = require('librechat-data-provider');
-const { bulkIncrementTagCounts, bulkSaveConvos, bulkSaveMessages, getFiles } = require('~/models');
+const {
+  bulkIncrementTagCounts,
+  bulkSaveConvos,
+  bulkSaveMessages,
+  deleteImportedConversations,
+  deleteImportedMessages,
+  getFiles,
+} = require('~/models');
 const { FALLBACK_MODEL_BY_ENDPOINT } = require('./defaults');
 
 /**
@@ -177,6 +187,13 @@ class ImportBatchBuilder {
    * @throws {Error} If there is an error saving the batch.
    */
   async saveBatch() {
+    const tenantId = getTenantId();
+    assertConversationImportWriteSize({
+      conversations: this.conversations,
+      messages: this.messages,
+      ...(tenantId == null ? {} : { tenantId }),
+    });
+
     await assertConversationContentAllowed(
       this.filters,
       {
@@ -190,17 +207,25 @@ class ImportBatchBuilder {
       },
     );
 
+    const conversationIds = this.conversations.map((convo) => convo.conversationId);
+    const cleanupScope = {
+      user: this.requestUserId,
+      conversationIds,
+      ...(tenantId == null ? {} : { tenantId }),
+    };
+    const tags = this.conversations.flatMap((convo) => convo.tags);
+
     try {
-      const promises = [];
-      promises.push(bulkSaveConvos(this.conversations));
-      promises.push(bulkSaveMessages(this.messages, true));
-      promises.push(
-        bulkIncrementTagCounts(
-          this.requestUserId,
-          this.conversations.flatMap((convo) => convo.tags),
-        ),
-      );
-      await Promise.all(promises);
+      await executeConversationImportWrites({
+        saveConversations: () => bulkSaveConvos(this.conversations),
+        saveMessages: () => bulkSaveMessages(this.messages, true),
+        updateTagCounts: () => bulkIncrementTagCounts(this.requestUserId, tags),
+        deleteMessages: () => deleteImportedMessages(cleanupScope),
+        deleteConversations: () => deleteImportedConversations(cleanupScope),
+        onTagCountError: (error) => logger.error('Error updating imported tag counts', error),
+        onCleanupError: (error, resource) =>
+          logger.error(`Error cleaning imported ${resource}`, error),
+      });
       logger.debug(
         `user: ${this.requestUserId} | Added ${this.conversations.length} conversations and ${this.messages.length} messages to the DB.`,
       );

--- a/api/server/utils/import/importBatchBuilder.spec.js
+++ b/api/server/utils/import/importBatchBuilder.spec.js
@@ -15,13 +15,22 @@ const {
   inspectContent,
 } = require('@librechat/api');
 const { EModelEndpoint } = require('librechat-data-provider');
-const { bulkIncrementTagCounts, bulkSaveConvos, bulkSaveMessages, getFiles } = require('~/models');
+const {
+  bulkIncrementTagCounts,
+  bulkSaveConvos,
+  bulkSaveMessages,
+  deleteImportedConversations,
+  deleteImportedMessages,
+  getFiles,
+} = require('~/models');
 const { ImportBatchBuilder } = require('./importBatchBuilder');
 
 jest.mock('~/models', () => ({
   bulkIncrementTagCounts: jest.fn(),
   bulkSaveConvos: jest.fn(),
   bulkSaveMessages: jest.fn(),
+  deleteImportedConversations: jest.fn(),
+  deleteImportedMessages: jest.fn(),
   getFiles: jest.fn(),
 }));
 
@@ -70,6 +79,8 @@ describe('ImportBatchBuilder content filtering', () => {
     bulkIncrementTagCounts.mockResolvedValue();
     bulkSaveConvos.mockResolvedValue();
     bulkSaveMessages.mockResolvedValue();
+    deleteImportedConversations.mockResolvedValue();
+    deleteImportedMessages.mockResolvedValue();
     getFiles.mockResolvedValue([]);
   });
 
@@ -255,6 +266,36 @@ describe('ImportBatchBuilder content filtering', () => {
     expect(bulkSaveConvos).toHaveBeenCalledTimes(1);
     expect(bulkSaveMessages).toHaveBeenCalledTimes(1);
     expect(bulkIncrementTagCounts).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an oversized conversation before starting any bulk write', async () => {
+    const builder = createBuilder(undefined);
+    builder.conversations[0].title = 'x'.repeat(16 * 1024 * 1024);
+
+    await expect(builder.saveBatch()).rejects.toThrow('storage size limit');
+
+    expect(bulkSaveConvos).not.toHaveBeenCalled();
+    expect(bulkSaveMessages).not.toHaveBeenCalled();
+    expect(bulkIncrementTagCounts).not.toHaveBeenCalled();
+  });
+
+  it('cleans only the generated owner scope when a message write fails', async () => {
+    const builder = createBuilder(undefined);
+    const writeError = new Error('message write failed');
+    bulkSaveMessages.mockRejectedValueOnce(writeError);
+
+    await expect(builder.saveBatch()).rejects.toBe(writeError);
+
+    const scope = {
+      user: 'user-123',
+      conversationIds: [builder.conversations[0].conversationId],
+    };
+    expect(deleteImportedMessages).toHaveBeenCalledWith(scope);
+    expect(deleteImportedConversations).toHaveBeenCalledWith(scope);
+    expect(bulkSaveConvos.mock.invocationCallOrder[0]).toBeLessThan(
+      bulkSaveMessages.mock.invocationCallOrder[0],
+    );
+    expect(bulkIncrementTagCounts).not.toHaveBeenCalled();
   });
 
   it('blocks opaque imported content before starting any bulk write', async () => {

--- a/api/server/utils/import/importBatchBuilder.spec.js
+++ b/api/server/utils/import/importBatchBuilder.spec.js
@@ -10,6 +10,7 @@ jest.mock('@librechat/api', () => ({
 
 const {
   ContentFilterError,
+  MAX_CONVERSATION_IMPORT_DOCUMENT_BYTES,
   contentFilterBlockResponse,
   extractConversationImportContent,
   inspectContent,
@@ -272,7 +273,9 @@ describe('ImportBatchBuilder content filtering', () => {
     const builder = createBuilder(undefined);
     builder.conversations[0].title = 'x'.repeat(16 * 1024 * 1024);
 
-    await expect(builder.saveBatch()).rejects.toThrow('storage size limit');
+    await expect(builder.saveBatch()).rejects.toThrow(
+      `at most ${MAX_CONVERSATION_IMPORT_DOCUMENT_BYTES} bytes`,
+    );
 
     expect(bulkSaveConvos).not.toHaveBeenCalled();
     expect(bulkSaveMessages).not.toHaveBeenCalled();

--- a/api/server/utils/import/importConversations.database.spec.js
+++ b/api/server/utils/import/importConversations.database.spec.js
@@ -1,0 +1,120 @@
+const fs = require('fs').promises;
+const os = require('os');
+const path = require('path');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const { createModels, runAsSystem, tenantStorage } = require('@librechat/data-schemas');
+const { MAX_CONVERSATION_IMPORT_BSON_BYTES } = require('@librechat/api');
+const { Constants, EModelEndpoint } = require('librechat-data-provider');
+
+jest.mock('~/server/services/Config', () => ({
+  getEndpointsConfig: jest.fn().mockResolvedValue({
+    openAI: { userProvide: false },
+  }),
+}));
+
+jest.mock('~/server/controllers/ModelController', () => ({
+  getModelsConfig: jest.fn().mockResolvedValue({
+    openAI: ['gpt-4o'],
+  }),
+}));
+
+createModels(mongoose);
+const importConversations = require('./importConversations');
+
+describe('importConversations database hardening', () => {
+  let mongoServer;
+  let tempDir;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    await mongoose.connect(mongoServer.getUri());
+  });
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'librechat-import-database-'));
+    await mongoose.connection.dropDatabase();
+  });
+
+  afterEach(async () => {
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    if (mongoServer) {
+      await mongoServer.stop();
+    }
+  });
+
+  it('round-trips an existing browser export for its owner and tenant', async () => {
+    const filepath = path.join(tempDir, 'browser-export.json');
+    const fixture = path.join(__dirname, '__data__', 'librechat-export.json');
+    const owner = 'browser-import-user';
+    const tenantId = 'browser-tenant';
+    await fs.copyFile(fixture, filepath);
+
+    await tenantStorage.run({ tenantId, userId: owner }, async () => {
+      await importConversations({ filepath, requestUserId: owner, userRole: 'USER' });
+    });
+
+    await expect(fs.stat(filepath)).rejects.toMatchObject({ code: 'ENOENT' });
+    const persisted = await runAsSystem(async () => {
+      const conversations = await mongoose.models.Conversation.find({ user: owner }).lean();
+      const messages = await mongoose.models.Message.find({ user: owner }).lean();
+      return { conversations, messages };
+    });
+    expect(persisted.conversations).toHaveLength(1);
+    expect(persisted.conversations[0]).toMatchObject({
+      user: owner,
+      tenantId,
+      title: 'Conversation 1. Web Search',
+    });
+    expect(persisted.messages).toHaveLength(6);
+    expect(persisted.messages.every((message) => message.tenantId === tenantId)).toBe(true);
+  });
+
+  it('rejects an oversized BSON record before persisting any part of a browser import', async () => {
+    const filepath = path.join(tempDir, 'oversized-conversation.json');
+    const owner = 'browser-import-user';
+    const tenantId = 'browser-tenant';
+    await fs.writeFile(
+      filepath,
+      JSON.stringify({
+        conversationId: 'source-conversation',
+        endpoint: EModelEndpoint.openAI,
+        title: 'x'.repeat(MAX_CONVERSATION_IMPORT_BSON_BYTES),
+        options: { endpoint: EModelEndpoint.openAI, model: 'gpt-4o' },
+        messages: [
+          {
+            messageId: 'source-message',
+            conversationId: 'source-conversation',
+            parentMessageId: Constants.NO_PARENT,
+            sender: 'User',
+            text: 'Hello',
+            isCreatedByUser: true,
+          },
+        ],
+      }),
+      'utf8',
+    );
+
+    await expect(
+      tenantStorage.run({ tenantId, userId: owner }, async () =>
+        importConversations({ filepath, requestUserId: owner, userRole: 'USER' }),
+      ),
+    ).rejects.toThrow('storage size limit');
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    await expect(fs.stat(filepath)).rejects.toMatchObject({ code: 'ENOENT' });
+    const persisted = await runAsSystem(async () => {
+      const conversations = await mongoose.models.Conversation.find({ user: owner }).lean();
+      const messages = await mongoose.models.Message.find({ user: owner }).lean();
+      return { conversations, messages };
+    });
+    expect(persisted.conversations).toEqual([]);
+    expect(persisted.messages).toEqual([]);
+  });
+});

--- a/api/server/utils/import/importConversations.database.spec.js
+++ b/api/server/utils/import/importConversations.database.spec.js
@@ -4,7 +4,10 @@ const path = require('path');
 const mongoose = require('mongoose');
 const { MongoMemoryServer } = require('mongodb-memory-server');
 const { createModels, runAsSystem, tenantStorage } = require('@librechat/data-schemas');
-const { MAX_CONVERSATION_IMPORT_BSON_BYTES } = require('@librechat/api');
+const {
+  MAX_CONVERSATION_IMPORT_BSON_BYTES,
+  MAX_CONVERSATION_IMPORT_DOCUMENT_BYTES,
+} = require('@librechat/api');
 const { Constants, EModelEndpoint } = require('librechat-data-provider');
 
 jest.mock('~/server/services/Config', () => ({
@@ -105,7 +108,7 @@ describe('importConversations database hardening', () => {
       tenantStorage.run({ tenantId, userId: owner }, async () =>
         importConversations({ filepath, requestUserId: owner, userRole: 'USER' }),
       ),
-    ).rejects.toThrow('storage size limit');
+    ).rejects.toThrow(`at most ${MAX_CONVERSATION_IMPORT_DOCUMENT_BYTES} bytes`);
 
     await new Promise((resolve) => setTimeout(resolve, 100));
     await expect(fs.stat(filepath)).rejects.toMatchObject({ code: 'ENOENT' });

--- a/packages/api/src/conversations/import.spec.ts
+++ b/packages/api/src/conversations/import.spec.ts
@@ -1,0 +1,164 @@
+import {
+  MAX_CONVERSATION_IMPORT_BSON_BYTES,
+  ConversationImportError,
+  assertConversationImportWriteSize,
+  executeConversationImportWrites,
+} from './import';
+
+describe('conversation import writes', () => {
+  it('rejects a document too close to the MongoDB BSON limit before writes begin', () => {
+    let thrown: Error | undefined;
+    try {
+      assertConversationImportWriteSize({
+        conversations: [
+          {
+            user: 'authenticated-user',
+            conversationId: 'generated-conversation',
+            title: 'x'.repeat(MAX_CONVERSATION_IMPORT_BSON_BYTES),
+          },
+        ],
+        messages: [],
+        tenantId: 'tenant-a',
+      });
+    } catch (error) {
+      if (error instanceof Error) {
+        thrown = error;
+      }
+    }
+    expect(thrown).toBeInstanceOf(ConversationImportError);
+    expect(thrown).toMatchObject({
+      code: 'invalid_request',
+      message: 'An imported record exceeds the storage size limit',
+    });
+
+    expect(() =>
+      assertConversationImportWriteSize({
+        conversations: [{ conversationId: 'generated-conversation', title: 'Imported' }],
+        messages: [{ conversationId: 'generated-conversation', text: 'Hello' }],
+      }),
+    ).not.toThrow();
+  });
+
+  it('compensates a partial conversation write before rethrowing its error', async () => {
+    const order: string[] = [];
+    const writeError = new Error('conversation write failed');
+
+    await expect(
+      executeConversationImportWrites({
+        saveConversations: jest.fn(async () => {
+          order.push('save conversations');
+          throw writeError;
+        }),
+        saveMessages: jest.fn(async () => {
+          order.push('save messages');
+        }),
+        updateTagCounts: jest.fn(async () => {
+          order.push('update tags');
+        }),
+        deleteMessages: jest.fn(async () => {
+          order.push('delete messages');
+        }),
+        deleteConversations: jest.fn(async () => {
+          order.push('delete conversations');
+        }),
+      }),
+    ).rejects.toBe(writeError);
+
+    expect(order).toEqual(['save conversations', 'delete messages', 'delete conversations']);
+  });
+
+  it('compensates partial messages before removing their conversation', async () => {
+    const order: string[] = [];
+    const writeError = new Error('message write failed');
+
+    await expect(
+      executeConversationImportWrites({
+        saveConversations: jest.fn(async () => {
+          order.push('save conversations');
+        }),
+        saveMessages: jest.fn(async () => {
+          order.push('save messages');
+          throw writeError;
+        }),
+        updateTagCounts: jest.fn(async () => {
+          order.push('update tags');
+        }),
+        deleteMessages: jest.fn(async () => {
+          order.push('delete messages');
+        }),
+        deleteConversations: jest.fn(async () => {
+          order.push('delete conversations');
+        }),
+      }),
+    ).rejects.toBe(writeError);
+
+    expect(order).toEqual([
+      'save conversations',
+      'save messages',
+      'delete messages',
+      'delete conversations',
+    ]);
+  });
+
+  it('keeps the conversation discoverable when message cleanup fails', async () => {
+    const writeError = new Error('message write failed');
+    const cleanupError = new Error('message cleanup failed');
+    const deleteConversations = jest.fn().mockResolvedValue(undefined);
+    const onCleanupError = jest.fn();
+
+    await expect(
+      executeConversationImportWrites({
+        saveConversations: jest.fn().mockResolvedValue(undefined),
+        saveMessages: jest.fn().mockRejectedValue(writeError),
+        updateTagCounts: jest.fn().mockResolvedValue(undefined),
+        deleteMessages: jest.fn().mockRejectedValue(cleanupError),
+        deleteConversations,
+        onCleanupError,
+      }),
+    ).rejects.toBe(writeError);
+
+    expect(deleteConversations).not.toHaveBeenCalled();
+    expect(onCleanupError).toHaveBeenCalledWith(cleanupError, 'messages');
+  });
+
+  it('reports failed conversation cleanup without replacing the write error', async () => {
+    const writeError = new Error('message write failed');
+    const cleanupError = new Error('conversation cleanup failed');
+    const onCleanupError = jest.fn();
+
+    await expect(
+      executeConversationImportWrites({
+        saveConversations: jest.fn().mockResolvedValue(undefined),
+        saveMessages: jest.fn().mockRejectedValue(writeError),
+        updateTagCounts: jest.fn().mockResolvedValue(undefined),
+        deleteMessages: jest.fn().mockResolvedValue(undefined),
+        deleteConversations: jest.fn().mockRejectedValue(cleanupError),
+        onCleanupError,
+      }),
+    ).rejects.toBe(writeError);
+
+    expect(onCleanupError).toHaveBeenCalledWith(cleanupError, 'conversations');
+  });
+
+  it('keeps the completed import when derived tag count refresh fails', async () => {
+    const tagError = new Error('tag count failed');
+    const onTagCountError = jest.fn();
+    const deleteMessages = jest.fn().mockResolvedValue(undefined);
+    const deleteConversations = jest.fn().mockResolvedValue(undefined);
+
+    await expect(
+      executeConversationImportWrites({
+        saveConversations: jest.fn().mockResolvedValue(undefined),
+        saveMessages: jest.fn().mockResolvedValue(undefined),
+        updateTagCounts: jest.fn().mockRejectedValue(tagError),
+        deleteMessages,
+        deleteConversations,
+        onTagCountError,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(deleteMessages).not.toHaveBeenCalled();
+    expect(deleteConversations).not.toHaveBeenCalled();
+    expect(onTagCountError).toHaveBeenCalledWith(tagError);
+  });
+});

--- a/packages/api/src/conversations/import.spec.ts
+++ b/packages/api/src/conversations/import.spec.ts
@@ -1,8 +1,10 @@
 import {
   MAX_CONVERSATION_IMPORT_BSON_BYTES,
+  MAX_CONVERSATION_IMPORT_DOCUMENT_BYTES,
   ConversationImportError,
   assertConversationImportWriteSize,
   executeConversationImportWrites,
+  isConversationImportError,
 } from './import';
 
 describe('conversation import writes', () => {
@@ -28,8 +30,14 @@ describe('conversation import writes', () => {
     expect(thrown).toBeInstanceOf(ConversationImportError);
     expect(thrown).toMatchObject({
       code: 'invalid_request',
-      message: 'An imported record exceeds the storage size limit',
+      statusCode: 413,
+      message: `Each imported conversation or message must be at most ${MAX_CONVERSATION_IMPORT_DOCUMENT_BYTES} bytes`,
+      body: {
+        error: 'invalid_request',
+        message: `Each imported conversation or message must be at most ${MAX_CONVERSATION_IMPORT_DOCUMENT_BYTES} bytes`,
+      },
     });
+    expect(isConversationImportError(thrown)).toBe(true);
 
     expect(() =>
       assertConversationImportWriteSize({

--- a/packages/api/src/conversations/import.ts
+++ b/packages/api/src/conversations/import.ts
@@ -1,0 +1,103 @@
+import { BSON, ObjectId } from 'mongodb';
+
+import type { Document } from 'mongodb';
+
+export const MAX_CONVERSATION_IMPORT_BSON_BYTES: number = 16 * 1024 * 1024;
+export const CONVERSATION_IMPORT_BSON_HEADROOM_BYTES: number = 64 * 1024;
+
+export interface ConversationImportWriteBatch {
+  conversations: readonly Document[];
+  messages: readonly Document[];
+  tenantId?: string;
+}
+
+export interface ConversationImportWriteOperations {
+  saveConversations: () => Promise<void>;
+  saveMessages: () => Promise<void>;
+  updateTagCounts: () => Promise<void>;
+  deleteMessages: () => Promise<void>;
+  deleteConversations: () => Promise<void>;
+  onTagCountError?: (error: Error) => void;
+  onCleanupError?: (error: Error, resource: 'messages' | 'conversations') => void;
+}
+
+export class ConversationImportError extends Error {
+  readonly code = 'invalid_request';
+
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'ConversationImportError';
+  }
+}
+
+function importWriteError(message: string, cause?: unknown): ConversationImportError {
+  return new ConversationImportError(message, cause === undefined ? undefined : { cause });
+}
+
+export function assertConversationImportWriteSize(batch: ConversationImportWriteBatch): void {
+  const maxDocumentBytes =
+    MAX_CONVERSATION_IMPORT_BSON_BYTES - CONVERSATION_IMPORT_BSON_HEADROOM_BYTES;
+  const assertDocumentSize = (document: Document): void => {
+    let size: number;
+    try {
+      size = BSON.calculateObjectSize({
+        ...document,
+        _id: new ObjectId(),
+        __v: 0,
+        ...(batch.tenantId == null ? {} : { tenantId: batch.tenantId }),
+      });
+    } catch (error) {
+      throw importWriteError('An imported record cannot be stored', error);
+    }
+    if (size > maxDocumentBytes) {
+      throw importWriteError('An imported record exceeds the storage size limit');
+    }
+  };
+  for (const conversation of batch.conversations) {
+    assertDocumentSize(conversation);
+  }
+  for (const message of batch.messages) {
+    assertDocumentSize(message);
+  }
+}
+
+export async function executeConversationImportWrites(
+  operations: ConversationImportWriteOperations,
+): Promise<void> {
+  try {
+    await operations.saveConversations();
+    await operations.saveMessages();
+  } catch (error) {
+    try {
+      await operations.deleteMessages();
+    } catch (cleanupError) {
+      operations.onCleanupError?.(
+        cleanupError instanceof Error
+          ? cleanupError
+          : new Error('Failed to clean imported messages'),
+        'messages',
+      );
+      throw error;
+    }
+
+    try {
+      await operations.deleteConversations();
+    } catch (cleanupError) {
+      operations.onCleanupError?.(
+        cleanupError instanceof Error
+          ? cleanupError
+          : new Error('Failed to clean imported conversations'),
+        'conversations',
+      );
+    }
+    throw error;
+  }
+
+  try {
+    await operations.updateTagCounts();
+  } catch (error) {
+    operations.onTagCountError?.(
+      error instanceof Error ? error : new Error('Failed to update imported tag counts'),
+    );
+  }
+}

--- a/packages/api/src/conversations/import.ts
+++ b/packages/api/src/conversations/import.ts
@@ -4,6 +4,8 @@ import type { Document } from 'mongodb';
 
 export const MAX_CONVERSATION_IMPORT_BSON_BYTES: number = 16 * 1024 * 1024;
 export const CONVERSATION_IMPORT_BSON_HEADROOM_BYTES: number = 64 * 1024;
+export const MAX_CONVERSATION_IMPORT_DOCUMENT_BYTES: number =
+  MAX_CONVERSATION_IMPORT_BSON_BYTES - CONVERSATION_IMPORT_BSON_HEADROOM_BYTES;
 
 export interface ConversationImportWriteBatch {
   conversations: readonly Document[];
@@ -23,20 +25,34 @@ export interface ConversationImportWriteOperations {
 
 export class ConversationImportError extends Error {
   readonly code = 'invalid_request';
+  readonly statusCode: number;
+  readonly body: { error: 'invalid_request'; message: string };
 
-  constructor(message: string, options?: ErrorOptions) {
+  constructor(message: string, statusCode: number, options?: ErrorOptions) {
     super(message, options);
     this.name = 'ConversationImportError';
+    this.statusCode = statusCode;
+    this.body = { error: 'invalid_request', message };
   }
 }
 
-function importWriteError(message: string, cause?: unknown): ConversationImportError {
-  return new ConversationImportError(message, cause === undefined ? undefined : { cause });
+function importWriteError(
+  message: string,
+  statusCode: number,
+  cause?: unknown,
+): ConversationImportError {
+  return new ConversationImportError(
+    message,
+    statusCode,
+    cause === undefined ? undefined : { cause },
+  );
+}
+
+export function isConversationImportError(error: unknown): error is ConversationImportError {
+  return error instanceof ConversationImportError;
 }
 
 export function assertConversationImportWriteSize(batch: ConversationImportWriteBatch): void {
-  const maxDocumentBytes =
-    MAX_CONVERSATION_IMPORT_BSON_BYTES - CONVERSATION_IMPORT_BSON_HEADROOM_BYTES;
   const assertDocumentSize = (document: Document): void => {
     let size: number;
     try {
@@ -47,10 +63,13 @@ export function assertConversationImportWriteSize(batch: ConversationImportWrite
         ...(batch.tenantId == null ? {} : { tenantId: batch.tenantId }),
       });
     } catch (error) {
-      throw importWriteError('An imported record cannot be stored', error);
+      throw importWriteError('An imported conversation or message cannot be stored', 400, error);
     }
-    if (size > maxDocumentBytes) {
-      throw importWriteError('An imported record exceeds the storage size limit');
+    if (size > MAX_CONVERSATION_IMPORT_DOCUMENT_BYTES) {
+      throw importWriteError(
+        `Each imported conversation or message must be at most ${MAX_CONVERSATION_IMPORT_DOCUMENT_BYTES} bytes`,
+        413,
+      );
     }
   };
   for (const conversation of batch.conversations) {

--- a/packages/api/src/conversations/index.ts
+++ b/packages/api/src/conversations/index.ts
@@ -1,1 +1,2 @@
 export * from './archive';
+export * from './import';

--- a/packages/data-schemas/src/methods/import.spec.ts
+++ b/packages/data-schemas/src/methods/import.spec.ts
@@ -1,0 +1,125 @@
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { runAsSystem, tenantStorage } from '~/config/tenantContext';
+import { createModels } from '~/models';
+import { createMethods } from './index';
+
+createModels(mongoose);
+
+describe('conversation import cleanup methods', () => {
+  let mongoServer: MongoMemoryServer;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    await mongoose.connect(mongoServer.getUri());
+  });
+
+  beforeEach(async () => {
+    await mongoose.connection.dropDatabase();
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+  });
+
+  it('removes only the generated IDs for the authenticated owner and tenant', async () => {
+    const methods = createMethods(mongoose);
+    const target = {
+      user: 'owner-a',
+      conversationId: 'generated-target',
+      tenantId: 'tenant-a',
+    };
+    const records = [
+      target,
+      { ...target, conversationId: 'untouched-id' },
+      { ...target, user: 'owner-b' },
+      { ...target, tenantId: 'tenant-b' },
+    ];
+
+    await runAsSystem(async () => {
+      await mongoose.models.Conversation.insertMany(
+        records.map((record) => ({
+          ...record,
+          endpoint: 'openAI',
+          title: record.conversationId,
+        })),
+      );
+      await mongoose.models.Message.insertMany(
+        records.map((record, index) => ({
+          ...record,
+          messageId: `message-${index}`,
+          parentMessageId: '00000000-0000-0000-0000-000000000000',
+          text: record.conversationId,
+        })),
+      );
+    });
+
+    await tenantStorage.run({ tenantId: target.tenantId, userId: target.user }, async () => {
+      const scope = {
+        user: target.user,
+        conversationIds: [target.conversationId],
+        tenantId: target.tenantId,
+      };
+      await methods.deleteImportedMessages(scope);
+      await methods.deleteImportedConversations(scope);
+    });
+
+    const remaining = await runAsSystem(async () => {
+      const conversations = await mongoose.models.Conversation.find({}).lean();
+      const messages = await mongoose.models.Message.find({}).lean();
+      return { conversations, messages };
+    });
+    expect(remaining.conversations).toHaveLength(3);
+    expect(remaining.messages).toHaveLength(3);
+    expect(
+      remaining.conversations.some(
+        (record) =>
+          record.user === target.user &&
+          record.tenantId === target.tenantId &&
+          record.conversationId === target.conversationId,
+      ),
+    ).toBe(false);
+    expect(
+      remaining.messages.some(
+        (record) =>
+          record.user === target.user &&
+          record.tenantId === target.tenantId &&
+          record.conversationId === target.conversationId,
+      ),
+    ).toBe(false);
+  });
+
+  it('requires an absent tenant field for tenantless cleanup', async () => {
+    const methods = createMethods(mongoose);
+    const base = { user: 'owner-a', conversationId: 'generated-target' };
+    await runAsSystem(async () => {
+      await mongoose.models.Conversation.insertMany([
+        { ...base, endpoint: 'openAI', title: 'tenantless' },
+        { ...base, endpoint: 'openAI', tenantId: 'tenant-a', title: 'tenant' },
+      ]);
+      await mongoose.models.Message.insertMany([
+        { ...base, messageId: 'tenantless-message', text: 'tenantless' },
+        { ...base, tenantId: 'tenant-a', messageId: 'tenant-message', text: 'tenant' },
+      ]);
+    });
+
+    await methods.deleteImportedMessages({
+      user: base.user,
+      conversationIds: [base.conversationId],
+    });
+    await methods.deleteImportedConversations({
+      user: base.user,
+      conversationIds: [base.conversationId],
+    });
+
+    const remaining = await runAsSystem(async () => ({
+      conversations: await mongoose.models.Conversation.find({}).lean(),
+      messages: await mongoose.models.Message.find({}).lean(),
+    }));
+    expect(remaining.conversations).toHaveLength(1);
+    expect(remaining.conversations[0].tenantId).toBe('tenant-a');
+    expect(remaining.messages).toHaveLength(1);
+    expect(remaining.messages[0].tenantId).toBe('tenant-a');
+  });
+});

--- a/packages/data-schemas/src/methods/import.spec.ts
+++ b/packages/data-schemas/src/methods/import.spec.ts
@@ -25,10 +25,15 @@ describe('conversation import cleanup methods', () => {
 
   it('removes only the generated IDs for the authenticated owner and tenant', async () => {
     const methods = createMethods(mongoose);
+    const project = await tenantStorage.run({ tenantId: 'tenant-a', userId: 'owner-a' }, async () =>
+      methods.createChatProject('owner-a', { name: 'Imported chats' }),
+    );
+    const chatProjectId = project._id!.toString();
     const target = {
       user: 'owner-a',
       conversationId: 'generated-target',
       tenantId: 'tenant-a',
+      chatProjectId,
     };
     const records = [
       target,
@@ -43,6 +48,16 @@ describe('conversation import cleanup methods', () => {
           ...record,
           endpoint: 'openAI',
           title: record.conversationId,
+          createdAt: new Date(
+            record.conversationId === target.conversationId
+              ? '2026-02-01T00:00:00.000Z'
+              : '2026-01-01T00:00:00.000Z',
+          ),
+          updatedAt: new Date(
+            record.conversationId === target.conversationId
+              ? '2026-02-01T00:00:00.000Z'
+              : '2026-01-01T00:00:00.000Z',
+          ),
         })),
       );
       await mongoose.models.Message.insertMany(
@@ -52,6 +67,16 @@ describe('conversation import cleanup methods', () => {
           parentMessageId: '00000000-0000-0000-0000-000000000000',
           text: record.conversationId,
         })),
+      );
+      await mongoose.models.ChatProject.updateOne(
+        { _id: project._id },
+        {
+          $set: {
+            conversationCount: 2,
+            lastConversationAt: new Date('2026-02-01T00:00:00.000Z'),
+            lastConversationId: target.conversationId,
+          },
+        },
       );
     });
 
@@ -68,7 +93,8 @@ describe('conversation import cleanup methods', () => {
     const remaining = await runAsSystem(async () => {
       const conversations = await mongoose.models.Conversation.find({}).lean();
       const messages = await mongoose.models.Message.find({}).lean();
-      return { conversations, messages };
+      const refreshedProject = await mongoose.models.ChatProject.findById(project._id).lean();
+      return { conversations, messages, refreshedProject };
     });
     expect(remaining.conversations).toHaveLength(3);
     expect(remaining.messages).toHaveLength(3);
@@ -88,6 +114,10 @@ describe('conversation import cleanup methods', () => {
           record.conversationId === target.conversationId,
       ),
     ).toBe(false);
+    expect(remaining.refreshedProject).toMatchObject({
+      conversationCount: 1,
+      lastConversationId: 'untouched-id',
+    });
   });
 
   it('requires an absent tenant field for tenantless cleanup', async () => {

--- a/packages/data-schemas/src/methods/import.spec.ts
+++ b/packages/data-schemas/src/methods/import.spec.ts
@@ -1,5 +1,6 @@
 import mongoose from 'mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
+import { CONVERSATION_IMPORT_CLEANUP_CHUNK_SIZE, createConversationImportMethods } from './import';
 import { runAsSystem, tenantStorage } from '~/config/tenantContext';
 import { createModels } from '~/models';
 import { createMethods } from './index';
@@ -151,5 +152,39 @@ describe('conversation import cleanup methods', () => {
     expect(remaining.conversations[0].tenantId).toBe('tenant-a');
     expect(remaining.messages).toHaveLength(1);
     expect(remaining.messages[0].tenantId).toBe('tenant-a');
+  });
+
+  it('chunks every cleanup query while retaining its exact owner and tenant scope', async () => {
+    const deleteMessages = jest.fn().mockResolvedValue(undefined);
+    const findProjects = jest.fn().mockResolvedValue([]);
+    const deleteConversations = jest.fn().mockResolvedValue(undefined);
+    const cleanupMongoose = {
+      models: {
+        Message: { deleteMany: deleteMessages },
+        Conversation: { distinct: findProjects, deleteMany: deleteConversations },
+      },
+    } as unknown as typeof mongoose;
+    const methods = createConversationImportMethods(cleanupMongoose);
+    const conversationIds = Array.from(
+      { length: CONVERSATION_IMPORT_CLEANUP_CHUNK_SIZE * 2 + 1 },
+      (_, index) => `generated-${index}`,
+    );
+    const scope = { user: 'owner-a', tenantId: 'tenant-a', conversationIds };
+
+    await methods.deleteImportedMessages(scope);
+    await methods.deleteImportedConversations(scope);
+
+    for (const cleanupMock of [deleteMessages, findProjects, deleteConversations]) {
+      expect(cleanupMock).toHaveBeenCalledTimes(3);
+      const filters = cleanupMock.mock.calls.map((call) => call.at(-1));
+      expect(filters.flatMap((filter) => filter.conversationId.$in)).toEqual(conversationIds);
+      expect(filters.every((filter) => filter.user === scope.user)).toBe(true);
+      expect(filters.every((filter) => filter.tenantId === scope.tenantId)).toBe(true);
+      expect(
+        filters.every(
+          (filter) => filter.conversationId.$in.length <= CONVERSATION_IMPORT_CLEANUP_CHUNK_SIZE,
+        ),
+      ).toBe(true);
+    }
   });
 });

--- a/packages/data-schemas/src/methods/import.ts
+++ b/packages/data-schemas/src/methods/import.ts
@@ -1,0 +1,48 @@
+import type { FilterQuery, Model } from 'mongoose';
+import type { IConversation, IMessage } from '~/types';
+import { runAsSystem } from '~/config/tenantContext';
+
+export interface ConversationImportCleanupScope {
+  user: string;
+  conversationIds: readonly string[];
+  tenantId?: string;
+}
+
+export interface ConversationImportMethods {
+  deleteImportedMessages(scope: ConversationImportCleanupScope): Promise<void>;
+  deleteImportedConversations(scope: ConversationImportCleanupScope): Promise<void>;
+}
+
+function createImportCleanupFilter<T>(scope: ConversationImportCleanupScope): FilterQuery<T> {
+  return {
+    user: scope.user,
+    conversationId: { $in: scope.conversationIds },
+    ...(scope.tenantId == null ? { tenantId: { $exists: false } } : { tenantId: scope.tenantId }),
+  };
+}
+
+export function createConversationImportMethods(
+  mongoose: typeof import('mongoose'),
+): ConversationImportMethods {
+  async function deleteImportedMessages(scope: ConversationImportCleanupScope): Promise<void> {
+    if (scope.conversationIds.length === 0) {
+      return;
+    }
+    const Message = mongoose.models.Message as Model<IMessage>;
+    await runAsSystem(async () => {
+      await Message.deleteMany(createImportCleanupFilter<IMessage>(scope));
+    });
+  }
+
+  async function deleteImportedConversations(scope: ConversationImportCleanupScope): Promise<void> {
+    if (scope.conversationIds.length === 0) {
+      return;
+    }
+    const Conversation = mongoose.models.Conversation as Model<IConversation>;
+    await runAsSystem(async () => {
+      await Conversation.deleteMany(createImportCleanupFilter<IConversation>(scope));
+    });
+  }
+
+  return { deleteImportedMessages, deleteImportedConversations };
+}

--- a/packages/data-schemas/src/methods/import.ts
+++ b/packages/data-schemas/src/methods/import.ts
@@ -14,12 +14,30 @@ export interface ConversationImportMethods {
   deleteImportedConversations(scope: ConversationImportCleanupScope): Promise<void>;
 }
 
-function createImportCleanupFilter<T>(scope: ConversationImportCleanupScope): FilterQuery<T> {
+/** Keeps generated UUID arrays well below MongoDB's 16 MiB command limit. */
+export const CONVERSATION_IMPORT_CLEANUP_CHUNK_SIZE = 10_000;
+
+function createImportCleanupFilter<T>(
+  scope: ConversationImportCleanupScope,
+  conversationIds: readonly string[],
+): FilterQuery<T> {
   return {
     user: scope.user,
-    conversationId: { $in: scope.conversationIds },
+    conversationId: { $in: conversationIds },
     ...(scope.tenantId == null ? { tenantId: { $exists: false } } : { tenantId: scope.tenantId }),
   };
+}
+
+function chunkConversationIds(conversationIds: readonly string[]): string[][] {
+  const chunks: string[][] = [];
+  for (
+    let index = 0;
+    index < conversationIds.length;
+    index += CONVERSATION_IMPORT_CLEANUP_CHUNK_SIZE
+  ) {
+    chunks.push(conversationIds.slice(index, index + CONVERSATION_IMPORT_CLEANUP_CHUNK_SIZE));
+  }
+  return chunks;
 }
 
 export function createConversationImportMethods(
@@ -31,7 +49,9 @@ export function createConversationImportMethods(
     }
     const Message = mongoose.models.Message as Model<IMessage>;
     await runAsSystem(async () => {
-      await Message.deleteMany(createImportCleanupFilter<IMessage>(scope));
+      for (const conversationIds of chunkConversationIds(scope.conversationIds)) {
+        await Message.deleteMany(createImportCleanupFilter<IMessage>(scope, conversationIds));
+      }
     });
   }
 
@@ -41,10 +61,18 @@ export function createConversationImportMethods(
     }
     const Conversation = mongoose.models.Conversation as Model<IConversation>;
     const projectIds = await runAsSystem(async () => {
-      const filter = createImportCleanupFilter<IConversation>(scope);
-      const affectedProjects = await Conversation.distinct('chatProjectId', filter);
-      await Conversation.deleteMany(filter);
-      return affectedProjects.filter((projectId): projectId is string => Boolean(projectId));
+      const affectedProjectIds = new Set<string>();
+      for (const conversationIds of chunkConversationIds(scope.conversationIds)) {
+        const filter = createImportCleanupFilter<IConversation>(scope, conversationIds);
+        const affectedProjects = await Conversation.distinct('chatProjectId', filter);
+        for (const projectId of affectedProjects) {
+          if (projectId) {
+            affectedProjectIds.add(String(projectId));
+          }
+        }
+        await Conversation.deleteMany(filter);
+      }
+      return [...affectedProjectIds];
     });
     const context = tenantStorage.getStore();
     await tenantStorage.run(

--- a/packages/data-schemas/src/methods/import.ts
+++ b/packages/data-schemas/src/methods/import.ts
@@ -1,6 +1,7 @@
 import type { FilterQuery, Model } from 'mongoose';
 import type { IConversation, IMessage } from '~/types';
-import { runAsSystem } from '~/config/tenantContext';
+import { runAsSystem, tenantStorage } from '~/config/tenantContext';
+import { refreshChatProjectStatsForUser } from './chatProject';
 
 export interface ConversationImportCleanupScope {
   user: string;
@@ -39,9 +40,23 @@ export function createConversationImportMethods(
       return;
     }
     const Conversation = mongoose.models.Conversation as Model<IConversation>;
-    await runAsSystem(async () => {
-      await Conversation.deleteMany(createImportCleanupFilter<IConversation>(scope));
+    const projectIds = await runAsSystem(async () => {
+      const filter = createImportCleanupFilter<IConversation>(scope);
+      const affectedProjects = await Conversation.distinct('chatProjectId', filter);
+      await Conversation.deleteMany(filter);
+      return affectedProjects.filter((projectId): projectId is string => Boolean(projectId));
     });
+    const context = tenantStorage.getStore();
+    await tenantStorage.run(
+      { ...context, tenantId: scope.tenantId, userId: scope.user },
+      async () => {
+        await Promise.all(
+          projectIds.map((projectId) =>
+            refreshChatProjectStatsForUser(mongoose, scope.user, projectId),
+          ),
+        );
+      },
+    );
   }
 
   return { deleteImportedMessages, deleteImportedConversations };

--- a/packages/data-schemas/src/methods/index.ts
+++ b/packages/data-schemas/src/methods/index.ts
@@ -58,6 +58,7 @@ import { createCategoriesMethods, type CategoriesMethods } from './categories';
 import { createPresetMethods, type PresetMethods } from './preset';
 /* Tier 2 — Moderate (service deps injected) */
 import { createConversationTagMethods, type ConversationTagMethods } from './conversationTag';
+import { createConversationImportMethods, type ConversationImportMethods } from './import';
 import {
   createMessageMethods,
   CLIENT_MESSAGE_SELECT,
@@ -232,6 +233,7 @@ export type AllMethods = UserMethods &
   CategoriesMethods &
   PresetMethods &
   ConversationTagMethods &
+  ConversationImportMethods &
   MessageMethods &
   ConversationMethods &
   ChatProjectMethods &
@@ -454,6 +456,7 @@ export function createMethods(
     ...createPresetMethods(mongoose),
     /* Tier 2 */
     ...createConversationTagMethods(mongoose),
+    ...createConversationImportMethods(mongoose),
     ...messageMethods,
     ...conversationMethods,
     ...createChatProjectMethods(mongoose),
@@ -508,6 +511,7 @@ export type {
   CategoriesMethods,
   PresetMethods,
   ConversationTagMethods,
+  ConversationImportMethods,
   MessageMethods,
   ParentSubagentTaskRecord,
   ParentSubagentThreadRecord,


### PR DESCRIPTION
## Summary

Conversation imports currently start conversation, message, and tag-count writes concurrently. If one MongoDB write rejects, another can still commit records that the failed request cannot discover. In addition, malformed percent escapes in multipart filenames throw synchronously from Multer storage, and upload-directory errors bypass Multer's callback.

This change validates each generated import record against MongoDB's BSON document limit before any write, persists conversations before messages, and compensates failed core writes with owner-, tenant-, and generated-conversation-ID-scoped deletes. Tag counts remain a best-effort derived update after the core records succeed. Multer storage now reports malformed filename encoding as a controlled 400 response and directory preparation failures as controlled callback errors.

The existing browser import formats, 250 MiB aggregate upload limit, content policy, and temporary-file cleanup behavior are preserved. There are no new package dependencies. This targets `dev` and provides shared hardening required by the follow-up conversation-management API.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

The browser-import Mongo regression round-trips an existing LibreChat export, then imports an oversized conversation with a valid message and verifies that neither collection retains records. A real-Mongo negative control using the unpatched concurrent write sequence produced outcomes `[rejected, fulfilled, fulfilled]` and retained `{ conversations: 0, messages: 1 }`. The Multer regression submits `%.json`, verifies a controlled 400 with an empty staging directory, then confirms that a healthy upload succeeds through the same server. Against the exact unpatched `dev` storage callback, its targeted negative run failed 1/1 with an uncaught `URIError: URI malformed`; the restored fix passed the same assertion 1/1.

- `cd packages/api && npx jest src/conversations/import.spec.ts --runInBand` — 6 tests passed
- `cd packages/data-schemas && MONGOMS_DOWNLOAD_DIR=/tmp/librechat-mongo npx jest src/methods/import.spec.ts --runInBand` — 2 tests passed
- `cd api && MONGOMS_DOWNLOAD_DIR=/tmp/librechat-mongo npx jest server/utils/import --runInBand` — 198 tests passed
- `cd api && npx jest server/routes/files/multer.spec.js --runInBand` — 37 tests passed
- `cd packages/api && npx tsc --noEmit` — passed
- `cd packages/data-schemas && npx tsc --noEmit` — passed
- Affected ESLint, import sorting, and `git diff --check` — passed

- `npm run lighthouse` — passed; median LCP 3.57s against the 4.5s budget, CLS below 0.04 and TBT below 127ms.

### **Test Configuration**:

- Node.js 24.16.0
- `mongodb-memory-server` using `MONGOMS_DOWNLOAD_DIR=/tmp/librechat-mongo`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
