### PR TITLE
🪡 fix: Persist and Continue Stored Responses

### DIFF
--- a/api/server/controllers/agents/__tests__/responses.unit.spec.js
+++ b/api/server/controllers/agents/__tests__/responses.unit.spec.js
@@ -380,6 +380,12 @@ jest.mock('@librechat/api', () => ({
     on_run_step_delta: { handle: jest.fn() },
     on_chat_model_end: { handle: jest.fn() },
   }),
+  isStoredResponseOutput: jest.fn(
+    (message) =>
+      message.isCreatedByUser !== true &&
+      message.isUserSubmitted !== true &&
+      message.metadata?.responsesInput == null,
+  ),
   resolveStoredResponse: jest.fn(async (deps, userId, responseId) => {
     if (mockStoredResponseReferences.has(responseId)) {
       return mockStoredResponseReferences.get(responseId);
@@ -398,6 +404,10 @@ jest.mock('@librechat/api', () => ({
     mockStoredResponseReferences.set(responseId, resolution);
     return resolution;
   }),
+  revalidateStoredResponseConversation: jest.fn(async (_deps, _userId, reference) => ({
+    status: 'found',
+    reference,
+  })),
   selectStoredResponseHistory: jest.fn((messages) => messages),
   executeAgentRun: async ({
     envelope,
@@ -852,6 +862,23 @@ describe('createResponse controller', () => {
   it('persists a continued response under its UUID conversation with linked message refs', async () => {
     const api = require('@librechat/api');
     const db = require('~/models');
+    const structuredOutput = [
+      {
+        type: 'function_call',
+        id: 'fc-weather',
+        call_id: 'call-weather',
+        name: 'weather',
+        arguments: '{"city":"Paris"}',
+        status: 'completed',
+      },
+      {
+        type: 'function_call_output',
+        id: 'fco-weather',
+        call_id: 'call-weather',
+        output: 'Sunny',
+        status: 'completed',
+      },
+    ];
     const previousMessage = {
       messageId: 'resp_previous',
       conversationId: '11111111-1111-4111-8111-111111111111',
@@ -870,13 +897,19 @@ describe('createResponse controller', () => {
         responseMessage: previousMessage,
       },
     };
-    api.resolveStoredResponse.mockResolvedValueOnce(resolution).mockResolvedValueOnce(resolution);
+    api.resolveStoredResponse.mockResolvedValueOnce(resolution);
     api.validateResponseRequest.mockReturnValueOnce({
       request: {
         ...req.body,
         store: true,
         previous_response_id: previousMessage.messageId,
       },
+    });
+    api.buildAggregatedResponse.mockReturnValueOnce({
+      id: 'resp_mock-123',
+      status: 'completed',
+      output: structuredOutput,
+      usage: { input_tokens: 100, output_tokens: 50, total_tokens: 150 },
     });
     api.convertInputToMessages.mockReturnValueOnce([
       { role: 'user', content: 'Continue', messageId: 'input-new' },
@@ -915,6 +948,11 @@ describe('createResponse controller', () => {
         conversationId: previousMessage.conversationId,
         messageId: 'resp_mock-123',
         parentMessageId: 'input-new',
+        isUserSubmitted: false,
+        metadata: {
+          responsesOutput: structuredOutput,
+          responsesPreviousResponseId: previousMessage.messageId,
+        },
       }),
       { context: 'Responses API - save assistant response' },
     );
@@ -1036,6 +1074,25 @@ describe('createResponse controller', () => {
       conversationId,
       isCreatedByUser: false,
       text: 'Done',
+      metadata: {
+        responsesOutput: [
+          {
+            type: 'function_call',
+            id: 'fc-generated',
+            call_id: 'call-generated',
+            name: 'lookup',
+            arguments: '{"query":"forecast"}',
+            status: 'completed',
+          },
+          {
+            type: 'function_call_output',
+            id: 'fco-generated',
+            call_id: 'call-generated',
+            output: 'Warm',
+            status: 'completed',
+          },
+        ],
+      },
     };
     const resolution = {
       status: 'found',
@@ -1045,11 +1102,26 @@ describe('createResponse controller', () => {
         responseMessage,
       },
     };
-    api.resolveStoredResponse.mockResolvedValueOnce(resolution).mockResolvedValueOnce(resolution);
+    api.resolveStoredResponse.mockResolvedValueOnce(resolution);
     api.validateResponseRequest.mockReturnValueOnce({
       request: { ...req.body, previous_response_id: responseMessage.messageId },
     });
-    api.convertInputToMessages.mockReturnValueOnce([{ role: 'user', content: 'Continue' }]);
+    api.convertInputToMessages
+      .mockReturnValueOnce([{ role: 'user', content: 'Continue' }])
+      .mockReturnValueOnce([
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [
+            {
+              id: 'call-generated',
+              type: 'function',
+              function: { name: 'lookup', arguments: '{"query":"forecast"}' },
+            },
+          ],
+        },
+        { role: 'tool', content: 'Warm', tool_call_id: 'call-generated' },
+      ]);
     db.getMessages.mockResolvedValueOnce([
       {
         messageId: 'input-system',
@@ -1096,7 +1168,17 @@ describe('createResponse controller', () => {
           tool_calls: [expect.objectContaining({ id: 'call-weather' })],
         }),
         expect.objectContaining({ role: 'tool', content: 'Sunny', tool_call_id: 'call-weather' }),
-        expect.objectContaining({ role: 'assistant', content: 'Done' }),
+        expect.objectContaining({
+          role: 'assistant',
+          tool_calls: [expect.objectContaining({ id: 'call-generated' })],
+          isUserSubmitted: false,
+        }),
+        expect.objectContaining({
+          role: 'tool',
+          content: 'Warm',
+          tool_call_id: 'call-generated',
+          isUserSubmitted: false,
+        }),
         { role: 'user', content: 'Continue' },
       ],
       {},
@@ -1156,6 +1238,22 @@ describe('createResponse controller', () => {
   it('retrieves only the assistant message identified by a canonical response ID', async () => {
     const api = require('@librechat/api');
     const db = require('~/models');
+    const structuredOutput = [
+      {
+        type: 'reasoning',
+        id: 'reason-target',
+        status: 'completed',
+        content: [{ type: 'reasoning_text', text: 'Reasoned' }],
+        summary: [],
+      },
+      {
+        type: 'message',
+        id: 'msg-target',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'Target output', annotations: [], logprobs: [] }],
+      },
+    ];
     const target = {
       messageId: 'resp_target',
       conversationId: '11111111-1111-4111-8111-111111111111',
@@ -1165,6 +1263,10 @@ describe('createResponse controller', () => {
       tokenCount: 7,
       createdAt: new Date('2026-01-01T00:00:00.000Z'),
       updatedAt: new Date('2026-01-01T00:00:01.000Z'),
+      metadata: {
+        responsesOutput: structuredOutput,
+        responsesPreviousResponseId: 'resp_previous',
+      },
     };
     api.resolveStoredResponse.mockResolvedValueOnce({
       status: 'found',
@@ -1183,7 +1285,8 @@ describe('createResponse controller', () => {
       expect.objectContaining({
         id: target.messageId,
         model: 'agent-123',
-        output: [expect.objectContaining({ id: target.messageId })],
+        previous_response_id: 'resp_previous',
+        output: structuredOutput,
         usage: { input_tokens: 0, output_tokens: 7, total_tokens: 7 },
       }),
     );
@@ -2195,6 +2298,92 @@ describe('createResponse controller', () => {
       );
     });
 
+    it('loads history while post-enrollment conversation revalidation is pending', async () => {
+      const api = require('@librechat/api');
+      const db = require('~/models');
+      const conversationId = '11111111-1111-4111-8111-111111111111';
+      const responseMessage = {
+        messageId: 'resp_previous',
+        conversationId,
+        isCreatedByUser: false,
+        text: 'Previous output',
+      };
+      const reference = {
+        conversation: { conversationId, user: 'user-123' },
+        conversationId,
+        responseMessage,
+      };
+      let finishRevalidation;
+      api.validateResponseRequest.mockReturnValueOnce({
+        request: {
+          model: 'agent-123',
+          input: 'Continue.',
+          stream: false,
+          previous_response_id: responseMessage.messageId,
+        },
+      });
+      api.resolveStoredResponse.mockResolvedValueOnce({ status: 'found', reference });
+      api.revalidateStoredResponseConversation.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finishRevalidation = resolve;
+          }),
+      );
+      db.getMessages.mockResolvedValueOnce([responseMessage]);
+
+      const pendingResponse = createResponse(req, res);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(api.resolveStoredResponse).toHaveBeenCalledTimes(1);
+      expect(api.revalidateStoredResponseConversation).toHaveBeenCalledWith(
+        { getConvo: db.getConvo },
+        'user-123',
+        reference,
+      );
+      expect(db.getMessages).toHaveBeenCalledWith(
+        expect.objectContaining({ conversationId, user: 'user-123' }),
+      );
+      expect(mockExecution.beginProviderExecution.mock.invocationCallOrder[0]).toBeLessThan(
+        api.revalidateStoredResponseConversation.mock.invocationCallOrder[0],
+      );
+      finishRevalidation({ status: 'found', reference });
+      await pendingResponse;
+    });
+
+    it('rejects a continuation deleted after enrollment while history is loading', async () => {
+      const api = require('@librechat/api');
+      const db = require('~/models');
+      const conversationId = '11111111-1111-4111-8111-111111111111';
+      const reference = {
+        conversation: { conversationId, user: 'user-123' },
+        conversationId,
+        responseMessage: null,
+      };
+      api.validateResponseRequest.mockReturnValueOnce({
+        request: {
+          model: 'agent-123',
+          input: 'Continue.',
+          stream: false,
+          previous_response_id: conversationId,
+        },
+      });
+      api.resolveStoredResponse.mockResolvedValueOnce({ status: 'found', reference });
+      api.revalidateStoredResponseConversation.mockResolvedValueOnce({ status: 'not_found' });
+      db.getMessages.mockResolvedValueOnce([
+        { messageId: 'existing', isCreatedByUser: false, text: 'Existing history' },
+      ]);
+
+      await createResponse(req, res);
+
+      expect(api.sendResponsesErrorResponse).toHaveBeenCalledWith(
+        res,
+        404,
+        'Conversation not found',
+        'not_found',
+      );
+      expect(api.createRun).not.toHaveBeenCalled();
+    });
+
     it('rejects a UUID continuation whose visible history is empty', async () => {
       const { validateResponseRequest, sendResponsesErrorResponse } = require('@librechat/api');
       const { getConvo, getMessages } = require('~/models');
@@ -2756,6 +2945,30 @@ describe('Responses persistence with MongoDB', () => {
     const { v4 } = require('uuid');
     const mongod = await MongoMemoryServer.create();
     const conversationId = '11111111-1111-4111-8111-111111111111';
+    const firstOutput = [
+      {
+        type: 'function_call',
+        id: 'fc-database',
+        call_id: 'call-database',
+        name: 'lookup',
+        arguments: '{"query":"first"}',
+        status: 'completed',
+      },
+      {
+        type: 'function_call_output',
+        id: 'fco-database',
+        call_id: 'call-database',
+        output: 'Stored tool result',
+        status: 'completed',
+      },
+      {
+        type: 'message',
+        id: 'msg-database',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'First answer', annotations: [], logprobs: [] }],
+      },
+    ];
 
     try {
       await mongoose.connect(mongod.getUri());
@@ -2781,7 +2994,28 @@ describe('Responses persistence with MongoDB', () => {
       api.selectStoredResponseHistory.mockImplementation((messages) => messages);
       api.convertInputToMessages
         .mockReturnValueOnce([{ role: 'user', content: 'First', messageId: 'input-one' }])
-        .mockReturnValueOnce([{ role: 'user', content: 'Second', messageId: 'input-two' }]);
+        .mockReturnValueOnce([{ role: 'user', content: 'Second', messageId: 'input-two' }])
+        .mockReturnValueOnce([
+          {
+            role: 'assistant',
+            content: '',
+            tool_calls: [
+              {
+                id: 'call-database',
+                type: 'function',
+                function: { name: 'lookup', arguments: '{"query":"first"}' },
+              },
+            ],
+          },
+          { role: 'tool', content: 'Stored tool result', tool_call_id: 'call-database' },
+          { role: 'assistant', content: 'First answer' },
+        ]);
+      api.buildAggregatedResponse.mockReturnValueOnce({
+        id: 'resp_mock-123',
+        status: 'completed',
+        output: firstOutput,
+        usage: { input_tokens: 100, output_tokens: 50, total_tokens: 150 },
+      });
       api.validateResponseRequest
         .mockReturnValueOnce({
           request: { model: 'agent-123', input: 'First', stream: false, store: true },
@@ -2837,7 +3071,7 @@ describe('Responses persistence with MongoDB', () => {
           expect(getResult.json).toHaveBeenCalledWith(
             expect.objectContaining({
               id: 'resp_mock-123',
-              output: [expect.objectContaining({ id: 'resp_mock-123' })],
+              output: firstOutput,
             }),
           );
 

--- a/api/server/controllers/agents/__tests__/responses.unit.spec.js
+++ b/api/server/controllers/agents/__tests__/responses.unit.spec.js
@@ -218,6 +218,7 @@ const mockPersistStoredResponse = jest.fn(async (params) => {
       metadata: {
         responsesResponse: {
           version: 1,
+          response,
           output: response.output,
           usage: response.usage,
           previousResponseId: response.previous_response_id ?? null,
@@ -467,6 +468,7 @@ jest.mock('@librechat/api', () => ({
     const snapshot = message.metadata?.responsesResponse;
     if (snapshot?.version === 1) {
       return {
+        ...(snapshot.response != null && { response: snapshot.response }),
         output: snapshot.output,
         usage: snapshot.usage,
         previousResponseId: snapshot.previousResponseId ?? null,
@@ -1061,6 +1063,7 @@ describe('createResponse controller', () => {
         metadata: {
           responsesResponse: {
             version: 1,
+            response: expect.any(Object),
             output: structuredOutput,
             usage: { input_tokens: 100, output_tokens: 50, total_tokens: 150 },
             previousResponseId: previousMessage.messageId,
@@ -3048,7 +3051,7 @@ describe('createResponse controller', () => {
 
       const finalizeStream =
         api.createResponsesEventHandlers.mock.results.at(-1).value.finalizeStream;
-      expect(finalizeStream).toHaveBeenCalledWith(mockResponsesUsage);
+      expect(finalizeStream).toHaveBeenCalledWith(mockResponsesUsage, expect.any(Object));
     });
   });
 
@@ -3277,6 +3280,10 @@ describe('Responses persistence with MongoDB', () => {
         ]);
       api.buildAggregatedResponse.mockReturnValueOnce({
         id: 'resp_mock-123',
+        object: 'response',
+        instructions: 'Use the supplied context.',
+        created_at: 1700000000,
+        completed_at: 1700000060,
         status: 'completed',
         output: firstOutput,
         usage: { input_tokens: 100, output_tokens: 50, total_tokens: 150 },
@@ -3324,15 +3331,17 @@ describe('Responses persistence with MongoDB', () => {
       await dataSchemas.tenantStorage.run(
         { tenantId: 'tenant-a', userId: 'user-123' },
         async () => {
+          const createdResult = makeResponse();
           await controller.createResponse(
             makeRequest({ model: 'agent-123', input: 'First', stream: false, store: true }),
-            makeResponse(),
+            createdResult,
           );
 
           const getRequest = makeRequest({});
           getRequest.params = { id: 'resp_mock-123' };
           const getResult = makeResponse();
           await controller.getResponse(getRequest, getResult);
+          expect(getResult.json).toHaveBeenCalledWith(createdResult.json.mock.calls[0][0]);
           expect(getResult.json).toHaveBeenCalledWith(
             expect.objectContaining({
               id: 'resp_mock-123',

--- a/api/server/controllers/agents/__tests__/responses.unit.spec.js
+++ b/api/server/controllers/agents/__tests__/responses.unit.spec.js
@@ -662,7 +662,7 @@ describe('createResponse controller', () => {
     );
 
     const request = createResponse(req, res);
-    await Promise.resolve();
+    await new Promise((resolve) => setImmediate(resolve));
     res.once.mock.calls[0][1]();
     finishEnrollment(mockExecution);
     await request;
@@ -2298,6 +2298,63 @@ describe('createResponse controller', () => {
       );
     });
 
+    it('starts agent and stored-response lookups together before enrollment', async () => {
+      const api = require('@librechat/api');
+      const db = require('~/models');
+      const conversationId = '11111111-1111-4111-8111-111111111111';
+      const responseMessage = {
+        messageId: 'resp_previous',
+        conversationId,
+        isCreatedByUser: false,
+        text: 'Previous output',
+      };
+      const reference = {
+        conversation: { conversationId, user: 'user-123' },
+        conversationId,
+        responseMessage,
+      };
+      let finishAgentLookup;
+      api.validateResponseRequest.mockReturnValueOnce({
+        request: {
+          model: 'agent-123',
+          input: 'Continue.',
+          stream: false,
+          previous_response_id: responseMessage.messageId,
+        },
+      });
+      db.getAgent.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finishAgentLookup = resolve;
+          }),
+      );
+      api.resolveStoredResponse.mockResolvedValueOnce({ status: 'found', reference });
+      db.getMessages.mockResolvedValueOnce([
+        { messageId: 'existing', isCreatedByUser: false, text: 'Existing history' },
+      ]);
+
+      const pendingResponse = createResponse(req, res);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(db.getAgent).toHaveBeenCalledWith({ id: 'agent-123' });
+      expect(api.resolveStoredResponse).toHaveBeenCalledWith(
+        { getConvo: db.getConvo, getMessage: db.getMessage },
+        'user-123',
+        responseMessage.messageId,
+      );
+      expect(mockEnrollAgentExecution).not.toHaveBeenCalled();
+
+      finishAgentLookup({
+        id: 'agent-123',
+        name: 'Test Agent',
+        provider: 'anthropic',
+        model_parameters: {},
+      });
+      await pendingResponse;
+
+      expect(mockEnrollAgentExecution).toHaveBeenCalledTimes(1);
+    });
+
     it('loads history while post-enrollment conversation revalidation is pending', async () => {
       const api = require('@librechat/api');
       const db = require('~/models');
@@ -2408,6 +2465,47 @@ describe('createResponse controller', () => {
         'not_found',
       );
       expect(require('@librechat/api').createRun).not.toHaveBeenCalled();
+    });
+
+    it('returns a server error when continuation history cannot be read', async () => {
+      const api = require('@librechat/api');
+      const db = require('~/models');
+      const conversationId = '11111111-1111-4111-8111-111111111111';
+      const reference = {
+        conversation: { conversationId, user: 'user-123' },
+        conversationId,
+        responseMessage: null,
+      };
+      api.validateResponseRequest.mockReturnValueOnce({
+        request: {
+          model: 'agent-123',
+          input: 'Continue.',
+          stream: false,
+          previous_response_id: conversationId,
+        },
+      });
+      api.resolveStoredResponse.mockResolvedValueOnce({ status: 'found', reference });
+      api.revalidateStoredResponseConversation.mockResolvedValueOnce({
+        status: 'found',
+        reference,
+      });
+      db.getMessages.mockRejectedValueOnce(new Error('history read failed'));
+
+      await createResponse(req, res);
+
+      expect(api.sendResponsesErrorResponse).toHaveBeenCalledWith(
+        res,
+        500,
+        'history read failed',
+        'server_error',
+      );
+      expect(api.sendResponsesErrorResponse).not.toHaveBeenCalledWith(
+        res,
+        404,
+        expect.any(String),
+        'not_found',
+      );
+      expect(api.createRun).not.toHaveBeenCalled();
     });
 
     it('rejects a remote response continuation of a view-only subagent thread', async () => {

--- a/api/server/controllers/agents/__tests__/responses.unit.spec.js
+++ b/api/server/controllers/agents/__tests__/responses.unit.spec.js
@@ -899,7 +899,7 @@ describe('createResponse controller', () => {
         messageId: 'input-new',
         parentMessageId: previousMessage.messageId,
       }),
-      { context: 'Responses API - save user input' },
+      { context: 'Responses API - save input' },
     );
     expect(db.saveMessage).toHaveBeenNthCalledWith(
       2,
@@ -918,6 +918,182 @@ describe('createResponse controller', () => {
         appendMessageIds: ['mongo-input-new', 'mongo-resp_mock-123'],
         noUpsert: true,
       }),
+    );
+  });
+
+  it('persists every accepted input role in one linked continuation chain', async () => {
+    const api = require('@librechat/api');
+    const db = require('~/models');
+    const toolCalls = [
+      {
+        id: 'call-weather',
+        type: 'function',
+        function: { name: 'weather', arguments: '{"city":"Paris"}' },
+      },
+    ];
+    api.validateResponseRequest.mockReturnValueOnce({
+      request: { ...req.body, store: true },
+    });
+    api.convertInputToMessages.mockReturnValueOnce([
+      { role: 'system', content: 'Be concise', messageId: 'input-system' },
+      {
+        role: 'assistant',
+        content: '',
+        messageId: 'input-call',
+        tool_calls: toolCalls,
+      },
+      {
+        role: 'tool',
+        content: 'Sunny',
+        messageId: 'input-output',
+        tool_call_id: 'call-weather',
+      },
+      { role: 'user', content: 'Thanks', messageId: 'input-user' },
+    ]);
+    db.saveMessage.mockImplementation(async (_context, params) => ({
+      ...params,
+      _id: `mongo-${params.messageId}`,
+    }));
+
+    await createResponse(req, res);
+
+    expect(
+      db.saveMessage.mock.calls.slice(0, 4).map(([, message]) => ({
+        messageId: message.messageId,
+        parentMessageId: message.parentMessageId,
+        isCreatedByUser: message.isCreatedByUser,
+        isUserSubmitted: message.isUserSubmitted,
+        metadata: message.metadata,
+      })),
+    ).toEqual([
+      {
+        messageId: 'input-system',
+        parentMessageId: null,
+        isCreatedByUser: false,
+        isUserSubmitted: true,
+        metadata: { responsesInput: { role: 'system' } },
+      },
+      {
+        messageId: 'input-call',
+        parentMessageId: 'input-system',
+        isCreatedByUser: false,
+        isUserSubmitted: true,
+        metadata: { responsesInput: { role: 'assistant', tool_calls: toolCalls } },
+      },
+      {
+        messageId: 'input-output',
+        parentMessageId: 'input-call',
+        isCreatedByUser: false,
+        isUserSubmitted: true,
+        metadata: { responsesInput: { role: 'tool', tool_call_id: 'call-weather' } },
+      },
+      {
+        messageId: 'input-user',
+        parentMessageId: 'input-output',
+        isCreatedByUser: true,
+        isUserSubmitted: true,
+        metadata: { responsesInput: { role: 'user' } },
+      },
+    ]);
+    expect(db.saveMessage).toHaveBeenNthCalledWith(
+      5,
+      expect.anything(),
+      expect.objectContaining({
+        messageId: 'resp_mock-123',
+        parentMessageId: 'input-user',
+      }),
+      { context: 'Responses API - save assistant response' },
+    );
+    expect(db.saveConvo).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        appendMessageIds: [
+          'mongo-input-system',
+          'mongo-input-call',
+          'mongo-input-output',
+          'mongo-input-user',
+          'mongo-resp_mock-123',
+        ],
+      }),
+    );
+  });
+
+  it('restores persisted response input roles and tool metadata for continuation', async () => {
+    const api = require('@librechat/api');
+    const db = require('~/models');
+    const { formatAgentMessages } = require('@librechat/agents');
+    const conversationId = '11111111-1111-4111-8111-111111111111';
+    const responseMessage = {
+      messageId: 'resp_previous',
+      conversationId,
+      isCreatedByUser: false,
+      text: 'Done',
+    };
+    const resolution = {
+      status: 'found',
+      reference: {
+        conversation: { conversationId, user: 'user-123' },
+        conversationId,
+        responseMessage,
+      },
+    };
+    api.resolveStoredResponse.mockResolvedValueOnce(resolution).mockResolvedValueOnce(resolution);
+    api.validateResponseRequest.mockReturnValueOnce({
+      request: { ...req.body, previous_response_id: responseMessage.messageId },
+    });
+    api.convertInputToMessages.mockReturnValueOnce([{ role: 'user', content: 'Continue' }]);
+    db.getMessages.mockResolvedValueOnce([
+      {
+        messageId: 'input-system',
+        isCreatedByUser: false,
+        isUserSubmitted: true,
+        text: 'Be concise',
+        metadata: { responsesInput: { role: 'system' } },
+      },
+      {
+        messageId: 'input-call',
+        isCreatedByUser: false,
+        isUserSubmitted: true,
+        text: '',
+        metadata: {
+          responsesInput: {
+            role: 'assistant',
+            tool_calls: [
+              {
+                id: 'call-weather',
+                type: 'function',
+                function: { name: 'weather', arguments: '{"city":"Paris"}' },
+              },
+            ],
+          },
+        },
+      },
+      {
+        messageId: 'input-output',
+        isCreatedByUser: false,
+        isUserSubmitted: true,
+        text: 'Sunny',
+        metadata: { responsesInput: { role: 'tool', tool_call_id: 'call-weather' } },
+      },
+      responseMessage,
+    ]);
+
+    await createResponse(req, res);
+
+    expect(formatAgentMessages).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({ role: 'system', content: 'Be concise' }),
+        expect.objectContaining({
+          role: 'assistant',
+          tool_calls: [expect.objectContaining({ id: 'call-weather' })],
+        }),
+        expect.objectContaining({ role: 'tool', content: 'Sunny', tool_call_id: 'call-weather' }),
+        expect.objectContaining({ role: 'assistant', content: 'Done' }),
+        { role: 'user', content: 'Continue' },
+      ],
+      {},
+      expect.any(Set),
     );
   });
 
@@ -1887,7 +2063,7 @@ describe('createResponse controller', () => {
 
     it('should proceed when conversation is owned by user', async () => {
       const { validateResponseRequest, sendResponsesErrorResponse } = require('@librechat/api');
-      const { getConvo } = require('~/models');
+      const { getConvo, getMessages } = require('~/models');
       validateResponseRequest.mockReturnValueOnce({
         request: {
           model: 'agent-123',
@@ -1897,6 +2073,9 @@ describe('createResponse controller', () => {
         },
       });
       getConvo.mockResolvedValueOnce({ conversationId: 'resp_abc', user: 'user-123' });
+      getMessages.mockResolvedValueOnce([
+        { messageId: 'existing', isCreatedByUser: false, text: 'Existing history' },
+      ]);
 
       await createResponse(req, res);
       expect(getConvo).toHaveBeenCalledWith('user-123', 'resp_abc');
@@ -1906,6 +2085,32 @@ describe('createResponse controller', () => {
         expect.any(String),
         expect.any(String),
       );
+    });
+
+    it('rejects a UUID continuation whose visible history is empty', async () => {
+      const { validateResponseRequest, sendResponsesErrorResponse } = require('@librechat/api');
+      const { getConvo, getMessages } = require('~/models');
+      const conversationId = '11111111-1111-4111-8111-111111111111';
+      validateResponseRequest.mockReturnValueOnce({
+        request: {
+          model: 'agent-123',
+          input: 'Continue.',
+          stream: false,
+          previous_response_id: conversationId,
+        },
+      });
+      getConvo.mockResolvedValueOnce({ conversationId, user: 'user-123' });
+      getMessages.mockResolvedValueOnce([]);
+
+      await createResponse(req, res);
+
+      expect(sendResponsesErrorResponse).toHaveBeenCalledWith(
+        res,
+        404,
+        'Conversation history not found',
+        'not_found',
+      );
+      expect(require('@librechat/api').createRun).not.toHaveBeenCalled();
     });
 
     it('rejects a remote response continuation of a view-only subagent thread', async () => {
@@ -1945,7 +2150,7 @@ describe('createResponse controller', () => {
 
     it('does not recreate a continued conversation deleted before persistence', async () => {
       const { validateResponseRequest } = require('@librechat/api');
-      const { getConvo, saveConvo, saveMessage } = require('~/models');
+      const { getConvo, getMessages, saveConvo, saveMessage } = require('~/models');
       validateResponseRequest.mockReturnValueOnce({
         request: {
           model: 'agent-123',
@@ -1959,6 +2164,9 @@ describe('createResponse controller', () => {
         conversationId: '11111111-1111-4111-8111-111111111111',
         user: 'user-123',
       });
+      getMessages.mockResolvedValueOnce([
+        { messageId: 'existing', isCreatedByUser: false, text: 'Existing history' },
+      ]);
       saveConvo.mockResolvedValueOnce(null);
 
       await createResponse(req, res);

--- a/api/server/controllers/agents/__tests__/responses.unit.spec.js
+++ b/api/server/controllers/agents/__tests__/responses.unit.spec.js
@@ -370,6 +370,7 @@ jest.mock('@librechat/api', () => ({
       on_run_step_delta: { handle: jest.fn() },
       on_chat_model_end: { handle: jest.fn() },
     },
+    completeOutput: jest.fn(),
     finalizeStream: jest.fn(),
   }),
   createAggregatorEventHandlers: jest.fn().mockReturnValue({
@@ -891,6 +892,12 @@ describe('createResponse controller', () => {
     expect(mockEnrollAgentExecution).toHaveBeenCalledWith(
       expect.objectContaining({ conversationId: previousMessage.conversationId }),
     );
+    expect(db.saveConvo).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ userId: 'user-123' }),
+      expect.objectContaining({ conversationId: previousMessage.conversationId }),
+      expect.objectContaining({ appendMessageIds: [], noUpsert: true }),
+    );
     expect(db.saveMessage).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({ userId: 'user-123' }),
@@ -1095,6 +1102,55 @@ describe('createResponse controller', () => {
       {},
       expect.any(Set),
     );
+  });
+
+  it('durably stores a streaming response before emitting its terminal event', async () => {
+    const api = require('@librechat/api');
+    const db = require('~/models');
+    api.validateResponseRequest.mockReturnValueOnce({
+      request: { ...req.body, stream: true, store: true },
+    });
+    api.convertInputToMessages.mockReturnValueOnce([
+      { role: 'user', content: 'Stream this', messageId: 'input-stream' },
+    ]);
+    db.saveMessage.mockImplementation(async (_context, params) => ({
+      ...params,
+      _id: `mongo-${params.messageId}`,
+    }));
+
+    await createResponse(req, res);
+
+    const streamHandlers = api.createResponsesEventHandlers.mock.results.at(-1).value;
+    const { completeOutput, finalizeStream } = streamHandlers;
+    expect(db.saveConvo).toHaveBeenCalledTimes(2);
+    expect(completeOutput.mock.invocationCallOrder[0]).toBeLessThan(
+      db.saveConvo.mock.invocationCallOrder[0],
+    );
+    expect(db.saveConvo.mock.invocationCallOrder.at(-1)).toBeLessThan(
+      finalizeStream.mock.invocationCallOrder[0],
+    );
+    expect(finalizeStream.mock.invocationCallOrder[0]).toBeLessThan(
+      res.end.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('does not emit a completed streaming response when durable storage fails', async () => {
+    const api = require('@librechat/api');
+    const db = require('~/models');
+    api.validateResponseRequest.mockReturnValueOnce({
+      request: { ...req.body, stream: true, store: true },
+    });
+    res.headersSent = true;
+    db.saveConvo.mockRejectedValueOnce(new Error('storage unavailable'));
+
+    await createResponse(req, res);
+
+    const { completeOutput, finalizeStream } =
+      api.createResponsesEventHandlers.mock.results.at(-1).value;
+    expect(completeOutput).toHaveBeenCalledTimes(1);
+    expect(finalizeStream).not.toHaveBeenCalled();
+    expect(api.writeDone).toHaveBeenCalledWith(res);
+    expect(res.end).toHaveBeenCalledTimes(1);
   });
 
   it('retrieves only the assistant message identified by a canonical response ID', async () => {

--- a/api/server/controllers/agents/__tests__/responses.unit.spec.js
+++ b/api/server/controllers/agents/__tests__/responses.unit.spec.js
@@ -341,6 +341,7 @@ jest.mock('@librechat/api', () => ({
     field: 'content',
   }),
   emitResponseCreated: jest.fn(),
+  emitResponseFailed: jest.fn(),
   createResponseContext: jest.fn().mockReturnValue({ responseId: 'resp_123' }),
   createResponseTracker: jest.fn().mockReturnValue({
     usage: { inputTokens: 100, outputTokens: 50, reasoningTokens: 0, cachedTokens: 0 },
@@ -1216,11 +1217,19 @@ describe('createResponse controller', () => {
     );
   });
 
-  it('does not emit a completed streaming response when durable storage fails', async () => {
+  it('emits a failed streaming response before DONE when durable storage fails', async () => {
     const api = require('@librechat/api');
     const db = require('~/models');
     api.validateResponseRequest.mockReturnValueOnce({
       request: { ...req.body, stream: true, store: true },
+    });
+    api.emitResponseFailed.mockImplementationOnce(({ res: streamResponse }, error) => {
+      streamResponse.write(
+        `event: response.failed\ndata: ${JSON.stringify({ type: 'response.failed', error })}\n\n`,
+      );
+    });
+    api.writeDone.mockImplementationOnce((streamResponse) => {
+      streamResponse.write('data: [DONE]\n\n');
     });
     res.headersSent = true;
     db.saveConvo.mockRejectedValueOnce(new Error('storage unavailable'));
@@ -1231,7 +1240,20 @@ describe('createResponse controller', () => {
       api.createResponsesEventHandlers.mock.results.at(-1).value;
     expect(completeOutput).toHaveBeenCalledTimes(1);
     expect(finalizeStream).not.toHaveBeenCalled();
+    expect(api.emitResponseFailed).toHaveBeenCalledWith(expect.objectContaining({ res }), {
+      type: 'server_error',
+      message: 'storage unavailable',
+    });
     expect(api.writeDone).toHaveBeenCalledWith(res);
+    expect(api.emitResponseFailed.mock.invocationCallOrder[0]).toBeLessThan(
+      api.writeDone.mock.invocationCallOrder[0],
+    );
+    const eventStream = res.write.mock.calls.map(([chunk]) => chunk).join('');
+    expect(eventStream).toContain('event: response.failed');
+    expect(eventStream.indexOf('event: response.failed')).toBeLessThan(
+      eventStream.indexOf('data: [DONE]'),
+    );
+    expect(eventStream).not.toContain('response.completed');
     expect(res.end).toHaveBeenCalledTimes(1);
   });
 

--- a/api/server/controllers/agents/__tests__/responses.unit.spec.js
+++ b/api/server/controllers/agents/__tests__/responses.unit.spec.js
@@ -32,6 +32,7 @@ const mockResolveConversationTitle = jest.fn(({ filters, candidate, fallback = '
     (fallback === candidate ? null : resolveAllowedTitle(fallback))
   );
 });
+
 const mockHasActivePiiPatterns = (config) =>
   config != null &&
   (config.starterPatterns == null ||
@@ -150,6 +151,7 @@ const mockResponsesUsage = {
 const mockBuildResponsesUsage = jest.fn().mockReturnValue(mockResponsesUsage);
 const mockEnrollAgentExecution = jest.fn();
 let mockExecution;
+const mockStoredResponseReferences = new Map();
 
 function resetMockExecution() {
   const controller = new AbortController();
@@ -179,6 +181,7 @@ jest.mock('uuid', () => ({
 }));
 
 jest.mock('@librechat/data-schemas', () => ({
+  buildRetentionVisibilityFilter: jest.fn().mockReturnValue({}),
   logger: {
     debug: jest.fn(),
     error: jest.fn(),
@@ -376,6 +379,25 @@ jest.mock('@librechat/api', () => ({
     on_run_step_delta: { handle: jest.fn() },
     on_chat_model_end: { handle: jest.fn() },
   }),
+  resolveStoredResponse: jest.fn(async (deps, userId, responseId) => {
+    if (mockStoredResponseReferences.has(responseId)) {
+      return mockStoredResponseReferences.get(responseId);
+    }
+    const conversation = await deps.getConvo(userId, responseId);
+    if (conversation == null) return { status: 'not_found' };
+    if (conversation.subagentThread != null) return { status: 'read_only' };
+    const resolution = {
+      status: 'found',
+      reference: {
+        conversation,
+        conversationId: conversation.conversationId,
+        responseMessage: null,
+      },
+    };
+    mockStoredResponseReferences.set(responseId, resolution);
+    return resolution;
+  }),
+  selectStoredResponseHistory: jest.fn((messages) => messages),
   executeAgentRun: async ({
     envelope,
     runId,
@@ -508,6 +530,7 @@ jest.mock('~/models', () => ({
   getFiles: jest.fn(),
   getUserKey: jest.fn(),
   getMessages: jest.fn().mockResolvedValue([]),
+  getMessage: jest.fn().mockResolvedValue(null),
   saveMessage: jest.fn().mockResolvedValue({}),
   updateFilesUsage: jest.fn(),
   getUserKeyValues: jest.fn(),
@@ -522,7 +545,7 @@ jest.mock('~/models', () => ({
   getCacheMultiplier: mockGetCacheMultiplier,
   getConvoFiles: jest.fn().mockResolvedValue([]),
   getFormattedMemories: jest.fn().mockResolvedValue({ withKeys: '', withoutKeys: '' }),
-  saveConvo: jest.fn().mockResolvedValue({}),
+  saveConvo: jest.fn().mockImplementation(async (_context, conversation) => conversation),
   getConvo: jest.fn().mockResolvedValue(null),
   isSubagentOwnerAdmissible: jest.fn().mockResolvedValue(true),
 }));
@@ -530,17 +553,19 @@ jest.mock('~/models', () => ({
 let mockGlobalDiscoveredAgentConfigs = null;
 
 describe('createResponse controller', () => {
-  let createResponse;
+  let createResponse, getResponse;
   let req, res;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockStoredResponseReferences.clear();
     resetMockExecution();
     mockGlobalDiscoveredAgentConfigs = null;
     require('@librechat/api').inspectContent.mockReset().mockReturnValue(null);
 
     const controller = require('../responses');
     createResponse = controller.createResponse;
+    getResponse = controller.getResponse;
 
     req = {
       body: {
@@ -807,7 +832,11 @@ describe('createResponse controller', () => {
 
     expect(api.getLangfuseTraceMessageFields).toHaveBeenCalledWith(req.config, 'resp_mock-123');
     expect(saveMessage).toHaveBeenCalledWith(
-      req,
+      {
+        userId: 'user-123',
+        isTemporary: undefined,
+        interfaceConfig: undefined,
+      },
       expect.objectContaining({
         messageId: 'resp_mock-123',
         isCreatedByUser: false,
@@ -816,6 +845,115 @@ describe('createResponse controller', () => {
         tokenCount: 50,
       }),
       { context: 'Responses API - save assistant response' },
+    );
+  });
+
+  it('persists a continued response under its UUID conversation with linked message refs', async () => {
+    const api = require('@librechat/api');
+    const db = require('~/models');
+    const previousMessage = {
+      messageId: 'resp_previous',
+      conversationId: '11111111-1111-4111-8111-111111111111',
+      isCreatedByUser: false,
+      parentMessageId: 'input-previous',
+      text: 'Previous output',
+    };
+    const resolution = {
+      status: 'found',
+      reference: {
+        conversation: {
+          conversationId: previousMessage.conversationId,
+          user: 'user-123',
+        },
+        conversationId: previousMessage.conversationId,
+        responseMessage: previousMessage,
+      },
+    };
+    api.resolveStoredResponse.mockResolvedValueOnce(resolution).mockResolvedValueOnce(resolution);
+    api.validateResponseRequest.mockReturnValueOnce({
+      request: {
+        ...req.body,
+        store: true,
+        previous_response_id: previousMessage.messageId,
+      },
+    });
+    api.convertInputToMessages.mockReturnValueOnce([
+      { role: 'user', content: 'Continue', messageId: 'input-new' },
+    ]);
+    db.getMessages.mockResolvedValueOnce([previousMessage]);
+    db.saveMessage.mockImplementation(async (_context, params) => ({
+      ...params,
+      _id: `mongo-${params.messageId}`,
+    }));
+
+    await createResponse(req, res);
+
+    expect(mockEnrollAgentExecution).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationId: previousMessage.conversationId }),
+    );
+    expect(db.saveMessage).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ userId: 'user-123' }),
+      expect.objectContaining({
+        conversationId: previousMessage.conversationId,
+        messageId: 'input-new',
+        parentMessageId: previousMessage.messageId,
+      }),
+      { context: 'Responses API - save user input' },
+    );
+    expect(db.saveMessage).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ userId: 'user-123' }),
+      expect.objectContaining({
+        conversationId: previousMessage.conversationId,
+        messageId: 'resp_mock-123',
+        parentMessageId: 'input-new',
+      }),
+      { context: 'Responses API - save assistant response' },
+    );
+    expect(db.saveConvo).toHaveBeenLastCalledWith(
+      expect.objectContaining({ userId: 'user-123' }),
+      expect.objectContaining({ conversationId: previousMessage.conversationId }),
+      expect.objectContaining({
+        appendMessageIds: ['mongo-input-new', 'mongo-resp_mock-123'],
+        noUpsert: true,
+      }),
+    );
+  });
+
+  it('retrieves only the assistant message identified by a canonical response ID', async () => {
+    const api = require('@librechat/api');
+    const db = require('~/models');
+    const target = {
+      messageId: 'resp_target',
+      conversationId: '11111111-1111-4111-8111-111111111111',
+      isCreatedByUser: false,
+      text: 'Target output',
+      model: 'agent-123',
+      tokenCount: 7,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:01.000Z'),
+    };
+    api.resolveStoredResponse.mockResolvedValueOnce({
+      status: 'found',
+      reference: {
+        conversation: { conversationId: target.conversationId, user: 'user-123' },
+        conversationId: target.conversationId,
+        responseMessage: target,
+      },
+    });
+    req.params = { id: target.messageId };
+
+    await getResponse(req, res);
+
+    expect(db.getMessages).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: target.messageId,
+        model: 'agent-123',
+        output: [expect.objectContaining({ id: target.messageId })],
+        usage: { input_tokens: 0, output_tokens: 7, total_tokens: 7 },
+      }),
     );
   });
 
@@ -1805,6 +1943,34 @@ describe('createResponse controller', () => {
       expect(saveMessage).not.toHaveBeenCalled();
     });
 
+    it('does not recreate a continued conversation deleted before persistence', async () => {
+      const { validateResponseRequest } = require('@librechat/api');
+      const { getConvo, saveConvo, saveMessage } = require('~/models');
+      validateResponseRequest.mockReturnValueOnce({
+        request: {
+          model: 'agent-123',
+          input: 'Continue.',
+          stream: false,
+          store: true,
+          previous_response_id: '11111111-1111-4111-8111-111111111111',
+        },
+      });
+      getConvo.mockResolvedValueOnce({
+        conversationId: '11111111-1111-4111-8111-111111111111',
+        user: 'user-123',
+      });
+      saveConvo.mockResolvedValueOnce(null);
+
+      await createResponse(req, res);
+
+      expect(saveConvo).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-123' }),
+        expect.objectContaining({ conversationId: '11111111-1111-4111-8111-111111111111' }),
+        expect.objectContaining({ noUpsert: true }),
+      );
+      expect(saveMessage).not.toHaveBeenCalled();
+    });
+
     it('should return 500 when getConvo throws a DB error', async () => {
       const { validateResponseRequest, sendResponsesErrorResponse } = require('@librechat/api');
       const { getConvo } = require('~/models');
@@ -2261,5 +2427,131 @@ describe('createResponse controller', () => {
         expect.anything(),
       );
     });
+  });
+});
+
+describe('Responses persistence with MongoDB', () => {
+  it('stores, retrieves, and continues one non-streaming and one streaming response', async () => {
+    const mongoose = require('mongoose');
+    const { MongoMemoryServer } = require('mongodb-memory-server');
+    const dataSchemas = jest.requireActual('@librechat/data-schemas');
+    const api = require('@librechat/api');
+    const db = require('~/models');
+    const { v4 } = require('uuid');
+    const mongod = await MongoMemoryServer.create();
+    const conversationId = '11111111-1111-4111-8111-111111111111';
+
+    try {
+      await mongoose.connect(mongod.getUri());
+      dataSchemas.createModels(mongoose);
+      const methods = dataSchemas.createMethods(mongoose);
+      jest.clearAllMocks();
+      resetMockExecution();
+      mockStoredResponseReferences.clear();
+      api.resolveStoredResponse.mockImplementation(async (deps, userId, responseId) => {
+        const responseMessage = await deps.getMessage({ user: userId, messageId: responseId });
+        if (responseMessage == null) return { status: 'not_found' };
+        const conversation = await deps.getConvo(userId, responseMessage.conversationId);
+        if (conversation == null) return { status: 'not_found' };
+        return {
+          status: 'found',
+          reference: {
+            conversation,
+            conversationId: conversation.conversationId,
+            responseMessage,
+          },
+        };
+      });
+      api.selectStoredResponseHistory.mockImplementation((messages) => messages);
+      api.convertInputToMessages
+        .mockReturnValueOnce([{ role: 'user', content: 'First', messageId: 'input-one' }])
+        .mockReturnValueOnce([{ role: 'user', content: 'Second', messageId: 'input-two' }]);
+      api.validateResponseRequest
+        .mockReturnValueOnce({
+          request: { model: 'agent-123', input: 'First', stream: false, store: true },
+        })
+        .mockReturnValueOnce({
+          request: {
+            model: 'agent-123',
+            input: 'Second',
+            stream: true,
+            store: true,
+            previous_response_id: 'resp_mock-123',
+          },
+        });
+      api.generateResponseId.mockReturnValueOnce('resp_mock-123').mockReturnValueOnce('resp_next');
+      v4.mockReturnValueOnce(conversationId);
+      db.saveConvo.mockImplementation(methods.saveConvo);
+      db.saveMessage.mockImplementation(methods.saveMessage);
+      db.getConvo.mockImplementation(methods.getConvo);
+      db.getMessage.mockImplementation(methods.getMessage);
+      db.getMessages.mockImplementation(methods.getMessages);
+
+      const makeRequest = (body) => ({
+        body,
+        user: { id: 'user-123' },
+        config: { endpoints: { agents: { allowedProviders: ['anthropic'] } } },
+        once: jest.fn(),
+        off: jest.fn(),
+      });
+      const makeResponse = () => ({
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+        setHeader: jest.fn(),
+        flushHeaders: jest.fn(),
+        end: jest.fn(),
+        write: jest.fn(),
+        once: jest.fn(),
+        off: jest.fn(),
+      });
+      const controller = require('../responses');
+
+      await dataSchemas.tenantStorage.run(
+        { tenantId: 'tenant-a', userId: 'user-123' },
+        async () => {
+          await controller.createResponse(
+            makeRequest({ model: 'agent-123', input: 'First', stream: false, store: true }),
+            makeResponse(),
+          );
+
+          const getRequest = makeRequest({});
+          getRequest.params = { id: 'resp_mock-123' };
+          const getResult = makeResponse();
+          await controller.getResponse(getRequest, getResult);
+          expect(getResult.json).toHaveBeenCalledWith(
+            expect.objectContaining({
+              id: 'resp_mock-123',
+              output: [expect.objectContaining({ id: 'resp_mock-123' })],
+            }),
+          );
+
+          await controller.createResponse(
+            makeRequest({
+              model: 'agent-123',
+              input: 'Second',
+              stream: true,
+              store: true,
+              previous_response_id: 'resp_mock-123',
+            }),
+            makeResponse(),
+          );
+
+          const storedConversation = await methods.getConvo('user-123', conversationId);
+          const messages = await methods.getMessages({ user: 'user-123', conversationId });
+          expect(storedConversation?.messages).toHaveLength(4);
+          expect(
+            messages.map(({ messageId, parentMessageId }) => ({ messageId, parentMessageId })),
+          ).toEqual([
+            { messageId: 'input-one', parentMessageId: null },
+            { messageId: 'resp_mock-123', parentMessageId: 'input-one' },
+            { messageId: 'input-two', parentMessageId: 'resp_mock-123' },
+            { messageId: 'resp_next', parentMessageId: 'input-two' },
+          ]);
+        },
+      );
+    } finally {
+      await mongoose.disconnect();
+      await mongod.stop();
+    }
   });
 });

--- a/api/server/controllers/agents/__tests__/responses.unit.spec.js
+++ b/api/server/controllers/agents/__tests__/responses.unit.spec.js
@@ -1189,6 +1189,58 @@ describe('createResponse controller', () => {
     );
   });
 
+  it('excludes stored caller context from legacy UUID response output', async () => {
+    const api = require('@librechat/api');
+    const db = require('~/models');
+    const conversationId = '11111111-1111-4111-8111-111111111111';
+    api.resolveStoredResponse.mockResolvedValueOnce({
+      status: 'found',
+      reference: {
+        conversation: { conversationId, user: 'user-123', agent_id: 'agent-123' },
+        conversationId,
+        responseMessage: null,
+      },
+    });
+    db.getMessages.mockResolvedValueOnce([
+      {
+        messageId: 'input-system',
+        isCreatedByUser: false,
+        isUserSubmitted: true,
+        text: 'Be concise',
+        metadata: { responsesInput: { role: 'system' } },
+      },
+      {
+        messageId: 'input-assistant',
+        isCreatedByUser: false,
+        text: 'Caller-provided context',
+        metadata: { responsesInput: { role: 'assistant' } },
+      },
+      {
+        messageId: 'legacy-imported-assistant',
+        isCreatedByUser: false,
+        isUserSubmitted: true,
+        text: 'Imported caller content without Responses metadata',
+      },
+      {
+        messageId: 'generated-output',
+        isCreatedByUser: false,
+        text: 'Generated answer',
+        model: 'agent-123',
+      },
+    ]);
+    req.params = { id: conversationId };
+
+    await getResponse(req, res);
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: conversationId,
+        model: 'agent-123',
+        output: [expect.objectContaining({ id: 'generated-output' })],
+      }),
+    );
+  });
+
   describe('execution envelope', () => {
     it('creates the portable run input before agent initialization', async () => {
       req.user = {

--- a/api/server/controllers/agents/__tests__/responses.unit.spec.js
+++ b/api/server/controllers/agents/__tests__/responses.unit.spec.js
@@ -149,6 +149,94 @@ const mockResponsesUsage = {
   subagent: { input_tokens: 25, output_tokens: 10, total_tokens: 35 },
 };
 const mockBuildResponsesUsage = jest.fn().mockReturnValue(mockResponsesUsage);
+const mockPersistStoredResponse = jest.fn(async (params) => {
+  const { deps, context, conversation, inputMessages, response, responseId, agentId } = params;
+  const initialConversation = await deps.saveConvo(context, conversation.data, {
+    context: 'Responses API - save conversation',
+    initialAgentId: conversation.initialAgentId,
+    appendMessageIds: [],
+    ...(conversation.isContinuation && { noUpsert: true }),
+  });
+  if (initialConversation?.conversationId !== conversation.data.conversationId) {
+    throw new Error('Conversation was deleted before the response could be stored');
+  }
+  const messageIds = [];
+  let parentMessageId = params.parentMessageId;
+  for (const input of inputMessages) {
+    const messageId = input.messageId ?? 'mock-nanoid-123';
+    let sender = 'Agent';
+    if (input.role === 'user') {
+      sender = 'User';
+    } else if (input.role === 'tool') {
+      sender = 'Tool';
+    }
+    const message = await deps.saveMessage(
+      context,
+      {
+        messageId,
+        conversationId: conversation.data.conversationId,
+        parentMessageId,
+        isCreatedByUser: input.role === 'user',
+        isUserSubmitted: true,
+        text: typeof input.content === 'string' ? input.content : JSON.stringify(input.content),
+        ...(Array.isArray(input.content) && { content: input.content }),
+        sender,
+        endpoint: conversation.data.endpoint,
+        model: agentId,
+        metadata: {
+          responsesInput: {
+            role: input.role,
+            ...(input.name != null && { name: input.name }),
+            ...(input.tool_call_id != null && { tool_call_id: input.tool_call_id }),
+            ...(input.tool_calls != null && { tool_calls: input.tool_calls }),
+          },
+        },
+      },
+      { context: 'Responses API - save input' },
+    );
+    if (message?._id == null)
+      throw new Error(`Response input message could not be stored: ${messageId}`);
+    messageIds.push(message._id);
+    parentMessageId = messageId;
+  }
+  const outputMessageFields = (await params.getOutputMessageFields?.()) ?? {};
+  const outputMessage = await deps.saveMessage(
+    context,
+    {
+      ...outputMessageFields,
+      messageId: responseId,
+      conversationId: conversation.data.conversationId,
+      parentMessageId,
+      isCreatedByUser: false,
+      isUserSubmitted: false,
+      text: '',
+      sender: 'Agent',
+      endpoint: conversation.data.endpoint,
+      model: agentId,
+      finish_reason: response.status === 'completed' ? 'stop' : response.status,
+      tokenCount: params.visibleOutputTokens ?? response.usage?.output_tokens,
+      metadata: {
+        responsesResponse: {
+          version: 1,
+          output: response.output,
+          usage: response.usage,
+          previousResponseId: response.previous_response_id ?? null,
+        },
+      },
+    },
+    { context: 'Responses API - save assistant response' },
+  );
+  if (outputMessage?._id == null)
+    throw new Error(`Response output message could not be stored: ${responseId}`);
+  messageIds.push(outputMessage._id);
+  const storedConversation = await deps.saveConvo(context, conversation.data, {
+    context: 'Responses API - save conversation',
+    initialAgentId: conversation.initialAgentId,
+    appendMessageIds: messageIds,
+    noUpsert: true,
+  });
+  return { conversation: storedConversation, outputMessage };
+});
 const mockEnrollAgentExecution = jest.fn();
 let mockExecution;
 const mockStoredResponseReferences = new Map();
@@ -374,6 +462,24 @@ jest.mock('@librechat/api', () => ({
     completeOutput: jest.fn(),
     finalizeStream: jest.fn(),
   }),
+  filterCommittedResponseMessages: jest.fn((messages) => messages),
+  getStoredResponseSnapshot: jest.fn((message) => {
+    const snapshot = message.metadata?.responsesResponse;
+    if (snapshot?.version === 1) {
+      return {
+        output: snapshot.output,
+        usage: snapshot.usage,
+        previousResponseId: snapshot.previousResponseId ?? null,
+      };
+    }
+    const output = message.metadata?.responsesOutput;
+    return Array.isArray(output)
+      ? {
+          output,
+          previousResponseId: message.metadata?.responsesPreviousResponseId ?? null,
+        }
+      : null;
+  }),
   createAggregatorEventHandlers: jest.fn().mockReturnValue({
     on_message_delta: { handle: jest.fn() },
     on_reasoning_delta: { handle: jest.fn() },
@@ -387,6 +493,7 @@ jest.mock('@librechat/api', () => ({
       message.isUserSubmitted !== true &&
       message.metadata?.responsesInput == null,
   ),
+  persistStoredResponse: mockPersistStoredResponse,
   resolveStoredResponse: jest.fn(async (deps, userId, responseId) => {
     if (mockStoredResponseReferences.has(responseId)) {
       return mockStoredResponseReferences.get(responseId);
@@ -909,6 +1016,7 @@ describe('createResponse controller', () => {
     api.buildAggregatedResponse.mockReturnValueOnce({
       id: 'resp_mock-123',
       status: 'completed',
+      previous_response_id: previousMessage.messageId,
       output: structuredOutput,
       usage: { input_tokens: 100, output_tokens: 50, total_tokens: 150 },
     });
@@ -951,8 +1059,12 @@ describe('createResponse controller', () => {
         parentMessageId: 'input-new',
         isUserSubmitted: false,
         metadata: {
-          responsesOutput: structuredOutput,
-          responsesPreviousResponseId: previousMessage.messageId,
+          responsesResponse: {
+            version: 1,
+            output: structuredOutput,
+            usage: { input_tokens: 100, output_tokens: 50, total_tokens: 150 },
+            previousResponseId: previousMessage.messageId,
+          },
         },
       }),
       { context: 'Responses API - save assistant response' },
@@ -1312,6 +1424,39 @@ describe('createResponse controller', () => {
         usage: { input_tokens: 0, output_tokens: 7, total_tokens: 7 },
       }),
     );
+  });
+
+  it('preserves explicitly null usage from a stored response snapshot', async () => {
+    const api = require('@librechat/api');
+    const target = {
+      messageId: 'resp_null_usage',
+      conversationId: '11111111-1111-4111-8111-111111111111',
+      isCreatedByUser: false,
+      isUserSubmitted: false,
+      tokenCount: 7,
+      metadata: {
+        responsesResponse: {
+          version: 1,
+          commitState: 'committed',
+          output: [],
+          usage: null,
+          previousResponseId: null,
+        },
+      },
+    };
+    api.resolveStoredResponse.mockResolvedValueOnce({
+      status: 'found',
+      reference: {
+        conversation: { conversationId: target.conversationId, user: 'user-123' },
+        conversationId: target.conversationId,
+        responseMessage: target,
+      },
+    });
+    req.params = { id: target.messageId };
+
+    await getResponse(req, res);
+
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ usage: null }));
   });
 
   it('excludes stored caller context from legacy UUID response output', async () => {

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -528,6 +528,65 @@ async function saveConversation(
   );
 }
 
+async function persistResponse({
+  req,
+  conversationId,
+  agentId,
+  agent,
+  previousResponse,
+  inputMessages,
+  parentMessageId,
+  responseId,
+  response,
+  visibleOutputTokens,
+}) {
+  const storedConversation = await saveConversation(
+    req,
+    conversationId,
+    agentId,
+    agent,
+    [],
+    previousResponse != null,
+  );
+  if (storedConversation?.conversationId !== conversationId) {
+    throw new Error('Conversation was deleted before the response could be stored');
+  }
+
+  const inputPersistence = await saveInputMessages(
+    req,
+    conversationId,
+    inputMessages,
+    agentId,
+    parentMessageId,
+  );
+  const outputMessage = await saveResponseOutput(
+    req,
+    conversationId,
+    responseId,
+    response,
+    agentId,
+    visibleOutputTokens,
+    inputPersistence.parentMessageId,
+  );
+  const messageIds = [...inputPersistence.messageIds];
+  if (outputMessage?._id != null) {
+    messageIds.push(outputMessage._id);
+  }
+  const refreshedConversation = await saveConversation(
+    req,
+    conversationId,
+    agentId,
+    agent,
+    messageIds,
+    true,
+  );
+  if (refreshedConversation?.conversationId !== conversationId) {
+    throw new Error('Conversation was deleted before message references were stored');
+  }
+
+  logger.debug(`[Responses API] Stored response ${responseId} in conversation ${conversationId}`);
+}
+
 /**
  * Convert stored messages to Open Responses output format
  * @param {Array} messages - Stored messages
@@ -1215,8 +1274,11 @@ const executeResponse = async (envelope, { req, res }) => {
         emitResponseInProgress(handlerConfig);
 
         // Create event handlers
-        const { handlers: responsesHandlers, finalizeStream } =
-          createResponsesEventHandlers(handlerConfig);
+        const {
+          handlers: responsesHandlers,
+          completeOutput,
+          finalizeStream,
+        } = createResponsesEventHandlers(handlerConfig);
 
         // Collect usage for balance tracking
         const collectedUsage = [];
@@ -1383,7 +1445,22 @@ const executeResponse = async (envelope, { req, res }) => {
 
         const usage = buildResponsesUsage(collectedUsage);
 
-        // Finalize the stream
+        if (request.store === true) {
+          completeOutput();
+          await persistResponse({
+            req,
+            conversationId,
+            agentId,
+            agent,
+            previousResponse,
+            inputMessages,
+            parentMessageId,
+            responseId,
+            response: buildResponse(context, tracker, 'completed', usage),
+            visibleOutputTokens: tracker.usage.outputTokens,
+          });
+        }
+
         finalizeStream(usage);
         res.end();
 
@@ -1391,67 +1468,6 @@ const executeResponse = async (envelope, { req, res }) => {
         logger.debug(
           `[Responses API] Request ${responseId} completed in ${duration}ms (streaming)`,
         );
-
-        // Save to database if store: true
-        if (request.store === true) {
-          try {
-            // Save conversation
-            const storedConversation = await saveConversation(
-              req,
-              conversationId,
-              agentId,
-              agent,
-              undefined,
-              previousResponse != null,
-            );
-            if (storedConversation?.conversationId !== conversationId) {
-              throw new Error('Conversation was deleted before the response could be stored');
-            }
-
-            // Save input messages
-            const inputPersistence = await saveInputMessages(
-              req,
-              conversationId,
-              inputMessages,
-              agentId,
-              parentMessageId,
-            );
-
-            // Build response for saving (use tracker with buildResponse for streaming)
-            const finalResponse = buildResponse(context, tracker, 'completed');
-            const outputMessage = await saveResponseOutput(
-              req,
-              conversationId,
-              responseId,
-              finalResponse,
-              agentId,
-              tracker.usage.outputTokens,
-              inputPersistence.parentMessageId,
-            );
-            const messageIds = [...inputPersistence.messageIds];
-            if (outputMessage?._id != null) {
-              messageIds.push(outputMessage._id);
-            }
-            const refreshedConversation = await saveConversation(
-              req,
-              conversationId,
-              agentId,
-              agent,
-              messageIds,
-              true,
-            );
-            if (refreshedConversation?.conversationId !== conversationId) {
-              throw new Error('Conversation was deleted before message references were stored');
-            }
-
-            logger.debug(
-              `[Responses API] Stored response ${responseId} in conversation ${conversationId}`,
-            );
-          } catch (saveError) {
-            logger.error('[Responses API] Error saving response:', getSafeErrorMetadata(saveError));
-            // Don't fail the request if saving fails
-          }
-        }
 
         // The HTTP response is complete, while destructive cleanup still waits for artifacts.
         if (artifactPromises.length > 0) {
@@ -1644,59 +1660,18 @@ const executeResponse = async (envelope, { req, res }) => {
         );
 
         if (request.store === true) {
-          try {
-            const storedConversation = await saveConversation(
-              req,
-              conversationId,
-              agentId,
-              agent,
-              undefined,
-              previousResponse != null,
-            );
-            if (storedConversation?.conversationId !== conversationId) {
-              throw new Error('Conversation was deleted before the response could be stored');
-            }
-
-            const inputPersistence = await saveInputMessages(
-              req,
-              conversationId,
-              inputMessages,
-              agentId,
-              parentMessageId,
-            );
-
-            const outputMessage = await saveResponseOutput(
-              req,
-              conversationId,
-              responseId,
-              response,
-              agentId,
-              aggregator.usage.outputTokens,
-              inputPersistence.parentMessageId,
-            );
-            const messageIds = [...inputPersistence.messageIds];
-            if (outputMessage?._id != null) {
-              messageIds.push(outputMessage._id);
-            }
-            const refreshedConversation = await saveConversation(
-              req,
-              conversationId,
-              agentId,
-              agent,
-              messageIds,
-              true,
-            );
-            if (refreshedConversation?.conversationId !== conversationId) {
-              throw new Error('Conversation was deleted before message references were stored');
-            }
-
-            logger.debug(
-              `[Responses API] Stored response ${responseId} in conversation ${conversationId}`,
-            );
-          } catch (saveError) {
-            logger.error('[Responses API] Error saving response:', getSafeErrorMetadata(saveError));
-            // Don't fail the request if saving fails
-          }
+          await persistResponse({
+            req,
+            conversationId,
+            agentId,
+            agent,
+            previousResponse,
+            inputMessages,
+            parentMessageId,
+            responseId,
+            response,
+            visibleOutputTokens: aggregator.usage.outputTokens,
+          });
         }
 
         res.json(response);

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -1,6 +1,6 @@
 const { nanoid } = require('nanoid');
 const { v4: uuidv4 } = require('uuid');
-const { logger } = require('@librechat/data-schemas');
+const { logger, buildRetentionVisibilityFilter } = require('@librechat/data-schemas');
 const { Callback, formatAgentMessages } = require('@librechat/agents');
 const {
   EModelEndpoint,
@@ -81,6 +81,8 @@ const {
   executeAgentRun,
   waitForAgentExecutionWrites,
   resolveToolRoleGrants,
+  resolveStoredResponse,
+  selectStoredResponseHistory,
 } = require('@librechat/api');
 const {
   createResponsesToolEndCallback,
@@ -315,15 +317,19 @@ function extractResponseRequestContent(request, messageFragments) {
  * @param {string} userId - The user ID
  * @returns {Promise<Array>} Messages from the conversation
  */
-async function loadPreviousMessages(conversationId, userId) {
+async function loadPreviousMessages(conversationId, userId, responseMessageId) {
   try {
-    const messages = await db.getMessages({ conversationId, user: userId });
+    const messages = await db.getMessages({
+      conversationId,
+      user: userId,
+      ...buildRetentionVisibilityFilter(),
+    });
     if (!messages || messages.length === 0) {
       return [];
     }
 
     // Convert stored messages to internal format
-    return messages.map((msg) => {
+    return selectStoredResponseHistory(messages, responseMessageId).map((msg) => {
       let text;
       if (typeof msg.text === 'string') {
         text = msg.text;
@@ -361,17 +367,25 @@ async function loadPreviousMessages(conversationId, userId) {
  * @param {string} conversationId
  * @param {Array} inputMessages - Internal format messages
  * @param {string} agentId
- * @returns {Promise<void>}
+ * @param {string | null} parentMessageId
+ * @returns {Promise<{ parentMessageId: string | null, messageIds: import('mongoose').Types.ObjectId[] }>}
  */
-async function saveInputMessages(req, conversationId, inputMessages, agentId) {
+async function saveInputMessages(req, conversationId, inputMessages, agentId, parentMessageId) {
+  const messageIds = [];
+  let currentParentMessageId = parentMessageId;
   for (const msg of inputMessages) {
     if (msg.role === 'user') {
-      await db.saveMessage(
-        req,
+      const messageId = msg.messageId || nanoid();
+      const message = await db.saveMessage(
         {
-          messageId: msg.messageId || nanoid(),
+          userId: req?.user?.id,
+          isTemporary: req?.body?.isTemporary,
+          interfaceConfig: req?.config?.interfaceConfig,
+        },
+        {
+          messageId,
           conversationId,
-          parentMessageId: null,
+          parentMessageId: currentParentMessageId,
           isCreatedByUser: true,
           text: typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content),
           sender: 'User',
@@ -380,8 +394,13 @@ async function saveInputMessages(req, conversationId, inputMessages, agentId) {
         },
         { context: 'Responses API - save user input' },
       );
+      if (message?._id != null) {
+        messageIds.push(message._id);
+      }
+      currentParentMessageId = messageId;
     }
   }
+  return { parentMessageId: currentParentMessageId, messageIds };
 }
 
 /**
@@ -392,7 +411,8 @@ async function saveInputMessages(req, conversationId, inputMessages, agentId) {
  * @param {import('@librechat/api').Response} response
  * @param {string} agentId
  * @param {number | undefined} visibleOutputTokens
- * @returns {Promise<void>}
+ * @param {string | null} parentMessageId
+ * @returns {Promise<import('@librechat/data-schemas').IMessage | null | undefined>}
  */
 async function saveResponseOutput(
   req,
@@ -401,6 +421,7 @@ async function saveResponseOutput(
   response,
   agentId,
   visibleOutputTokens,
+  parentMessageId,
 ) {
   // Extract text content from output items
   let responseText = '';
@@ -417,12 +438,16 @@ async function saveResponseOutput(
   const langfuseTraceFields = await getLangfuseTraceMessageFields(req.config, responseId);
 
   // Save the assistant message
-  await db.saveMessage(
-    req,
+  return db.saveMessage(
+    {
+      userId: req?.user?.id,
+      isTemporary: req?.body?.isTemporary,
+      interfaceConfig: req?.config?.interfaceConfig,
+    },
     {
       messageId: responseId,
       conversationId,
-      parentMessageId: null,
+      parentMessageId,
       isCreatedByUser: false,
       ...langfuseTraceFields,
       text: responseText,
@@ -442,11 +467,20 @@ async function saveResponseOutput(
  * @param {string} conversationId
  * @param {string} agentId
  * @param {object} agent
- * @returns {Promise<void>}
+ * @param {import('mongoose').Types.ObjectId[] | undefined} appendMessageIds
+ * @param {boolean} noUpsert
+ * @returns {Promise<object | null>}
  */
-async function saveConversation(req, conversationId, agentId, agent) {
+async function saveConversation(
+  req,
+  conversationId,
+  agentId,
+  agent,
+  appendMessageIds,
+  noUpsert = false,
+) {
   const title = resolveConversationTitle(req, agent?.name || 'Open Responses Conversation');
-  await db.saveConvo(
+  return db.saveConvo(
     {
       userId: req?.user?.id,
       isTemporary: req?.body?.isTemporary,
@@ -462,6 +496,8 @@ async function saveConversation(req, conversationId, agentId, agent) {
     {
       context: 'Responses API - save conversation',
       initialAgentId: agent?.id === agentId ? agentId : null,
+      ...(appendMessageIds != null && { appendMessageIds }),
+      ...(noUpsert && { noUpsert: true }),
     },
   );
 }
@@ -613,6 +649,41 @@ const executeResponse = async (envelope, { req, res }) => {
     );
   }
 
+  let previousResponse = null;
+  if (request.previous_response_id != null) {
+    if (typeof request.previous_response_id !== 'string') {
+      return sendResponsesErrorResponse(
+        res,
+        400,
+        'previous_response_id must be a string',
+        'invalid_request',
+      );
+    }
+    let resolution;
+    try {
+      resolution = await resolveStoredResponse(
+        { getConvo: db.getConvo, getMessage: db.getMessage },
+        principal.userId,
+        request.previous_response_id,
+      );
+    } catch (error) {
+      return handleExecutionError({ error, res, appConfig });
+    }
+    if (resolution.status === 'read_only') {
+      return sendResponsesErrorResponse(
+        res,
+        409,
+        CHILD_THREAD_READ_ONLY_ERROR,
+        'invalid_request',
+        'conversation_read_only',
+      );
+    }
+    if (resolution.status === 'not_found') {
+      return sendResponsesErrorResponse(res, 404, 'Conversation not found', 'not_found');
+    }
+    previousResponse = resolution.reference;
+  }
+
   // Generate IDs
   const responseId = generateResponseId();
   const context = createResponseContext(request, responseId);
@@ -621,7 +692,7 @@ const executeResponse = async (envelope, { req, res }) => {
     `[Responses API] Request ${responseId} started for agent ${agentId}, stream: ${isStreaming}`,
   );
 
-  const conversationId = request.previous_response_id ?? uuidv4();
+  const conversationId = previousResponse?.conversationId ?? uuidv4();
   /** @type {Promise<import('librechat-data-provider').TAttachment | null>[]} */
   const artifactPromises = [];
   let artifactWritesCovered = false;
@@ -662,23 +733,13 @@ const executeResponse = async (envelope, { req, res }) => {
     },
     handleExecutionError: (error) => handleExecutionError({ error, res, appConfig }),
     execute: async (execution) => {
-      if (request.previous_response_id != null) {
-        if (typeof request.previous_response_id !== 'string') {
-          return sendResponsesErrorResponse(
-            res,
-            400,
-            'previous_response_id must be a string',
-            'invalid_request',
-          );
-        }
-        const previousConversation = await db.getConvo(
+      if (previousResponse != null) {
+        const revalidated = await resolveStoredResponse(
+          { getConvo: db.getConvo, getMessage: db.getMessage },
           principal.userId,
           request.previous_response_id,
         );
-        if (!previousConversation) {
-          return sendResponsesErrorResponse(res, 404, 'Conversation not found', 'not_found');
-        }
-        if (previousConversation.subagentThread != null) {
+        if (revalidated.status === 'read_only') {
           return sendResponsesErrorResponse(
             res,
             409,
@@ -687,24 +748,36 @@ const executeResponse = async (envelope, { req, res }) => {
             'conversation_read_only',
           );
         }
+        if (revalidated.status === 'not_found') {
+          return sendResponsesErrorResponse(res, 404, 'Conversation not found', 'not_found');
+        }
+        previousResponse = revalidated.reference;
       }
 
-      const parentMessageId = null;
       const mcpRequestBody = createMCPRuntimeRequestBody({
         messageId: responseId,
         conversationId,
       });
       const agentsEConfig = appConfig?.endpoints?.[EModelEndpoint.agents];
-      const previousMessages = request.previous_response_id
-        ? await loadPreviousMessages(request.previous_response_id, principal.userId)
+      const previousMessages = previousResponse
+        ? await loadPreviousMessages(
+            conversationId,
+            principal.userId,
+            previousResponse.responseMessage?.messageId,
+          )
         : [];
-      if (request.previous_response_id) {
+      if (previousResponse?.responseMessage != null && previousMessages.length === 0) {
+        return sendResponsesErrorResponse(res, 404, 'Conversation history not found', 'not_found');
+      }
+      if (previousResponse) {
         assertModelBoundContent({
           filters: appConfig?.filters,
           legacyPii: appConfig?.messageFilter?.pii,
           storedMessages: previousMessages,
         });
       }
+      const parentMessageId =
+        previousResponse?.responseMessage?.messageId ?? previousMessages.at(-1)?.messageId ?? null;
 
       // Build allowed providers set
       const allowedProviders = new Set(agentsEConfig?.allowedProviders);
@@ -1297,21 +1370,53 @@ const executeResponse = async (envelope, { req, res }) => {
         if (request.store === true) {
           try {
             // Save conversation
-            await saveConversation(req, conversationId, agentId, agent);
+            const storedConversation = await saveConversation(
+              req,
+              conversationId,
+              agentId,
+              agent,
+              undefined,
+              previousResponse != null,
+            );
+            if (storedConversation?.conversationId !== conversationId) {
+              throw new Error('Conversation was deleted before the response could be stored');
+            }
 
             // Save input messages
-            await saveInputMessages(req, conversationId, inputMessages, agentId);
+            const inputPersistence = await saveInputMessages(
+              req,
+              conversationId,
+              inputMessages,
+              agentId,
+              parentMessageId,
+            );
 
             // Build response for saving (use tracker with buildResponse for streaming)
             const finalResponse = buildResponse(context, tracker, 'completed');
-            await saveResponseOutput(
+            const outputMessage = await saveResponseOutput(
               req,
               conversationId,
               responseId,
               finalResponse,
               agentId,
               tracker.usage.outputTokens,
+              inputPersistence.parentMessageId,
             );
+            const messageIds = [...inputPersistence.messageIds];
+            if (outputMessage?._id != null) {
+              messageIds.push(outputMessage._id);
+            }
+            const refreshedConversation = await saveConversation(
+              req,
+              conversationId,
+              agentId,
+              agent,
+              messageIds,
+              true,
+            );
+            if (refreshedConversation?.conversationId !== conversationId) {
+              throw new Error('Conversation was deleted before message references were stored');
+            }
 
             logger.debug(
               `[Responses API] Stored response ${responseId} in conversation ${conversationId}`,
@@ -1514,18 +1619,50 @@ const executeResponse = async (envelope, { req, res }) => {
 
         if (request.store === true) {
           try {
-            await saveConversation(req, conversationId, agentId, agent);
+            const storedConversation = await saveConversation(
+              req,
+              conversationId,
+              agentId,
+              agent,
+              undefined,
+              previousResponse != null,
+            );
+            if (storedConversation?.conversationId !== conversationId) {
+              throw new Error('Conversation was deleted before the response could be stored');
+            }
 
-            await saveInputMessages(req, conversationId, inputMessages, agentId);
+            const inputPersistence = await saveInputMessages(
+              req,
+              conversationId,
+              inputMessages,
+              agentId,
+              parentMessageId,
+            );
 
-            await saveResponseOutput(
+            const outputMessage = await saveResponseOutput(
               req,
               conversationId,
               responseId,
               response,
               agentId,
               aggregator.usage.outputTokens,
+              inputPersistence.parentMessageId,
             );
+            const messageIds = [...inputPersistence.messageIds];
+            if (outputMessage?._id != null) {
+              messageIds.push(outputMessage._id);
+            }
+            const refreshedConversation = await saveConversation(
+              req,
+              conversationId,
+              agentId,
+              agent,
+              messageIds,
+              true,
+            );
+            if (refreshedConversation?.conversationId !== conversationId) {
+              throw new Error('Conversation was deleted before message references were stored');
+            }
 
             logger.debug(
               `[Responses API] Stored response ${responseId} in conversation ${conversationId}`,
@@ -1644,7 +1781,6 @@ const listModels = async (req, res) => {
  * Get Response - GET /v1/responses/:id
  *
  * Retrieves a stored response by its ID.
- * The response ID maps to a conversationId in LibreChat's storage.
  *
  * @param {import('express').Request} req
  * @param {import('express').Response} res
@@ -1658,11 +1794,12 @@ const getResponse = async (req, res) => {
       return sendResponsesErrorResponse(res, 400, 'Response ID is required');
     }
 
-    // The responseId could be either the response ID or the conversation ID
-    // Try to find a conversation with this ID
-    const conversation = await db.getConvo(userId, responseId);
-
-    if (!conversation) {
+    const resolution = await resolveStoredResponse(
+      { getConvo: db.getConvo, getMessage: db.getMessage },
+      userId,
+      responseId,
+    );
+    if (resolution.status !== 'found') {
       return sendResponsesErrorResponse(
         res,
         404,
@@ -1671,9 +1808,15 @@ const getResponse = async (req, res) => {
         'response_not_found',
       );
     }
+    const { conversation, conversationId, responseMessage } = resolution.reference;
 
-    // Load messages for this conversation
-    const messages = await db.getMessages({ conversationId: responseId, user: userId });
+    const messages = responseMessage
+      ? [responseMessage]
+      : await db.getMessages({
+          conversationId,
+          user: userId,
+          ...buildRetentionVisibilityFilter(),
+        });
 
     if (!messages || messages.length === 0) {
       return sendResponsesErrorResponse(
@@ -1688,18 +1831,25 @@ const getResponse = async (req, res) => {
     // Convert messages to Open Responses output format
     const output = convertMessagesToOutputItems(messages);
 
-    // Find the last assistant message for usage info
-    const lastAssistantMessage = messages.filter((m) => !m.isCreatedByUser).pop();
+    const lastAssistantMessage =
+      responseMessage ?? messages.filter((m) => !m.isCreatedByUser).pop();
+    const createdAt = responseMessage?.createdAt ?? conversation.createdAt ?? Date.now();
+    const completedAt = responseMessage?.updatedAt ?? conversation.updatedAt ?? Date.now();
 
     // Build the response object
     const response = {
       id: responseId,
       object: 'response',
-      created_at: Math.floor(new Date(conversation.createdAt || Date.now()).getTime() / 1000),
-      completed_at: Math.floor(new Date(conversation.updatedAt || Date.now()).getTime() / 1000),
+      created_at: Math.floor(new Date(createdAt).getTime() / 1000),
+      completed_at: Math.floor(new Date(completedAt).getTime() / 1000),
       status: 'completed',
       incomplete_details: null,
-      model: conversation.agentId || conversation.model || 'unknown',
+      model:
+        lastAssistantMessage?.model ||
+        conversation.agent_id ||
+        conversation.agentId ||
+        conversation.model ||
+        'unknown',
       previous_response_id: null,
       instructions: null,
       output,

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -588,6 +588,16 @@ async function persistResponse({
 }
 
 /**
+ * @param {object} msg - Stored message
+ * @returns {boolean} Whether the message contains model-generated response output
+ */
+function isStoredResponseOutput(msg) {
+  return (
+    !msg.isCreatedByUser && msg.isUserSubmitted !== true && msg.metadata?.responsesInput == null
+  );
+}
+
+/**
  * Convert stored messages to Open Responses output format
  * @param {Array} messages - Stored messages
  * @returns {Array} Output items
@@ -596,7 +606,7 @@ function convertMessagesToOutputItems(messages) {
   const output = [];
 
   for (const msg of messages) {
-    if (!msg.isCreatedByUser) {
+    if (isStoredResponseOutput(msg)) {
       output.push({
         type: 'message',
         id: msg.messageId,
@@ -1832,8 +1842,7 @@ const getResponse = async (req, res) => {
     // Convert messages to Open Responses output format
     const output = convertMessagesToOutputItems(messages);
 
-    const lastAssistantMessage =
-      responseMessage ?? messages.filter((m) => !m.isCreatedByUser).pop();
+    const lastAssistantMessage = responseMessage ?? messages.filter(isStoredResponseOutput).pop();
     const createdAt = responseMessage?.createdAt ?? conversation.createdAt ?? Date.now();
     const completedAt = responseMessage?.updatedAt ?? conversation.updatedAt ?? Date.now();
 

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -82,7 +82,10 @@ const {
   executeAgentRun,
   waitForAgentExecutionWrites,
   resolveToolRoleGrants,
+  filterCommittedResponseMessages,
+  getStoredResponseSnapshot,
   isStoredResponseOutput,
+  persistStoredResponse,
   resolveStoredResponse,
   revalidateStoredResponseConversation,
   selectStoredResponseHistory,
@@ -316,14 +319,14 @@ function extractResponseRequestContent(request, messageFragments) {
 
 /**
  * Load messages from a previous response/conversation
- * @param {string} conversationId - The conversation/response ID
+ * @param {import('@librechat/data-schemas').IConversation} conversation
  * @param {string} userId - The user ID
  * @param {string | undefined} responseMessageId - Canonical response branch target
  * @returns {Promise<Array>} Messages from the conversation
  */
-async function loadPreviousMessages(conversationId, userId, responseMessageId) {
+async function loadPreviousMessages(conversation, userId, responseMessageId) {
   const messages = await db.getMessages({
-    conversationId,
+    conversationId: conversation.conversationId,
     user: userId,
     ...buildRetentionVisibilityFilter(),
   });
@@ -332,10 +335,13 @@ async function loadPreviousMessages(conversationId, userId, responseMessageId) {
   }
 
   // Convert stored messages to internal format
-  return selectStoredResponseHistory(messages, responseMessageId).flatMap((msg) => {
-    const responsesOutput = msg.metadata?.responsesOutput;
-    if (Array.isArray(responsesOutput)) {
-      const restoredOutput = convertToInternalMessages(responsesOutput);
+  return selectStoredResponseHistory(
+    filterCommittedResponseMessages(messages),
+    responseMessageId,
+  ).flatMap((msg) => {
+    const snapshot = getStoredResponseSnapshot(msg);
+    if (snapshot != null) {
+      const restoredOutput = convertToInternalMessages(snapshot.output);
       if (restoredOutput.length > 0) {
         return restoredOutput.map((outputMessage) => ({
           ...outputMessage,
@@ -384,169 +390,8 @@ async function loadPreviousMessages(conversationId, userId, responseMessageId) {
   });
 }
 
-/**
- * Save input messages to database
- * @param {import('express').Request} req
- * @param {string} conversationId
- * @param {Array} inputMessages - Internal format messages
- * @param {string} agentId
- * @param {string | null} parentMessageId
- * @returns {Promise<{ parentMessageId: string | null, messageIds: import('mongoose').Types.ObjectId[] }>}
- */
-async function saveInputMessages(req, conversationId, inputMessages, agentId, parentMessageId) {
-  const messageIds = [];
-  let currentParentMessageId = parentMessageId;
-  for (const msg of inputMessages) {
-    const messageId = msg.messageId || nanoid();
-    let sender = 'Agent';
-    if (msg.role === 'user') {
-      sender = 'User';
-    } else if (msg.role === 'tool') {
-      sender = 'Tool';
-    }
-    const message = await db.saveMessage(
-      {
-        userId: req?.user?.id,
-        isTemporary: req?.body?.isTemporary,
-        interfaceConfig: req?.config?.interfaceConfig,
-      },
-      {
-        messageId,
-        conversationId,
-        parentMessageId: currentParentMessageId,
-        isCreatedByUser: msg.role === 'user',
-        isUserSubmitted: true,
-        text: typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content),
-        ...(Array.isArray(msg.content) && { content: msg.content }),
-        sender,
-        endpoint: EModelEndpoint.agents,
-        model: agentId,
-        metadata: {
-          responsesInput: {
-            role: msg.role,
-            ...(typeof msg.name === 'string' && { name: msg.name }),
-            ...(typeof msg.tool_call_id === 'string' && { tool_call_id: msg.tool_call_id }),
-            ...(Array.isArray(msg.tool_calls) && { tool_calls: msg.tool_calls }),
-          },
-        },
-      },
-      { context: 'Responses API - save input' },
-    );
-    if (message?._id != null) {
-      messageIds.push(message._id);
-    }
-    currentParentMessageId = messageId;
-  }
-  return { parentMessageId: currentParentMessageId, messageIds };
-}
-
-/**
- * Save response output to database
- * @param {import('express').Request} req
- * @param {string} conversationId
- * @param {string} responseId
- * @param {import('@librechat/api').Response} response
- * @param {string} agentId
- * @param {number | undefined} visibleOutputTokens
- * @param {string | null} parentMessageId
- * @param {string | null} previousResponseId
- * @returns {Promise<import('@librechat/data-schemas').IMessage | null | undefined>}
- */
-async function saveResponseOutput(
-  req,
-  conversationId,
-  responseId,
-  response,
-  agentId,
-  visibleOutputTokens,
-  parentMessageId,
-  previousResponseId,
-) {
-  // Extract text content from output items
-  let responseText = '';
-  for (const item of response.output) {
-    if (item.type === 'message' && item.content) {
-      for (const part of item.content) {
-        if (part.type === 'output_text' && part.text) {
-          responseText += part.text;
-        }
-      }
-    }
-  }
-
-  const langfuseTraceFields = await getLangfuseTraceMessageFields(req.config, responseId);
-
-  // Save the assistant message
-  return db.saveMessage(
-    {
-      userId: req?.user?.id,
-      isTemporary: req?.body?.isTemporary,
-      interfaceConfig: req?.config?.interfaceConfig,
-    },
-    {
-      messageId: responseId,
-      conversationId,
-      parentMessageId,
-      isCreatedByUser: false,
-      isUserSubmitted: false,
-      ...langfuseTraceFields,
-      text: responseText,
-      sender: 'Agent',
-      endpoint: EModelEndpoint.agents,
-      model: agentId,
-      finish_reason: response.status === 'completed' ? 'stop' : response.status,
-      tokenCount: visibleOutputTokens ?? response.usage?.output_tokens,
-      metadata: {
-        responsesOutput: response.output,
-        ...(previousResponseId != null && { responsesPreviousResponseId: previousResponseId }),
-      },
-    },
-    { context: 'Responses API - save assistant response' },
-  );
-}
-
-/**
- * Save or update conversation
- * @param {import('express').Request} req
- * @param {string} conversationId
- * @param {string} agentId
- * @param {object} agent
- * @param {import('mongoose').Types.ObjectId[] | undefined} appendMessageIds
- * @param {boolean} noUpsert
- * @returns {Promise<object | null>}
- */
-async function saveConversation(
-  req,
-  conversationId,
-  agentId,
-  agent,
-  appendMessageIds,
-  noUpsert = false,
-) {
-  const title = resolveConversationTitle(req, agent?.name || 'Open Responses Conversation');
-  return db.saveConvo(
-    {
-      userId: req?.user?.id,
-      isTemporary: req?.body?.isTemporary,
-      interfaceConfig: req?.config?.interfaceConfig,
-    },
-    {
-      conversationId,
-      endpoint: EModelEndpoint.agents,
-      agent_id: agentId,
-      ...(title != null && { title }),
-      model: agent?.model,
-    },
-    {
-      context: 'Responses API - save conversation',
-      initialAgentId: agent?.id === agentId ? agentId : null,
-      ...(appendMessageIds != null && { appendMessageIds }),
-      ...(noUpsert && { noUpsert: true }),
-    },
-  );
-}
-
-async function persistResponse({
+/** Persist one complete Responses turn through the shared manifest protocol. */
+function persistResponse({
   req,
   conversationId,
   agentId,
@@ -558,52 +403,43 @@ async function persistResponse({
   response,
   visibleOutputTokens,
 }) {
-  const storedConversation = await saveConversation(
-    req,
-    conversationId,
+  const title = resolveConversationTitle(req, agent?.name || 'Open Responses Conversation');
+  return persistStoredResponse({
+    deps: {
+      saveConvo: db.saveConvo,
+      saveMessage: db.saveMessage,
+      getConvo: db.getConvo,
+      getMessage: db.getMessage,
+      commitStoredResponseTurn: db.commitStoredResponseTurn,
+      deleteStoredResponseTurn: db.deleteStoredResponseTurn,
+    },
+    context: {
+      userId: req?.user?.id,
+      isTemporary: req?.body?.isTemporary,
+      interfaceConfig: req?.config?.interfaceConfig,
+    },
+    conversation: {
+      data: {
+        conversationId,
+        endpoint: EModelEndpoint.agents,
+        agent_id: agentId,
+        ...(title != null && { title }),
+        model: agent?.model,
+      },
+      initialAgentId: agent?.id === agentId ? agentId : null,
+      isContinuation: previousResponse != null,
+    },
     agentId,
-    agent,
-    [],
-    previousResponse != null,
-  );
-  if (storedConversation?.conversationId !== conversationId) {
-    throw new Error('Conversation was deleted before the response could be stored');
-  }
-
-  const inputPersistence = await saveInputMessages(
-    req,
-    conversationId,
     inputMessages,
-    agentId,
     parentMessageId,
-  );
-  const outputMessage = await saveResponseOutput(
-    req,
-    conversationId,
     responseId,
     response,
-    agentId,
     visibleOutputTokens,
-    inputPersistence.parentMessageId,
-    previousResponse?.responseMessage?.messageId ?? previousResponse?.conversationId ?? null,
-  );
-  const messageIds = [...inputPersistence.messageIds];
-  if (outputMessage?._id != null) {
-    messageIds.push(outputMessage._id);
-  }
-  const refreshedConversation = await saveConversation(
-    req,
-    conversationId,
-    agentId,
-    agent,
-    messageIds,
-    true,
-  );
-  if (refreshedConversation?.conversationId !== conversationId) {
-    throw new Error('Conversation was deleted before message references were stored');
-  }
-
-  logger.debug(`[Responses API] Stored response ${responseId} in conversation ${conversationId}`);
+    getOutputMessageFields: () => getLangfuseTraceMessageFields(req.config, responseId),
+  }).then((result) => {
+    logger.debug(`[Responses API] Stored response ${responseId} in conversation ${conversationId}`);
+    return result;
+  });
 }
 
 /**
@@ -616,9 +452,9 @@ function convertMessagesToOutputItems(messages) {
 
   for (const msg of messages) {
     if (isStoredResponseOutput(msg)) {
-      const responsesOutput = msg.metadata?.responsesOutput;
-      if (Array.isArray(responsesOutput)) {
-        output.push(...responsesOutput);
+      const snapshot = getStoredResponseSnapshot(msg);
+      if (snapshot != null) {
+        output.push(...snapshot.output);
       } else {
         output.push({
           type: 'message',
@@ -857,7 +693,7 @@ const executeResponse = async (envelope, { req, res }) => {
             previousResponse,
           ),
           loadPreviousMessages(
-            conversationId,
+            previousResponse.conversation,
             principal.userId,
             previousResponse.responseMessage?.messageId,
           ),
@@ -1860,11 +1696,13 @@ const getResponse = async (req, res) => {
 
     const messages = responseMessage
       ? [responseMessage]
-      : await db.getMessages({
-          conversationId,
-          user: userId,
-          ...buildRetentionVisibilityFilter(),
-        });
+      : filterCommittedResponseMessages(
+          await db.getMessages({
+            conversationId,
+            user: userId,
+            ...buildRetentionVisibilityFilter(),
+          }),
+        );
 
     if (!messages || messages.length === 0) {
       return sendResponsesErrorResponse(
@@ -1880,6 +1718,18 @@ const getResponse = async (req, res) => {
     const output = convertMessagesToOutputItems(messages);
 
     const lastAssistantMessage = responseMessage ?? messages.filter(isStoredResponseOutput).pop();
+    const storedSnapshot =
+      lastAssistantMessage == null ? null : getStoredResponseSnapshot(lastAssistantMessage);
+    let storedUsage = null;
+    if (storedSnapshot != null && Object.prototype.hasOwnProperty.call(storedSnapshot, 'usage')) {
+      storedUsage = storedSnapshot.usage;
+    } else if (lastAssistantMessage?.tokenCount) {
+      storedUsage = {
+        input_tokens: 0,
+        output_tokens: lastAssistantMessage.tokenCount,
+        total_tokens: lastAssistantMessage.tokenCount,
+      };
+    }
     const createdAt = responseMessage?.createdAt ?? conversation.createdAt ?? Date.now();
     const completedAt = responseMessage?.updatedAt ?? conversation.updatedAt ?? Date.now();
 
@@ -1897,10 +1747,7 @@ const getResponse = async (req, res) => {
         conversation.agentId ||
         conversation.model ||
         'unknown',
-      previous_response_id:
-        typeof responseMessage?.metadata?.responsesPreviousResponseId === 'string'
-          ? responseMessage.metadata.responsesPreviousResponseId
-          : null,
+      previous_response_id: storedSnapshot?.previousResponseId ?? null,
       instructions: null,
       output,
       error: null,
@@ -1916,13 +1763,7 @@ const getResponse = async (req, res) => {
       top_logprobs: null,
       reasoning: null,
       user: userId,
-      usage: lastAssistantMessage?.tokenCount
-        ? {
-            input_tokens: 0,
-            output_tokens: lastAssistantMessage.tokenCount,
-            total_tokens: lastAssistantMessage.tokenCount,
-          }
-        : null,
+      usage: storedUsage,
       max_output_tokens: null,
       max_tool_calls: null,
       store: true,

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -321,71 +321,66 @@ function extractResponseRequestContent(request, messageFragments) {
  * @returns {Promise<Array>} Messages from the conversation
  */
 async function loadPreviousMessages(conversationId, userId, responseMessageId) {
-  try {
-    const messages = await db.getMessages({
-      conversationId,
-      user: userId,
-      ...buildRetentionVisibilityFilter(),
-    });
-    if (!messages || messages.length === 0) {
-      return [];
-    }
-
-    // Convert stored messages to internal format
-    return selectStoredResponseHistory(messages, responseMessageId).flatMap((msg) => {
-      const responsesOutput = msg.metadata?.responsesOutput;
-      if (Array.isArray(responsesOutput)) {
-        const restoredOutput = convertToInternalMessages(responsesOutput);
-        if (restoredOutput.length > 0) {
-          return restoredOutput.map((outputMessage) => ({
-            ...outputMessage,
-            messageId: msg.messageId,
-            isCreatedByUser: false,
-            isUserSubmitted: false,
-          }));
-        }
-      }
-      const responsesInput = msg.metadata?.responsesInput;
-      let role = responsesInput?.role;
-      if (!['system', 'user', 'assistant', 'tool'].includes(role)) {
-        role = msg.isCreatedByUser ? 'user' : 'assistant';
-      }
-      let text;
-      if (typeof msg.text === 'string') {
-        text = msg.text;
-      } else if (msg.text != null) {
-        text = String(msg.text);
-      }
-      const internalMsg = {
-        role,
-        content: Array.isArray(msg.content) ? msg.content : (text ?? ''),
-        messageId: msg.messageId,
-        isCreatedByUser: msg.isCreatedByUser === true,
-        ...(text !== undefined && { text }),
-        ...(typeof msg.isUserSubmitted === 'boolean' && {
-          isUserSubmitted: msg.isUserSubmitted,
-        }),
-        ...(Array.isArray(msg.userSubmittedPaths) && {
-          userSubmittedPaths: msg.userSubmittedPaths,
-        }),
-        ...(Array.isArray(msg.userSubmittedMessageFieldPaths) && {
-          userSubmittedMessageFieldPaths: msg.userSubmittedMessageFieldPaths,
-        }),
-        ...(typeof responsesInput?.name === 'string' && { name: responsesInput.name }),
-        ...(typeof responsesInput?.tool_call_id === 'string' && {
-          tool_call_id: responsesInput.tool_call_id,
-        }),
-        ...(Array.isArray(responsesInput?.tool_calls) && {
-          tool_calls: responsesInput.tool_calls,
-        }),
-      };
-
-      return [internalMsg];
-    });
-  } catch (error) {
-    logger.error('[Responses API] Error loading previous messages:', getSafeErrorMetadata(error));
+  const messages = await db.getMessages({
+    conversationId,
+    user: userId,
+    ...buildRetentionVisibilityFilter(),
+  });
+  if (!messages || messages.length === 0) {
     return [];
   }
+
+  // Convert stored messages to internal format
+  return selectStoredResponseHistory(messages, responseMessageId).flatMap((msg) => {
+    const responsesOutput = msg.metadata?.responsesOutput;
+    if (Array.isArray(responsesOutput)) {
+      const restoredOutput = convertToInternalMessages(responsesOutput);
+      if (restoredOutput.length > 0) {
+        return restoredOutput.map((outputMessage) => ({
+          ...outputMessage,
+          messageId: msg.messageId,
+          isCreatedByUser: false,
+          isUserSubmitted: false,
+        }));
+      }
+    }
+    const responsesInput = msg.metadata?.responsesInput;
+    let role = responsesInput?.role;
+    if (!['system', 'user', 'assistant', 'tool'].includes(role)) {
+      role = msg.isCreatedByUser ? 'user' : 'assistant';
+    }
+    let text;
+    if (typeof msg.text === 'string') {
+      text = msg.text;
+    } else if (msg.text != null) {
+      text = String(msg.text);
+    }
+    const internalMsg = {
+      role,
+      content: Array.isArray(msg.content) ? msg.content : (text ?? ''),
+      messageId: msg.messageId,
+      isCreatedByUser: msg.isCreatedByUser === true,
+      ...(text !== undefined && { text }),
+      ...(typeof msg.isUserSubmitted === 'boolean' && {
+        isUserSubmitted: msg.isUserSubmitted,
+      }),
+      ...(Array.isArray(msg.userSubmittedPaths) && {
+        userSubmittedPaths: msg.userSubmittedPaths,
+      }),
+      ...(Array.isArray(msg.userSubmittedMessageFieldPaths) && {
+        userSubmittedMessageFieldPaths: msg.userSubmittedMessageFieldPaths,
+      }),
+      ...(typeof responsesInput?.name === 'string' && { name: responsesInput.name }),
+      ...(typeof responsesInput?.tool_call_id === 'string' && {
+        tool_call_id: responsesInput.tool_call_id,
+      }),
+      ...(Array.isArray(responsesInput?.tool_calls) && {
+        tool_calls: responsesInput.tool_calls,
+      }),
+    };
+
+    return [internalMsg];
+  });
 }
 
 /**
@@ -750,8 +745,32 @@ const executeResponse = async (envelope, { req, res }) => {
     );
   }
 
-  // Look up the agent
-  const agent = await db.getAgent({ id: agentId });
+  const previousResponseId = request.previous_response_id;
+  if (previousResponseId != null && typeof previousResponseId !== 'string') {
+    return sendResponsesErrorResponse(
+      res,
+      400,
+      'previous_response_id must be a string',
+      'invalid_request',
+    );
+  }
+
+  let agent;
+  let resolution = null;
+  try {
+    [agent, resolution] = await Promise.all([
+      db.getAgent({ id: agentId }),
+      previousResponseId == null
+        ? Promise.resolve(null)
+        : resolveStoredResponse(
+            { getConvo: db.getConvo, getMessage: db.getMessage },
+            principal.userId,
+            previousResponseId,
+          ),
+    ]);
+  } catch (error) {
+    return handleExecutionError({ error, res, appConfig });
+  }
   if (!agent) {
     return sendResponsesErrorResponse(
       res,
@@ -763,25 +782,7 @@ const executeResponse = async (envelope, { req, res }) => {
   }
 
   let previousResponse = null;
-  if (request.previous_response_id != null) {
-    if (typeof request.previous_response_id !== 'string') {
-      return sendResponsesErrorResponse(
-        res,
-        400,
-        'previous_response_id must be a string',
-        'invalid_request',
-      );
-    }
-    let resolution;
-    try {
-      resolution = await resolveStoredResponse(
-        { getConvo: db.getConvo, getMessage: db.getMessage },
-        principal.userId,
-        request.previous_response_id,
-      );
-    } catch (error) {
-      return handleExecutionError({ error, res, appConfig });
-    }
+  if (resolution != null) {
     if (resolution.status === 'read_only') {
       return sendResponsesErrorResponse(
         res,

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -63,6 +63,7 @@ const {
   generateResponseId,
   isValidationFailure,
   emitResponseCreated,
+  emitResponseFailed,
   createResponseContext,
   createResponseTracker,
   setupStreamingResponse,
@@ -1478,18 +1479,33 @@ const executeResponse = async (envelope, { req, res }) => {
 
         if (request.store === true) {
           completeOutput();
-          await persistResponse({
-            req,
-            conversationId,
-            agentId,
-            agent,
-            previousResponse,
-            inputMessages,
-            parentMessageId,
-            responseId,
-            response: buildResponse(context, tracker, 'completed', usage),
-            visibleOutputTokens: tracker.usage.outputTokens,
-          });
+          try {
+            await persistResponse({
+              req,
+              conversationId,
+              agentId,
+              agent,
+              previousResponse,
+              inputMessages,
+              parentMessageId,
+              responseId,
+              response: buildResponse(context, tracker, 'completed', usage),
+              visibleOutputTokens: tracker.usage.outputTokens,
+            });
+          } catch (error) {
+            const protectionEnabled = hasModelBoundContentProtection(
+              appConfig?.filters,
+              appConfig?.messageFilter?.pii,
+            );
+            const errorCode =
+              !protectionEnabled && typeof error?.code === 'string' ? error.code : undefined;
+            emitResponseFailed(handlerConfig, {
+              type: 'server_error',
+              message: getUserFacingProviderError(error, protectionEnabled),
+              ...(errorCode !== undefined && { code: errorCode }),
+            });
+            return handleExecutionError({ error, res, appConfig });
+          }
         }
 
         finalizeStream(usage);

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -1312,9 +1312,10 @@ const executeResponse = async (envelope, { req, res }) => {
         );
 
         const usage = buildResponsesUsage(collectedUsage);
+        completeOutput();
+        const completedResponse = buildResponse(context, tracker, 'completed', usage);
 
         if (request.store === true) {
-          completeOutput();
           try {
             await persistResponse({
               req,
@@ -1325,7 +1326,7 @@ const executeResponse = async (envelope, { req, res }) => {
               inputMessages,
               parentMessageId,
               responseId,
-              response: buildResponse(context, tracker, 'completed', usage),
+              response: completedResponse,
               visibleOutputTokens: tracker.usage.outputTokens,
             });
           } catch (error) {
@@ -1344,7 +1345,7 @@ const executeResponse = async (envelope, { req, res }) => {
           }
         }
 
-        finalizeStream(usage);
+        finalizeStream(usage, completedResponse);
         res.end();
 
         const duration = Date.now() - requestStartTime;
@@ -1714,12 +1715,13 @@ const getResponse = async (req, res) => {
       );
     }
 
-    // Convert messages to Open Responses output format
-    const output = convertMessagesToOutputItems(messages);
-
     const lastAssistantMessage = responseMessage ?? messages.filter(isStoredResponseOutput).pop();
     const storedSnapshot =
       lastAssistantMessage == null ? null : getStoredResponseSnapshot(lastAssistantMessage);
+    if (responseMessage != null && storedSnapshot?.response != null) {
+      return res.json(storedSnapshot.response);
+    }
+    const output = convertMessagesToOutputItems(messages);
     let storedUsage = null;
     if (storedSnapshot != null && Object.prototype.hasOwnProperty.call(storedSnapshot, 'usage')) {
       storedUsage = storedSnapshot.usage;

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -81,7 +81,9 @@ const {
   executeAgentRun,
   waitForAgentExecutionWrites,
   resolveToolRoleGrants,
+  isStoredResponseOutput,
   resolveStoredResponse,
+  revalidateStoredResponseConversation,
   selectStoredResponseHistory,
 } = require('@librechat/api');
 const {
@@ -315,6 +317,7 @@ function extractResponseRequestContent(request, messageFragments) {
  * Load messages from a previous response/conversation
  * @param {string} conversationId - The conversation/response ID
  * @param {string} userId - The user ID
+ * @param {string | undefined} responseMessageId - Canonical response branch target
  * @returns {Promise<Array>} Messages from the conversation
  */
 async function loadPreviousMessages(conversationId, userId, responseMessageId) {
@@ -329,7 +332,19 @@ async function loadPreviousMessages(conversationId, userId, responseMessageId) {
     }
 
     // Convert stored messages to internal format
-    return selectStoredResponseHistory(messages, responseMessageId).map((msg) => {
+    return selectStoredResponseHistory(messages, responseMessageId).flatMap((msg) => {
+      const responsesOutput = msg.metadata?.responsesOutput;
+      if (Array.isArray(responsesOutput)) {
+        const restoredOutput = convertToInternalMessages(responsesOutput);
+        if (restoredOutput.length > 0) {
+          return restoredOutput.map((outputMessage) => ({
+            ...outputMessage,
+            messageId: msg.messageId,
+            isCreatedByUser: false,
+            isUserSubmitted: false,
+          }));
+        }
+      }
       const responsesInput = msg.metadata?.responsesInput;
       let role = responsesInput?.role;
       if (!['system', 'user', 'assistant', 'tool'].includes(role)) {
@@ -365,7 +380,7 @@ async function loadPreviousMessages(conversationId, userId, responseMessageId) {
         }),
       };
 
-      return internalMsg;
+      return [internalMsg];
     });
   } catch (error) {
     logger.error('[Responses API] Error loading previous messages:', getSafeErrorMetadata(error));
@@ -438,6 +453,7 @@ async function saveInputMessages(req, conversationId, inputMessages, agentId, pa
  * @param {string} agentId
  * @param {number | undefined} visibleOutputTokens
  * @param {string | null} parentMessageId
+ * @param {string | null} previousResponseId
  * @returns {Promise<import('@librechat/data-schemas').IMessage | null | undefined>}
  */
 async function saveResponseOutput(
@@ -448,6 +464,7 @@ async function saveResponseOutput(
   agentId,
   visibleOutputTokens,
   parentMessageId,
+  previousResponseId,
 ) {
   // Extract text content from output items
   let responseText = '';
@@ -475,6 +492,7 @@ async function saveResponseOutput(
       conversationId,
       parentMessageId,
       isCreatedByUser: false,
+      isUserSubmitted: false,
       ...langfuseTraceFields,
       text: responseText,
       sender: 'Agent',
@@ -482,6 +500,10 @@ async function saveResponseOutput(
       model: agentId,
       finish_reason: response.status === 'completed' ? 'stop' : response.status,
       tokenCount: visibleOutputTokens ?? response.usage?.output_tokens,
+      metadata: {
+        responsesOutput: response.output,
+        ...(previousResponseId != null && { responsesPreviousResponseId: previousResponseId }),
+      },
     },
     { context: 'Responses API - save assistant response' },
   );
@@ -567,6 +589,7 @@ async function persistResponse({
     agentId,
     visibleOutputTokens,
     inputPersistence.parentMessageId,
+    previousResponse?.responseMessage?.messageId ?? previousResponse?.conversationId ?? null,
   );
   const messageIds = [...inputPersistence.messageIds];
   if (outputMessage?._id != null) {
@@ -588,16 +611,6 @@ async function persistResponse({
 }
 
 /**
- * @param {object} msg - Stored message
- * @returns {boolean} Whether the message contains model-generated response output
- */
-function isStoredResponseOutput(msg) {
-  return (
-    !msg.isCreatedByUser && msg.isUserSubmitted !== true && msg.metadata?.responsesInput == null
-  );
-}
-
-/**
  * Convert stored messages to Open Responses output format
  * @param {Array} messages - Stored messages
  * @returns {Array} Output items
@@ -607,19 +620,24 @@ function convertMessagesToOutputItems(messages) {
 
   for (const msg of messages) {
     if (isStoredResponseOutput(msg)) {
-      output.push({
-        type: 'message',
-        id: msg.messageId,
-        role: 'assistant',
-        status: 'completed',
-        content: [
-          {
-            type: 'output_text',
-            text: msg.text || '',
-            annotations: [],
-          },
-        ],
-      });
+      const responsesOutput = msg.metadata?.responsesOutput;
+      if (Array.isArray(responsesOutput)) {
+        output.push(...responsesOutput);
+      } else {
+        output.push({
+          type: 'message',
+          id: msg.messageId,
+          role: 'assistant',
+          status: 'completed',
+          content: [
+            {
+              type: 'output_text',
+              text: msg.text || '',
+              annotations: [],
+            },
+          ],
+        });
+      }
     }
   }
 
@@ -828,12 +846,20 @@ const executeResponse = async (envelope, { req, res }) => {
     },
     handleExecutionError: (error) => handleExecutionError({ error, res, appConfig }),
     execute: async (execution) => {
+      let previousMessages = [];
       if (previousResponse != null) {
-        const revalidated = await resolveStoredResponse(
-          { getConvo: db.getConvo, getMessage: db.getMessage },
-          principal.userId,
-          request.previous_response_id,
-        );
+        const [revalidated, history] = await Promise.all([
+          revalidateStoredResponseConversation(
+            { getConvo: db.getConvo },
+            principal.userId,
+            previousResponse,
+          ),
+          loadPreviousMessages(
+            conversationId,
+            principal.userId,
+            previousResponse.responseMessage?.messageId,
+          ),
+        ]);
         if (revalidated.status === 'read_only') {
           return sendResponsesErrorResponse(
             res,
@@ -847,6 +873,7 @@ const executeResponse = async (envelope, { req, res }) => {
           return sendResponsesErrorResponse(res, 404, 'Conversation not found', 'not_found');
         }
         previousResponse = revalidated.reference;
+        previousMessages = history;
       }
 
       const mcpRequestBody = createMCPRuntimeRequestBody({
@@ -854,13 +881,6 @@ const executeResponse = async (envelope, { req, res }) => {
         conversationId,
       });
       const agentsEConfig = appConfig?.endpoints?.[EModelEndpoint.agents];
-      const previousMessages = previousResponse
-        ? await loadPreviousMessages(
-            conversationId,
-            principal.userId,
-            previousResponse.responseMessage?.messageId,
-          )
-        : [];
       if (previousResponse != null && previousMessages.length === 0) {
         return sendResponsesErrorResponse(res, 404, 'Conversation history not found', 'not_found');
       }
@@ -1860,7 +1880,10 @@ const getResponse = async (req, res) => {
         conversation.agentId ||
         conversation.model ||
         'unknown',
-      previous_response_id: null,
+      previous_response_id:
+        typeof responseMessage?.metadata?.responsesPreviousResponseId === 'string'
+          ? responseMessage.metadata.responsesPreviousResponseId
+          : null,
       instructions: null,
       output,
       error: null,

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -330,6 +330,11 @@ async function loadPreviousMessages(conversationId, userId, responseMessageId) {
 
     // Convert stored messages to internal format
     return selectStoredResponseHistory(messages, responseMessageId).map((msg) => {
+      const responsesInput = msg.metadata?.responsesInput;
+      let role = responsesInput?.role;
+      if (!['system', 'user', 'assistant', 'tool'].includes(role)) {
+        role = msg.isCreatedByUser ? 'user' : 'assistant';
+      }
       let text;
       if (typeof msg.text === 'string') {
         text = msg.text;
@@ -337,7 +342,7 @@ async function loadPreviousMessages(conversationId, userId, responseMessageId) {
         text = String(msg.text);
       }
       const internalMsg = {
-        role: msg.isCreatedByUser ? 'user' : 'assistant',
+        role,
         content: Array.isArray(msg.content) ? msg.content : (text ?? ''),
         messageId: msg.messageId,
         isCreatedByUser: msg.isCreatedByUser === true,
@@ -350,6 +355,13 @@ async function loadPreviousMessages(conversationId, userId, responseMessageId) {
         }),
         ...(Array.isArray(msg.userSubmittedMessageFieldPaths) && {
           userSubmittedMessageFieldPaths: msg.userSubmittedMessageFieldPaths,
+        }),
+        ...(typeof responsesInput?.name === 'string' && { name: responsesInput.name }),
+        ...(typeof responsesInput?.tool_call_id === 'string' && {
+          tool_call_id: responsesInput.tool_call_id,
+        }),
+        ...(Array.isArray(responsesInput?.tool_calls) && {
+          tool_calls: responsesInput.tool_calls,
         }),
       };
 
@@ -374,31 +386,45 @@ async function saveInputMessages(req, conversationId, inputMessages, agentId, pa
   const messageIds = [];
   let currentParentMessageId = parentMessageId;
   for (const msg of inputMessages) {
+    const messageId = msg.messageId || nanoid();
+    let sender = 'Agent';
     if (msg.role === 'user') {
-      const messageId = msg.messageId || nanoid();
-      const message = await db.saveMessage(
-        {
-          userId: req?.user?.id,
-          isTemporary: req?.body?.isTemporary,
-          interfaceConfig: req?.config?.interfaceConfig,
-        },
-        {
-          messageId,
-          conversationId,
-          parentMessageId: currentParentMessageId,
-          isCreatedByUser: true,
-          text: typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content),
-          sender: 'User',
-          endpoint: EModelEndpoint.agents,
-          model: agentId,
-        },
-        { context: 'Responses API - save user input' },
-      );
-      if (message?._id != null) {
-        messageIds.push(message._id);
-      }
-      currentParentMessageId = messageId;
+      sender = 'User';
+    } else if (msg.role === 'tool') {
+      sender = 'Tool';
     }
+    const message = await db.saveMessage(
+      {
+        userId: req?.user?.id,
+        isTemporary: req?.body?.isTemporary,
+        interfaceConfig: req?.config?.interfaceConfig,
+      },
+      {
+        messageId,
+        conversationId,
+        parentMessageId: currentParentMessageId,
+        isCreatedByUser: msg.role === 'user',
+        isUserSubmitted: true,
+        text: typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content),
+        ...(Array.isArray(msg.content) && { content: msg.content }),
+        sender,
+        endpoint: EModelEndpoint.agents,
+        model: agentId,
+        metadata: {
+          responsesInput: {
+            role: msg.role,
+            ...(typeof msg.name === 'string' && { name: msg.name }),
+            ...(typeof msg.tool_call_id === 'string' && { tool_call_id: msg.tool_call_id }),
+            ...(Array.isArray(msg.tool_calls) && { tool_calls: msg.tool_calls }),
+          },
+        },
+      },
+      { context: 'Responses API - save input' },
+    );
+    if (message?._id != null) {
+      messageIds.push(message._id);
+    }
+    currentParentMessageId = messageId;
   }
   return { parentMessageId: currentParentMessageId, messageIds };
 }
@@ -766,7 +792,7 @@ const executeResponse = async (envelope, { req, res }) => {
             previousResponse.responseMessage?.messageId,
           )
         : [];
-      if (previousResponse?.responseMessage != null && previousMessages.length === 0) {
+      if (previousResponse != null && previousMessages.length === 0) {
         return sendResponsesErrorResponse(res, 404, 'Conversation history not found', 'not_found');
       }
       if (previousResponse) {

--- a/packages/api/src/agents/responses/__tests__/service.test.ts
+++ b/packages/api/src/agents/responses/__tests__/service.test.ts
@@ -4,11 +4,12 @@ import {
   buildAggregatedResponse,
   convertInputToMessages,
   createAggregatorEventHandlers,
+  createResponseContext,
   createResponseAggregator,
   createResponsesEventHandlers,
   buildResponsesUsage,
 } from '../service';
-import { createResponseTracker } from '../handlers';
+import { buildResponse, createResponseTracker } from '../handlers';
 
 describe('response usage aggregation', () => {
   const context: ResponseContext = {
@@ -96,6 +97,16 @@ describe('response usage aggregation', () => {
 
     const completed = writes.find((chunk) => chunk.startsWith('data: {'));
     expect(JSON.parse(completed?.slice(6) ?? '{}').response.usage).toEqual(usage);
+  });
+
+  it('reports the validated storage choice in JSON and streaming responses', () => {
+    const storedContext = createResponseContext(
+      { model: 'agent_test', input: 'Hello', store: true },
+      'resp_stored',
+    );
+
+    expect(buildAggregatedResponse(storedContext, createResponseAggregator()).store).toBe(true);
+    expect(buildResponse(storedContext, createResponseTracker(), 'completed').store).toBe(true);
   });
 });
 

--- a/packages/api/src/agents/responses/__tests__/service.test.ts
+++ b/packages/api/src/agents/responses/__tests__/service.test.ts
@@ -108,6 +108,30 @@ describe('response usage aggregation', () => {
     expect(buildAggregatedResponse(storedContext, createResponseAggregator()).store).toBe(true);
     expect(buildResponse(storedContext, createResponseTracker(), 'completed').store).toBe(true);
   });
+
+  it('completes streamed output for persistence without emitting the terminal response', () => {
+    const writes: string[] = [];
+    const res = {
+      write: (chunk: string) => {
+        writes.push(chunk);
+      },
+    } as unknown as ServerResponse;
+    const tracker = createResponseTracker();
+    const { handlers, completeOutput } = createResponsesEventHandlers({ res, context, tracker });
+
+    handlers.on_message_delta.handle('on_message_delta', {
+      delta: { content: [{ type: 'text', text: 'Persisted first' }] },
+    });
+    completeOutput();
+
+    expect(buildResponse(context, tracker, 'completed').output).toEqual([
+      expect.objectContaining({
+        status: 'completed',
+        content: [expect.objectContaining({ text: 'Persisted first' })],
+      }),
+    ]);
+    expect(writes.some((chunk) => chunk.includes('"type":"response.completed"'))).toBe(false);
+  });
 });
 
 describe('convertInputToMessages', () => {

--- a/packages/api/src/agents/responses/__tests__/service.test.ts
+++ b/packages/api/src/agents/responses/__tests__/service.test.ts
@@ -99,6 +99,26 @@ describe('response usage aggregation', () => {
     expect(JSON.parse(completed?.slice(6) ?? '{}').response.usage).toEqual(usage);
   });
 
+  it('emits the persisted envelope unchanged after storage delays', () => {
+    const writes: string[] = [];
+    const res = { write: (chunk: string) => writes.push(chunk) } as unknown as ServerResponse;
+    const tracker = createResponseTracker();
+    const handlers = createResponsesEventHandlers({ res, context, tracker });
+    const now = jest.spyOn(Date, 'now');
+    try {
+      now.mockReturnValue(1700000000000);
+      handlers.completeOutput();
+      const response = buildResponse(context, tracker, 'completed');
+      now.mockReturnValue(1700000060000);
+      handlers.finalizeStream(undefined, response);
+      const completed = writes.find((chunk) => chunk.startsWith('data: {'));
+      expect(JSON.parse(completed?.slice(6) ?? '{}').response).toEqual(response);
+      expect(writes[writes.length - 1]).toBe('data: [DONE]\n\n');
+    } finally {
+      now.mockRestore();
+    }
+  });
+
   it('reports the validated storage choice in JSON and streaming responses', () => {
     const storedContext = createResponseContext(
       { model: 'agent_test', input: 'Hello', store: true },

--- a/packages/api/src/agents/responses/__tests__/service.test.ts
+++ b/packages/api/src/agents/responses/__tests__/service.test.ts
@@ -8,8 +8,40 @@ import {
   createResponseAggregator,
   createResponsesEventHandlers,
   buildResponsesUsage,
+  validateResponseRequest,
 } from '../service';
 import { buildResponse, createResponseTracker } from '../handlers';
+
+describe('response storage validation', () => {
+  it.each([false, true])(
+    'rejects temporary stored responses before execution (stream=%s)',
+    (stream) => {
+      expect(
+        validateResponseRequest({
+          model: 'agent_test',
+          input: 'Hello',
+          store: true,
+          isTemporary: true,
+          stream,
+        }),
+      ).toEqual({
+        valid: false,
+        error: 'store: true cannot be combined with isTemporary: true',
+      });
+    },
+  );
+
+  it.each([
+    { store: true, isTemporary: false },
+    { store: true },
+    { store: false, isTemporary: true },
+    { isTemporary: true },
+  ])('preserves supported storage choices %j', (options) => {
+    expect(validateResponseRequest({ model: 'agent_test', input: 'Hello', ...options }).valid).toBe(
+      true,
+    );
+  });
+});
 
 describe('response usage aggregation', () => {
   const context: ResponseContext = {

--- a/packages/api/src/agents/responses/handlers.ts
+++ b/packages/api/src/agents/responses/handlers.ts
@@ -165,7 +165,7 @@ export function buildResponse(
       : null,
     max_output_tokens: null,
     max_tool_calls: null,
-    store: false,
+    store: context.store === true,
     background: false,
     service_tier: 'default',
     metadata: {},

--- a/packages/api/src/agents/responses/handlers.ts
+++ b/packages/api/src/agents/responses/handlers.ts
@@ -310,10 +310,14 @@ export function emitResponseInProgress(config: StreamHandlerConfig): void {
 /**
  * Emit response.completed event
  */
-export function emitResponseCompleted(config: StreamHandlerConfig, usage?: Usage): void {
+export function emitResponseCompleted(
+  config: StreamHandlerConfig,
+  usage?: Usage,
+  completedResponse?: Response,
+): void {
   const { res, context, tracker } = config;
   tracker.status = 'completed';
-  const response = buildResponse(context, tracker, 'completed', usage);
+  const response = completedResponse ?? buildResponse(context, tracker, 'completed', usage);
   writeEvent(res, {
     type: 'response.completed',
     sequence_number: tracker.nextSequence(),

--- a/packages/api/src/agents/responses/index.ts
+++ b/packages/api/src/agents/responses/index.ts
@@ -182,3 +182,11 @@ export {
   createAggregatorEventHandlers,
   type ResponseAggregator,
 } from './service';
+
+export {
+  resolveStoredResponse,
+  selectStoredResponseHistory,
+  type StoredResponseLookup,
+  type StoredResponseReference,
+  type StoredResponseResolution,
+} from './persistence';

--- a/packages/api/src/agents/responses/index.ts
+++ b/packages/api/src/agents/responses/index.ts
@@ -184,8 +184,11 @@ export {
 } from './service';
 
 export {
+  isStoredResponseOutput,
   resolveStoredResponse,
+  revalidateStoredResponseConversation,
   selectStoredResponseHistory,
+  type StoredResponseConversationLookup,
   type StoredResponseLookup,
   type StoredResponseReference,
   type StoredResponseResolution,

--- a/packages/api/src/agents/responses/index.ts
+++ b/packages/api/src/agents/responses/index.ts
@@ -184,12 +184,21 @@ export {
 } from './service';
 
 export {
+  buildStoredResponseMetadata,
+  filterCommittedResponseMessages,
+  getStoredResponseSnapshot,
+  isCommittedStoredResponse,
   isStoredResponseOutput,
+  persistStoredResponse,
   resolveStoredResponse,
   revalidateStoredResponseConversation,
   selectStoredResponseHistory,
+  type PersistStoredResponseParams,
   type StoredResponseConversationLookup,
+  type StoredResponseInputMessage,
   type StoredResponseLookup,
   type StoredResponseReference,
   type StoredResponseResolution,
+  type StoredResponseSnapshot,
+  type StoredResponseWriteDependencies,
 } from './persistence';

--- a/packages/api/src/agents/responses/persistence.database.spec.ts
+++ b/packages/api/src/agents/responses/persistence.database.spec.ts
@@ -3,7 +3,14 @@ import { EModelEndpoint } from 'librechat-data-provider';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import { createMethods, createModels, tenantStorage } from '@librechat/data-schemas';
 import type { AllMethods, IConversation, IMessage } from '@librechat/data-schemas';
-import { resolveStoredResponse } from './persistence';
+import type { Response } from './types';
+import {
+  buildStoredResponseMetadata,
+  filterCommittedResponseMessages,
+  getStoredResponseSnapshot,
+  persistStoredResponse,
+  resolveStoredResponse,
+} from './persistence';
 
 const TENANT_A = 'tenant-aaaaaaaaaaaaaaaaaaaa';
 const TENANT_B = 'tenant-bbbbbbbbbbbbbbbbbbbb';
@@ -178,4 +185,222 @@ describe('resolveStoredResponse with Mongo tenant scope', () => {
       ),
     ).resolves.toEqual({ status: 'not_found' });
   });
+
+  it('does not let an ordinary conversation save publish a pending Responses turn', async () => {
+    const conversationId = '82bb41c5-5c41-4e3b-8488-d110386d6315';
+    const responseId = 'resp_pending_browser_save';
+    await asTenant(TENANT_A, async () => {
+      await Conversation.create({
+        conversationId,
+        user: OWNER,
+        title: 'pending',
+        endpoint: EModelEndpoint.agents,
+        isTemporary: false,
+      });
+      await Message.create([
+        {
+          messageId: 'pending-input',
+          conversationId,
+          user: OWNER,
+          sender: 'User',
+          text: 'question',
+          isCreatedByUser: true,
+          isUserSubmitted: true,
+          metadata: {
+            responsesTurn: { version: 1, responseId },
+            responsesInput: { role: 'user' },
+          },
+        },
+        {
+          messageId: responseId,
+          conversationId,
+          user: OWNER,
+          sender: 'Agent',
+          text: 'answer',
+          isCreatedByUser: false,
+          isUserSubmitted: false,
+          metadata: buildStoredResponseMetadata(storedResponse({ id: responseId })),
+        },
+      ]);
+
+      await methods.saveConvo({ userId: OWNER }, { conversationId, title: 'renamed by browser' });
+      const rebuilt = await methods.getConvo(OWNER, conversationId);
+      const messages = await methods.getMessages({ user: OWNER, conversationId });
+
+      expect(rebuilt?.messages).toHaveLength(2);
+      expect(filterCommittedResponseMessages(messages)).toEqual([]);
+      await expect(resolveStoredResponse(lookup(), OWNER, responseId)).resolves.toEqual({
+        status: 'not_found',
+      });
+    });
+  });
+
+  it('publishes one complete turn only after the manifest and output marker commit', async () => {
+    const conversationId = '92bb41c5-5c41-4e3b-8488-d110386d6315';
+    const responseId = 'resp_committed_turn';
+    const response = storedResponse({ id: responseId });
+
+    await asTenant(TENANT_A, async () => {
+      const result = await persistStoredResponse({
+        deps: {
+          saveConvo: methods.saveConvo,
+          saveMessage: methods.saveMessage,
+          getConvo: methods.getConvo,
+          getMessage: methods.getMessage,
+          commitStoredResponseTurn: methods.commitStoredResponseTurn,
+          deleteStoredResponseTurn: methods.deleteStoredResponseTurn,
+          createMessageId: () => 'committed-input',
+        },
+        context: { userId: OWNER },
+        conversation: {
+          data: { conversationId, endpoint: EModelEndpoint.agents, agent_id: 'agent-1' },
+          initialAgentId: 'agent-1',
+          isContinuation: false,
+        },
+        inputMessages: [{ role: 'user', content: 'question' }],
+        parentMessageId: null,
+        responseId,
+        response,
+        agentId: 'agent-1',
+      });
+      const messages = await methods.getMessages({ user: OWNER, conversationId });
+
+      expect(filterCommittedResponseMessages(messages)).toHaveLength(2);
+      expect(getStoredResponseSnapshot(result.outputMessage)).toEqual({
+        output: response.output,
+        usage: response.usage,
+        previousResponseId: response.previous_response_id,
+      });
+      await expect(resolveStoredResponse(lookup(), OWNER, responseId)).resolves.toMatchObject({
+        status: 'found',
+        reference: { responseMessage: { messageId: responseId } },
+      });
+    });
+  });
+
+  it('preserves both turns when concurrent Responses commits append to one conversation', async () => {
+    const conversationId = 'a2bb41c5-5c41-4e3b-8488-d110386d6315';
+    await asTenant(TENANT_A, async () => {
+      await methods.saveConvo(
+        { userId: OWNER },
+        { conversationId, endpoint: EModelEndpoint.agents, agent_id: 'agent-1' },
+        { appendMessageIds: [] },
+      );
+      const persist = (responseId: string, inputId: string) =>
+        persistStoredResponse({
+          deps: {
+            saveConvo: methods.saveConvo,
+            saveMessage: methods.saveMessage,
+            getConvo: methods.getConvo,
+            getMessage: methods.getMessage,
+            commitStoredResponseTurn: methods.commitStoredResponseTurn,
+            deleteStoredResponseTurn: methods.deleteStoredResponseTurn,
+            createMessageId: () => inputId,
+          },
+          context: { userId: OWNER },
+          conversation: {
+            data: { conversationId, endpoint: EModelEndpoint.agents, agent_id: 'agent-1' },
+            initialAgentId: 'agent-1',
+            isContinuation: true,
+          },
+          inputMessages: [{ role: 'user', content: inputId }],
+          parentMessageId: null,
+          responseId,
+          response: storedResponse({ id: responseId }),
+          agentId: 'agent-1',
+        });
+
+      await Promise.all([
+        persist('resp_concurrent_a', 'concurrent-input-a'),
+        persist('resp_concurrent_b', 'concurrent-input-b'),
+      ]);
+      const storedConversation = await methods.getConvo(OWNER, conversationId);
+      const messages = await methods.getMessages({ user: OWNER, conversationId });
+
+      expect(storedConversation?.messages).toHaveLength(4);
+      expect(filterCommittedResponseMessages(messages)).toHaveLength(4);
+    });
+  });
+
+  it('does not recreate a deleted pending output and cleans only its exact turn', async () => {
+    const conversationId = 'b2bb41c5-5c41-4e3b-8488-d110386d6315';
+    const responseId = 'resp_deleted_pending';
+    await asTenant(TENANT_A, async () => {
+      await Message.create([
+        {
+          messageId: 'deleted-turn-input',
+          conversationId,
+          user: OWNER,
+          isCreatedByUser: true,
+          isUserSubmitted: true,
+          metadata: {
+            responsesTurn: { version: 1, responseId },
+            responsesInput: { role: 'user' },
+          },
+        },
+        {
+          messageId: responseId,
+          conversationId,
+          user: OWNER,
+          isCreatedByUser: false,
+          isUserSubmitted: false,
+          metadata: buildStoredResponseMetadata(storedResponse({ id: responseId })),
+        },
+        {
+          messageId: 'sibling-turn',
+          conversationId,
+          user: OWNER,
+          isCreatedByUser: false,
+          isUserSubmitted: false,
+          metadata: buildStoredResponseMetadata(
+            storedResponse({ id: 'sibling-turn' }),
+            'committed',
+          ),
+        },
+      ]);
+      await Message.deleteOne({ user: OWNER, conversationId, messageId: responseId });
+
+      await expect(
+        methods.commitStoredResponseTurn({ userId: OWNER, conversationId, responseId }),
+      ).resolves.toBeNull();
+      await methods.deleteStoredResponseTurn({ userId: OWNER, conversationId, responseId });
+
+      expect(
+        await Message.exists({ user: OWNER, conversationId, messageId: responseId }),
+      ).toBeNull();
+      expect(
+        await Message.exists({ user: OWNER, conversationId, messageId: 'deleted-turn-input' }),
+      ).toBeNull();
+      expect(
+        await Message.exists({ user: OWNER, conversationId, messageId: 'sibling-turn' }),
+      ).not.toBeNull();
+    });
+  });
 });
+
+function storedResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    id: 'resp_stored',
+    status: 'completed',
+    previous_response_id: null,
+    output: [
+      {
+        type: 'message',
+        id: 'output-item',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'answer', annotations: [], logprobs: [] }],
+      },
+    ],
+    usage: {
+      input_tokens: 4,
+      output_tokens: 2,
+      total_tokens: 6,
+      input_tokens_details: { cached_tokens: 1 },
+      output_tokens_details: { reasoning_tokens: 0 },
+      primary: { input_tokens: 4, output_tokens: 2, total_tokens: 6 },
+      subagent: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
+    },
+    ...overrides,
+  } as Response;
+}

--- a/packages/api/src/agents/responses/persistence.database.spec.ts
+++ b/packages/api/src/agents/responses/persistence.database.spec.ts
@@ -1,0 +1,181 @@
+import mongoose from 'mongoose';
+import { EModelEndpoint } from 'librechat-data-provider';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { createMethods, createModels, tenantStorage } from '@librechat/data-schemas';
+import type { AllMethods, IConversation, IMessage } from '@librechat/data-schemas';
+import { resolveStoredResponse } from './persistence';
+
+const TENANT_A = 'tenant-aaaaaaaaaaaaaaaaaaaa';
+const TENANT_B = 'tenant-bbbbbbbbbbbbbbbbbbbb';
+const OWNER = 'response-owner';
+const FOREIGN_OWNER = 'response-foreign-owner';
+const SHARED_CONVERSATION_ID = '5dbb41c5-5c41-4e3b-8488-d110386d6315';
+const SHARED_RESPONSE_ID = 'resp_shared_response';
+
+let mongoServer: MongoMemoryServer;
+let methods: AllMethods;
+let Conversation: mongoose.Model<IConversation>;
+let Message: mongoose.Model<IMessage>;
+
+function asTenant<T>(tenantId: string, operation: () => Promise<T>): Promise<T> {
+  return tenantStorage.run({ tenantId }, operation);
+}
+
+function lookup() {
+  return { getConvo: methods.getConvo, getMessage: methods.getMessage };
+}
+
+async function seedResponse(
+  tenantId: string,
+  user: string,
+  values: {
+    conversationId: string;
+    responseId: string;
+    title: string;
+    text: string;
+    conversationTemporary?: boolean;
+    conversationExpiredAt?: Date;
+    messageTemporary?: boolean;
+    messageExpiredAt?: Date;
+  },
+): Promise<void> {
+  await asTenant(tenantId, async () => {
+    await Conversation.create({
+      conversationId: values.conversationId,
+      user,
+      title: values.title,
+      endpoint: EModelEndpoint.agents,
+      isTemporary: values.conversationTemporary ?? false,
+      ...(values.conversationExpiredAt == null ? {} : { expiredAt: values.conversationExpiredAt }),
+    });
+    await Message.create({
+      messageId: values.responseId,
+      conversationId: values.conversationId,
+      user,
+      sender: 'Agent',
+      text: values.text,
+      isCreatedByUser: false,
+      isTemporary: values.messageTemporary ?? false,
+      ...(values.messageExpiredAt == null ? {} : { expiredAt: values.messageExpiredAt }),
+    });
+  });
+}
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+  createModels(mongoose);
+  methods = createMethods(mongoose);
+  Conversation = mongoose.models.Conversation as mongoose.Model<IConversation>;
+  Message = mongoose.models.Message as mongoose.Model<IMessage>;
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+beforeEach(async () => {
+  await mongoose.connection.dropDatabase();
+});
+
+describe('resolveStoredResponse with Mongo tenant scope', () => {
+  it('resolves duplicate response and conversation ids only from the active tenant', async () => {
+    await Promise.all([
+      seedResponse(TENANT_A, OWNER, {
+        conversationId: SHARED_CONVERSATION_ID,
+        responseId: SHARED_RESPONSE_ID,
+        title: 'tenant A conversation',
+        text: 'tenant A response',
+      }),
+      seedResponse(TENANT_B, OWNER, {
+        conversationId: SHARED_CONVERSATION_ID,
+        responseId: SHARED_RESPONSE_ID,
+        title: 'tenant B conversation',
+        text: 'tenant B response',
+      }),
+    ]);
+
+    const tenantA = await asTenant(TENANT_A, () =>
+      resolveStoredResponse(lookup(), OWNER, SHARED_RESPONSE_ID),
+    );
+    const tenantB = await asTenant(TENANT_B, () =>
+      resolveStoredResponse(lookup(), OWNER, SHARED_RESPONSE_ID),
+    );
+
+    expect(tenantA).toMatchObject({
+      status: 'found',
+      reference: {
+        conversationId: SHARED_CONVERSATION_ID,
+        conversation: { title: 'tenant A conversation', tenantId: TENANT_A },
+        responseMessage: { text: 'tenant A response', tenantId: TENANT_A },
+      },
+    });
+    expect(tenantB).toMatchObject({
+      status: 'found',
+      reference: {
+        conversationId: SHARED_CONVERSATION_ID,
+        conversation: { title: 'tenant B conversation', tenantId: TENANT_B },
+        responseMessage: { text: 'tenant B response', tenantId: TENANT_B },
+      },
+    });
+  });
+
+  it('does not resolve another owner response in the same tenant', async () => {
+    await seedResponse(TENANT_A, FOREIGN_OWNER, {
+      conversationId: '62bb41c5-5c41-4e3b-8488-d110386d6315',
+      responseId: 'resp_foreign_response',
+      title: 'foreign',
+      text: 'foreign response',
+    });
+
+    await expect(
+      asTenant(TENANT_A, () => resolveStoredResponse(lookup(), OWNER, 'resp_foreign_response')),
+    ).resolves.toEqual({ status: 'not_found' });
+  });
+
+  it.each([
+    [
+      'temporary conversation',
+      '72bb41c5-5c41-4e3b-8488-d110386d6315',
+      {
+        conversationTemporary: true,
+      },
+    ],
+    [
+      'expired conversation',
+      '73bb41c5-5c41-4e3b-8488-d110386d6315',
+      {
+        conversationExpiredAt: new Date('2020-01-01T00:00:00.000Z'),
+      },
+    ],
+    [
+      'temporary response message',
+      '74bb41c5-5c41-4e3b-8488-d110386d6315',
+      {
+        messageTemporary: true,
+      },
+    ],
+    [
+      'expired response message',
+      '75bb41c5-5c41-4e3b-8488-d110386d6315',
+      {
+        messageExpiredAt: new Date('2020-01-01T00:00:00.000Z'),
+      },
+    ],
+  ])('hides a %s', async (_name, conversationId, visibility) => {
+    await seedResponse(TENANT_A, OWNER, {
+      conversationId,
+      responseId: `resp_hidden_${_name.replaceAll(' ', '_')}`,
+      title: 'hidden',
+      text: 'hidden response',
+      ...visibility,
+    });
+
+    await expect(
+      asTenant(TENANT_A, () =>
+        resolveStoredResponse(lookup(), OWNER, `resp_hidden_${_name.replaceAll(' ', '_')}`),
+      ),
+    ).resolves.toEqual({ status: 'not_found' });
+  });
+});

--- a/packages/api/src/agents/responses/persistence.database.spec.ts
+++ b/packages/api/src/agents/responses/persistence.database.spec.ts
@@ -267,6 +267,7 @@ describe('resolveStoredResponse with Mongo tenant scope', () => {
 
       expect(filterCommittedResponseMessages(messages)).toHaveLength(2);
       expect(getStoredResponseSnapshot(result.outputMessage)).toEqual({
+        response,
         output: response.output,
         usage: response.usage,
         previousResponseId: response.previous_response_id,
@@ -381,6 +382,10 @@ describe('resolveStoredResponse with Mongo tenant scope', () => {
 function storedResponse(overrides: Partial<Response> = {}): Response {
   return {
     id: 'resp_stored',
+    object: 'response',
+    instructions: 'Use the supplied context.',
+    created_at: 1700000000,
+    completed_at: 1700000060,
     status: 'completed',
     previous_response_id: null,
     output: [

--- a/packages/api/src/agents/responses/persistence.database.spec.ts
+++ b/packages/api/src/agents/responses/persistence.database.spec.ts
@@ -228,7 +228,12 @@ describe('resolveStoredResponse with Mongo tenant scope', () => {
       const messages = await methods.getMessages({ user: OWNER, conversationId });
 
       expect(rebuilt?.messages).toHaveLength(2);
-      expect(filterCommittedResponseMessages(messages)).toEqual([]);
+      expect(messages).toEqual([]);
+      expect(await methods.getMessage({ user: OWNER, messageId: responseId })).toBeNull();
+      expect(await methods.getMessagesByCursor({ user: OWNER, conversationId })).toEqual({
+        messages: [],
+        nextCursor: null,
+      });
       await expect(resolveStoredResponse(lookup(), OWNER, responseId)).resolves.toEqual({
         status: 'not_found',
       });
@@ -275,6 +280,41 @@ describe('resolveStoredResponse with Mongo tenant scope', () => {
       await expect(resolveStoredResponse(lookup(), OWNER, responseId)).resolves.toMatchObject({
         status: 'found',
         reference: { responseMessage: { messageId: responseId } },
+      });
+    });
+  });
+
+  it('keeps an ambiguously failed publication hidden from ordinary reads', async () => {
+    const conversationId = 'b2bb41c5-5c41-4e3b-8488-d110386d6315';
+    const responseId = 'resp_failed_publication';
+    await asTenant(TENANT_A, async () => {
+      await expect(
+        persistStoredResponse({
+          deps: {
+            ...methods,
+            commitStoredResponseTurn: async () => {
+              throw new Error('unavailable');
+            },
+          },
+          context: { userId: OWNER, isTemporary: false },
+          conversation: {
+            data: { conversationId, endpoint: EModelEndpoint.agents, title: 'failed turn' },
+            initialAgentId: null,
+            isContinuation: false,
+          },
+          inputMessages: [{ role: 'user', content: 'question' }],
+          parentMessageId: null,
+          responseId,
+          response: storedResponse({ id: responseId }),
+          agentId: 'agent-1',
+        }),
+      ).rejects.toThrow();
+      expect(await Message.find({ user: OWNER, conversationId })).toHaveLength(2);
+      expect(await methods.getMessages({ user: OWNER, conversationId })).toEqual([]);
+      expect(await methods.getMessage({ user: OWNER, messageId: responseId })).toBeNull();
+      expect(await methods.getMessagesByCursor({ user: OWNER, conversationId })).toEqual({
+        messages: [],
+        nextCursor: null,
       });
     });
   });

--- a/packages/api/src/agents/responses/persistence.spec.ts
+++ b/packages/api/src/agents/responses/persistence.spec.ts
@@ -264,15 +264,29 @@ describe('Responses persistence', () => {
     ).toEqual([committedInput, committedOutput, legacy]);
   });
 
-  it('round-trips the exact stored output, usage, and predecessor snapshot', () => {
+  it('round-trips the complete response envelope', () => {
     const storedResponse = response();
     const storedMessage = message({ metadata: buildStoredResponseMetadata(storedResponse) });
 
     expect(getStoredResponseSnapshot(storedMessage)).toEqual({
+      response: storedResponse,
       output: storedResponse.output,
       usage: storedResponse.usage,
       previousResponseId: storedResponse.previous_response_id,
     });
+  });
+
+  it('reads earlier snapshots without a complete envelope', () => {
+    const stored = response();
+    const snapshot = {
+      output: stored.output,
+      usage: stored.usage,
+      previousResponseId: stored.previous_response_id,
+    };
+    const storedMessage = message({
+      metadata: { responsesResponse: { version: 1, commitState: 'committed', ...snapshot } },
+    });
+    expect(getStoredResponseSnapshot(storedMessage)).toEqual(snapshot);
   });
 
   it('stages a turn and publishes all message ids through one manifest commit', async () => {
@@ -451,6 +465,10 @@ describe('Responses persistence', () => {
 function response(overrides: Partial<Response> = {}): Response {
   return {
     id: 'resp_target',
+    object: 'response',
+    instructions: 'Use the supplied context.',
+    created_at: 1700000000,
+    completed_at: 1700000060,
     status: 'completed',
     previous_response_id: 'resp_previous',
     output: [

--- a/packages/api/src/agents/responses/persistence.spec.ts
+++ b/packages/api/src/agents/responses/persistence.spec.ts
@@ -1,16 +1,26 @@
+import { Types } from 'mongoose';
 import { Constants } from 'librechat-data-provider';
 import type { IConversation, IMessage } from '@librechat/data-schemas';
+import type { Response } from './types';
 import {
+  buildStoredResponseMetadata,
+  filterCommittedResponseMessages,
+  getStoredResponseSnapshot,
+  persistStoredResponse,
   resolveStoredResponse,
   revalidateStoredResponseConversation,
   selectStoredResponseHistory,
   type StoredResponseLookup,
+  type StoredResponseWriteDependencies,
 } from './persistence';
+
+const DEFAULT_MESSAGE_OBJECT_ID = new Types.ObjectId();
 
 const conversation = (overrides: Partial<IConversation> = {}): IConversation =>
   ({
     conversationId: '11111111-1111-4111-8111-111111111111',
     user: 'owner',
+    messages: [DEFAULT_MESSAGE_OBJECT_ID],
     isTemporary: false,
     expiredAt: null,
     ...overrides,
@@ -21,10 +31,13 @@ const message = (overrides: Partial<IMessage> = {}): IMessage =>
     messageId: 'resp_target',
     conversationId: '11111111-1111-4111-8111-111111111111',
     user: 'owner',
+    _id: DEFAULT_MESSAGE_OBJECT_ID,
     isCreatedByUser: false,
+    isUserSubmitted: false,
     parentMessageId: 'input-target',
     isTemporary: false,
     expiredAt: null,
+    metadata: buildStoredResponseMetadata(response(), 'committed'),
     ...overrides,
   }) as IMessage;
 
@@ -65,6 +78,18 @@ describe('Responses persistence', () => {
       status: 'not_found',
     });
     expect(deps.getConvo).not.toHaveBeenCalled();
+  });
+
+  it('rejects a canonical response that was staged but not committed', async () => {
+    const storedMessage = message({ metadata: buildStoredResponseMetadata(response(), 'pending') });
+    const deps: StoredResponseLookup = {
+      getMessage: jest.fn().mockResolvedValue(storedMessage),
+      getConvo: jest.fn().mockResolvedValue(conversation()),
+    };
+
+    await expect(resolveStoredResponse(deps, 'owner', 'resp_target')).resolves.toEqual({
+      status: 'not_found',
+    });
   });
 
   it('rejects hidden conversations and classifies child threads as read-only', async () => {
@@ -170,4 +195,325 @@ describe('Responses persistence', () => {
     expect(selectStoredResponseHistory(legacy, 'resp_old')).toEqual(legacy);
     expect(selectStoredResponseHistory(broken, 'resp_broken')).toEqual([]);
   });
+
+  it('prepends the flat legacy prefix when a canonical branch reaches its last flat response', () => {
+    const messages = [
+      message({ messageId: 'legacy-input', parentMessageId: null, isCreatedByUser: true }),
+      message({ messageId: 'legacy-response', parentMessageId: null }),
+      message({
+        messageId: 'canonical-input',
+        parentMessageId: 'legacy-response',
+        isCreatedByUser: true,
+      }),
+      message({ messageId: 'resp_canonical', parentMessageId: 'canonical-input' }),
+      message({
+        messageId: 'sibling-input',
+        parentMessageId: 'legacy-response',
+        isCreatedByUser: true,
+      }),
+      message({ messageId: 'resp_sibling', parentMessageId: 'sibling-input' }),
+    ];
+
+    expect(
+      selectStoredResponseHistory(messages, 'resp_canonical').map((item) => item.messageId),
+    ).toEqual(['legacy-input', 'legacy-response', 'canonical-input', 'resp_canonical']);
+  });
+
+  it('admits marked inputs only with their exact committed output and preserves unmarked legacy rows', () => {
+    const committedOutput = message();
+    const committedInput = message({
+      messageId: 'input-committed',
+      isCreatedByUser: true,
+      isUserSubmitted: true,
+      metadata: {
+        responsesTurn: { version: 1, responseId: 'resp_target' },
+        responsesInput: { role: 'user' },
+      },
+    });
+    const pendingOutput = message({
+      messageId: 'resp_pending',
+      metadata: buildStoredResponseMetadata(
+        response({ id: 'resp_pending', previous_response_id: null }),
+        'pending',
+      ),
+    });
+    const pendingInput = message({
+      messageId: 'input-pending',
+      isCreatedByUser: true,
+      isUserSubmitted: true,
+      metadata: {
+        responsesTurn: { version: 1, responseId: 'resp_pending' },
+        responsesInput: { role: 'user' },
+      },
+    });
+    const malformedMarker = message({
+      messageId: 'malformed-marker',
+      metadata: { responsesTurn: { version: 99, responseId: 'resp_target' } },
+    });
+    const legacy = message({ messageId: 'legacy', metadata: undefined });
+
+    expect(
+      filterCommittedResponseMessages([
+        committedInput,
+        committedOutput,
+        pendingInput,
+        pendingOutput,
+        malformedMarker,
+        legacy,
+      ]),
+    ).toEqual([committedInput, committedOutput, legacy]);
+  });
+
+  it('round-trips the exact stored output, usage, and predecessor snapshot', () => {
+    const storedResponse = response();
+    const storedMessage = message({ metadata: buildStoredResponseMetadata(storedResponse) });
+
+    expect(getStoredResponseSnapshot(storedMessage)).toEqual({
+      output: storedResponse.output,
+      usage: storedResponse.usage,
+      previousResponseId: storedResponse.previous_response_id,
+    });
+  });
+
+  it('stages a turn and publishes all message ids through one manifest commit', async () => {
+    const inputId = new Types.ObjectId();
+    const outputId = new Types.ObjectId();
+    const saveMessage = jest
+      .fn()
+      .mockResolvedValueOnce(message({ _id: inputId, messageId: 'input' }))
+      .mockResolvedValueOnce(message({ _id: outputId, messageId: 'resp_target' }));
+    const saveConvo = jest
+      .fn()
+      .mockResolvedValueOnce(conversation({ messages: [] }))
+      .mockImplementationOnce((_context, _data, metadata) =>
+        conversation({ messages: metadata?.appendMessageIds }),
+      );
+    const params = persistenceParams({ saveConvo, saveMessage });
+
+    await expect(persistStoredResponse(params)).resolves.toMatchObject({
+      conversation: { conversationId: params.conversation.data.conversationId },
+      outputMessage: { messageId: 'resp_target' },
+    });
+    expect(saveConvo).toHaveBeenNthCalledWith(
+      1,
+      params.context,
+      params.conversation.data,
+      expect.objectContaining({ appendMessageIds: [] }),
+    );
+    expect(saveConvo).toHaveBeenNthCalledWith(
+      2,
+      params.context,
+      params.conversation.data,
+      expect.objectContaining({ appendMessageIds: [inputId, outputId], noUpsert: true }),
+    );
+    expect(saveMessage.mock.calls[1][1].metadata).toEqual(
+      buildStoredResponseMetadata(params.response),
+    );
+    expect(params.deps.commitStoredResponseTurn).toHaveBeenCalledWith({
+      userId: params.context.userId,
+      conversationId: params.conversation.data.conversationId,
+      responseId: params.responseId,
+    });
+    expect(saveMessage.mock.calls[0][1].metadata).toEqual(
+      expect.objectContaining({
+        responsesTurn: { version: 1, responseId: params.responseId },
+      }),
+    );
+  });
+
+  it('accepts a lost manifest-write result only after read-back proves the commit', async () => {
+    const inputId = new Types.ObjectId();
+    const outputId = new Types.ObjectId();
+    const committedConversation = conversation({ messages: [inputId, outputId] });
+    const saveConvo = jest
+      .fn()
+      .mockResolvedValueOnce(conversation({ messages: [] }))
+      .mockRejectedValueOnce(new Error('acknowledgement lost'));
+    const params = persistenceParams({
+      saveConvo,
+      saveMessage: stagedMessages(inputId, outputId),
+      getConvo: jest.fn().mockResolvedValue(committedConversation),
+    });
+
+    await expect(persistStoredResponse(params)).resolves.toMatchObject({
+      conversation: committedConversation,
+    });
+    expect(saveConvo).toHaveBeenCalledTimes(2);
+  });
+
+  it('accepts an indeterminate marker result only after read-back proves the commit', async () => {
+    const inputId = new Types.ObjectId();
+    const outputId = new Types.ObjectId();
+    const committedOutput = message({ _id: outputId });
+    const params = persistenceParams({
+      saveConvo: jest
+        .fn()
+        .mockResolvedValueOnce(conversation({ messages: [] }))
+        .mockResolvedValueOnce(conversation({ messages: [inputId, outputId] })),
+      saveMessage: stagedMessages(inputId, outputId),
+      commitStoredResponseTurn: jest.fn().mockRejectedValue(new Error('acknowledgement lost')),
+      getMessage: jest.fn().mockResolvedValue(committedOutput),
+    });
+
+    await expect(persistStoredResponse(params)).resolves.toMatchObject({
+      outputMessage: committedOutput,
+    });
+    expect(params.deps.commitStoredResponseTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it('never rolls back a turn after an indeterminate marker write', async () => {
+    const inputId = new Types.ObjectId();
+    const outputId = new Types.ObjectId();
+    let markerState = 'pending';
+    const params = persistenceParams({
+      saveConvo: jest
+        .fn()
+        .mockResolvedValueOnce(conversation({ messages: [] }))
+        .mockResolvedValueOnce(conversation({ messages: [inputId, outputId] })),
+      saveMessage: stagedMessages(inputId, outputId),
+      commitStoredResponseTurn: jest.fn().mockImplementation(async () => {
+        markerState = 'committed';
+        throw new Error('acknowledgement lost');
+      }),
+      getMessage: jest.fn().mockRejectedValue(new Error('readback unavailable')),
+    });
+
+    await expect(persistStoredResponse(params)).rejects.toThrow('readback unavailable');
+    expect(markerState).toBe('committed');
+    expect(params.deps.commitStoredResponseTurn).toHaveBeenCalledTimes(2);
+    expect(params.deps.deleteStoredResponseTurn).not.toHaveBeenCalled();
+  });
+
+  it('retries one incomplete manifest append without upserting', async () => {
+    const inputId = new Types.ObjectId();
+    const outputId = new Types.ObjectId();
+    const saveConvo = jest
+      .fn()
+      .mockResolvedValueOnce(conversation({ messages: [] }))
+      .mockResolvedValueOnce({ message: 'write failed' })
+      .mockResolvedValueOnce(conversation({ messages: [inputId, outputId] }));
+    const getConvo = jest.fn().mockResolvedValue(conversation({ messages: [] }));
+    const params = persistenceParams({
+      saveConvo,
+      saveMessage: stagedMessages(inputId, outputId),
+      getConvo,
+    });
+
+    await expect(persistStoredResponse(params)).resolves.toBeDefined();
+    expect(saveConvo).toHaveBeenCalledTimes(3);
+    expect(saveConvo.mock.calls[1][2]).toEqual(
+      expect.objectContaining({ appendMessageIds: [inputId, outputId], noUpsert: true }),
+    );
+    expect(saveConvo.mock.calls[2][2]).toEqual(
+      expect.objectContaining({ appendMessageIds: [inputId, outputId], noUpsert: true }),
+    );
+  });
+
+  it('fails when deletion wins during staging and never upserts the final manifest', async () => {
+    const inputId = new Types.ObjectId();
+    const outputId = new Types.ObjectId();
+    const saveConvo = jest
+      .fn()
+      .mockResolvedValueOnce(conversation({ messages: [] }))
+      .mockResolvedValueOnce(null);
+    const params = persistenceParams({
+      saveConvo,
+      saveMessage: stagedMessages(inputId, outputId),
+      getConvo: jest.fn().mockResolvedValue(null),
+    });
+
+    await expect(persistStoredResponse(params)).rejects.toThrow(
+      'Conversation was deleted before message references were stored',
+    );
+    expect(saveConvo.mock.calls[1][2]).toEqual(expect.objectContaining({ noUpsert: true }));
+    expect(params.deps.deleteStoredResponseTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['input', jest.fn().mockResolvedValue(undefined)],
+    [
+      'output',
+      jest
+        .fn()
+        .mockResolvedValueOnce(message({ _id: new Types.ObjectId(), messageId: 'input' }))
+        .mockResolvedValueOnce(message({ _id: undefined, messageId: 'resp_target' })),
+    ],
+  ])('does not publish a turn with a missing %s message id', async (_label, saveMessage) => {
+    const saveConvo = jest.fn().mockResolvedValue(conversation({ messages: [] }));
+    const params = persistenceParams({ saveConvo, saveMessage });
+
+    await expect(persistStoredResponse(params)).rejects.toThrow(/message could not be stored/);
+    expect(saveConvo).toHaveBeenCalledTimes(1);
+    expect(params.deps.deleteStoredResponseTurn).toHaveBeenCalledTimes(1);
+  });
 });
+
+function response(overrides: Partial<Response> = {}): Response {
+  return {
+    id: 'resp_target',
+    status: 'completed',
+    previous_response_id: 'resp_previous',
+    output: [
+      {
+        type: 'message',
+        id: 'message-output',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'Answer', annotations: [], logprobs: [] }],
+      },
+    ],
+    usage: {
+      input_tokens: 12,
+      output_tokens: 7,
+      total_tokens: 19,
+      input_tokens_details: { cached_tokens: 3 },
+      output_tokens_details: { reasoning_tokens: 2 },
+      primary: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+      subagent: { input_tokens: 2, output_tokens: 2, total_tokens: 4 },
+    },
+    ...overrides,
+  } as Response;
+}
+
+function stagedMessages(inputId: Types.ObjectId, outputId: Types.ObjectId) {
+  return jest
+    .fn()
+    .mockResolvedValueOnce(message({ _id: inputId, messageId: 'input' }))
+    .mockResolvedValueOnce(message({ _id: outputId, messageId: 'resp_target' }));
+}
+
+function persistenceParams(
+  overrides: Partial<StoredResponseWriteDependencies> = {},
+): Parameters<typeof persistStoredResponse>[0] {
+  return {
+    deps: {
+      saveConvo: jest.fn(),
+      saveMessage: jest.fn(),
+      getConvo: jest.fn(),
+      getMessage: jest.fn().mockResolvedValue(message()),
+      commitStoredResponseTurn: jest.fn().mockResolvedValue(message()),
+      deleteStoredResponseTurn: jest
+        .fn()
+        .mockResolvedValue({ acknowledged: true, deletedCount: 0 }),
+      createMessageId: () => 'generated-input',
+      ...overrides,
+    },
+    context: { userId: 'owner' },
+    conversation: {
+      data: {
+        conversationId: '11111111-1111-4111-8111-111111111111',
+        endpoint: 'agents',
+        agent_id: 'agent-1',
+        model: 'model-1',
+      },
+      initialAgentId: 'agent-1',
+      isContinuation: false,
+    },
+    inputMessages: [{ role: 'user', content: 'Question' }],
+    parentMessageId: null,
+    responseId: 'resp_target',
+    response: response(),
+    agentId: 'agent-1',
+    visibleOutputTokens: 7,
+  };
+}

--- a/packages/api/src/agents/responses/persistence.spec.ts
+++ b/packages/api/src/agents/responses/persistence.spec.ts
@@ -180,6 +180,20 @@ describe('Responses persistence', () => {
       'input-a',
       'resp_a',
     ]);
+    const uuidHistory = selectStoredResponseHistory(messages);
+    expect(uuidHistory.map((item) => item.messageId)).toEqual(['root', 'input-b', 'resp_b']);
+    const continued = [
+      ...messages,
+      message({
+        messageId: 'next-input',
+        parentMessageId: uuidHistory[uuidHistory.length - 1]?.messageId,
+      }),
+      message({ messageId: 'resp_next', parentMessageId: 'next-input' }),
+    ];
+    expect(selectStoredResponseHistory(continued, 'resp_next')).toEqual([
+      ...uuidHistory,
+      ...continued.slice(-2),
+    ]);
   });
 
   it('supports flat legacy Responses history without admitting malformed branches', () => {
@@ -193,7 +207,9 @@ describe('Responses persistence', () => {
     ];
 
     expect(selectStoredResponseHistory(legacy, 'resp_old')).toEqual(legacy);
+    expect(selectStoredResponseHistory(legacy)).toEqual(legacy);
     expect(selectStoredResponseHistory(broken, 'resp_broken')).toEqual([]);
+    expect(selectStoredResponseHistory(broken)).toEqual([]);
   });
 
   it('prepends the flat legacy prefix when a canonical branch reaches its last flat response', () => {

--- a/packages/api/src/agents/responses/persistence.spec.ts
+++ b/packages/api/src/agents/responses/persistence.spec.ts
@@ -2,6 +2,7 @@ import { Constants } from 'librechat-data-provider';
 import type { IConversation, IMessage } from '@librechat/data-schemas';
 import {
   resolveStoredResponse,
+  revalidateStoredResponseConversation,
   selectStoredResponseHistory,
   type StoredResponseLookup,
 } from './persistence';
@@ -50,6 +51,8 @@ describe('Responses persistence', () => {
 
   it.each([
     ['user message', message({ isCreatedByUser: true })],
+    ['user-submitted assistant message', message({ isUserSubmitted: true })],
+    ['Responses caller input', message({ metadata: { responsesInput: { role: 'assistant' } } })],
     ['temporary message', message({ isTemporary: true })],
     ['expired message', message({ expiredAt: new Date(0) })],
   ])('rejects a %s response target', async (_label, storedMessage) => {
@@ -113,6 +116,29 @@ describe('Responses persistence', () => {
       },
     });
     expect(deps.getMessage).not.toHaveBeenCalled();
+  });
+
+  it('revalidates the conversation while retaining the resolved response target', async () => {
+    const storedConversation = conversation({ title: 'fresh' });
+    const storedMessage = message();
+    const deps = { getConvo: jest.fn().mockResolvedValue(storedConversation) };
+
+    await expect(
+      revalidateStoredResponseConversation(deps, 'owner', {
+        conversation: conversation({ title: 'stale' }),
+        conversationId: storedConversation.conversationId,
+        responseMessage: storedMessage,
+      }),
+    ).resolves.toEqual({
+      status: 'found',
+      reference: {
+        conversation: storedConversation,
+        conversationId: storedConversation.conversationId,
+        responseMessage: storedMessage,
+      },
+    });
+    expect(deps.getConvo).toHaveBeenCalledTimes(1);
+    expect(deps.getConvo).toHaveBeenCalledWith('owner', storedConversation.conversationId);
   });
 
   it('selects only the target response branch', () => {

--- a/packages/api/src/agents/responses/persistence.spec.ts
+++ b/packages/api/src/agents/responses/persistence.spec.ts
@@ -1,0 +1,147 @@
+import { Constants } from 'librechat-data-provider';
+import type { IConversation, IMessage } from '@librechat/data-schemas';
+import {
+  resolveStoredResponse,
+  selectStoredResponseHistory,
+  type StoredResponseLookup,
+} from './persistence';
+
+const conversation = (overrides: Partial<IConversation> = {}): IConversation =>
+  ({
+    conversationId: '11111111-1111-4111-8111-111111111111',
+    user: 'owner',
+    isTemporary: false,
+    expiredAt: null,
+    ...overrides,
+  }) as IConversation;
+
+const message = (overrides: Partial<IMessage> = {}): IMessage =>
+  ({
+    messageId: 'resp_target',
+    conversationId: '11111111-1111-4111-8111-111111111111',
+    user: 'owner',
+    isCreatedByUser: false,
+    parentMessageId: 'input-target',
+    isTemporary: false,
+    expiredAt: null,
+    ...overrides,
+  }) as IMessage;
+
+describe('Responses persistence', () => {
+  it('resolves a canonical response through its owned assistant message', async () => {
+    const storedConversation = conversation();
+    const storedMessage = message();
+    const deps: StoredResponseLookup = {
+      getMessage: jest.fn().mockResolvedValue(storedMessage),
+      getConvo: jest.fn().mockResolvedValue(storedConversation),
+    };
+
+    await expect(resolveStoredResponse(deps, 'owner', 'resp_target')).resolves.toEqual({
+      status: 'found',
+      reference: {
+        conversation: storedConversation,
+        conversationId: storedConversation.conversationId,
+        responseMessage: storedMessage,
+      },
+    });
+    expect(deps.getMessage).toHaveBeenCalledWith({ user: 'owner', messageId: 'resp_target' });
+    expect(deps.getConvo).toHaveBeenCalledWith('owner', storedMessage.conversationId);
+  });
+
+  it.each([
+    ['user message', message({ isCreatedByUser: true })],
+    ['temporary message', message({ isTemporary: true })],
+    ['expired message', message({ expiredAt: new Date(0) })],
+  ])('rejects a %s response target', async (_label, storedMessage) => {
+    const deps: StoredResponseLookup = {
+      getMessage: jest.fn().mockResolvedValue(storedMessage),
+      getConvo: jest.fn(),
+    };
+
+    await expect(resolveStoredResponse(deps, 'owner', 'resp_target')).resolves.toEqual({
+      status: 'not_found',
+    });
+    expect(deps.getConvo).not.toHaveBeenCalled();
+  });
+
+  it('rejects hidden conversations and classifies child threads as read-only', async () => {
+    const getMessage = jest.fn().mockResolvedValue(message());
+    const temporary: StoredResponseLookup = {
+      getMessage,
+      getConvo: jest.fn().mockResolvedValue(conversation({ isTemporary: true })),
+    };
+    const child: StoredResponseLookup = {
+      getMessage,
+      getConvo: jest.fn().mockResolvedValue(
+        conversation({
+          subagentThread: {
+            parentMessageId: 'parent-message',
+            rootConversationId: 'root',
+            parentConversationId: 'parent',
+            parentToolCallId: 'tool-call',
+            subagentType: 'worker',
+            subagentKind: 'agent',
+            depth: 1,
+          },
+        }),
+      ),
+    };
+
+    await expect(resolveStoredResponse(temporary, 'owner', 'resp_target')).resolves.toEqual({
+      status: 'not_found',
+    });
+    await expect(resolveStoredResponse(child, 'owner', 'resp_target')).resolves.toEqual({
+      status: 'read_only',
+    });
+  });
+
+  it('preserves legacy conversation-id lookup behavior', async () => {
+    const storedConversation = conversation();
+    const deps: StoredResponseLookup = {
+      getMessage: jest.fn(),
+      getConvo: jest.fn().mockResolvedValue(storedConversation),
+    };
+
+    await expect(
+      resolveStoredResponse(deps, 'owner', storedConversation.conversationId),
+    ).resolves.toEqual({
+      status: 'found',
+      reference: {
+        conversation: storedConversation,
+        conversationId: storedConversation.conversationId,
+        responseMessage: null,
+      },
+    });
+    expect(deps.getMessage).not.toHaveBeenCalled();
+  });
+
+  it('selects only the target response branch', () => {
+    const messages = [
+      message({ messageId: 'root', parentMessageId: String(Constants.NO_PARENT) }),
+      message({ messageId: 'input-a', parentMessageId: 'root', isCreatedByUser: true }),
+      message({ messageId: 'resp_a', parentMessageId: 'input-a' }),
+      message({ messageId: 'input-b', parentMessageId: 'root', isCreatedByUser: true }),
+      message({ messageId: 'resp_b', parentMessageId: 'input-b' }),
+    ];
+
+    expect(selectStoredResponseHistory(messages, 'resp_a').map((item) => item.messageId)).toEqual([
+      'root',
+      'input-a',
+      'resp_a',
+    ]);
+  });
+
+  it('supports flat legacy Responses history without admitting malformed branches', () => {
+    const legacy = [
+      message({ messageId: 'input', parentMessageId: null, isCreatedByUser: true }),
+      message({ messageId: 'resp_old', parentMessageId: null }),
+    ];
+    const broken = [
+      message({ messageId: 'unrelated', parentMessageId: String(Constants.NO_PARENT) }),
+      message({ messageId: 'resp_broken', parentMessageId: 'missing' }),
+    ];
+
+    expect(selectStoredResponseHistory(legacy, 'resp_old')).toEqual(legacy);
+    expect(selectStoredResponseHistory(broken, 'resp_broken')).toEqual([]);
+  });
+});

--- a/packages/api/src/agents/responses/persistence.ts
+++ b/packages/api/src/agents/responses/persistence.ts
@@ -30,6 +30,7 @@ export type StoredResponseResolution =
   | { status: 'read_only' };
 
 export interface StoredResponseSnapshot {
+  response?: Response;
   output: OutputItem[];
   usage?: Usage | null;
   previousResponseId: string | null;
@@ -156,12 +157,25 @@ function getStoredResponseRecord(message: IMessage): StoredResponseRecord | null
     return null;
   }
   const stored = snapshot as Record<string, unknown>;
-  const previousResponseId = stored.previousResponseId;
+  const response = stored.response as Response | undefined;
+  if (
+    response != null &&
+    (response.id !== message.messageId ||
+      response.object !== 'response' ||
+      response.status !== 'completed' ||
+      !Array.isArray(response.output))
+  ) {
+    return null;
+  }
+  const output = response?.output ?? stored.output;
+  const usage = response == null ? stored.usage : response.usage;
+  const previousResponseId =
+    response == null ? stored.previousResponseId : response.previous_response_id;
   if (
     stored.version !== RESPONSE_SNAPSHOT_VERSION ||
     (stored.commitState !== 'pending' && stored.commitState !== 'committed') ||
-    !Array.isArray(stored.output) ||
-    (stored.usage != null && typeof stored.usage !== 'object') ||
+    !Array.isArray(output) ||
+    (usage != null && typeof usage !== 'object') ||
     (previousResponseId != null && typeof previousResponseId !== 'string')
   ) {
     return null;
@@ -169,8 +183,9 @@ function getStoredResponseRecord(message: IMessage): StoredResponseRecord | null
   return {
     version: RESPONSE_SNAPSHOT_VERSION,
     commitState: stored.commitState,
-    output: stored.output as OutputItem[],
-    usage: (stored.usage ?? null) as Usage | null,
+    ...(response != null && { response }),
+    output: output as OutputItem[],
+    usage: (usage ?? null) as Usage | null,
     previousResponseId: previousResponseId ?? null,
   };
 }
@@ -229,9 +244,7 @@ export function buildStoredResponseMetadata(
     responsesResponse: {
       version: RESPONSE_SNAPSHOT_VERSION,
       commitState,
-      output: response.output,
-      usage: response.usage,
-      previousResponseId: response.previous_response_id,
+      response,
     },
   };
 }
@@ -241,6 +254,7 @@ export function getStoredResponseSnapshot(message: IMessage): StoredResponseSnap
   const record = getStoredResponseRecord(message);
   if (record != null) {
     return {
+      ...(record.response != null && { response: record.response }),
       output: record.output,
       usage: record.usage,
       previousResponseId: record.previousResponseId,

--- a/packages/api/src/agents/responses/persistence.ts
+++ b/packages/api/src/agents/responses/persistence.ts
@@ -362,10 +362,11 @@ export function selectStoredResponseHistory(
   messages: IMessage[],
   responseMessageId?: string,
 ): IMessage[] {
-  if (responseMessageId == null) {
-    return messages;
+  const targetId = responseMessageId ?? messages[messages.length - 1]?.messageId;
+  if (targetId == null) {
+    return [];
   }
-  const targetIndex = messages.findIndex((message) => message.messageId === responseMessageId);
+  const targetIndex = messages.findIndex((message) => message.messageId === targetId);
   if (targetIndex < 0) {
     return [];
   }

--- a/packages/api/src/agents/responses/persistence.ts
+++ b/packages/api/src/agents/responses/persistence.ts
@@ -1,0 +1,133 @@
+import { Constants } from 'librechat-data-provider';
+import { isRetentionVisible } from '@librechat/data-schemas';
+import type { IConversation, IMessage } from '@librechat/data-schemas';
+
+export interface StoredResponseLookup {
+  getConvo(userId: string, conversationId: string): Promise<IConversation | null>;
+  getMessage(input: { user: string; messageId: string }): Promise<IMessage | null>;
+}
+
+export interface StoredResponseReference {
+  conversation: IConversation;
+  conversationId: string;
+  responseMessage: IMessage | null;
+}
+
+export type StoredResponseResolution =
+  | { status: 'found'; reference: StoredResponseReference }
+  | { status: 'not_found' }
+  | { status: 'read_only' };
+
+const classifyConversation = (
+  conversation: IConversation | null,
+): 'found' | 'not_found' | 'read_only' => {
+  if (conversation == null || !isRetentionVisible(conversation)) {
+    return 'not_found';
+  }
+  return conversation.subagentThread == null ? 'found' : 'read_only';
+};
+
+export async function resolveStoredResponse(
+  deps: StoredResponseLookup,
+  userId: string,
+  responseId: string,
+): Promise<StoredResponseResolution> {
+  if (!responseId.startsWith('resp_')) {
+    const conversation = await deps.getConvo(userId, responseId);
+    const status = classifyConversation(conversation);
+    if (status === 'not_found') {
+      return { status: 'not_found' };
+    }
+    if (status === 'read_only') {
+      return { status: 'read_only' };
+    }
+    if (conversation == null) {
+      return { status: 'not_found' };
+    }
+    return {
+      status: 'found',
+      reference: {
+        conversation,
+        conversationId: conversation.conversationId,
+        responseMessage: null,
+      },
+    };
+  }
+
+  const responseMessage = await deps.getMessage({ user: userId, messageId: responseId });
+  if (
+    responseMessage == null ||
+    responseMessage.isCreatedByUser !== false ||
+    typeof responseMessage.conversationId !== 'string' ||
+    !isRetentionVisible(responseMessage)
+  ) {
+    return { status: 'not_found' };
+  }
+  const conversation = await deps.getConvo(userId, responseMessage.conversationId);
+  const status = classifyConversation(conversation);
+  if (status === 'not_found') {
+    return { status: 'not_found' };
+  }
+  if (status === 'read_only') {
+    return { status: 'read_only' };
+  }
+  if (conversation == null) {
+    return { status: 'not_found' };
+  }
+  return {
+    status: 'found',
+    reference: {
+      conversation,
+      conversationId: conversation.conversationId,
+      responseMessage,
+    },
+  };
+}
+
+export function selectStoredResponseHistory(
+  messages: IMessage[],
+  responseMessageId?: string,
+): IMessage[] {
+  if (responseMessageId == null) {
+    return messages;
+  }
+  const targetIndex = messages.findIndex((message) => message.messageId === responseMessageId);
+  if (targetIndex < 0) {
+    return [];
+  }
+  const target = messages[targetIndex];
+  const rootParent = (parentMessageId: string | null | undefined): boolean =>
+    parentMessageId == null || parentMessageId === String(Constants.NO_PARENT);
+  if (rootParent(target.parentMessageId)) {
+    const legacyHistory = messages.slice(0, targetIndex + 1);
+    return legacyHistory.every((message) => rootParent(message.parentMessageId))
+      ? legacyHistory
+      : [target];
+  }
+
+  const byId = new Map<string, IMessage>();
+  for (const message of messages) {
+    if (typeof message.messageId === 'string') {
+      byId.set(message.messageId, message);
+    }
+  }
+  const selected: IMessage[] = [];
+  const seen = new Set<string>();
+  let current: IMessage | undefined = target;
+  while (current != null && typeof current.messageId === 'string' && !seen.has(current.messageId)) {
+    selected.push(current);
+    seen.add(current.messageId);
+    const parentMessageId: string | null | undefined = current.parentMessageId;
+    current =
+      rootParent(parentMessageId) || typeof parentMessageId !== 'string'
+        ? undefined
+        : byId.get(parentMessageId);
+  }
+  if (
+    current != null ||
+    !rootParent(selected.length === 0 ? undefined : selected[selected.length - 1].parentMessageId)
+  ) {
+    return [];
+  }
+  return selected.reverse();
+}

--- a/packages/api/src/agents/responses/persistence.ts
+++ b/packages/api/src/agents/responses/persistence.ts
@@ -1,6 +1,13 @@
+import { nanoid } from 'nanoid';
 import { Constants } from 'librechat-data-provider';
 import { isRetentionVisible } from '@librechat/data-schemas';
-import type { IConversation, IMessage } from '@librechat/data-schemas';
+import type {
+  ConversationMethods,
+  IConversation,
+  IMessage,
+  MessageMethods,
+} from '@librechat/data-schemas';
+import type { OutputItem, Response, Usage } from './types';
 
 export interface StoredResponseLookup {
   getConvo(userId: string, conversationId: string): Promise<IConversation | null>;
@@ -22,6 +29,64 @@ export type StoredResponseResolution =
   | { status: 'not_found' }
   | { status: 'read_only' };
 
+export interface StoredResponseSnapshot {
+  output: OutputItem[];
+  usage?: Usage | null;
+  previousResponseId: string | null;
+}
+
+export interface StoredResponseInputMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string | Array<{ type: string; text?: string; image_url?: unknown }>;
+  name?: string;
+  tool_call_id?: string;
+  tool_calls?: Array<{
+    id: string;
+    type: 'function';
+    function: { name: string; arguments: string };
+  }>;
+}
+
+export interface StoredResponseWriteDependencies {
+  saveConvo: ConversationMethods['saveConvo'];
+  saveMessage: MessageMethods['saveMessage'];
+  getConvo: ConversationMethods['getConvo'];
+  getMessage: MessageMethods['getMessage'];
+  commitStoredResponseTurn: MessageMethods['commitStoredResponseTurn'];
+  deleteStoredResponseTurn: MessageMethods['deleteStoredResponseTurn'];
+  createMessageId?: () => string;
+}
+
+export interface PersistStoredResponseParams {
+  deps: StoredResponseWriteDependencies;
+  context: Parameters<MessageMethods['saveMessage']>[0];
+  conversation: {
+    data: Parameters<ConversationMethods['saveConvo']>[1];
+    initialAgentId: string | null;
+    isContinuation: boolean;
+  };
+  inputMessages: StoredResponseInputMessage[];
+  parentMessageId: string | null;
+  responseId: string;
+  response: Response;
+  agentId: string;
+  visibleOutputTokens?: number;
+  getOutputMessageFields?: () => Promise<Partial<IMessage> | undefined>;
+}
+
+const RESPONSE_SNAPSHOT_VERSION = 1;
+const MAX_PERSISTENCE_WRITE_ATTEMPTS = 2;
+
+interface StoredResponseRecord extends StoredResponseSnapshot {
+  version: typeof RESPONSE_SNAPSHOT_VERSION;
+  commitState: 'pending' | 'committed';
+}
+
+interface StoredResponseTurn {
+  version: typeof RESPONSE_SNAPSHOT_VERSION;
+  responseId: string;
+}
+
 const classifyConversation = (
   conversation: IConversation | null,
 ): 'found' | 'not_found' | 'read_only' => {
@@ -31,12 +96,168 @@ const classifyConversation = (
   return conversation.subagentThread == null ? 'found' : 'read_only';
 };
 
+const normalizeDocumentId = (value: unknown): string | null => {
+  if (value == null) {
+    return null;
+  }
+  const normalized = String(value);
+  return normalized.length > 0 ? normalized : null;
+};
+
+const isExpectedConversation = (
+  conversation: IConversation | { message: string } | null | undefined,
+  conversationId: string,
+): conversation is IConversation =>
+  conversation != null &&
+  'conversationId' in conversation &&
+  conversation.conversationId === conversationId;
+
+const includesEveryMessageId = (
+  conversation: IConversation,
+  messageIds: readonly unknown[],
+): boolean => {
+  if (!Array.isArray(conversation.messages)) {
+    return false;
+  }
+  const committedIds = new Set(conversation.messages.map(normalizeDocumentId));
+  return messageIds.every((id) => {
+    const normalized = normalizeDocumentId(id);
+    return normalized != null && committedIds.has(normalized);
+  });
+};
+
+function getStoredResponseTurn(message: IMessage): StoredResponseTurn | null {
+  const turn = message.metadata?.responsesTurn;
+  if (turn == null || typeof turn !== 'object' || Array.isArray(turn)) {
+    return null;
+  }
+  const stored = turn as Record<string, unknown>;
+  if (stored.version !== RESPONSE_SNAPSHOT_VERSION || typeof stored.responseId !== 'string') {
+    return null;
+  }
+  return { version: RESPONSE_SNAPSHOT_VERSION, responseId: stored.responseId };
+}
+
+function hasStoredResponseTurnMarker(message: IMessage): boolean {
+  return Object.prototype.hasOwnProperty.call(message.metadata ?? {}, 'responsesTurn');
+}
+
 export function isStoredResponseOutput(message: IMessage): boolean {
   return (
     message.isCreatedByUser !== true &&
     message.isUserSubmitted !== true &&
     message.metadata?.responsesInput == null
   );
+}
+
+function getStoredResponseRecord(message: IMessage): StoredResponseRecord | null {
+  const snapshot = message.metadata?.responsesResponse;
+  if (snapshot == null || typeof snapshot !== 'object' || Array.isArray(snapshot)) {
+    return null;
+  }
+  const stored = snapshot as Record<string, unknown>;
+  const previousResponseId = stored.previousResponseId;
+  if (
+    stored.version !== RESPONSE_SNAPSHOT_VERSION ||
+    (stored.commitState !== 'pending' && stored.commitState !== 'committed') ||
+    !Array.isArray(stored.output) ||
+    (stored.usage != null && typeof stored.usage !== 'object') ||
+    (previousResponseId != null && typeof previousResponseId !== 'string')
+  ) {
+    return null;
+  }
+  return {
+    version: RESPONSE_SNAPSHOT_VERSION,
+    commitState: stored.commitState,
+    output: stored.output as OutputItem[],
+    usage: (stored.usage ?? null) as Usage | null,
+    previousResponseId: previousResponseId ?? null,
+  };
+}
+
+function isCommittedTurnOutput(message: IMessage, responseId: string): boolean {
+  const turn = getStoredResponseTurn(message);
+  const record = getStoredResponseRecord(message);
+  return (
+    turn?.responseId === responseId &&
+    message.messageId === responseId &&
+    message.isCreatedByUser === false &&
+    message.isUserSubmitted === false &&
+    isStoredResponseOutput(message) &&
+    record?.commitState === 'committed'
+  );
+}
+
+function responseTurnKey(message: IMessage, responseId: string): string {
+  return `${String(message.user)}\u0000${message.conversationId}\u0000${responseId}`;
+}
+
+export function filterCommittedResponseMessages(messages: IMessage[]): IMessage[] {
+  const committedTurns = new Set<string>();
+  for (const message of messages) {
+    const responseId = getStoredResponseTurn(message)?.responseId;
+    if (responseId != null && isCommittedTurnOutput(message, responseId)) {
+      committedTurns.add(responseTurnKey(message, responseId));
+    }
+  }
+  return messages.filter((message) => {
+    const responseId = getStoredResponseTurn(message)?.responseId;
+    if (responseId == null) {
+      return !hasStoredResponseTurnMarker(message);
+    }
+    return committedTurns.has(responseTurnKey(message, responseId));
+  });
+}
+
+export function isCommittedStoredResponse(message: IMessage): boolean {
+  const turn = getStoredResponseTurn(message);
+  if (turn == null) {
+    return !hasStoredResponseTurnMarker(message);
+  }
+  return isCommittedTurnOutput(message, turn.responseId);
+}
+
+export function buildStoredResponseMetadata(
+  response: Response,
+  commitState: StoredResponseRecord['commitState'] = 'pending',
+): Record<string, unknown> {
+  return {
+    responsesTurn: {
+      version: RESPONSE_SNAPSHOT_VERSION,
+      responseId: response.id,
+    },
+    responsesResponse: {
+      version: RESPONSE_SNAPSHOT_VERSION,
+      commitState,
+      output: response.output,
+      usage: response.usage,
+      previousResponseId: response.previous_response_id,
+    },
+  };
+}
+
+export function getStoredResponseSnapshot(message: IMessage): StoredResponseSnapshot | null {
+  const metadata = message.metadata;
+  const record = getStoredResponseRecord(message);
+  if (record != null) {
+    return {
+      output: record.output,
+      usage: record.usage,
+      previousResponseId: record.previousResponseId,
+    };
+  }
+
+  const legacyOutput = metadata?.responsesOutput;
+  if (!Array.isArray(legacyOutput)) {
+    return null;
+  }
+  return {
+    output: legacyOutput as OutputItem[],
+    previousResponseId:
+      typeof metadata?.responsesPreviousResponseId === 'string'
+        ? metadata.responsesPreviousResponseId
+        : null,
+  };
 }
 
 export async function resolveStoredResponse(
@@ -84,7 +305,7 @@ export async function resolveStoredResponse(
   if (status === 'read_only') {
     return { status: 'read_only' };
   }
-  if (conversation == null) {
+  if (conversation == null || !isCommittedStoredResponse(responseMessage)) {
     return { status: 'not_found' };
   }
   return {
@@ -109,6 +330,9 @@ export async function revalidateStoredResponseConversation(
   }
   if (status === 'read_only') {
     return { status: 'read_only' };
+  }
+  if (reference.responseMessage != null && !isCommittedStoredResponse(reference.responseMessage)) {
+    return { status: 'not_found' };
   }
   return {
     status: 'found',
@@ -165,5 +389,250 @@ export function selectStoredResponseHistory(
   ) {
     return [];
   }
-  return selected.reverse();
+
+  const linkedHistory = selected.reverse();
+  const rootIndex = messages.indexOf(linkedHistory[0]);
+  const legacyPrefix = messages.slice(0, rootIndex);
+  return legacyPrefix.every((message) => rootParent(message.parentMessageId))
+    ? [...legacyPrefix, ...linkedHistory]
+    : linkedHistory;
+}
+
+async function saveConversationFence(params: PersistStoredResponseParams): Promise<IConversation> {
+  const { deps, context, conversation } = params;
+  const conversationId = conversation.data.conversationId;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < MAX_PERSISTENCE_WRITE_ATTEMPTS; attempt += 1) {
+    try {
+      const stored = await deps.saveConvo(context, conversation.data, {
+        context: 'Responses API - save conversation',
+        initialAgentId: conversation.initialAgentId,
+        appendMessageIds: [],
+        ...(conversation.isContinuation && { noUpsert: true }),
+      });
+      if (isExpectedConversation(stored, conversationId)) {
+        return stored;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+
+    const current = await deps.getConvo(context.userId, conversationId);
+    if (current != null) {
+      return current;
+    }
+    if (conversation.isContinuation) {
+      throw new Error('Conversation was deleted before the response could be stored');
+    }
+  }
+
+  if (lastError != null) {
+    throw lastError;
+  }
+  throw new Error('Conversation could not be initialized for response storage');
+}
+
+async function commitMessageManifest(
+  params: PersistStoredResponseParams,
+  messageIds: NonNullable<IMessage['_id']>[],
+): Promise<IConversation> {
+  const { deps, context, conversation } = params;
+  const conversationId = conversation.data.conversationId;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < MAX_PERSISTENCE_WRITE_ATTEMPTS; attempt += 1) {
+    let stored: IConversation | { message: string } | null = null;
+    try {
+      stored = await deps.saveConvo(context, conversation.data, {
+        context: 'Responses API - save conversation',
+        initialAgentId: conversation.initialAgentId,
+        appendMessageIds: messageIds,
+        noUpsert: true,
+      });
+    } catch (error) {
+      lastError = error;
+    }
+
+    if (
+      isExpectedConversation(stored, conversationId) &&
+      includesEveryMessageId(stored, messageIds)
+    ) {
+      return stored;
+    }
+    const current = await deps.getConvo(context.userId, conversationId);
+    if (current == null) {
+      throw new Error('Conversation was deleted before message references were stored');
+    }
+    if (includesEveryMessageId(current, messageIds)) {
+      return current;
+    }
+  }
+
+  if (lastError != null) {
+    throw lastError;
+  }
+  throw new Error('Response message references could not be committed');
+}
+
+async function commitResponseMarker(params: PersistStoredResponseParams): Promise<IMessage> {
+  const { deps, context, conversation, responseId } = params;
+  const conversationId = conversation.data.conversationId;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < MAX_PERSISTENCE_WRITE_ATTEMPTS; attempt += 1) {
+    try {
+      const committed = await deps.commitStoredResponseTurn({
+        userId: context.userId,
+        conversationId,
+        responseId,
+      });
+      if (
+        committed?.conversationId === conversationId &&
+        isCommittedTurnOutput(committed, responseId)
+      ) {
+        return committed;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+
+    try {
+      const current = await deps.getMessage({ user: context.userId, messageId: responseId });
+      if (
+        current?.conversationId === conversationId &&
+        isCommittedTurnOutput(current, responseId)
+      ) {
+        return current;
+      }
+      if (current == null || current.conversationId !== conversationId) {
+        throw new Error('Response output was deleted before the turn could be committed');
+      }
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  if (lastError != null) {
+    throw lastError;
+  }
+  throw new Error('Response output could not be committed');
+}
+
+async function cleanupResponseTurn(params: PersistStoredResponseParams): Promise<void> {
+  try {
+    await params.deps.deleteStoredResponseTurn({
+      userId: params.context.userId,
+      conversationId: params.conversation.data.conversationId,
+      responseId: params.responseId,
+    });
+  } catch {
+    return;
+  }
+}
+
+function getResponseText(response: Response): string {
+  let responseText = '';
+  for (const item of response.output) {
+    if (item.type !== 'message') {
+      continue;
+    }
+    for (const part of item.content) {
+      if (part.type === 'output_text' && part.text) {
+        responseText += part.text;
+      }
+    }
+  }
+  return responseText;
+}
+
+export async function persistStoredResponse(
+  params: PersistStoredResponseParams,
+): Promise<{ conversation: IConversation; outputMessage: IMessage }> {
+  const { deps, context, conversation, inputMessages, response, responseId, agentId } = params;
+  await saveConversationFence(params);
+
+  let markerAttempted = false;
+  try {
+    const createMessageId = deps.createMessageId ?? nanoid;
+    const messageIds: NonNullable<IMessage['_id']>[] = [];
+    let currentParentMessageId = params.parentMessageId;
+    for (const input of inputMessages) {
+      const messageId = createMessageId();
+      let sender = 'Agent';
+      if (input.role === 'user') {
+        sender = 'User';
+      } else if (input.role === 'tool') {
+        sender = 'Tool';
+      }
+      const stored = await deps.saveMessage(
+        context,
+        {
+          messageId,
+          conversationId: conversation.data.conversationId,
+          parentMessageId: currentParentMessageId,
+          isCreatedByUser: input.role === 'user',
+          isUserSubmitted: true,
+          text: typeof input.content === 'string' ? input.content : JSON.stringify(input.content),
+          ...(Array.isArray(input.content) && { content: input.content }),
+          sender,
+          endpoint: conversation.data.endpoint as string | undefined,
+          model: agentId,
+          metadata: {
+            responsesTurn: {
+              version: RESPONSE_SNAPSHOT_VERSION,
+              responseId,
+            },
+            responsesInput: {
+              role: input.role,
+              ...(typeof input.name === 'string' && { name: input.name }),
+              ...(typeof input.tool_call_id === 'string' && { tool_call_id: input.tool_call_id }),
+              ...(Array.isArray(input.tool_calls) && { tool_calls: input.tool_calls }),
+            },
+          },
+        },
+        { context: 'Responses API - save input' },
+      );
+      if (stored?._id == null) {
+        throw new Error(`Response input message could not be stored: ${messageId}`);
+      }
+      messageIds.push(stored._id);
+      currentParentMessageId = messageId;
+    }
+
+    const outputMessageFields = (await params.getOutputMessageFields?.()) ?? {};
+    const outputMessage = await deps.saveMessage(
+      context,
+      {
+        ...outputMessageFields,
+        messageId: responseId,
+        conversationId: conversation.data.conversationId,
+        parentMessageId: currentParentMessageId,
+        isCreatedByUser: false,
+        isUserSubmitted: false,
+        text: getResponseText(response),
+        sender: 'Agent',
+        endpoint: conversation.data.endpoint as string | undefined,
+        model: agentId,
+        finish_reason: response.status === 'completed' ? 'stop' : response.status,
+        tokenCount: params.visibleOutputTokens ?? response.usage?.output_tokens,
+        metadata: buildStoredResponseMetadata(response),
+      },
+      { context: 'Responses API - save assistant response' },
+    );
+    if (outputMessage?._id == null) {
+      throw new Error(`Response output message could not be stored: ${responseId}`);
+    }
+    messageIds.push(outputMessage._id);
+
+    const committedConversation = await commitMessageManifest(params, messageIds);
+    markerAttempted = true;
+    const committedOutput = await commitResponseMarker(params);
+    return { conversation: committedConversation, outputMessage: committedOutput };
+  } catch (error) {
+    if (!markerAttempted) {
+      await cleanupResponseTurn(params);
+    }
+    throw error;
+  }
 }

--- a/packages/api/src/agents/responses/persistence.ts
+++ b/packages/api/src/agents/responses/persistence.ts
@@ -7,6 +7,10 @@ export interface StoredResponseLookup {
   getMessage(input: { user: string; messageId: string }): Promise<IMessage | null>;
 }
 
+export interface StoredResponseConversationLookup {
+  getConvo(userId: string, conversationId: string): Promise<IConversation | null>;
+}
+
 export interface StoredResponseReference {
   conversation: IConversation;
   conversationId: string;
@@ -26,6 +30,14 @@ const classifyConversation = (
   }
   return conversation.subagentThread == null ? 'found' : 'read_only';
 };
+
+export function isStoredResponseOutput(message: IMessage): boolean {
+  return (
+    message.isCreatedByUser !== true &&
+    message.isUserSubmitted !== true &&
+    message.metadata?.responsesInput == null
+  );
+}
 
 export async function resolveStoredResponse(
   deps: StoredResponseLookup,
@@ -58,6 +70,7 @@ export async function resolveStoredResponse(
   if (
     responseMessage == null ||
     responseMessage.isCreatedByUser !== false ||
+    !isStoredResponseOutput(responseMessage) ||
     typeof responseMessage.conversationId !== 'string' ||
     !isRetentionVisible(responseMessage)
   ) {
@@ -80,6 +93,29 @@ export async function resolveStoredResponse(
       conversation,
       conversationId: conversation.conversationId,
       responseMessage,
+    },
+  };
+}
+
+export async function revalidateStoredResponseConversation(
+  deps: StoredResponseConversationLookup,
+  userId: string,
+  reference: StoredResponseReference,
+): Promise<StoredResponseResolution> {
+  const conversation = await deps.getConvo(userId, reference.conversationId);
+  const status = classifyConversation(conversation);
+  if (status === 'not_found' || conversation == null) {
+    return { status: 'not_found' };
+  }
+  if (status === 'read_only') {
+    return { status: 'read_only' };
+  }
+  return {
+    status: 'found',
+    reference: {
+      conversation,
+      conversationId: conversation.conversationId,
+      responseMessage: reference.responseMessage,
     },
   };
 }

--- a/packages/api/src/agents/responses/service.ts
+++ b/packages/api/src/agents/responses/service.ts
@@ -366,7 +366,7 @@ export function createResponsesEventHandlers(config: StreamHandlerConfig): {
   handlers: Record<string, { handle: (event: string, data: unknown) => void }>;
   state: StreamState;
   completeOutput: () => void;
-  finalizeStream: (usage?: Usage) => void;
+  finalizeStream: (usage?: Usage, completedResponse?: Response) => void;
 } {
   const state: StreamState = {
     messageStarted: false,
@@ -592,9 +592,9 @@ export function createResponsesEventHandlers(config: StreamHandlerConfig): {
   /**
    * Finalize the stream - close open items and emit completed
    */
-  const finalizeStream = (usage?: Usage): void => {
+  const finalizeStream = (usage?: Usage, completedResponse?: Response): void => {
     closeOpenStreams();
-    emitResponseCompleted(config, usage);
+    emitResponseCompleted(config, usage, completedResponse);
     writeDone(config.res);
   };
 

--- a/packages/api/src/agents/responses/service.ts
+++ b/packages/api/src/agents/responses/service.ts
@@ -100,6 +100,10 @@ export function validateResponseRequest(body: unknown): RequestValidationResult 
     return { valid: false, error: 'stream must be a boolean' };
   }
 
+  if (request.store === true && request.isTemporary === true) {
+    return { valid: false, error: 'store: true cannot be combined with isTemporary: true' };
+  }
+
   if (request.temperature !== undefined) {
     const temp = request.temperature as number;
     if (typeof temp !== 'number' || temp < 0 || temp > 2) {

--- a/packages/api/src/agents/responses/service.ts
+++ b/packages/api/src/agents/responses/service.ts
@@ -365,6 +365,7 @@ interface StreamState {
 export function createResponsesEventHandlers(config: StreamHandlerConfig): {
   handlers: Record<string, { handle: (event: string, data: unknown) => void }>;
   state: StreamState;
+  completeOutput: () => void;
   finalizeStream: (usage?: Usage) => void;
 } {
   const state: StreamState = {
@@ -597,7 +598,7 @@ export function createResponsesEventHandlers(config: StreamHandlerConfig): {
     writeDone(config.res);
   };
 
-  return { handlers, state, finalizeStream };
+  return { handlers, state, completeOutput: closeOpenStreams, finalizeStream };
 }
 
 /* =============================================================================

--- a/packages/api/src/agents/responses/service.ts
+++ b/packages/api/src/agents/responses/service.ts
@@ -324,6 +324,7 @@ export function createResponseContext(
     createdAt: Math.floor(Date.now() / 1000),
     previousResponseId: request.previous_response_id,
     instructions: request.instructions,
+    store: request.store === true,
   };
 }
 
@@ -749,7 +750,7 @@ export function buildAggregatedResponse(
     },
     max_output_tokens: null,
     max_tool_calls: null,
-    store: false,
+    store: context.store === true,
     background: false,
     service_tier: 'default',
     metadata: {},

--- a/packages/api/src/agents/responses/types.ts
+++ b/packages/api/src/agents/responses/types.ts
@@ -779,6 +779,8 @@ export interface ResponseContext {
   previousResponseId?: string;
   /** Instructions */
   instructions?: string;
+  /** Whether the response should be stored */
+  store?: boolean;
 }
 
 /** Validation result for requests */

--- a/packages/api/src/middleware/code.spec.ts
+++ b/packages/api/src/middleware/code.spec.ts
@@ -21,6 +21,7 @@ type LimiterOptions = {
   max: number;
   windowMs: number;
   keyGenerator: (req: Request) => string;
+  handler: (req: Request, res: Response) => void;
 };
 
 describe('code environment limiters', () => {
@@ -29,22 +30,44 @@ describe('code environment limiters', () => {
   });
 
   test('uses a bounded per-user pairing bucket', () => {
-    const req = { user: { id: 'user-1' } } as Request;
+    const req = { user: { id: 'user-1' } } as Request & { user: { id: string } };
 
     codeEnvironmentPairingLimiter(req, {} as Response, jest.fn());
 
-    const options = mockRateLimit.mock.calls.at(-1)?.[0] as LimiterOptions;
+    const options = mockRateLimit.mock.calls[
+      mockRateLimit.mock.calls.length - 1
+    ]?.[0] as LimiterOptions;
     expect(options).toEqual(expect.objectContaining({ max: 5, windowMs: 3_600_000 }));
     expect(options.keyGenerator(req)).toBe('user-1');
     expect(mockLimiterCache).toHaveBeenCalledWith('code_environment_pairing_user_limiter');
+    const res = {
+      set: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    } as Partial<Response> as Response;
+    const now = jest.spyOn(Date, 'now').mockReturnValue(1700000000000);
+    try {
+      options.handler(
+        Object.assign(req, { rateLimit: { resetTime: new Date(1700000030000) } }),
+        res,
+      );
+      expect(res.set).toHaveBeenLastCalledWith('Retry-After', '30');
+      options.handler(Object.assign(req, { rateLimit: undefined }), res);
+      expect(res.set).toHaveBeenLastCalledWith('Retry-After', '3600');
+      expect(res.status).toHaveBeenCalledWith(429);
+    } finally {
+      now.mockRestore();
+    }
   });
 
   test('keys status user limits by immutable user ID', () => {
-    const req = { user: { id: 'user-1' }, ip: '2001:db8::1' } as Request;
+    const req = { user: { id: 'user-1' }, ip: '2001:db8::1' } as Request & { user: { id: string } };
 
     codeEnvironmentStatusLimiter(req, {} as Response, jest.fn());
 
-    const options = mockRateLimit.mock.calls.at(-1)?.[0] as LimiterOptions;
+    const options = mockRateLimit.mock.calls[
+      mockRateLimit.mock.calls.length - 1
+    ]?.[0] as LimiterOptions;
     expect(options).toEqual(expect.objectContaining({ max: 120, windowMs: 60_000 }));
     expect(options.keyGenerator(req)).toBe('user-1');
     expect(mockIpKeyGenerator).not.toHaveBeenCalled();
@@ -52,14 +75,18 @@ describe('code environment limiters', () => {
   });
 
   test('applies an independent normalized IP status limit', () => {
-    const req = { user: { id: 'user-1' }, ip: '2001:db8::1' } as Request;
+    const req = { user: { id: 'user-1' }, ip: '2001:db8::1' } as Request & { user: { id: string } };
 
     codeEnvironmentStatusIpLimiter(req, {} as Response, jest.fn());
 
-    const options = mockRateLimit.mock.calls.at(-1)?.[0] as LimiterOptions;
+    const options = mockRateLimit.mock.calls[
+      mockRateLimit.mock.calls.length - 1
+    ]?.[0] as LimiterOptions;
     expect(options).toEqual(expect.objectContaining({ max: 300, windowMs: 60_000 }));
     expect(options.keyGenerator(req)).toBe('2001:db8::1');
     expect(mockIpKeyGenerator).toHaveBeenCalledWith('2001:db8::1');
     expect(mockLimiterCache).toHaveBeenCalledWith('code_environment_status_ip_limiter');
+    expect(options.keyGenerator({} as Request)).toBe('');
+    expect(mockIpKeyGenerator).toHaveBeenLastCalledWith('');
   });
 });

--- a/packages/api/src/middleware/code.ts
+++ b/packages/api/src/middleware/code.ts
@@ -1,4 +1,5 @@
 import { rateLimit, ipKeyGenerator } from 'express-rate-limit';
+import type { AugmentedRequest } from 'express-rate-limit';
 import type { Request, RequestHandler } from 'express';
 import { limiterCache } from '~/cache/cacheFactory';
 
@@ -21,10 +22,11 @@ export const codeEnvironmentPairingLimiter: RequestHandler = (req, res, next) =>
       windowMs: windowInMinutes * 60 * 1000,
       max,
       handler: (limitedReq, limitedRes) => {
-        const resetAt = limitedReq.rateLimit?.resetTime?.getTime?.();
-        const retryAfterSeconds = Number.isFinite(resetAt)
-          ? Math.max(1, Math.ceil((resetAt - Date.now()) / 1000))
-          : Math.max(1, Math.ceil(windowInMinutes * 60));
+        const resetAt = (limitedReq as AugmentedRequest).rateLimit?.resetTime?.getTime?.();
+        const retryAfterSeconds =
+          resetAt != null && Number.isFinite(resetAt)
+            ? Math.max(1, Math.ceil((resetAt - Date.now()) / 1000))
+            : Math.max(1, Math.ceil(windowInMinutes * 60));
         limitedRes.set('Retry-After', String(retryAfterSeconds));
         return limitedRes.status(429).json({
           error: {
@@ -78,7 +80,7 @@ export const codeEnvironmentStatusIpLimiter: RequestHandler = (req, res, next) =
             type: 'rate_limit_error',
           },
         }),
-      keyGenerator: (limitedReq) => ipKeyGenerator(limitedReq.ip),
+      keyGenerator: (limitedReq) => ipKeyGenerator(limitedReq.ip ?? ''),
       store: limiterCache('code_environment_status_ip_limiter'),
     });
   }

--- a/packages/data-schemas/src/methods/conversation.spec.ts
+++ b/packages/data-schemas/src/methods/conversation.spec.ts
@@ -227,6 +227,7 @@ describe('Conversation Operations', () => {
       expect(getMessages).toHaveBeenCalledWith(
         { conversationId: mockConversationData.conversationId, user: mockCtx.userId },
         '_id',
+        { includePendingResponses: true },
       );
     });
 
@@ -1102,7 +1103,9 @@ describe('Conversation Operations', () => {
 
       await saveConvo(ctx, { conversationId, title: 'rebuild' });
 
-      expect(getMessages).toHaveBeenCalledWith({ conversationId, user: ctx.userId }, '_id');
+      expect(getMessages).toHaveBeenCalledWith({ conversationId, user: ctx.userId }, '_id', {
+        includePendingResponses: true,
+      });
       const stored = await Conversation.findOne({ conversationId }).lean();
       expect(stored?.messages?.map(String)).toEqual(rebuilt.map(String));
     });

--- a/packages/data-schemas/src/methods/conversation.ts
+++ b/packages/data-schemas/src/methods/conversation.ts
@@ -2142,7 +2142,9 @@ export function createConversationMethods(
       const update: Record<string, unknown> = { ...convo, user: userId };
       delete update.initial_agent_id;
       if (appendMessageIds == null) {
-        update.messages = await getMessages({ conversationId, user: userId }, '_id');
+        update.messages = await getMessages({ conversationId, user: userId }, '_id', {
+          includePendingResponses: true,
+        });
       } else {
         delete update.messages;
       }

--- a/packages/data-schemas/src/methods/insights.ts
+++ b/packages/data-schemas/src/methods/insights.ts
@@ -14,6 +14,7 @@ import type {
 } from 'librechat-data-provider';
 import type { Model, PipelineStage } from 'mongoose';
 import type { IConversation, IMessage, IUser } from '~/types';
+import { committedMessageStages } from '~/utils/responses';
 
 export type InsightsOptions = TInsightsParams & {
   tenantId?: string;
@@ -206,6 +207,7 @@ function messageScope(
         };
   return [
     { $match: attributedMatch },
+    ...committedMessageStages(),
     {
       $lookup: {
         from: 'conversations',

--- a/packages/data-schemas/src/methods/message.ts
+++ b/packages/data-schemas/src/methods/message.ts
@@ -7,6 +7,7 @@ import type { AppConfig, IConversation, IMessage } from '~/types';
 import { activeExpirationFilter, createFallbackRetentionDate } from '~/utils/retention';
 import { createTempChatExpirationDate } from '~/utils/tempChatRetention';
 import { tenantSafeBulkWrite } from '~/utils/tenantBulkWrite';
+import { readVisibleMessages } from '~/utils/responses';
 import logger from '~/config/winston';
 
 /** Simple UUID v4 regex to replace zod validation */
@@ -426,6 +427,8 @@ export const CLIENT_MESSAGE_SELECT: string = [
 ].join(' ');
 
 interface MessageQueryOptions {
+  /** Internal manifest maintenance must retain staged row references. */
+  includePendingResponses?: boolean;
   limit?: number;
   sort?: Record<string, 1 | -1> | false;
 }
@@ -711,6 +714,7 @@ export interface MessageMethods {
       sortOrder?: 1 | -1;
       limit?: number;
       cursor?: string | null;
+      select?: string;
     },
   ): Promise<{ messages: IMessage[]; nextCursor: string | null }>;
   searchMessages(
@@ -2091,6 +2095,9 @@ export function createMessageMethods(mongoose: typeof import('mongoose')): Messa
   ) {
     try {
       const Message = mongoose.models.Message as Model<IMessage>;
+      if (options.includePendingResponses !== true) {
+        return await readVisibleMessages(Message, filter, select, options);
+      }
       const query = Message.find(filter);
       if (select) {
         query.select(select);
@@ -3132,7 +3139,10 @@ export function createMessageMethods(mongoose: typeof import('mongoose')): Messa
   async function getMessage({ user, messageId }: { user: string; messageId: string }) {
     try {
       const Message = mongoose.models.Message as Model<IMessage>;
-      return await Message.findOne({ user, messageId }).lean<IMessage>();
+      const messages = await readVisibleMessages(Message, { user, messageId }, undefined, {
+        limit: 1,
+      });
+      return messages[0] ?? null;
     } catch (err) {
       logger.error('Error getting message:', err);
       throw err;
@@ -3220,14 +3230,10 @@ export function createMessageMethods(mongoose: typeof import('mongoose')): Messa
     if (cursor) {
       queryFilter[sortField] = sortOrder === 1 ? { $gt: cursor } : { $lt: cursor };
     }
-    const query = Message.find(queryFilter);
-    if (select) {
-      query.select(select);
-    }
-    const messages = await query
-      .sort({ [sortField]: sortOrder })
-      .limit(limit + 1)
-      .lean<IMessage[]>();
+    const messages = await readVisibleMessages(Message, queryFilter, select, {
+      sort: { [sortField]: sortOrder },
+      limit: limit + 1,
+    });
 
     let nextCursor: string | null = null;
     if (messages.length > limit) {
@@ -3253,7 +3259,31 @@ export function createMessageMethods(mongoose: typeof import('mongoose')): Messa
     if (typeof Message.meiliSearch !== 'function') {
       throw new Error('MeiliSearch plugin not registered on Message model');
     }
-    return Message.meiliSearch(query, searchOptions, hydrate);
+    const results = await Message.meiliSearch(query, searchOptions, hydrate);
+    if (results.hits.length === 0) {
+      return results;
+    }
+    const identities = results.hits.flatMap((hit) =>
+      typeof hit.messageId === 'string' && typeof hit.user === 'string'
+        ? [{ messageId: hit.messageId, user: hit.user }]
+        : [],
+    );
+    if (identities.length === 0) {
+      return { ...results, hits: [] };
+    }
+    const visible = await readVisibleMessages(
+      mongoose.models.Message as Model<IMessage>,
+      { $or: identities },
+      'messageId user',
+      { sort: false },
+    );
+    const visibleIds = new Set(
+      visible.map((message) => JSON.stringify([message.user, message.messageId])),
+    );
+    return {
+      ...results,
+      hits: results.hits.filter((hit) => visibleIds.has(JSON.stringify([hit.user, hit.messageId]))),
+    };
   }
 
   return {

--- a/packages/data-schemas/src/methods/message.ts
+++ b/packages/data-schemas/src/methods/message.ts
@@ -694,6 +694,16 @@ export interface MessageMethods {
     limitPerThread: number;
   }): Promise<ParentSubagentTaskRecord[]>;
   getMessage(params: { user: string; messageId: string }): Promise<IMessage | null>;
+  commitStoredResponseTurn(params: {
+    userId: string;
+    conversationId: string;
+    responseId: string;
+  }): Promise<IMessage | null>;
+  deleteStoredResponseTurn(params: {
+    userId: string;
+    conversationId: string;
+    responseId: string;
+  }): Promise<DeleteResult>;
   getMessagesByCursor(
     filter: FilterQuery<IMessage>,
     options?: {
@@ -3129,6 +3139,54 @@ export function createMessageMethods(mongoose: typeof import('mongoose')): Messa
     }
   }
 
+  /** Publishes a staged Responses turn without recreating a deleted output row. */
+  async function commitStoredResponseTurn({
+    userId,
+    conversationId,
+    responseId,
+  }: {
+    userId: string;
+    conversationId: string;
+    responseId: string;
+  }): Promise<IMessage | null> {
+    const Message = mongoose.models.Message as Model<IMessage>;
+    return Message.findOneAndUpdate(
+      {
+        user: userId,
+        conversationId,
+        messageId: responseId,
+        isCreatedByUser: false,
+        isUserSubmitted: false,
+        'metadata.responsesInput': null,
+        'metadata.responsesTurn.version': 1,
+        'metadata.responsesTurn.responseId': responseId,
+        'metadata.responsesResponse.version': 1,
+        'metadata.responsesResponse.commitState': 'pending',
+      },
+      { $set: { 'metadata.responsesResponse.commitState': 'committed' } },
+      { new: true },
+    ).lean<IMessage | null>();
+  }
+
+  /** Removes only rows staged for one Responses turn. */
+  async function deleteStoredResponseTurn({
+    userId,
+    conversationId,
+    responseId,
+  }: {
+    userId: string;
+    conversationId: string;
+    responseId: string;
+  }): Promise<DeleteResult> {
+    const Message = mongoose.models.Message as Model<IMessage>;
+    return Message.deleteMany({
+      user: userId,
+      conversationId,
+      'metadata.responsesTurn.version': 1,
+      'metadata.responsesTurn.responseId': responseId,
+    });
+  }
+
   /**
    * Deletes messages from the database.
    */
@@ -3217,6 +3275,8 @@ export function createMessageMethods(mongoose: typeof import('mongoose')): Messa
     getMessagesForSubagentThreadView,
     listSubagentTasksForThreads,
     getMessage,
+    commitStoredResponseTurn,
+    deleteStoredResponseTurn,
     getMessagesByCursor,
     searchMessages,
     deleteMessages,

--- a/packages/data-schemas/src/methods/message.ts
+++ b/packages/data-schemas/src/methods/message.ts
@@ -3259,31 +3259,70 @@ export function createMessageMethods(mongoose: typeof import('mongoose')): Messa
     if (typeof Message.meiliSearch !== 'function') {
       throw new Error('MeiliSearch plugin not registered on Message model');
     }
-    const results = await Message.meiliSearch(query, searchOptions, hydrate);
-    if (results.hits.length === 0) {
-      return results;
+    const attributes = searchOptions.attributesToRetrieve;
+    const internalAttributes =
+      attributes && !attributes.includes('*')
+        ? [...new Set([...attributes, 'messageId', 'user'])]
+        : attributes;
+    const limit = searchOptions.limit ?? 20;
+    let offset = searchOptions.offset ?? 0;
+    const search = () =>
+      Message.meiliSearch(
+        query,
+        {
+          ...searchOptions,
+          attributesToRetrieve: internalAttributes,
+          offset,
+          limit,
+        },
+        false,
+      );
+    const results = await search();
+    const hits: typeof results.hits = [];
+    let page = results;
+    while (page.hits.length > 0 && hits.length < limit) {
+      const identities = page.hits.flatMap((hit) =>
+        typeof hit.messageId === 'string' && typeof hit.user === 'string'
+          ? [{ messageId: hit.messageId, user: hit.user }]
+          : [],
+      );
+      const visible =
+        identities.length === 0
+          ? []
+          : await readVisibleMessages(
+              mongoose.models.Message as Model<IMessage>,
+              { $or: identities },
+              hydrate ? undefined : 'messageId user',
+              { sort: false },
+            );
+      const byIdentity = new Map(
+        visible.map((message) => [JSON.stringify([message.user, message.messageId]), message]),
+      );
+      for (const hit of page.hits) {
+        const message = byIdentity.get(JSON.stringify([hit.user, hit.messageId]));
+        if (!message) {
+          continue;
+        }
+        const projected = { ...hit };
+        if (attributes && !attributes.includes('*')) {
+          for (const field of ['messageId', 'user']) {
+            if (!attributes.includes(field)) {
+              delete projected[field];
+            }
+          }
+        }
+        hits.push(hydrate ? { ...message, ...projected } : projected);
+        if (hits.length === limit) {
+          break;
+        }
+      }
+      if (hits.length >= limit || page.hits.length < limit) {
+        break;
+      }
+      offset += page.hits.length;
+      page = await search();
     }
-    const identities = results.hits.flatMap((hit) =>
-      typeof hit.messageId === 'string' && typeof hit.user === 'string'
-        ? [{ messageId: hit.messageId, user: hit.user }]
-        : [],
-    );
-    if (identities.length === 0) {
-      return { ...results, hits: [] };
-    }
-    const visible = await readVisibleMessages(
-      mongoose.models.Message as Model<IMessage>,
-      { $or: identities },
-      'messageId user',
-      { sort: false },
-    );
-    const visibleIds = new Set(
-      visible.map((message) => JSON.stringify([message.user, message.messageId])),
-    );
-    return {
-      ...results,
-      hits: results.hits.filter((hit) => visibleIds.has(JSON.stringify([hit.user, hit.messageId]))),
-    };
+    return { ...results, hits };
   }
 
   return {

--- a/packages/data-schemas/src/methods/share.ts
+++ b/packages/data-schemas/src/methods/share.ts
@@ -10,6 +10,7 @@ import {
 } from '~/utils/stripUIResourceMarkers';
 import { activeExpirationFilter } from '~/utils/retention';
 import { isValidObjectIdString } from '~/utils/objectId';
+import { readVisibleMessages } from '~/utils/responses';
 import { MEILI_SEARCH_LIMIT } from '~/common/search';
 import { CLIENT_MESSAGE_SELECT } from './message';
 import logger from '~/config/winston';
@@ -834,22 +835,20 @@ export function createShareMethods(mongoose: typeof import('mongoose')): {
         ? SharedLink.findOne({ _id: shareObjectId, ...activeExpirationFilter<t.ISharedLink>() })
         : SharedLink.findOne({ shareId, ...activeExpirationFilter<t.ISharedLink>() });
 
-      const share = (await query
-        .populate({
-          path: 'messages',
-          select: CLIENT_MESSAGE_SELECT,
-        })
-        .select('-__v')
-        .lean()) as (t.ISharedLink & { messages: t.IMessage[] }) | null;
+      const share = await query.select('-__v').lean<t.ISharedLink>();
 
       if (!share?.conversationId) {
         return null;
       }
 
       /** Filtered messages based on targetMessageId if present (branch-specific sharing) */
-      let messagesToShare: t.IMessage[] = share.messages;
+      let messagesToShare = await readVisibleMessages(
+        mongoose.models.Message as Model<t.IMessage>,
+        { _id: { $in: share.messages ?? [] } },
+        CLIENT_MESSAGE_SELECT,
+      );
       if (share.targetMessageId) {
-        messagesToShare = getMessagesUpToTarget(share.messages, share.targetMessageId);
+        messagesToShare = getMessagesUpToTarget(messagesToShare, share.targetMessageId);
       }
 
       // Keep anonymous ids consistent within a response without retaining a
@@ -1106,7 +1105,7 @@ export function createShareMethods(mongoose: typeof import('mongoose')): {
     }
     let preflightFailed = false;
     try {
-      const Message = mongoose.models.Message as SchemaWithMeiliMethods;
+      const Message = mongoose.models.Message as Model<t.IMessage>;
       const SharedLink = mongoose.models.SharedLink as Model<t.ISharedLink>;
       const Conversation = mongoose.models.Conversation as SchemaWithMeiliMethods;
 
@@ -1119,7 +1118,7 @@ export function createShareMethods(mongoose: typeof import('mongoose')): {
         })
           .select('-_id -__v -user')
           .lean() as Promise<t.ISharedLink | null>,
-        Message.find({ conversationId, user }).sort({ createdAt: 1 }).lean(),
+        readVisibleMessages(Message, { conversationId, user }),
       ]);
 
       if (existingShare) {
@@ -1284,7 +1283,7 @@ export function createShareMethods(mongoose: typeof import('mongoose')): {
     let preflightFailed = false;
     try {
       const SharedLink = mongoose.models.SharedLink as Model<t.ISharedLink>;
-      const Message = mongoose.models.Message as SchemaWithMeiliMethods;
+      const Message = mongoose.models.Message as Model<t.IMessage>;
       const share = (await SharedLink.findOne({ shareId, user })
         .select('-_id -__v -user')
         .lean()) as t.ISharedLink | null;
@@ -1293,9 +1292,10 @@ export function createShareMethods(mongoose: typeof import('mongoose')): {
         throw new ShareServiceError('Share not found', 'SHARE_NOT_FOUND');
       }
 
-      const updatedMessages = await Message.find({ conversationId: share.conversationId, user })
-        .sort({ createdAt: 1 })
-        .lean();
+      const updatedMessages = await readVisibleMessages(Message, {
+        conversationId: share.conversationId,
+        user,
+      });
 
       if (updatedMessages.length === 0) {
         throw new ShareServiceError('No messages to share', 'NO_MESSAGES');
@@ -1463,18 +1463,20 @@ export function createShareMethods(mongoose: typeof import('mongoose')): {
   ): Promise<t.SharedFileSnapshot | t.SharedFileSnapshot[] | null> {
     try {
       const SharedLink = mongoose.models.SharedLink as Model<t.ISharedLink>;
-      const share = (await SharedLink.findOne({
+      const share = await SharedLink.findOne({
         shareId,
         ...activeExpirationFilter<t.ISharedLink>(),
-      })
-        .populate({ path: 'messages', select: '-_id -__v -user' })
-        .lean()) as (t.ISharedLink & { messages: t.IMessage[] }) | null;
+      }).lean<t.ISharedLink>();
 
       if (!share) {
         return null;
       }
 
-      let messages: t.IMessage[] = share.messages ?? [];
+      let messages = await readVisibleMessages(
+        mongoose.models.Message as Model<t.IMessage>,
+        { _id: { $in: share.messages ?? [] } },
+        '-_id -__v -user',
+      );
       if (share.targetMessageId) {
         messages = getMessagesUpToTarget(messages, share.targetMessageId);
       }

--- a/packages/data-schemas/src/utils/responses.spec.ts
+++ b/packages/data-schemas/src/utils/responses.spec.ts
@@ -1,0 +1,184 @@
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { createMethods, createModels, tenantStorage } from '..';
+import type { AllMethods, IMessage } from '..';
+
+let server: MongoMemoryServer;
+let methods: AllMethods;
+let Message: mongoose.Model<IMessage>;
+const owner = 'visibility-owner';
+const conversationId = '527cccb0-2624-4e3c-b754-88b7bcb0ac19';
+const responseId = 'resp_visibility';
+const scope = <T>(work: () => Promise<T>, tenantId = 'tenant-visible') =>
+  tenantStorage.run({ tenantId }, work);
+
+beforeAll(async () => {
+  server = await MongoMemoryServer.create();
+  await mongoose.connect(server.getUri());
+  createModels(mongoose);
+  methods = createMethods(mongoose);
+  Message = mongoose.models.Message as mongoose.Model<IMessage>;
+});
+afterAll(async () => {
+  await mongoose.disconnect();
+  await server.stop();
+});
+beforeEach(async () => {
+  await mongoose.connection.dropDatabase();
+});
+
+async function seedTurn(commitState: 'pending' | 'committed' = 'pending') {
+  await mongoose.models.Conversation.create({
+    conversationId,
+    user: owner,
+    title: 'visible',
+    endpoint: 'agents',
+  });
+  return Message.create([
+    {
+      messageId: 'input-visible',
+      conversationId,
+      user: owner,
+      text: 'pending question',
+      sender: 'User',
+      isCreatedByUser: true,
+      isUserSubmitted: true,
+      createdAt: new Date(1000),
+      metadata: {
+        responsesTurn: { version: 1, responseId },
+        responsesInput: { role: 'user' },
+      },
+    },
+    {
+      messageId: responseId,
+      conversationId,
+      user: owner,
+      text: 'pending answer',
+      sender: 'Agent',
+      isCreatedByUser: false,
+      isUserSubmitted: false,
+      createdAt: new Date(2000),
+      metadata: {
+        responsesTurn: { version: 1, responseId },
+        responsesResponse: { version: 1, commitState, output: [], usage: null },
+      },
+    },
+  ]);
+}
+
+it('hides every staged row until the owned output is committed', async () => {
+  await scope(async () => {
+    await seedTurn();
+    expect(await methods.getMessages({ user: owner, conversationId })).toEqual([]);
+    expect(await methods.getMessages({ user: owner, messageId: 'input-visible' })).toEqual([]);
+    expect(await methods.getMessage({ user: owner, messageId: responseId })).toBeNull();
+    await methods.commitStoredResponseTurn({ userId: owner, conversationId, responseId });
+    expect(await methods.getMessages({ user: owner, conversationId })).toHaveLength(2);
+    expect(await methods.getMessage({ user: owner, messageId: responseId })).not.toBeNull();
+  });
+});
+
+it('filters before limits and preserves cursors and schema-private projections', async () => {
+  await scope(async () => {
+    await seedTurn();
+    await Message.create(
+      [3, 4, 5].map((id) => ({
+        messageId: `legacy-${id}`,
+        conversationId,
+        user: owner,
+        text: 'visible',
+        sender: 'User',
+        createdAt: new Date(id * 1000),
+      })),
+    );
+    await Message.collection.updateMany(
+      {},
+      {
+        $set: {
+          contextMeta: { secret: 'private' },
+          subagentTranscript: { messagesJson: 'private' },
+        },
+      },
+    );
+    const first = await methods.getMessagesByCursor(
+      { user: owner, conversationId },
+      { limit: 2, sortOrder: 1, select: '-contextMeta' },
+    );
+    expect(first.messages.map((message) => message.messageId)).toEqual(['legacy-3', 'legacy-4']);
+    expect(first.messages[0]).not.toHaveProperty('contextMeta');
+    const second = await methods.getMessagesByCursor(
+      { user: owner, conversationId },
+      { limit: 2, sortOrder: 1, cursor: first.nextCursor },
+    );
+    expect(second.messages.map((message) => message.messageId)).toEqual(['legacy-5']);
+    expect(second.nextCursor).toBeNull();
+    const ids = await methods.getMessages({ user: owner }, '_id');
+    expect(Object.keys(ids[0])).toEqual(['_id']);
+    const ordinary = await methods.getMessages({ user: owner });
+    expect(ordinary[0]).not.toHaveProperty('subagentTranscript');
+    const internal = await methods.getMessages({ user: owner }, '+subagentTranscript');
+    expect(internal[0].subagentTranscript).toEqual({ messagesJson: 'private' });
+  });
+});
+
+it('does not publish a turn through another tenant or owner with the same response ID', async () => {
+  await scope(async () => {
+    await seedTurn();
+  });
+  await scope(async () => {
+    await seedTurn('committed');
+  }, 'tenant-other');
+  await scope(async () => {
+    const output = await Message.findOne({ messageId: responseId }).lean();
+    await Message.create({
+      ...output,
+      _id: new mongoose.Types.ObjectId(),
+      user: 'another-owner',
+      metadata: {
+        responsesTurn: { version: 1, responseId },
+        responsesResponse: { version: 1, commitState: 'committed', output: [] },
+      },
+    });
+    expect(await methods.getMessages({ user: owner, conversationId })).toEqual([]);
+  });
+});
+
+it('excludes pending rows from new shares and existing share reads', async () => {
+  await scope(async () => {
+    const pending = await seedTurn();
+    await expect(methods.createSharedLink(owner, conversationId)).rejects.toMatchObject({
+      code: 'NO_MESSAGES',
+    });
+    await mongoose.models.SharedLink.create({
+      shareId: 'pending-share',
+      conversationId,
+      user: owner,
+      title: 'pending',
+      messages: pending.map((message) => message._id),
+    });
+    const shared = await methods.getSharedMessages('pending-share');
+    expect(shared?.messages ?? []).toEqual([]);
+    await methods.commitStoredResponseTurn({ userId: owner, conversationId, responseId });
+    const committed = await methods.getSharedMessages('pending-share');
+    expect(committed?.messages).toHaveLength(2);
+  });
+});
+
+it('removes pending search hits even if the external index has already indexed them', async () => {
+  await scope(async () => {
+    await seedTurn();
+    Object.defineProperty(Message, 'meiliSearch', {
+      configurable: true,
+      value: jest
+        .fn()
+        .mockResolvedValue({ hits: [{ user: owner, messageId: responseId, text: 'pending' }] }),
+    });
+    try {
+      expect((await methods.searchMessages('pending', {}, true)).hits).toEqual([]);
+      await methods.commitStoredResponseTurn({ userId: owner, conversationId, responseId });
+      expect((await methods.searchMessages('pending', {}, true)).hits).toHaveLength(1);
+    } finally {
+      Reflect.deleteProperty(Message, 'meiliSearch');
+    }
+  });
+});

--- a/packages/data-schemas/src/utils/responses.spec.ts
+++ b/packages/data-schemas/src/utils/responses.spec.ts
@@ -1,6 +1,7 @@
 import mongoose from 'mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import { createMethods, createModels, tenantStorage } from '..';
+import type { SearchParams } from 'meilisearch';
 import type { AllMethods, IMessage } from '..';
 
 let server: MongoMemoryServer;
@@ -97,6 +98,7 @@ it('filters before limits and preserves cursors and schema-private projections',
         $set: {
           contextMeta: { secret: 'private' },
           subagentTranscript: { messagesJson: 'private' },
+          subagentTask: { status: 'completed' },
         },
       },
     );
@@ -118,8 +120,84 @@ it('filters before limits and preserves cursors and schema-private projections',
     expect(ordinary[0]).not.toHaveProperty('subagentTranscript');
     const internal = await methods.getMessages({ user: owner }, '+subagentTranscript');
     expect(internal[0].subagentTranscript).toEqual({ messagesJson: 'private' });
+    const transcript = await methods.getMessages(
+      { user: owner },
+      'messageId parentMessageId text createdAt +subagentTranscript +subagentTask',
+    );
+    expect(transcript[0].subagentTranscript).toEqual({ messagesJson: 'private' });
+    expect(transcript[0].subagentTask).toEqual({ status: 'completed' });
+    expect(transcript[0]).not.toHaveProperty('contextMeta');
+    expect(transcript[0]).not.toHaveProperty('user');
   });
 });
+
+it.each([false, true])(
+  'refills projected search results with one visibility read per page (hydrate=%s)',
+  async (hydrate) => {
+    await scope(async () => {
+      await seedTurn();
+      await Message.create({
+        messageId: 'search-visible',
+        conversationId,
+        user: owner,
+        sender: 'User',
+        text: 'visible',
+      });
+      const indexed = [
+        { messageId: responseId, user: owner, conversationId },
+        { messageId: 'search-visible', user: owner, conversationId },
+      ];
+      const search = jest.fn(async (_query: string, options: SearchParams) => ({
+        hits: indexed
+          .slice(options.offset ?? 0, (options.offset ?? 0) + (options.limit ?? 20))
+          .map((hit) =>
+            Object.fromEntries(
+              Object.entries(hit).filter(
+                ([field]) =>
+                  !options.attributesToRetrieve || options.attributesToRetrieve.includes(field),
+              ),
+            ),
+          ),
+      }));
+      Object.defineProperty(Message, 'meiliSearch', { configurable: true, value: search });
+      const aggregate = jest.spyOn(Message, 'aggregate');
+      try {
+        const result = await methods.searchMessages(
+          'visible',
+          {
+            limit: 1,
+            attributesToRetrieve: ['conversationId', 'originalConversationId'],
+            filter: `user = "${owner}"`,
+          },
+          hydrate,
+        );
+        expect(result.hits).toHaveLength(1);
+        expect(result.hits[0].conversationId).toBe(conversationId);
+        if (hydrate) {
+          expect(result.hits[0].messageId).toBe('search-visible');
+          expect(result.hits[0].text).toBe('visible');
+        } else {
+          expect(result.hits[0]).toEqual({ conversationId });
+        }
+        expect(search).toHaveBeenCalledTimes(2);
+        expect(aggregate).toHaveBeenCalledTimes(2);
+        expect(search).toHaveBeenLastCalledWith(
+          'visible',
+          expect.objectContaining({
+            offset: 1,
+            limit: 1,
+            filter: `user = "${owner}"`,
+            attributesToRetrieve: ['conversationId', 'originalConversationId', 'messageId', 'user'],
+          }),
+          false,
+        );
+      } finally {
+        aggregate.mockRestore();
+        Reflect.deleteProperty(Message, 'meiliSearch');
+      }
+    });
+  },
+);
 
 it('does not publish a turn through another tenant or owner with the same response ID', async () => {
   await scope(async () => {

--- a/packages/data-schemas/src/utils/responses.ts
+++ b/packages/data-schemas/src/utils/responses.ts
@@ -70,18 +70,24 @@ export async function readVisibleMessages(
   const castFilter = query.cast(Message, filter);
   const projection: Record<string, 0 | 1> = {};
   const selected = new Set<string>();
+  const forced = new Set<string>();
   let inclusive = false;
   for (const field of select?.split(/\s+/).filter(Boolean) ?? []) {
     const name = field.replace(/^[-+]/, '');
     selected.add(name);
     if (field.startsWith('+')) {
+      forced.add(name);
       continue;
     }
     const include = field.startsWith('-') ? 0 : 1;
     projection[name] = include;
     inclusive ||= include === 1;
   }
-  if (!inclusive) {
+  if (inclusive) {
+    for (const name of forced) {
+      projection[name] = 1;
+    }
+  } else {
     Message.schema.eachPath((name, schemaType) => {
       if (schemaType.options.select === false && !selected.has(name)) {
         projection[name] = 0;

--- a/packages/data-schemas/src/utils/responses.ts
+++ b/packages/data-schemas/src/utils/responses.ts
@@ -1,0 +1,104 @@
+import type { FilterQuery, Model, PipelineStage } from 'mongoose';
+import type { IMessage } from '~/types';
+
+/** Resolve turn publication inside MongoDB, before pagination or projection. */
+export function committedMessageStages(collection = 'messages'): PipelineStage[] {
+  return [
+    {
+      $addFields: {
+        _responsesTurnId: { $ifNull: ['$metadata.responsesTurn.responseId', []] },
+      },
+    },
+    {
+      $lookup: {
+        from: collection,
+        localField: '_responsesTurnId',
+        foreignField: 'messageId',
+        as: '_responseOutputs',
+      },
+    },
+    {
+      $addFields: {
+        _committedResponseOutput: {
+          $filter: {
+            input: '$_responseOutputs',
+            as: 'output',
+            cond: {
+              $and: [
+                { $eq: ['$$output.isCreatedByUser', false] },
+                { $eq: ['$$output.isUserSubmitted', false] },
+                { $eq: [{ $ifNull: ['$$output.metadata.responsesInput', null] }, null] },
+                { $eq: ['$$output.metadata.responsesTurn.version', 1] },
+                { $eq: ['$$output.metadata.responsesResponse.version', 1] },
+                { $eq: ['$$output.metadata.responsesResponse.commitState', 'committed'] },
+                { $eq: ['$$output.metadata.responsesTurn.responseId', '$_responsesTurnId'] },
+                { $eq: ['$$output.user', '$user'] },
+                { $eq: ['$$output.conversationId', '$conversationId'] },
+                {
+                  $eq: [{ $ifNull: ['$$output.tenantId', null] }, { $ifNull: ['$tenantId', null] }],
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+    {
+      $match: {
+        $or: [
+          { 'metadata.responsesTurn': { $exists: false } },
+          {
+            'metadata.responsesTurn.version': 1,
+            'metadata.responsesTurn.responseId': { $gt: '' },
+            '_committedResponseOutput.0': { $exists: true },
+          },
+        ],
+      },
+    },
+    { $project: { _responsesTurnId: 0, _responseOutputs: 0, _committedResponseOutput: 0 } },
+  ];
+}
+
+/** Preserve find's casting and schema-private fields when reading through aggregation. */
+export async function readVisibleMessages(
+  Message: Model<IMessage>,
+  filter: FilterQuery<IMessage>,
+  select?: string,
+  options: { sort?: Record<string, 1 | -1> | false; limit?: number } = {},
+): Promise<IMessage[]> {
+  const query = Message.find(filter);
+  const castFilter = query.cast(Message, filter);
+  const projection: Record<string, 0 | 1> = {};
+  const selected = new Set<string>();
+  let inclusive = false;
+  for (const field of select?.split(/\s+/).filter(Boolean) ?? []) {
+    const name = field.replace(/^[-+]/, '');
+    selected.add(name);
+    if (field.startsWith('+')) {
+      continue;
+    }
+    const include = field.startsWith('-') ? 0 : 1;
+    projection[name] = include;
+    inclusive ||= include === 1;
+  }
+  if (!inclusive) {
+    Message.schema.eachPath((name, schemaType) => {
+      if (schemaType.options.select === false && !selected.has(name)) {
+        projection[name] = 0;
+      }
+    });
+  }
+  const pipeline: PipelineStage[] = [{ $match: castFilter }];
+  if (options.sort !== false) {
+    pipeline.push({ $sort: options.sort ?? { createdAt: 1 } });
+  }
+  // eslint-disable-next-line no-restricted-syntax -- Reads the collection name, not the raw driver.
+  pipeline.push(...committedMessageStages(Message.collection.name));
+  if (options.limit != null && options.limit > 0) {
+    pipeline.push({ $limit: options.limit });
+  }
+  if (Object.keys(projection).length > 0) {
+    pipeline.push({ $project: projection });
+  }
+  return Message.aggregate<IMessage>(pipeline);
+}

--- a/packages/data-schemas/src/utils/retention.ts
+++ b/packages/data-schemas/src/utils/retention.ts
@@ -28,5 +28,18 @@ export const buildRetentionVisibilityFilter = <
     ],
   }) as FilterQuery<T>;
 
+export const isRetentionVisible = (
+  document: RetentionFilterDocument,
+  now: Date = new Date(),
+): boolean => {
+  if (document.isTemporary === true) {
+    return false;
+  }
+  if (document.isTemporary == null) {
+    return document.expiredAt == null;
+  }
+  return document.expiredAt == null || document.expiredAt > now;
+};
+
 export const createFallbackRetentionDate = (now: number = Date.now()): Date =>
   new Date(now + DEFAULT_RETENTION_HOURS * 60 * 60 * 1000);


### PR DESCRIPTION
## Summary

Requests to `/api/agents/v1/responses` with `store: true` could return success while saving an empty conversation, and the returned `resp_*` ID could not be used to retrieve or continue it. Stored turns now retain their agent association and linked messages; retrieval returns the original completed response, and continuation restores the selected branch through the authenticated owner's response ID.

Fixes #14466.

Documentation: [librechat.ai PR #760](https://github.com/LibreChat-AI/librechat.ai/pull/760). No new package or deployment dependencies are required.

## How it works

`persistStoredResponse` owns turn publication. Shared message reads expose the turn only after its output marker commits, so a partial save cannot appear in history, search, shares, or insights.

```text
persistStoredResponse
  saveConversationFence       establish the conversation and agent association
  saveMessage                 stage linked input and output rows
  commitMessageManifest       append references without replacing concurrent appends
  commitStoredResponseTurn    publish the turn through its output marker
return completed response     emit the same stored envelope for JSON or SSE
```

Response IDs resolve through the owner's generated output to its conversation. Continuation follows that output's parent chain; legacy UUID continuation selects the latest visible branch, while flat legacy history and earlier snapshots remain readable. Shared visibility uses DocumentDB-compatible joins and does not require MongoDB transactions.

**Compatibility:** `store: true` combined with `isTemporary: true` now returns HTTP 400 before execution, because temporary conversations are excluded from response retrieval. A branched legacy UUID continuation now uses the latest branch instead of combining sibling branches. Persistence failures are reported instead of returning a successful stored response; streaming failures emit `response.failed` before `[DONE]`.

## Change Type

- [x] Bug fix
- [x] Breaking change (the request-validation and legacy branch-selection changes described above)
- [x] This change requires a documentation update

## Testing

549 focused tests passed, covering create/GET envelope equality, streamed completion, canonical and legacy continuation, tenant ownership, concurrent appends, failed and ambiguous writes, deletion, staged-row visibility, pagination, search projections, sharing, and limiter regression cases.

Run from the repository root after installing dependencies and building the workspaces:

```sh
(cd packages/data-schemas && npx jest --runInBand src/utils/responses.spec.ts src/methods/message.spec.ts src/methods/share.test.ts src/methods/insights.spec.ts src/methods/conversation.spec.ts)
(cd packages/api && npx jest --runInBand src/agents/responses/persistence.spec.ts src/agents/responses/persistence.database.spec.ts src/agents/responses/__tests__/service.test.ts src/middleware/code.spec.ts)
(cd api && npx jest --runInBand server/controllers/agents/__tests__/responses.unit.spec.js)
npm run lighthouse
```

The full application build, shared-package typecheck, scoped ESLint/Prettier/import checks, and Lighthouse passed locally. CI at `5de9d1c6fc` has 30 passing checks and two intentional skips, including TypeScript, API/shared tests, E2E, integration tests, Lighthouse, and container smoke tests. The local API typecheck reports a Langfuse dependency diagnostic in an unchanged file; CI's TypeScript job passes.

### **Test Configuration**:

- Node.js 24.16.0; dependencies from the repository lockfile.
- Focused database tests use ephemeral MongoDB instances through `mongodb-memory-server` and require local socket access; no live model provider is needed.
- Lighthouse 13.4.1 with Chromium and the seeded application described in [the Lighthouse test guide](https://github.com/danny-avila/LibreChat/blob/5de9d1c6fc269eede17f3665e241e2d3b6f95606/e2e/lighthouse/README.md).

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] A pull request for updating the documentation has been submitted.
