### PR TITLE
🗳️ feat: Define Conversation Code Approval Modes

### DIFF
--- a/packages/data-provider/src/code/approval.spec.ts
+++ b/packages/data-provider/src/code/approval.spec.ts
@@ -1,3 +1,4 @@
+import type { CodeApprovalConstraints } from './approval';
 import {
   CODE_APPROVAL_MODES,
   CodeApprovalModeError,
@@ -5,7 +6,6 @@ import {
   resolveCodeApprovalMode,
   resolveCodePermissionDecision,
 } from './approval';
-import type { CodeApprovalConstraints } from './approval';
 
 const constraints: CodeApprovalConstraints = {
   attached: true,

--- a/packages/data-provider/src/code/approval.spec.ts
+++ b/packages/data-provider/src/code/approval.spec.ts
@@ -1,0 +1,112 @@
+import {
+  CODE_APPROVAL_MODES,
+  CodeApprovalModeError,
+  getAllowedCodeApprovalModes,
+  resolveCodeApprovalMode,
+  resolveCodePermissionDecision,
+} from './approval';
+import type { CodeApprovalConstraints } from './approval';
+
+const constraints: CodeApprovalConstraints = {
+  attached: true,
+  allowedModes: CODE_APPROVAL_MODES,
+  configSchema: {
+    permissions: {
+      fileWrite: { allowed: ['ask', 'allow', 'deny'], default: 'ask' },
+      commandExecution: { allowed: ['ask', 'allow', 'deny'], default: 'ask' },
+    },
+  },
+};
+
+describe('conversation code approval constraints', () => {
+  test('defaults to asking without enabling unattended execution', () => {
+    expect(getAllowedCodeApprovalModes({})).toEqual(['ask']);
+    expect(getAllowedCodeApprovalModes({ attached: true })).toEqual(['ask']);
+    expect(resolveCodeApprovalMode(undefined, constraints)).toBeUndefined();
+  });
+
+  test('honors endpoint disablement and an explicit empty allowlist', () => {
+    expect(getAllowedCodeApprovalModes({ ...constraints, enabled: false })).toEqual([]);
+    expect(getAllowedCodeApprovalModes({ ...constraints, allowedModes: [] })).toEqual([]);
+  });
+
+  test('intersects deployment choices with machine policy in stable UI order', () => {
+    expect(getAllowedCodeApprovalModes(constraints)).toEqual(CODE_APPROVAL_MODES);
+    expect(
+      getAllowedCodeApprovalModes({
+        ...constraints,
+        configSchema: {
+          permissions: { fileWrite: constraints.configSchema?.permissions?.fileWrite },
+        },
+      }),
+    ).toEqual(['ask', 'acceptEdits']);
+    expect(getAllowedCodeApprovalModes({ ...constraints, configSchema: undefined })).toEqual([
+      'ask',
+    ]);
+    expect(
+      getAllowedCodeApprovalModes({ ...constraints, allowedModes: ['acceptEdits', 'ask'] }),
+    ).toEqual(['ask', 'acceptEdits']);
+  });
+
+  test('never loosens an effective machine deny', () => {
+    expect(
+      getAllowedCodeApprovalModes({
+        ...constraints,
+        settings: { permissions: { fileWrite: 'deny' } },
+      }),
+    ).toEqual(['ask']);
+    expect(
+      getAllowedCodeApprovalModes({
+        ...constraints,
+        settings: { permissions: { commandExecution: 'deny' } },
+      }),
+    ).toEqual(['ask', 'acceptEdits']);
+  });
+
+  test('does not trust settings values excluded by the current schema', () => {
+    expect(
+      getAllowedCodeApprovalModes({
+        ...constraints,
+        settings: { permissions: { fileWrite: 'allow', commandExecution: 'allow' } },
+        configSchema: {
+          permissions: {
+            fileWrite: { allowed: ['ask'], default: 'ask' },
+            commandExecution: { allowed: ['ask'], default: 'ask' },
+          },
+        },
+      }),
+    ).toEqual(['ask']);
+  });
+
+  test.each(['autoApprove', 'bypass', 'fullAccess', '', {}, ['ask'], true, 1])(
+    'rejects invalid request state: %j',
+    (value) => {
+      expect(() => resolveCodeApprovalMode(value, constraints)).toThrow(CodeApprovalModeError);
+    },
+  );
+
+  test('revalidates a once-permitted selection after a policy restriction', () => {
+    expect(resolveCodeApprovalMode('acceptEdits', constraints)).toBe('acceptEdits');
+    expect(() =>
+      resolveCodeApprovalMode('acceptEdits', { ...constraints, allowedModes: ['ask'] }),
+    ).toThrow(CodeApprovalModeError);
+  });
+
+  test.each(CODE_APPROVAL_MODES)('preserves deny under %s', (mode) => {
+    for (const category of ['fileWrite', 'commandExecution'] as const) {
+      expect(resolveCodePermissionDecision({ mode, category, decision: 'deny' })).toBe('deny');
+    }
+  });
+
+  test('accept edits asks for commands and does not mutate its input', () => {
+    const before = JSON.stringify(constraints);
+    const mode = resolveCodeApprovalMode('acceptEdits', constraints);
+    expect(resolveCodePermissionDecision({ mode, category: 'fileWrite', decision: 'ask' })).toBe(
+      'allow',
+    );
+    expect(
+      resolveCodePermissionDecision({ mode, category: 'commandExecution', decision: 'allow' }),
+    ).toBe('ask');
+    expect(JSON.stringify(constraints)).toBe(before);
+  });
+});

--- a/packages/data-provider/src/code/approval.spec.ts
+++ b/packages/data-provider/src/code/approval.spec.ts
@@ -8,7 +8,7 @@ import {
 } from './approval';
 
 const constraints: CodeApprovalConstraints = {
-  attached: true,
+  environment: 'attached',
   allowedModes: CODE_APPROVAL_MODES,
   configSchema: {
     permissions: {
@@ -20,9 +20,28 @@ const constraints: CodeApprovalConstraints = {
 
 describe('conversation code approval constraints', () => {
   test('defaults to asking without enabling unattended execution', () => {
-    expect(getAllowedCodeApprovalModes({})).toEqual(['ask']);
-    expect(getAllowedCodeApprovalModes({ attached: true })).toEqual(['ask']);
+    expect(getAllowedCodeApprovalModes({ environment: 'managed' })).toEqual(['ask']);
+    expect(getAllowedCodeApprovalModes({ environment: 'attached' })).toEqual(['ask']);
     expect(resolveCodeApprovalMode(undefined, constraints)).toBeUndefined();
+  });
+
+  test('requires callers to identify attached environments before applying machine policy', () => {
+    expect(
+      getAllowedCodeApprovalModes({
+        environment: 'managed',
+        allowedModes: CODE_APPROVAL_MODES,
+      }),
+    ).toEqual(CODE_APPROVAL_MODES);
+    expect(
+      getAllowedCodeApprovalModes({
+        ...constraints,
+        configSchema: {
+          permissions: {
+            fileWrite: { allowed: ['ask'], default: 'ask' },
+          },
+        },
+      }),
+    ).toEqual(['ask']);
   });
 
   test('honors endpoint disablement and an explicit empty allowlist', () => {
@@ -84,6 +103,16 @@ describe('conversation code approval constraints', () => {
       expect(() => resolveCodeApprovalMode(value, constraints)).toThrow(CodeApprovalModeError);
     },
   );
+
+  test('rejects an unvalidated runtime mode before permission lookup', () => {
+    expect(() =>
+      resolveCodePermissionDecision({
+        mode: 'fullAccess' as never,
+        category: 'fileWrite',
+        decision: 'ask',
+      }),
+    ).toThrow(CodeApprovalModeError);
+  });
 
   test('revalidates a once-permitted selection after a policy restriction', () => {
     expect(resolveCodeApprovalMode('acceptEdits', constraints)).toBe('acceptEdits');

--- a/packages/data-provider/src/code/approval.ts
+++ b/packages/data-provider/src/code/approval.ts
@@ -1,0 +1,85 @@
+import type {
+  CodeEnvironmentPermissionDecision,
+  CodeEnvironmentUserConfigSchema,
+  CodeEnvironmentUserSettings,
+} from '../config';
+
+export const CODE_APPROVAL_MODES = ['ask', 'acceptEdits'] as const;
+export type CodeApprovalMode = (typeof CODE_APPROVAL_MODES)[number];
+
+type CodePermissions = Required<NonNullable<CodeEnvironmentUserSettings['permissions']>>;
+
+const MODE_PERMISSIONS: Record<CodeApprovalMode, CodePermissions> = {
+  ask: { fileWrite: 'ask', commandExecution: 'ask' },
+  acceptEdits: { fileWrite: 'allow', commandExecution: 'ask' },
+};
+
+export type CodeApprovalConstraints = {
+  enabled?: boolean;
+  allowedModes?: readonly CodeApprovalMode[];
+  configSchema?: CodeEnvironmentUserConfigSchema;
+  settings?: CodeEnvironmentUserSettings;
+  attached?: boolean;
+};
+
+/** Omitted deployment configuration never grants unattended execution. */
+export function getAllowedCodeApprovalModes({
+  enabled,
+  allowedModes,
+  configSchema,
+  settings,
+  attached,
+}: CodeApprovalConstraints): CodeApprovalMode[] {
+  if (enabled === false) return [];
+  const permitted = new Set(allowedModes ?? ['ask']);
+  return CODE_APPROVAL_MODES.filter((mode) => {
+    if (!permitted.has(mode)) return false;
+    if (attached !== true) return true;
+    for (const category of ['fileWrite', 'commandExecution'] as const) {
+      if (MODE_PERMISSIONS[mode][category] !== 'allow') continue;
+      const field = configSchema?.permissions?.[category];
+      const configured = settings?.permissions?.[category];
+      const effective =
+        configured != null && field?.allowed.includes(configured) === true
+          ? configured
+          : (field?.default ?? 'ask');
+      if (effective === 'deny' || field?.allowed.includes('allow') !== true) return false;
+    }
+    return true;
+  });
+}
+
+export class CodeApprovalModeError extends Error {
+  readonly code = 'CODE_APPROVAL_MODE_NOT_ALLOWED';
+
+  constructor() {
+    super('The selected code approval mode is not permitted by the current policy.');
+    this.name = 'CodeApprovalModeError';
+  }
+}
+
+/** Validate untrusted request state again at admission, including after policy changes. */
+export function resolveCodeApprovalMode(
+  requested: unknown,
+  constraints: CodeApprovalConstraints,
+): CodeApprovalMode | undefined {
+  if (requested == null) return undefined;
+  const allowed = getAllowedCodeApprovalModes(constraints);
+  const selected = allowed.find((mode) => mode === requested);
+  if (selected == null) throw new CodeApprovalModeError();
+  return selected;
+}
+
+/** Apply a turn preference without modifying machine settings or overriding an existing deny. */
+export function resolveCodePermissionDecision({
+  mode,
+  category,
+  decision,
+}: {
+  mode?: CodeApprovalMode;
+  category: keyof CodePermissions;
+  decision: CodeEnvironmentPermissionDecision;
+}): CodeEnvironmentPermissionDecision {
+  if (mode == null || decision === 'deny') return decision;
+  return MODE_PERMISSIONS[mode][category];
+}

--- a/packages/data-provider/src/code/approval.ts
+++ b/packages/data-provider/src/code/approval.ts
@@ -15,11 +15,11 @@ const MODE_PERMISSIONS: Record<CodeApprovalMode, CodePermissions> = {
 };
 
 export type CodeApprovalConstraints = {
+  environment: 'attached' | 'managed';
   enabled?: boolean;
   allowedModes?: readonly CodeApprovalMode[];
   configSchema?: CodeEnvironmentUserConfigSchema;
   settings?: CodeEnvironmentUserSettings;
-  attached?: boolean;
 };
 
 /** Omitted deployment configuration never grants unattended execution. */
@@ -28,13 +28,13 @@ export function getAllowedCodeApprovalModes({
   allowedModes,
   configSchema,
   settings,
-  attached,
+  environment,
 }: CodeApprovalConstraints): CodeApprovalMode[] {
   if (enabled === false) return [];
   const permitted = new Set(allowedModes ?? ['ask']);
   return CODE_APPROVAL_MODES.filter((mode) => {
     if (!permitted.has(mode)) return false;
-    if (attached !== true) return true;
+    if (environment === 'managed') return true;
     for (const category of ['fileWrite', 'commandExecution'] as const) {
       if (MODE_PERMISSIONS[mode][category] !== 'allow') continue;
       const field = configSchema?.permissions?.[category];
@@ -81,5 +81,6 @@ export function resolveCodePermissionDecision({
   decision: CodeEnvironmentPermissionDecision;
 }): CodeEnvironmentPermissionDecision {
   if (mode == null || decision === 'deny') return decision;
+  if (MODE_PERMISSIONS[mode] == null) throw new CodeApprovalModeError();
   return MODE_PERMISSIONS[mode][category];
 }

--- a/packages/data-provider/src/index.ts
+++ b/packages/data-provider/src/index.ts
@@ -72,3 +72,4 @@ export * from './agentToolOptions';
 /* code-execution sandbox */
 export * from './codeEnvRef';
 export * from './code/worker';
+export * from './code/approval';


### PR DESCRIPTION
## Summary

I started conversation-scoped code approval modes with a portable policy resolver. **This is an incomplete draft, not a merge-ready feature.** The requested composer selector and server integration are still required before this PR leaves draft.

- Define Ask Before Changes and Accept Edits; defer automatic approval and AI-based safety classification.
- Intersect deployment choices with attached-machine configuration without mutating machine settings.
- Preserve effective denies and reject forged or newly disallowed selections.
- Keep policy resolution independent of Express, MongoDB, and UI state.

### Required Before Ready

- Add the accessible, localized composer selector using shared UI primitives.
- Persist conversation-scoped selection without affecting sibling chats or machine-wide settings.
- Wire one resolver through pre-run admission and runtime enforcement, preserving mandatory admin approval rules.
- Pin the selected policy through pause/resume and prevent request tampering.
- Verify UI behavior and live native BYOM execution on isolated ports.

No production behavior changes in the current draft. Do not merge the foundation alone.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Run the focused resolver tests: `node node_modules/jest/bin/jest.js --config packages/data-provider/jest.config.js --runInBand packages/data-provider/src/code/approval.spec.ts`.
- Run touched-file ESLint and the data-provider workspace typecheck.
- Reserve broad regression coverage for CI; no live UI validation is claimed for this draft.

### Test Configuration

Node 24; existing local development dependencies; no deployment or machine setting changes.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
