### PR TITLE
🥽 fix: Stop the DocumentDB Guard Flagging Mongoose's Document `$where`

### DIFF
--- a/packages/data-schemas/src/methods/documentdb.spec.ts
+++ b/packages/data-schemas/src/methods/documentdb.spec.ts
@@ -23,8 +23,9 @@ import ts from 'typescript';
  * that talks to MongoDB — this package, `packages/api`, and `api` — because the
  * regression class is repo-wide and new backend code lands in `packages/api`.
  * Dataflow is followed within a file only — a pipeline imported from another
- * module is out of reach — and the method sweep and the live cluster run are
- * the completeness backstops, not this guard.
+ * module is out of reach — and a dotted `$where` is judged only where syntax is
+ * unambiguous (see `isUnjudgedDottedWhere`); the method sweep and the live
+ * cluster run are the completeness backstops, not this guard.
  * If a construct here becomes genuinely necessary, the fix is a compatible
  * rewrite, not an exception list: `misc/documentdb/audit.documentdb.spec.ts`
  * re-adjudicates any of this against a real cluster.
@@ -415,227 +416,63 @@ function isJavaScriptSource(expression: ts.Expression): boolean {
   );
 }
 
-/** Mongoose's own document types, which declare the `$where` save-condition bag. */
-const MONGOOSE_DOCUMENT_TYPES = new Set(['Document', 'HydratedDocument']);
+/**
+ * A dotted `$where` is Mongoose's per-document save-condition bag on a document
+ * (`mongoose/lib/model.js` copies its keys into the save filter as ordinary field
+ * predicates, so nothing named `$where` reaches the server) and the JavaScript
+ * evaluation operator on a query or filter, and syntax alone cannot tell the two
+ * apart. So it is judged only where the syntax is unambiguous: a CALL
+ * (`query.$where(js)`, parenthesised, or through `call`/`apply`/`bind`) or an
+ * assignment of CODE (a string, template, arrow or function). A read, or an
+ * assignment of anything else — `document.$where = { … }` in
+ * `tenantIsolation.ts`, but equally `filter.$where = predicate` — is not claimed
+ * either way; for the latter the method sweep and the live cluster run are the
+ * backstop. Every other way of writing the operator (`{ $where: … }`,
+ * `'$where'`, `obj['$where']`) remains an offense.
+ */
+const CALL_FORWARDERS = new Set(['call', 'apply', 'bind']);
 
-type NamedTypeDeclaration = ts.TypeAliasDeclaration | ts.InterfaceDeclaration;
-
-/** Same-file `type` and `interface` declarations by name, so a local alias of a
- * document type resolves; an imported one does not, and fails closed. */
-function collectTypeDeclarations(sourceFile: ts.SourceFile): Map<string, NamedTypeDeclaration> {
-  const declarations = new Map<string, NamedTypeDeclaration>();
-  const visit = (node: ts.Node): void => {
-    if (ts.isTypeAliasDeclaration(node) || ts.isInterfaceDeclaration(node)) {
-      declarations.set(node.name.text, node);
-    }
-    ts.forEachChild(node, visit);
-  };
-  visit(sourceFile);
-  return declarations;
-}
-
-function declaresWhereMember(members: ts.NodeArray<ts.TypeElement>): boolean {
-  return members.some(
-    (member) =>
-      ts.isPropertySignature(member) &&
-      (ts.isIdentifier(member.name) || ts.isStringLiteral(member.name)) &&
-      member.name.text === '$where',
-  );
-}
-
-function isNullishType(type: ts.TypeNode): boolean {
-  return (
-    type.kind === ts.SyntaxKind.UndefinedKeyword ||
-    (ts.isLiteralTypeNode(type) && type.literal.kind === ts.SyntaxKind.NullKeyword)
-  );
-}
-
-/** Whether a type NAME is a bag carrier: one of Mongoose's document types, or a
- * same-file declaration that declares a `$where` member itself or reaches one
- * through its alias or `extends` chain. `resolved` memoises and breaks cycles. */
-function isDocumentTypeName(
-  name: string,
-  types: Map<string, NamedTypeDeclaration>,
-  resolved: Map<string, boolean>,
-): boolean {
-  if (MONGOOSE_DOCUMENT_TYPES.has(name)) {
+function isCalled(access: ts.PropertyAccessExpression): boolean {
+  let callee: ts.Node = access;
+  while (ts.isParenthesizedExpression(callee.parent)) {
+    callee = callee.parent;
+  }
+  const use = callee.parent;
+  if (ts.isCallExpression(use) && use.expression === callee) {
     return true;
   }
-  const known = resolved.get(name);
-  if (known != null) {
-    return known;
-  }
-  resolved.set(name, false);
-  const declaration = types.get(name);
-  if (declaration == null) {
-    return false;
-  }
-  const carrier = ts.isTypeAliasDeclaration(declaration)
-    ? isDocumentType(declaration.type, types, resolved)
-    : declaresWhereMember(declaration.members) ||
-      (declaration.heritageClauses ?? []).some((clause) =>
-        clause.types.some(
-          (heritage) =>
-            ts.isIdentifier(heritage.expression) &&
-            isDocumentTypeName(heritage.expression.text, types, resolved),
-        ),
-      );
-  resolved.set(name, carrier);
-  return carrier;
-}
-
-/** Whether a type annotation is a bag carrier: a carrier NAME, a type literal
- * declaring `$where`, an intersection with a carrier arm, or a union whose every
- * non-nullish arm is a carrier. A mixed union is not, since a narrowed branch
- * may hold the non-document arm. */
-function isDocumentType(
-  type: ts.TypeNode | undefined,
-  types: Map<string, NamedTypeDeclaration>,
-  resolved: Map<string, boolean>,
-): boolean {
-  if (type == null) {
-    return false;
-  }
-  if (ts.isParenthesizedTypeNode(type)) {
-    return isDocumentType(type.type, types, resolved);
-  }
-  if (ts.isTypeLiteralNode(type)) {
-    return declaresWhereMember(type.members);
-  }
-  if (ts.isIntersectionTypeNode(type)) {
-    return type.types.some((arm) => isDocumentType(arm, types, resolved));
-  }
-  if (ts.isUnionTypeNode(type)) {
-    const arms = type.types.filter((arm) => !isNullishType(arm));
-    return arms.length > 0 && arms.every((arm) => isDocumentType(arm, types, resolved));
-  }
-  if (!ts.isTypeReferenceNode(type)) {
-    return false;
-  }
-  const name = ts.isIdentifier(type.typeName) ? type.typeName.text : type.typeName.right.text;
-  return isDocumentTypeName(name, types, resolved);
-}
-
-function findNamedDeclaration<T extends ts.ParameterDeclaration | ts.VariableDeclaration>(
-  declarations: readonly T[],
-  name: string,
-): T | undefined {
-  return declarations.find(
-    (declaration) => ts.isIdentifier(declaration.name) && declaration.name.text === name,
+  return (
+    ts.isPropertyAccessExpression(use) &&
+    use.expression === callee &&
+    CALL_FORWARDERS.has(use.name.text)
   );
 }
 
-/** The declaration that governs `name` at `from`: walking outward, the nearest
- * enclosing function's parameter of that name, a `for…in`/`for…of` binding, or a
- * variable declared in the nearest enclosing block. A name declared elsewhere in
- * the file — another function's parameter, say — does not reach here. */
-function declarationInScope(
-  from: ts.Node,
-  name: string,
-): ts.ParameterDeclaration | ts.VariableDeclaration | undefined {
-  for (let scope: ts.Node | undefined = from.parent; scope != null; scope = scope.parent) {
-    if (ts.isFunctionLike(scope)) {
-      const parameter = findNamedDeclaration(scope.parameters, name);
-      if (parameter != null) {
-        return parameter;
-      }
-    }
-    if (
-      (ts.isForOfStatement(scope) || ts.isForInStatement(scope)) &&
-      ts.isVariableDeclarationList(scope.initializer)
-    ) {
-      const binding = findNamedDeclaration(scope.initializer.declarations, name);
-      if (binding != null) {
-        return binding;
-      }
-    }
-    if (
-      ts.isBlock(scope) ||
-      ts.isSourceFile(scope) ||
-      ts.isModuleBlock(scope) ||
-      ts.isCaseClause(scope) ||
-      ts.isDefaultClause(scope)
-    ) {
-      for (const statement of scope.statements) {
-        if (!ts.isVariableStatement(statement)) {
-          continue;
-        }
-        const variable = findNamedDeclaration(statement.declarationList.declarations, name);
-        if (variable != null) {
-          return variable;
-        }
-      }
-    }
-  }
-  return undefined;
-}
-
-/** Whether the receiver of a property access is, by ITS OWN in-scope declaration,
- * a document-bag carrier. `this` never qualifies: Mongoose binds it to a Query in
- * query middleware, and a document hook aliases to a typed local (as
- * `tenantIsolation.ts` does). An unresolved name fails closed. */
-function isDocumentReceiver(
-  expression: ts.Expression,
-  types: Map<string, NamedTypeDeclaration>,
-): boolean {
-  const receiver = unwrapExpression(expression);
-  if (!ts.isIdentifier(receiver)) {
-    return false;
-  }
-  const declaration = declarationInScope(receiver, receiver.text);
-  return declaration != null && isDocumentType(declaration.type, types, new Map());
-}
-
-/**
- * Mongoose's `Document.prototype.$where` is a per-document save-condition bag, not
- * MongoDB's `$where` JavaScript-evaluation operator: `mongoose/lib/model.js` copies
- * its keys into the save filter as ordinary field predicates, so nothing named
- * `$where` reaches the server. The RECEIVER's OWN DECLARED TYPE is the tell:
- * the bag lives on a Mongoose document, so the receiver's in-scope declaration
- * must resolve, within this file, to a type that carries a `$where` member —
- * Mongoose's `Document`/`HydratedDocument`, or a local interface that declares
- * one, as `tenantIsolation.ts` declares `document: TenantWhereDocument` — and
- * it is read or assigned, never called and never handed code. A `$where` on
- * any other receiver, in any position, is the operator, so no amount of
- * indirection on the value or the call (`filter.$where = predicate`,
- * `(query.$where)(js)`, `query.$where.call(…)`, `const w = query.$where`) needs
- * tracing: every one of them fails on the receiver alone.
- */
-function isMongooseDocumentWhere(node: ts.Node, types: Map<string, NamedTypeDeclaration>): boolean {
+function isUnjudgedDottedWhere(node: ts.Node): boolean {
   if (!ts.isIdentifier(node) || node.text !== '$where') {
     return false;
   }
   const access = node.parent;
-  if (
-    !ts.isPropertyAccessExpression(access) ||
-    access.name !== node ||
-    !isDocumentReceiver(access.expression, types)
-  ) {
+  if (!ts.isPropertyAccessExpression(access) || access.name !== node || isCalled(access)) {
     return false;
   }
   const use = access.parent;
-  if (ts.isCallExpression(use) && use.expression === access) {
-    return false;
-  }
-  if (
+  const assignsCode =
     ts.isBinaryExpression(use) &&
     use.left === access &&
-    use.operatorToken.kind === ts.SyntaxKind.EqualsToken
-  ) {
-    return !isJavaScriptSource(use.right);
-  }
-  return true;
+    use.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+    isJavaScriptSource(use.right);
+  return !assignsCode;
 }
 
 function findForbiddenTokens(sourceFile: ts.SourceFile): string[] {
   if (OPERATOR_GUARDS.has(sourceFile.fileName)) {
     return [];
   }
-  const types = collectTypeDeclarations(sourceFile);
   const offenses: string[] = [];
   const visit = (node: ts.Node): void => {
     if (
-      !isMongooseDocumentWhere(node, types) &&
+      !isUnjudgedDottedWhere(node) &&
       (ts.isStringLiteralLike(node) ||
         (ts.isIdentifier(node) && !ts.isPropertySignature(node.parent)))
     ) {
@@ -955,42 +792,24 @@ describe('Amazon DocumentDB compatibility', () => {
           parse('fixture.ts', `interface Doc { $where: Record<string, unknown> }`),
         ),
       ).toEqual([]);
-      /** Mongoose's document save-condition bag: on a receiver whose in-scope
-       * declaration resolves to a type that carries a `$where` member, a read and
-       * an object write both stay exempt. */
+      /** A dotted `$where` is judged only where the syntax is unambiguous. Not
+       * claimed either way — Mongoose's document save-condition bag in
+       * `tenantIsolation.ts` is read and written exactly like this: */
+      expect(findForbiddenTokens(parse('fixture.ts', `const where = document.$where;`))).toEqual(
+        [],
+      );
       expect(
-        findForbiddenTokens(
-          parse(
-            'fixture.ts',
-            `interface TenantWhereDocument {\n  $where?: Record<string, unknown>;\n}\nfunction f(document: TenantWhereDocument) {\n  const where = document.$where;\n  document.$where = { ...where, tenantId: predicate };\n}`,
-          ),
-        ),
+        findForbiddenTokens(parse('fixture.ts', `document.$where = { tenantId: predicate };`)),
       ).toEqual([]);
       expect(
         findForbiddenTokens(
-          parse(
-            'fixture.ts',
-            `interface TenantWhereDocument {\n  $where?: Record<string, unknown>;\n}\ninterface TenantSaveDocument extends TenantWhereDocument {\n  get(path: string): unknown;\n}\nfunction f(document: TenantSaveDocument) {\n  document.$where = Object.keys(rest).length > 0 ? rest : undefined;\n}`,
-          ),
+          parse('fixture.ts', `document.$where = Object.keys(rest).length > 0 ? rest : undefined;`),
         ),
       ).toEqual([]);
-      expect(
-        findForbiddenTokens(
-          parse(
-            'fixture.ts',
-            `const doc: HydratedDocument<IUser> = await load(id);\ndoc.$where = where;`,
-          ),
-        ),
-      ).toEqual([]);
-      expect(
-        findForbiddenTokens(
-          parse(
-            'fixture.ts',
-            `type Saved = Document & { tenantId?: string };\nfunction f(doc: Saved | null) {\n  if (doc) {\n    doc.$where = where;\n  }\n}`,
-          ),
-        ),
-      ).toEqual([]);
-      /** ...but every shape that builds a real query still fails. */
+      /** ...including a non-literal assigned to a filter, which no syntax can tell
+       * from the bag write; the method sweep and the live run are the backstop. */
+      expect(findForbiddenTokens(parse('fixture.ts', `filter.$where = predicate;`))).toEqual([]);
+      /** Every way of writing the operator itself is an offense: */
       expect(
         findForbiddenTokens(parse('fixture.ts', `const filter = { $where: 'this.a == 1' };`)),
       ).not.toEqual([]);
@@ -998,7 +817,7 @@ describe('Amazon DocumentDB compatibility', () => {
       expect(
         findForbiddenTokens(parse('fixture.ts', `filter['$where'] = 'this.a == 1';`)),
       ).not.toEqual([]);
-      /** A dotted `$where` that is called or assigned code IS the operator. */
+      /** ...and so is a dotted `$where` that is called or assigned code: */
       expect(
         findForbiddenTokens(parse('fixture.ts', `filter.$where = 'this.a == 1';`)),
       ).not.toEqual([]);
@@ -1006,22 +825,13 @@ describe('Amazon DocumentDB compatibility', () => {
         findForbiddenTokens(parse('fixture.ts', 'filter.$where = `this.a == ${value}`;')),
       ).not.toEqual([]);
       expect(
-        findForbiddenTokens(parse('fixture.ts', `Model.find().$where('this.a == 1');`)),
+        findForbiddenTokens(parse('fixture.ts', `filter.$where = () => this.a == 1;`)),
       ).not.toEqual([]);
       expect(
         findForbiddenTokens(parse('fixture.ts', `query.$where(function () { return true; });`)),
       ).not.toEqual([]);
       expect(
-        findForbiddenTokens(parse('fixture.ts', `filter.$where = () => this.a == 1;`)),
-      ).not.toEqual([]);
-      /** The receiver decides, so indirection on the value or the call changes nothing. */
-      expect(
-        findForbiddenTokens(
-          parse('fixture.ts', `const predicate = 'this.a == 1';\nfilter.$where = predicate;`),
-        ),
-      ).not.toEqual([]);
-      expect(
-        findForbiddenTokens(parse('fixture.ts', `filter.$where = buildPredicate(ids);`)),
+        findForbiddenTokens(parse('fixture.ts', `Model.find().$where('this.a == 1');`)),
       ).not.toEqual([]);
       expect(
         findForbiddenTokens(parse('fixture.ts', `(query.$where)('this.a == 1');`)),
@@ -1029,72 +839,17 @@ describe('Amazon DocumentDB compatibility', () => {
       expect(
         findForbiddenTokens(parse('fixture.ts', `query.$where.call(query, 'this.a == 1');`)),
       ).not.toEqual([]);
-      expect(findForbiddenTokens(parse('fixture.ts', `const w = query.$where;`))).not.toEqual([]);
+      expect(
+        findForbiddenTokens(parse('fixture.ts', `query.$where.apply(query, ['this.a == 1']);`)),
+      ).not.toEqual([]);
+      expect(
+        findForbiddenTokens(parse('fixture.ts', `const w = query.$where.bind(query);`)),
+      ).not.toEqual([]);
+      expect(findForbiddenTokens(parse('fixture.ts', `this.$where('this.a == 1');`))).not.toEqual(
+        [],
+      );
       expect(
         findForbiddenTokens(parse('fixture.ts', `document.$where('this.a == 1');`)),
-      ).not.toEqual([]);
-      /** `this` is a Query in query middleware and a Document in document
-       * middleware, so it is no tell either way — a document hook aliases to
-       * `document` (as `tenantIsolation.ts` does) rather than earning an exemption. */
-      expect(
-        findForbiddenTokens(parse('fixture.ts', `this.$where.call(this, predicate);`)),
-      ).not.toEqual([]);
-      expect(
-        findForbiddenTokens(parse('fixture.ts', `this.$where = { isDeleted: false };`)),
-      ).not.toEqual([]);
-      /** The declared type decides, not the spelling: a filter named `document`
-       * or declared as a filter is the operator. */
-      expect(
-        findForbiddenTokens(
-          parse(
-            'fixture.ts',
-            `const document = filter;\ndocument.$where = predicate;\nModel.find(document);`,
-          ),
-        ),
-      ).not.toEqual([]);
-      expect(
-        findForbiddenTokens(
-          parse(
-            'fixture.ts',
-            `function f(document: FilterQuery<IUser>) {\n  document.$where = 'this.a == 1';\n}`,
-          ),
-        ),
-      ).not.toEqual([]);
-      expect(findForbiddenTokens(parse('fixture.ts', `doc.$where = where;`))).not.toEqual([]);
-      /** The receiver resolves to ITS OWN declaration, the type to what it
-       * declares: a redeclared name, a `…Document` alias of a filter, an alias this
-       * file does not declare, and a mixed union are all the operator. */
-      expect(
-        findForbiddenTokens(
-          parse(
-            'fixture.ts',
-            `function a(doc: HydratedDocument<IUser>) {\n  doc.$where = where;\n}\nfunction b(doc: FilterQuery<IUser>) {\n  doc.$where = predicate;\n}`,
-          ),
-        ),
-      ).toHaveLength(1);
-      expect(
-        findForbiddenTokens(
-          parse(
-            'fixture.ts',
-            `type SearchDocument = FilterQuery<IUser>;\nfunction f(filter: SearchDocument) {\n  filter.$where = predicate;\n}`,
-          ),
-        ),
-      ).not.toEqual([]);
-      expect(
-        findForbiddenTokens(
-          parse(
-            'fixture.ts',
-            `function f(document: TenantWhereDocument) {\n  document.$where = { tenantId: predicate };\n}`,
-          ),
-        ),
-      ).not.toEqual([]);
-      expect(
-        findForbiddenTokens(
-          parse(
-            'fixture.ts',
-            `function f(value: HydratedDocument<IUser> | FilterQuery<IUser>) {\n  value.$where = predicate;\n}`,
-          ),
-        ),
       ).not.toEqual([]);
     });
 

--- a/packages/data-schemas/src/methods/documentdb.spec.ts
+++ b/packages/data-schemas/src/methods/documentdb.spec.ts
@@ -404,6 +404,23 @@ function findPipelineUpdates(sourceFile: ts.SourceFile): string[] {
  * ignoring prose — the rewrites explain themselves by naming the construct —
  * and type members, which never reach the engine (Mongoose documents declare
  * a `$where` field). */
+/**
+ * Mongoose's `Document.prototype.$where` is a per-document save-condition bag, not
+ * MongoDB's `$where` JavaScript-evaluation operator: `mongoose/lib/model.js` copies
+ * its keys into the save filter as ordinary field predicates, so nothing named
+ * `$where` reaches the server. Only a dotted read or write of that property is
+ * exempt -- a literal `'$where'`, an object-literal `{ $where: ... }` and a computed
+ * `obj['$where']` still fail, since those are how a real query is built.
+ */
+function isMongooseDocumentWhere(node: ts.Node): boolean {
+  return (
+    ts.isIdentifier(node) &&
+    node.text === '$where' &&
+    ts.isPropertyAccessExpression(node.parent) &&
+    node.parent.name === node
+  );
+}
+
 function findForbiddenTokens(sourceFile: ts.SourceFile): string[] {
   if (OPERATOR_GUARDS.has(sourceFile.fileName)) {
     return [];
@@ -411,8 +428,9 @@ function findForbiddenTokens(sourceFile: ts.SourceFile): string[] {
   const offenses: string[] = [];
   const visit = (node: ts.Node): void => {
     if (
-      ts.isStringLiteralLike(node) ||
-      (ts.isIdentifier(node) && !ts.isPropertySignature(node.parent))
+      !isMongooseDocumentWhere(node) &&
+      (ts.isStringLiteralLike(node) ||
+        (ts.isIdentifier(node) && !ts.isPropertySignature(node.parent)))
     ) {
       for (const token of FORBIDDEN_TOKENS) {
         if (node.text === token || node.text.startsWith(`${token}.`)) {
@@ -730,6 +748,21 @@ describe('Amazon DocumentDB compatibility', () => {
           parse('fixture.ts', `interface Doc { $where: Record<string, unknown> }`),
         ),
       ).toEqual([]);
+      /** Mongoose's document save-condition bag: read and write both stay exempt. */
+      expect(findForbiddenTokens(parse('fixture.ts', `const where = document.$where;`))).toEqual(
+        [],
+      );
+      expect(
+        findForbiddenTokens(parse('fixture.ts', `document.$where = { tenantId: predicate };`)),
+      ).toEqual([]);
+      /** ...but every shape that builds a real query still fails. */
+      expect(
+        findForbiddenTokens(parse('fixture.ts', `const filter = { $where: 'this.a == 1' };`)),
+      ).not.toEqual([]);
+      expect(findForbiddenTokens(parse('fixture.ts', `const op = '$where';`))).not.toEqual([]);
+      expect(
+        findForbiddenTokens(parse('fixture.ts', `filter['$where'] = 'this.a == 1';`)),
+      ).not.toEqual([]);
     });
 
     it.each([

--- a/packages/data-schemas/src/methods/documentdb.spec.ts
+++ b/packages/data-schemas/src/methods/documentdb.spec.ts
@@ -415,23 +415,39 @@ function isJavaScriptSource(expression: ts.Expression): boolean {
   );
 }
 
+/** Receivers on which `$where` is Mongoose's document save-condition bag. */
+const DOCUMENT_RECEIVERS = new Set(['document', 'doc']);
+
+function isDocumentReceiver(expression: ts.Expression): boolean {
+  const receiver = unwrapExpression(expression);
+  return (
+    receiver.kind === ts.SyntaxKind.ThisKeyword ||
+    (ts.isIdentifier(receiver) && DOCUMENT_RECEIVERS.has(receiver.text))
+  );
+}
+
 /**
  * Mongoose's `Document.prototype.$where` is a per-document save-condition bag, not
  * MongoDB's `$where` JavaScript-evaluation operator: `mongoose/lib/model.js` copies
  * its keys into the save filter as ordinary field predicates, so nothing named
- * `$where` reaches the server. The bag is only ever READ or ASSIGNED AN OBJECT, so
- * a dotted `$where` is exempt in exactly those two positions. Every way of
- * building the operator still fails: a literal `'$where'`, an object-literal
- * `{ $where: ... }`, a computed `obj['$where']`, a dotted access that is CALLED
- * (Mongoose's `Query.prototype.$where(js)` sends the operator), and a dotted
- * access ASSIGNED CODE (`filter.$where = 'this.a == 1'`).
+ * `$where` reaches the server. The RECEIVER is the tell: the bag lives on a
+ * Mongoose document, which this codebase reaches as `document`, `doc` or `this`,
+ * and it is read or assigned — never called and never handed code. A `$where` on
+ * any other receiver, in any position, is the operator, so no amount of
+ * indirection on the value or the call (`filter.$where = predicate`,
+ * `(query.$where)(js)`, `query.$where.call(…)`, `const w = query.$where`) needs
+ * tracing: every one of them fails on the receiver alone.
  */
 function isMongooseDocumentWhere(node: ts.Node): boolean {
   if (!ts.isIdentifier(node) || node.text !== '$where') {
     return false;
   }
   const access = node.parent;
-  if (!ts.isPropertyAccessExpression(access) || access.name !== node) {
+  if (
+    !ts.isPropertyAccessExpression(access) ||
+    access.name !== node ||
+    !isDocumentReceiver(access.expression)
+  ) {
     return false;
   }
   const use = access.parent;
@@ -787,6 +803,10 @@ describe('Amazon DocumentDB compatibility', () => {
           parse('fixture.ts', `document.$where = Object.keys(rest).length > 0 ? rest : undefined;`),
         ),
       ).toEqual([]);
+      expect(
+        findForbiddenTokens(parse('fixture.ts', `this.$where = { isDeleted: false };`)),
+      ).toEqual([]);
+      expect(findForbiddenTokens(parse('fixture.ts', `doc.$where = where;`))).toEqual([]);
       /** ...but every shape that builds a real query still fails. */
       expect(
         findForbiddenTokens(parse('fixture.ts', `const filter = { $where: 'this.a == 1' };`)),
@@ -810,6 +830,25 @@ describe('Amazon DocumentDB compatibility', () => {
       ).not.toEqual([]);
       expect(
         findForbiddenTokens(parse('fixture.ts', `filter.$where = () => this.a == 1;`)),
+      ).not.toEqual([]);
+      /** The receiver decides, so indirection on the value or the call changes nothing. */
+      expect(
+        findForbiddenTokens(
+          parse('fixture.ts', `const predicate = 'this.a == 1';\nfilter.$where = predicate;`),
+        ),
+      ).not.toEqual([]);
+      expect(
+        findForbiddenTokens(parse('fixture.ts', `filter.$where = buildPredicate(ids);`)),
+      ).not.toEqual([]);
+      expect(
+        findForbiddenTokens(parse('fixture.ts', `(query.$where)('this.a == 1');`)),
+      ).not.toEqual([]);
+      expect(
+        findForbiddenTokens(parse('fixture.ts', `query.$where.call(query, 'this.a == 1');`)),
+      ).not.toEqual([]);
+      expect(findForbiddenTokens(parse('fixture.ts', `const w = query.$where;`))).not.toEqual([]);
+      expect(
+        findForbiddenTokens(parse('fixture.ts', `document.$where('this.a == 1');`)),
       ).not.toEqual([]);
     });
 

--- a/packages/data-schemas/src/methods/documentdb.spec.ts
+++ b/packages/data-schemas/src/methods/documentdb.spec.ts
@@ -415,15 +415,15 @@ function isJavaScriptSource(expression: ts.Expression): boolean {
   );
 }
 
-/** Receivers on which `$where` is Mongoose's document save-condition bag. */
+/** Receivers on which `$where` is Mongoose's document save-condition bag. `this`
+ * is deliberately absent: Mongoose binds it to a Query in query middleware and
+ * to a Document in document middleware, so it is no tell either way — a
+ * document hook aliases to `document` (as `tenantIsolation.ts` does). */
 const DOCUMENT_RECEIVERS = new Set(['document', 'doc']);
 
 function isDocumentReceiver(expression: ts.Expression): boolean {
   const receiver = unwrapExpression(expression);
-  return (
-    receiver.kind === ts.SyntaxKind.ThisKeyword ||
-    (ts.isIdentifier(receiver) && DOCUMENT_RECEIVERS.has(receiver.text))
-  );
+  return ts.isIdentifier(receiver) && DOCUMENT_RECEIVERS.has(receiver.text);
 }
 
 /**
@@ -431,8 +431,8 @@ function isDocumentReceiver(expression: ts.Expression): boolean {
  * MongoDB's `$where` JavaScript-evaluation operator: `mongoose/lib/model.js` copies
  * its keys into the save filter as ordinary field predicates, so nothing named
  * `$where` reaches the server. The RECEIVER is the tell: the bag lives on a
- * Mongoose document, which this codebase reaches as `document`, `doc` or `this`,
- * and it is read or assigned — never called and never handed code. A `$where` on
+ * Mongoose document, which this codebase reaches as `document` or `doc`, and it
+ * is read or assigned — never called and never handed code. A `$where` on
  * any other receiver, in any position, is the operator, so no amount of
  * indirection on the value or the call (`filter.$where = predicate`,
  * `(query.$where)(js)`, `query.$where.call(…)`, `const w = query.$where`) needs
@@ -803,9 +803,6 @@ describe('Amazon DocumentDB compatibility', () => {
           parse('fixture.ts', `document.$where = Object.keys(rest).length > 0 ? rest : undefined;`),
         ),
       ).toEqual([]);
-      expect(
-        findForbiddenTokens(parse('fixture.ts', `this.$where = { isDeleted: false };`)),
-      ).toEqual([]);
       expect(findForbiddenTokens(parse('fixture.ts', `doc.$where = where;`))).toEqual([]);
       /** ...but every shape that builds a real query still fails. */
       expect(
@@ -849,6 +846,15 @@ describe('Amazon DocumentDB compatibility', () => {
       expect(findForbiddenTokens(parse('fixture.ts', `const w = query.$where;`))).not.toEqual([]);
       expect(
         findForbiddenTokens(parse('fixture.ts', `document.$where('this.a == 1');`)),
+      ).not.toEqual([]);
+      /** `this` is a Query in query middleware and a Document in document
+       * middleware, so it is no tell either way — a document hook aliases to
+       * `document` (as `tenantIsolation.ts` does) rather than earning an exemption. */
+      expect(
+        findForbiddenTokens(parse('fixture.ts', `this.$where.call(this, predicate);`)),
+      ).not.toEqual([]);
+      expect(
+        findForbiddenTokens(parse('fixture.ts', `this.$where = { isDeleted: false };`)),
       ).not.toEqual([]);
     });
 

--- a/packages/data-schemas/src/methods/documentdb.spec.ts
+++ b/packages/data-schemas/src/methods/documentdb.spec.ts
@@ -404,21 +404,48 @@ function findPipelineUpdates(sourceFile: ts.SourceFile): string[] {
  * ignoring prose — the rewrites explain themselves by naming the construct —
  * and type members, which never reach the engine (Mongoose documents declare
  * a `$where` field). */
+/** The operator's value is code; the document bag's value is field predicates. */
+function isJavaScriptSource(expression: ts.Expression): boolean {
+  const unwrapped = unwrapExpression(expression);
+  return (
+    ts.isStringLiteralLike(unwrapped) ||
+    ts.isTemplateExpression(unwrapped) ||
+    ts.isArrowFunction(unwrapped) ||
+    ts.isFunctionExpression(unwrapped)
+  );
+}
+
 /**
  * Mongoose's `Document.prototype.$where` is a per-document save-condition bag, not
  * MongoDB's `$where` JavaScript-evaluation operator: `mongoose/lib/model.js` copies
  * its keys into the save filter as ordinary field predicates, so nothing named
- * `$where` reaches the server. Only a dotted read or write of that property is
- * exempt -- a literal `'$where'`, an object-literal `{ $where: ... }` and a computed
- * `obj['$where']` still fail, since those are how a real query is built.
+ * `$where` reaches the server. The bag is only ever READ or ASSIGNED AN OBJECT, so
+ * a dotted `$where` is exempt in exactly those two positions. Every way of
+ * building the operator still fails: a literal `'$where'`, an object-literal
+ * `{ $where: ... }`, a computed `obj['$where']`, a dotted access that is CALLED
+ * (Mongoose's `Query.prototype.$where(js)` sends the operator), and a dotted
+ * access ASSIGNED CODE (`filter.$where = 'this.a == 1'`).
  */
 function isMongooseDocumentWhere(node: ts.Node): boolean {
-  return (
-    ts.isIdentifier(node) &&
-    node.text === '$where' &&
-    ts.isPropertyAccessExpression(node.parent) &&
-    node.parent.name === node
-  );
+  if (!ts.isIdentifier(node) || node.text !== '$where') {
+    return false;
+  }
+  const access = node.parent;
+  if (!ts.isPropertyAccessExpression(access) || access.name !== node) {
+    return false;
+  }
+  const use = access.parent;
+  if (ts.isCallExpression(use) && use.expression === access) {
+    return false;
+  }
+  if (
+    ts.isBinaryExpression(use) &&
+    use.left === access &&
+    use.operatorToken.kind === ts.SyntaxKind.EqualsToken
+  ) {
+    return !isJavaScriptSource(use.right);
+  }
+  return true;
 }
 
 function findForbiddenTokens(sourceFile: ts.SourceFile): string[] {
@@ -755,6 +782,11 @@ describe('Amazon DocumentDB compatibility', () => {
       expect(
         findForbiddenTokens(parse('fixture.ts', `document.$where = { tenantId: predicate };`)),
       ).toEqual([]);
+      expect(
+        findForbiddenTokens(
+          parse('fixture.ts', `document.$where = Object.keys(rest).length > 0 ? rest : undefined;`),
+        ),
+      ).toEqual([]);
       /** ...but every shape that builds a real query still fails. */
       expect(
         findForbiddenTokens(parse('fixture.ts', `const filter = { $where: 'this.a == 1' };`)),
@@ -762,6 +794,22 @@ describe('Amazon DocumentDB compatibility', () => {
       expect(findForbiddenTokens(parse('fixture.ts', `const op = '$where';`))).not.toEqual([]);
       expect(
         findForbiddenTokens(parse('fixture.ts', `filter['$where'] = 'this.a == 1';`)),
+      ).not.toEqual([]);
+      /** A dotted `$where` that is called or assigned code IS the operator. */
+      expect(
+        findForbiddenTokens(parse('fixture.ts', `filter.$where = 'this.a == 1';`)),
+      ).not.toEqual([]);
+      expect(
+        findForbiddenTokens(parse('fixture.ts', 'filter.$where = `this.a == ${value}`;')),
+      ).not.toEqual([]);
+      expect(
+        findForbiddenTokens(parse('fixture.ts', `Model.find().$where('this.a == 1');`)),
+      ).not.toEqual([]);
+      expect(
+        findForbiddenTokens(parse('fixture.ts', `query.$where(function () { return true; });`)),
+      ).not.toEqual([]);
+      expect(
+        findForbiddenTokens(parse('fixture.ts', `filter.$where = () => this.a == 1;`)),
       ).not.toEqual([]);
     });
 

--- a/packages/data-schemas/src/methods/documentdb.spec.ts
+++ b/packages/data-schemas/src/methods/documentdb.spec.ts
@@ -431,20 +431,45 @@ function isJavaScriptSource(expression: ts.Expression): boolean {
  * `'$where'`, `obj['$where']`) remains an offense.
  */
 const CALL_FORWARDERS = new Set(['call', 'apply', 'bind']);
+const CODE_ASSIGNMENT_OPERATORS = new Set([
+  ts.SyntaxKind.EqualsToken,
+  ts.SyntaxKind.QuestionQuestionEqualsToken,
+  ts.SyntaxKind.BarBarEqualsToken,
+  ts.SyntaxKind.AmpersandAmpersandEqualsToken,
+]);
 
-function isCalled(access: ts.PropertyAccessExpression): boolean {
-  let callee: ts.Node = access;
-  while (ts.isParenthesizedExpression(callee.parent)) {
-    callee = callee.parent;
+/** Steps outward through the wrappers `unwrapExpression` peels inward, so a
+ * call on `(x)`, `x as T`, `x satisfies T` or `x!` is still a call on `x`. */
+function outermostWrapper(node: ts.Node): ts.Node {
+  let current = node;
+  while (
+    ts.isParenthesizedExpression(current.parent) ||
+    ts.isAsExpression(current.parent) ||
+    ts.isSatisfiesExpression(current.parent) ||
+    ts.isNonNullExpression(current.parent)
+  ) {
+    current = current.parent;
   }
-  const use = callee.parent;
-  if (ts.isCallExpression(use) && use.expression === callee) {
+  return current;
+}
+
+function isInvoked(callee: ts.Node): boolean {
+  const use = outermostWrapper(callee).parent;
+  return ts.isCallExpression(use) && use.expression === outermostWrapper(callee);
+}
+
+/** A direct call, or a call through `call`/`apply`/`bind` — the forwarder itself
+ * must be invoked, so a bag field that merely shares one of those names is not a call. */
+function isCalled(access: ts.PropertyAccessExpression): boolean {
+  if (isInvoked(access)) {
     return true;
   }
+  const use = outermostWrapper(access).parent;
   return (
     ts.isPropertyAccessExpression(use) &&
-    use.expression === callee &&
-    CALL_FORWARDERS.has(use.name.text)
+    use.expression === outermostWrapper(access) &&
+    CALL_FORWARDERS.has(use.name.text) &&
+    isInvoked(use)
   );
 }
 
@@ -460,7 +485,7 @@ function isUnjudgedDottedWhere(node: ts.Node): boolean {
   const assignsCode =
     ts.isBinaryExpression(use) &&
     use.left === access &&
-    use.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+    CODE_ASSIGNMENT_OPERATORS.has(use.operatorToken.kind) &&
     isJavaScriptSource(use.right);
   return !assignsCode;
 }
@@ -809,6 +834,10 @@ describe('Amazon DocumentDB compatibility', () => {
       /** ...including a non-literal assigned to a filter, which no syntax can tell
        * from the bag write; the method sweep and the live run are the backstop. */
       expect(findForbiddenTokens(parse('fixture.ts', `filter.$where = predicate;`))).toEqual([]);
+      /** ...and a bag field that happens to be named like a call forwarder. */
+      expect(findForbiddenTokens(parse('fixture.ts', `document.$where.call = expected;`))).toEqual(
+        [],
+      );
       /** Every way of writing the operator itself is an offense: */
       expect(
         findForbiddenTokens(parse('fixture.ts', `const filter = { $where: 'this.a == 1' };`)),
@@ -850,6 +879,25 @@ describe('Amazon DocumentDB compatibility', () => {
       );
       expect(
         findForbiddenTokens(parse('fixture.ts', `document.$where('this.a == 1');`)),
+      ).not.toEqual([]);
+      /** Compound assignments of code, and calls through TypeScript's transparent
+       * wrappers, are the same two shapes spelled differently. */
+      expect(
+        findForbiddenTokens(parse('fixture.ts', `filter.$where ??= 'this.a == 1';`)),
+      ).not.toEqual([]);
+      expect(
+        findForbiddenTokens(parse('fixture.ts', `filter.$where ||= () => this.a == 1;`)),
+      ).not.toEqual([]);
+      expect(
+        findForbiddenTokens(
+          parse('fixture.ts', `(query.$where as typeof query.$where)('this.a == 1');`),
+        ),
+      ).not.toEqual([]);
+      expect(findForbiddenTokens(parse('fixture.ts', `query.$where!('this.a == 1');`))).not.toEqual(
+        [],
+      );
+      expect(
+        findForbiddenTokens(parse('fixture.ts', `(query.$where!).call(query, 'this.a == 1');`)),
       ).not.toEqual([]);
     });
 

--- a/packages/data-schemas/src/methods/documentdb.spec.ts
+++ b/packages/data-schemas/src/methods/documentdb.spec.ts
@@ -187,11 +187,13 @@ function parse(fileName: string, source: string): ts.SourceFile {
   return ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true);
 }
 
-/** Peels casts and parentheses so `[...] as PipelineStage[]` is still an array. */
+/** Peels casts, assertions and parentheses so `[...] as PipelineStage[]` and
+ * `<PipelineStage[]>[...]` are still arrays. */
 function unwrapExpression(expression: ts.Expression): ts.Expression {
   let current = expression;
   while (
     ts.isAsExpression(current) ||
+    ts.isTypeAssertionExpression(current) ||
     ts.isSatisfiesExpression(current) ||
     ts.isParenthesizedExpression(current) ||
     ts.isNonNullExpression(current)
@@ -433,18 +435,21 @@ function isJavaScriptSource(expression: ts.Expression): boolean {
 const CALL_FORWARDERS = new Set(['call', 'apply', 'bind']);
 const CODE_ASSIGNMENT_OPERATORS = new Set([
   ts.SyntaxKind.EqualsToken,
+  ts.SyntaxKind.PlusEqualsToken,
   ts.SyntaxKind.QuestionQuestionEqualsToken,
   ts.SyntaxKind.BarBarEqualsToken,
   ts.SyntaxKind.AmpersandAmpersandEqualsToken,
 ]);
 
 /** Steps outward through the wrappers `unwrapExpression` peels inward, so a
- * call on `(x)`, `x as T`, `x satisfies T` or `x!` is still a call on `x`. */
+ * call on or an assignment to `(x)`, `x as T`, `<T>x`, `x satisfies T` or `x!`
+ * is still one on `x`. */
 function outermostWrapper(node: ts.Node): ts.Node {
   let current = node;
   while (
     ts.isParenthesizedExpression(current.parent) ||
     ts.isAsExpression(current.parent) ||
+    ts.isTypeAssertionExpression(current.parent) ||
     ts.isSatisfiesExpression(current.parent) ||
     ts.isNonNullExpression(current.parent)
   ) {
@@ -458,19 +463,28 @@ function isInvoked(callee: ts.Node): boolean {
   return ts.isCallExpression(use) && use.expression === outermostWrapper(callee);
 }
 
+/** The member name a node is accessed through, whether dotted (`x.call`) or by a
+ * string element (`x['call']`). */
+function memberName(use: ts.Node, receiver: ts.Node): string | undefined {
+  if (ts.isPropertyAccessExpression(use) && use.expression === receiver) {
+    return use.name.text;
+  }
+  if (ts.isElementAccessExpression(use) && use.expression === receiver) {
+    const argument = unwrapExpression(use.argumentExpression);
+    return ts.isStringLiteralLike(argument) ? argument.text : undefined;
+  }
+  return undefined;
+}
+
 /** A direct call, or a call through `call`/`apply`/`bind` — the forwarder itself
  * must be invoked, so a bag field that merely shares one of those names is not a call. */
 function isCalled(access: ts.PropertyAccessExpression): boolean {
   if (isInvoked(access)) {
     return true;
   }
-  const use = outermostWrapper(access).parent;
-  return (
-    ts.isPropertyAccessExpression(use) &&
-    use.expression === outermostWrapper(access) &&
-    CALL_FORWARDERS.has(use.name.text) &&
-    isInvoked(use)
-  );
+  const target = outermostWrapper(access);
+  const forwarder = memberName(target.parent, target);
+  return forwarder != null && CALL_FORWARDERS.has(forwarder) && isInvoked(target.parent);
 }
 
 function isUnjudgedDottedWhere(node: ts.Node): boolean {
@@ -481,10 +495,11 @@ function isUnjudgedDottedWhere(node: ts.Node): boolean {
   if (!ts.isPropertyAccessExpression(access) || access.name !== node || isCalled(access)) {
     return false;
   }
-  const use = access.parent;
+  const target = outermostWrapper(access);
+  const use = target.parent;
   const assignsCode =
     ts.isBinaryExpression(use) &&
-    use.left === access &&
+    use.left === target &&
     CODE_ASSIGNMENT_OPERATORS.has(use.operatorToken.kind) &&
     isJavaScriptSource(use.right);
   return !assignsCode;
@@ -763,6 +778,10 @@ describe('Amazon DocumentDB compatibility', () => {
         'annotated variable with a builder initializer',
         `const update: PipelineStage[] = importedBuilder();\nModel.updateMany(filter, update);`,
       ],
+      [
+        'angle-bracket cast literal',
+        `Model.updateOne(filter, <PipelineStage[]>[{ $set: { a: 1 } }]);`,
+      ],
     ])('flags a pipeline update: %s', (_shape, source) => {
       expect(findPipelineUpdates(parse('fixture.ts', source))).not.toEqual([]);
     });
@@ -879,6 +898,23 @@ describe('Amazon DocumentDB compatibility', () => {
       );
       expect(
         findForbiddenTokens(parse('fixture.ts', `document.$where('this.a == 1');`)),
+      ).not.toEqual([]);
+      /** The assignment target and the assigned value may each be wrapped, the
+       * operator may append, and a forwarder may be reached by element access. */
+      expect(
+        findForbiddenTokens(parse('fixture.ts', `(filter.$where as string) = 'this.a == 1';`)),
+      ).not.toEqual([]);
+      expect(
+        findForbiddenTokens(parse('fixture.ts', `filter.$where! = 'this.a == 1';`)),
+      ).not.toEqual([]);
+      expect(
+        findForbiddenTokens(parse('fixture.ts', `filter.$where += ' && this.b == 2';`)),
+      ).not.toEqual([]);
+      expect(
+        findForbiddenTokens(parse('fixture.ts', `filter.$where = <string>'this.a == 1';`)),
+      ).not.toEqual([]);
+      expect(
+        findForbiddenTokens(parse('fixture.ts', `query.$where['call'](query, 'this.a == 1');`)),
       ).not.toEqual([]);
       /** Compound assignments of code, and calls through TypeScript's transparent
        * wrappers, are the same two shapes spelled differently. */

--- a/packages/data-schemas/src/methods/documentdb.spec.ts
+++ b/packages/data-schemas/src/methods/documentdb.spec.ts
@@ -415,30 +415,64 @@ function isJavaScriptSource(expression: ts.Expression): boolean {
   );
 }
 
-/** Receivers on which `$where` is Mongoose's document save-condition bag. `this`
- * is deliberately absent: Mongoose binds it to a Query in query middleware and
- * to a Document in document middleware, so it is no tell either way — a
- * document hook aliases to `document` (as `tenantIsolation.ts` does). */
-const DOCUMENT_RECEIVERS = new Set(['document', 'doc']);
+/** A type annotation naming a Mongoose document type: `Document`,
+ * `HydratedDocument<…>`, or a project alias ending in `Document` such as
+ * `TenantWhereDocument`; unions and intersections of those count. */
+function isDocumentType(type: ts.TypeNode | undefined): boolean {
+  if (type == null) {
+    return false;
+  }
+  if (ts.isUnionTypeNode(type) || ts.isIntersectionTypeNode(type)) {
+    return type.types.some(isDocumentType);
+  }
+  if (!ts.isTypeReferenceNode(type)) {
+    return false;
+  }
+  const name = ts.isIdentifier(type.typeName) ? type.typeName.text : type.typeName.right.text;
+  return name.endsWith('Document');
+}
 
-function isDocumentReceiver(expression: ts.Expression): boolean {
+/** Names declared in this file — as a parameter or a variable — with a document
+ * type annotation. The declared type is the tell, not the spelling: a filter
+ * that happens to be named `document` has no such annotation. `this` never
+ * qualifies, since Mongoose binds it to a Query in query middleware. Scope-naive
+ * like the array names. */
+function collectDocumentReceiverNames(sourceFile: ts.SourceFile): Set<string> {
+  const names = new Set<string>();
+  const visit = (node: ts.Node): void => {
+    if (
+      (ts.isParameter(node) || ts.isVariableDeclaration(node)) &&
+      ts.isIdentifier(node.name) &&
+      isDocumentType(node.type)
+    ) {
+      names.add(node.name.text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return names;
+}
+
+function isDocumentReceiver(expression: ts.Expression, documentNames: Set<string>): boolean {
   const receiver = unwrapExpression(expression);
-  return ts.isIdentifier(receiver) && DOCUMENT_RECEIVERS.has(receiver.text);
+  return ts.isIdentifier(receiver) && documentNames.has(receiver.text);
 }
 
 /**
  * Mongoose's `Document.prototype.$where` is a per-document save-condition bag, not
  * MongoDB's `$where` JavaScript-evaluation operator: `mongoose/lib/model.js` copies
  * its keys into the save filter as ordinary field predicates, so nothing named
- * `$where` reaches the server. The RECEIVER is the tell: the bag lives on a
- * Mongoose document, which this codebase reaches as `document` or `doc`, and it
- * is read or assigned — never called and never handed code. A `$where` on
+ * `$where` reaches the server. The RECEIVER's DECLARED TYPE is the tell: the
+ * bag lives on a Mongoose document, so the receiver must be declared in this
+ * file with a document type (as `tenantIsolation.ts` declares
+ * `document: TenantWhereDocument`), and it is read or assigned — never called
+ * and never handed code. A `$where` on
  * any other receiver, in any position, is the operator, so no amount of
  * indirection on the value or the call (`filter.$where = predicate`,
  * `(query.$where)(js)`, `query.$where.call(…)`, `const w = query.$where`) needs
  * tracing: every one of them fails on the receiver alone.
  */
-function isMongooseDocumentWhere(node: ts.Node): boolean {
+function isMongooseDocumentWhere(node: ts.Node, documentNames: Set<string>): boolean {
   if (!ts.isIdentifier(node) || node.text !== '$where') {
     return false;
   }
@@ -446,7 +480,7 @@ function isMongooseDocumentWhere(node: ts.Node): boolean {
   if (
     !ts.isPropertyAccessExpression(access) ||
     access.name !== node ||
-    !isDocumentReceiver(access.expression)
+    !isDocumentReceiver(access.expression, documentNames)
   ) {
     return false;
   }
@@ -468,10 +502,11 @@ function findForbiddenTokens(sourceFile: ts.SourceFile): string[] {
   if (OPERATOR_GUARDS.has(sourceFile.fileName)) {
     return [];
   }
+  const documentNames = collectDocumentReceiverNames(sourceFile);
   const offenses: string[] = [];
   const visit = (node: ts.Node): void => {
     if (
-      !isMongooseDocumentWhere(node) &&
+      !isMongooseDocumentWhere(node, documentNames) &&
       (ts.isStringLiteralLike(node) ||
         (ts.isIdentifier(node) && !ts.isPropertySignature(node.parent)))
     ) {
@@ -791,19 +826,32 @@ describe('Amazon DocumentDB compatibility', () => {
           parse('fixture.ts', `interface Doc { $where: Record<string, unknown> }`),
         ),
       ).toEqual([]);
-      /** Mongoose's document save-condition bag: read and write both stay exempt. */
-      expect(findForbiddenTokens(parse('fixture.ts', `const where = document.$where;`))).toEqual(
-        [],
-      );
+      /** Mongoose's document save-condition bag: on a receiver DECLARED as a
+       * document type, a read and an object write both stay exempt. */
       expect(
-        findForbiddenTokens(parse('fixture.ts', `document.$where = { tenantId: predicate };`)),
+        findForbiddenTokens(
+          parse(
+            'fixture.ts',
+            `function f(document: TenantWhereDocument) {\n  const where = document.$where;\n  document.$where = { ...where, tenantId: predicate };\n}`,
+          ),
+        ),
       ).toEqual([]);
       expect(
         findForbiddenTokens(
-          parse('fixture.ts', `document.$where = Object.keys(rest).length > 0 ? rest : undefined;`),
+          parse(
+            'fixture.ts',
+            `function f(document: TenantWhereDocument) {\n  document.$where = Object.keys(rest).length > 0 ? rest : undefined;\n}`,
+          ),
         ),
       ).toEqual([]);
-      expect(findForbiddenTokens(parse('fixture.ts', `doc.$where = where;`))).toEqual([]);
+      expect(
+        findForbiddenTokens(
+          parse(
+            'fixture.ts',
+            `const doc: HydratedDocument<IUser> = await load(id);\ndoc.$where = where;`,
+          ),
+        ),
+      ).toEqual([]);
       /** ...but every shape that builds a real query still fails. */
       expect(
         findForbiddenTokens(parse('fixture.ts', `const filter = { $where: 'this.a == 1' };`)),
@@ -856,6 +904,25 @@ describe('Amazon DocumentDB compatibility', () => {
       expect(
         findForbiddenTokens(parse('fixture.ts', `this.$where = { isDeleted: false };`)),
       ).not.toEqual([]);
+      /** The declared type decides, not the spelling: a filter named `document`
+       * or declared as a filter is the operator. */
+      expect(
+        findForbiddenTokens(
+          parse(
+            'fixture.ts',
+            `const document = filter;\ndocument.$where = predicate;\nModel.find(document);`,
+          ),
+        ),
+      ).not.toEqual([]);
+      expect(
+        findForbiddenTokens(
+          parse(
+            'fixture.ts',
+            `function f(document: FilterQuery<IUser>) {\n  document.$where = 'this.a == 1';\n}`,
+          ),
+        ),
+      ).not.toEqual([]);
+      expect(findForbiddenTokens(parse('fixture.ts', `doc.$where = where;`))).not.toEqual([]);
     });
 
     it.each([

--- a/packages/data-schemas/src/methods/documentdb.spec.ts
+++ b/packages/data-schemas/src/methods/documentdb.spec.ts
@@ -415,64 +415,193 @@ function isJavaScriptSource(expression: ts.Expression): boolean {
   );
 }
 
-/** A type annotation naming a Mongoose document type: `Document`,
- * `HydratedDocument<…>`, or a project alias ending in `Document` such as
- * `TenantWhereDocument`; unions and intersections of those count. */
-function isDocumentType(type: ts.TypeNode | undefined): boolean {
+/** Mongoose's own document types, which declare the `$where` save-condition bag. */
+const MONGOOSE_DOCUMENT_TYPES = new Set(['Document', 'HydratedDocument']);
+
+type NamedTypeDeclaration = ts.TypeAliasDeclaration | ts.InterfaceDeclaration;
+
+/** Same-file `type` and `interface` declarations by name, so a local alias of a
+ * document type resolves; an imported one does not, and fails closed. */
+function collectTypeDeclarations(sourceFile: ts.SourceFile): Map<string, NamedTypeDeclaration> {
+  const declarations = new Map<string, NamedTypeDeclaration>();
+  const visit = (node: ts.Node): void => {
+    if (ts.isTypeAliasDeclaration(node) || ts.isInterfaceDeclaration(node)) {
+      declarations.set(node.name.text, node);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return declarations;
+}
+
+function declaresWhereMember(members: ts.NodeArray<ts.TypeElement>): boolean {
+  return members.some(
+    (member) =>
+      ts.isPropertySignature(member) &&
+      (ts.isIdentifier(member.name) || ts.isStringLiteral(member.name)) &&
+      member.name.text === '$where',
+  );
+}
+
+function isNullishType(type: ts.TypeNode): boolean {
+  return (
+    type.kind === ts.SyntaxKind.UndefinedKeyword ||
+    (ts.isLiteralTypeNode(type) && type.literal.kind === ts.SyntaxKind.NullKeyword)
+  );
+}
+
+/** Whether a type NAME is a bag carrier: one of Mongoose's document types, or a
+ * same-file declaration that declares a `$where` member itself or reaches one
+ * through its alias or `extends` chain. `resolved` memoises and breaks cycles. */
+function isDocumentTypeName(
+  name: string,
+  types: Map<string, NamedTypeDeclaration>,
+  resolved: Map<string, boolean>,
+): boolean {
+  if (MONGOOSE_DOCUMENT_TYPES.has(name)) {
+    return true;
+  }
+  const known = resolved.get(name);
+  if (known != null) {
+    return known;
+  }
+  resolved.set(name, false);
+  const declaration = types.get(name);
+  if (declaration == null) {
+    return false;
+  }
+  const carrier = ts.isTypeAliasDeclaration(declaration)
+    ? isDocumentType(declaration.type, types, resolved)
+    : declaresWhereMember(declaration.members) ||
+      (declaration.heritageClauses ?? []).some((clause) =>
+        clause.types.some(
+          (heritage) =>
+            ts.isIdentifier(heritage.expression) &&
+            isDocumentTypeName(heritage.expression.text, types, resolved),
+        ),
+      );
+  resolved.set(name, carrier);
+  return carrier;
+}
+
+/** Whether a type annotation is a bag carrier: a carrier NAME, a type literal
+ * declaring `$where`, an intersection with a carrier arm, or a union whose every
+ * non-nullish arm is a carrier. A mixed union is not, since a narrowed branch
+ * may hold the non-document arm. */
+function isDocumentType(
+  type: ts.TypeNode | undefined,
+  types: Map<string, NamedTypeDeclaration>,
+  resolved: Map<string, boolean>,
+): boolean {
   if (type == null) {
     return false;
   }
-  if (ts.isUnionTypeNode(type) || ts.isIntersectionTypeNode(type)) {
-    return type.types.some(isDocumentType);
+  if (ts.isParenthesizedTypeNode(type)) {
+    return isDocumentType(type.type, types, resolved);
+  }
+  if (ts.isTypeLiteralNode(type)) {
+    return declaresWhereMember(type.members);
+  }
+  if (ts.isIntersectionTypeNode(type)) {
+    return type.types.some((arm) => isDocumentType(arm, types, resolved));
+  }
+  if (ts.isUnionTypeNode(type)) {
+    const arms = type.types.filter((arm) => !isNullishType(arm));
+    return arms.length > 0 && arms.every((arm) => isDocumentType(arm, types, resolved));
   }
   if (!ts.isTypeReferenceNode(type)) {
     return false;
   }
   const name = ts.isIdentifier(type.typeName) ? type.typeName.text : type.typeName.right.text;
-  return name.endsWith('Document');
+  return isDocumentTypeName(name, types, resolved);
 }
 
-/** Names declared in this file — as a parameter or a variable — with a document
- * type annotation. The declared type is the tell, not the spelling: a filter
- * that happens to be named `document` has no such annotation. `this` never
- * qualifies, since Mongoose binds it to a Query in query middleware. Scope-naive
- * like the array names. */
-function collectDocumentReceiverNames(sourceFile: ts.SourceFile): Set<string> {
-  const names = new Set<string>();
-  const visit = (node: ts.Node): void => {
-    if (
-      (ts.isParameter(node) || ts.isVariableDeclaration(node)) &&
-      ts.isIdentifier(node.name) &&
-      isDocumentType(node.type)
-    ) {
-      names.add(node.name.text);
+function findNamedDeclaration<T extends ts.ParameterDeclaration | ts.VariableDeclaration>(
+  declarations: readonly T[],
+  name: string,
+): T | undefined {
+  return declarations.find(
+    (declaration) => ts.isIdentifier(declaration.name) && declaration.name.text === name,
+  );
+}
+
+/** The declaration that governs `name` at `from`: walking outward, the nearest
+ * enclosing function's parameter of that name, a `for…in`/`for…of` binding, or a
+ * variable declared in the nearest enclosing block. A name declared elsewhere in
+ * the file — another function's parameter, say — does not reach here. */
+function declarationInScope(
+  from: ts.Node,
+  name: string,
+): ts.ParameterDeclaration | ts.VariableDeclaration | undefined {
+  for (let scope: ts.Node | undefined = from.parent; scope != null; scope = scope.parent) {
+    if (ts.isFunctionLike(scope)) {
+      const parameter = findNamedDeclaration(scope.parameters, name);
+      if (parameter != null) {
+        return parameter;
+      }
     }
-    ts.forEachChild(node, visit);
-  };
-  visit(sourceFile);
-  return names;
+    if (
+      (ts.isForOfStatement(scope) || ts.isForInStatement(scope)) &&
+      ts.isVariableDeclarationList(scope.initializer)
+    ) {
+      const binding = findNamedDeclaration(scope.initializer.declarations, name);
+      if (binding != null) {
+        return binding;
+      }
+    }
+    if (
+      ts.isBlock(scope) ||
+      ts.isSourceFile(scope) ||
+      ts.isModuleBlock(scope) ||
+      ts.isCaseClause(scope) ||
+      ts.isDefaultClause(scope)
+    ) {
+      for (const statement of scope.statements) {
+        if (!ts.isVariableStatement(statement)) {
+          continue;
+        }
+        const variable = findNamedDeclaration(statement.declarationList.declarations, name);
+        if (variable != null) {
+          return variable;
+        }
+      }
+    }
+  }
+  return undefined;
 }
 
-function isDocumentReceiver(expression: ts.Expression, documentNames: Set<string>): boolean {
+/** Whether the receiver of a property access is, by ITS OWN in-scope declaration,
+ * a document-bag carrier. `this` never qualifies: Mongoose binds it to a Query in
+ * query middleware, and a document hook aliases to a typed local (as
+ * `tenantIsolation.ts` does). An unresolved name fails closed. */
+function isDocumentReceiver(
+  expression: ts.Expression,
+  types: Map<string, NamedTypeDeclaration>,
+): boolean {
   const receiver = unwrapExpression(expression);
-  return ts.isIdentifier(receiver) && documentNames.has(receiver.text);
+  if (!ts.isIdentifier(receiver)) {
+    return false;
+  }
+  const declaration = declarationInScope(receiver, receiver.text);
+  return declaration != null && isDocumentType(declaration.type, types, new Map());
 }
 
 /**
  * Mongoose's `Document.prototype.$where` is a per-document save-condition bag, not
  * MongoDB's `$where` JavaScript-evaluation operator: `mongoose/lib/model.js` copies
  * its keys into the save filter as ordinary field predicates, so nothing named
- * `$where` reaches the server. The RECEIVER's DECLARED TYPE is the tell: the
- * bag lives on a Mongoose document, so the receiver must be declared in this
- * file with a document type (as `tenantIsolation.ts` declares
- * `document: TenantWhereDocument`), and it is read or assigned — never called
- * and never handed code. A `$where` on
+ * `$where` reaches the server. The RECEIVER's OWN DECLARED TYPE is the tell:
+ * the bag lives on a Mongoose document, so the receiver's in-scope declaration
+ * must resolve, within this file, to a type that carries a `$where` member —
+ * Mongoose's `Document`/`HydratedDocument`, or a local interface that declares
+ * one, as `tenantIsolation.ts` declares `document: TenantWhereDocument` — and
+ * it is read or assigned, never called and never handed code. A `$where` on
  * any other receiver, in any position, is the operator, so no amount of
  * indirection on the value or the call (`filter.$where = predicate`,
  * `(query.$where)(js)`, `query.$where.call(…)`, `const w = query.$where`) needs
  * tracing: every one of them fails on the receiver alone.
  */
-function isMongooseDocumentWhere(node: ts.Node, documentNames: Set<string>): boolean {
+function isMongooseDocumentWhere(node: ts.Node, types: Map<string, NamedTypeDeclaration>): boolean {
   if (!ts.isIdentifier(node) || node.text !== '$where') {
     return false;
   }
@@ -480,7 +609,7 @@ function isMongooseDocumentWhere(node: ts.Node, documentNames: Set<string>): boo
   if (
     !ts.isPropertyAccessExpression(access) ||
     access.name !== node ||
-    !isDocumentReceiver(access.expression, documentNames)
+    !isDocumentReceiver(access.expression, types)
   ) {
     return false;
   }
@@ -502,11 +631,11 @@ function findForbiddenTokens(sourceFile: ts.SourceFile): string[] {
   if (OPERATOR_GUARDS.has(sourceFile.fileName)) {
     return [];
   }
-  const documentNames = collectDocumentReceiverNames(sourceFile);
+  const types = collectTypeDeclarations(sourceFile);
   const offenses: string[] = [];
   const visit = (node: ts.Node): void => {
     if (
-      !isMongooseDocumentWhere(node, documentNames) &&
+      !isMongooseDocumentWhere(node, types) &&
       (ts.isStringLiteralLike(node) ||
         (ts.isIdentifier(node) && !ts.isPropertySignature(node.parent)))
     ) {
@@ -826,13 +955,14 @@ describe('Amazon DocumentDB compatibility', () => {
           parse('fixture.ts', `interface Doc { $where: Record<string, unknown> }`),
         ),
       ).toEqual([]);
-      /** Mongoose's document save-condition bag: on a receiver DECLARED as a
-       * document type, a read and an object write both stay exempt. */
+      /** Mongoose's document save-condition bag: on a receiver whose in-scope
+       * declaration resolves to a type that carries a `$where` member, a read and
+       * an object write both stay exempt. */
       expect(
         findForbiddenTokens(
           parse(
             'fixture.ts',
-            `function f(document: TenantWhereDocument) {\n  const where = document.$where;\n  document.$where = { ...where, tenantId: predicate };\n}`,
+            `interface TenantWhereDocument {\n  $where?: Record<string, unknown>;\n}\nfunction f(document: TenantWhereDocument) {\n  const where = document.$where;\n  document.$where = { ...where, tenantId: predicate };\n}`,
           ),
         ),
       ).toEqual([]);
@@ -840,7 +970,7 @@ describe('Amazon DocumentDB compatibility', () => {
         findForbiddenTokens(
           parse(
             'fixture.ts',
-            `function f(document: TenantWhereDocument) {\n  document.$where = Object.keys(rest).length > 0 ? rest : undefined;\n}`,
+            `interface TenantWhereDocument {\n  $where?: Record<string, unknown>;\n}\ninterface TenantSaveDocument extends TenantWhereDocument {\n  get(path: string): unknown;\n}\nfunction f(document: TenantSaveDocument) {\n  document.$where = Object.keys(rest).length > 0 ? rest : undefined;\n}`,
           ),
         ),
       ).toEqual([]);
@@ -849,6 +979,14 @@ describe('Amazon DocumentDB compatibility', () => {
           parse(
             'fixture.ts',
             `const doc: HydratedDocument<IUser> = await load(id);\ndoc.$where = where;`,
+          ),
+        ),
+      ).toEqual([]);
+      expect(
+        findForbiddenTokens(
+          parse(
+            'fixture.ts',
+            `type Saved = Document & { tenantId?: string };\nfunction f(doc: Saved | null) {\n  if (doc) {\n    doc.$where = where;\n  }\n}`,
           ),
         ),
       ).toEqual([]);
@@ -923,6 +1061,41 @@ describe('Amazon DocumentDB compatibility', () => {
         ),
       ).not.toEqual([]);
       expect(findForbiddenTokens(parse('fixture.ts', `doc.$where = where;`))).not.toEqual([]);
+      /** The receiver resolves to ITS OWN declaration, the type to what it
+       * declares: a redeclared name, a `…Document` alias of a filter, an alias this
+       * file does not declare, and a mixed union are all the operator. */
+      expect(
+        findForbiddenTokens(
+          parse(
+            'fixture.ts',
+            `function a(doc: HydratedDocument<IUser>) {\n  doc.$where = where;\n}\nfunction b(doc: FilterQuery<IUser>) {\n  doc.$where = predicate;\n}`,
+          ),
+        ),
+      ).toHaveLength(1);
+      expect(
+        findForbiddenTokens(
+          parse(
+            'fixture.ts',
+            `type SearchDocument = FilterQuery<IUser>;\nfunction f(filter: SearchDocument) {\n  filter.$where = predicate;\n}`,
+          ),
+        ),
+      ).not.toEqual([]);
+      expect(
+        findForbiddenTokens(
+          parse(
+            'fixture.ts',
+            `function f(document: TenantWhereDocument) {\n  document.$where = { tenantId: predicate };\n}`,
+          ),
+        ),
+      ).not.toEqual([]);
+      expect(
+        findForbiddenTokens(
+          parse(
+            'fixture.ts',
+            `function f(value: HydratedDocument<IUser> | FilterQuery<IUser>) {\n  value.$where = predicate;\n}`,
+          ),
+        ),
+      ).not.toEqual([]);
     });
 
     it.each([


### PR DESCRIPTION
`dev` is red on `Tests: data-schemas` ([run 34077191567](https://github.com/danny-avila/LibreChat/actions/runs/34077191567)): the DocumentDB compatibility guard reports four offenses in `packages/data-schemas/src/models/plugins/tenantIsolation.ts` (lines 60, 72, 76, 82), all reads and writes of `document.$where`.

## Why these are false positives

Those lines use Mongoose's **per-document save-condition bag**, not MongoDB's `$where` JavaScript-evaluation operator that DocumentDB rejects. `mongoose/lib/model.js` copies the **keys** of `doc.$where` into the save filter as ordinary field predicates, so nothing named `$where` reaches the server.

## The change

The guard now judges a dotted `$where` **only where the syntax is unambiguous**, and does not try to infer what the receiver is:

- **Offense** — a call in any form (`query.$where(js)`, parenthesised, `as`/`!`/`satisfies`-wrapped, or through an *invoked* `call`/`apply`/`bind`, dotted or `['call']`), or an assignment of **code** (a string, template, arrow or function) through `=`, `+=`, `??=`, `||=` or `&&=`, with the target possibly wrapped.
- **Not claimed either way** — a read, or an assignment of anything else: `document.$where = { … }` in `tenantIsolation.ts`, but equally `filter.$where = predicate`. That last shape is the one declared limit: no syntax tells it from the bag write without types, and the method sweep and the live cluster run are its backstop. The guard header states this beside its other scope limits.
- Every other way of writing the operator (`{ $where: … }`, `'$where'`, `obj['$where']`) remains an offense, as before.

Along the way `unwrapExpression` learned to peel angle-bracket assertions, which closes a gap in pipeline-update detection itself (`Model.updateOne(filter, <PipelineStage[]>[…])`).

## Review history

Eight codex rounds. Rounds 1–5 refined an *exemption* — call/code-RHS, receiver name, declared type, same-file alias and scope resolution — and each met a counterexample no syntactic check can decide (a filter named `document`, `mongodb`'s own `Document` type, a `…Document` alias of a filter, mixed unions, a filter type declaring `$where?: string`). Round 6 replaced the inference with positive detection; rounds 7–8 were precision fixes to that rule. Every fix landed with a fixture that failed before it.

## Verification

`packages/data-schemas`: `documentdb.spec.ts` 54/54 including the full backend scan; `tsc --noEmit` and `eslint` clean on every commit.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
