### PR TITLE
fix: decode S3 URL object keys

### DIFF
--- a/packages/api/src/storage/s3/__tests__/crud.test.ts
+++ b/packages/api/src/storage/s3/__tests__/crud.test.ts
@@ -1111,11 +1111,13 @@ describe('S3 CRUD', () => {
       const { getS3FileStream } = await import('../crud');
       const result = await getS3FileStream(
         {} as ServerRequest,
-        'https://bucket.s3.amazonaws.com/images/user123/file.pdf',
+        'https://bucket.s3.amazonaws.com/images/user123/mi%C4%99dzynarodowy%20%28CE%29.pdf',
       );
 
       expect(result).toBeInstanceOf(Readable);
-      expect(s3Mock.commandCalls(GetObjectCommand)).toHaveLength(1);
+      expect(s3Mock.commandCalls(GetObjectCommand)[0].args[0].input).toMatchObject({
+        Key: 'images/user123/międzynarodowy (CE).pdf',
+      });
     });
 
     it('handles errors when retrieving stream', async () => {
@@ -1511,12 +1513,28 @@ describe('S3 CRUD', () => {
       expect(key).toBe('folder/file.txt');
     });
 
-    it('handles URLs with encoded characters', async () => {
+    it('decodes URL-encoded object keys exactly once', async () => {
       const { extractKeyFromS3Url } = await import('../crud');
       const key = extractKeyFromS3Url(
-        'https://bucket.s3.amazonaws.com/test-bucket/images/user123/my%20file%20name.jpg',
+        'https://bucket.s3.amazonaws.com/test-bucket/images/user123/mi%C4%99dzynarodowy%20%28CE%29%20%2B%20%23%20%2525.pdf',
       );
-      expect(key).toBe('images/user123/my%20file%20name.jpg');
+      expect(key).toBe('images/user123/międzynarodowy (CE) + # %25.pdf');
+    });
+
+    it('decodes keys from path-style regional URLs', async () => {
+      const { extractKeyFromS3Url } = await import('../crud');
+      const key = extractKeyFromS3Url(
+        'https://s3.us-west-2.amazonaws.com/test-bucket/uploads/user123/za%C5%BC%C3%B3%C5%82%C4%87.pdf',
+      );
+      expect(key).toBe('uploads/user123/zażółć.pdf');
+    });
+
+    it('preserves malformed percent escapes instead of throwing', async () => {
+      const { extractKeyFromS3Url } = await import('../crud');
+      const key = extractKeyFromS3Url(
+        'https://bucket.s3.amazonaws.com/test-bucket/uploads/user123/report%Q1.pdf',
+      );
+      expect(key).toBe('uploads/user123/report%Q1.pdf');
     });
 
     it('handles deep nested paths', async () => {

--- a/packages/api/src/storage/s3/crud.ts
+++ b/packages/api/src/storage/s3/crud.ts
@@ -638,6 +638,14 @@ export async function saveURLToS3(
   return filepath;
 }
 
+const decodeS3UrlKey = (key: string): string => {
+  try {
+    return decodeURIComponent(key);
+  } catch {
+    return key;
+  }
+};
+
 export function extractKeyFromS3Url(fileUrlOrKey: string): string {
   if (!fileUrlOrKey) {
     throw new Error('Invalid input: URL or key is empty');
@@ -659,7 +667,7 @@ export function extractKeyFromS3Url(fileUrlOrKey: string): string {
         (endpointUrl.pathname.endsWith('/') ? 0 : 1) +
         bucketName.length +
         1;
-      const key = url.pathname.substring(startPos);
+      const key = decodeS3UrlKey(url.pathname.substring(startPos));
       if (!key) {
         logger.warn(
           `[extractKeyFromS3Url] Extracted key is empty for endpoint path-style URL: ${fileUrlOrKey}`,
@@ -677,7 +685,7 @@ export function extractKeyFromS3Url(fileUrlOrKey: string): string {
     ) {
       const firstSlashIndex = pathname.indexOf('/');
       if (firstSlashIndex > 0) {
-        const key = pathname.substring(firstSlashIndex + 1);
+        const key = decodeS3UrlKey(pathname.substring(firstSlashIndex + 1));
         if (key === '') {
           logger.warn(
             `[extractKeyFromS3Url] Extracted key is empty after removing bucket name from URL: ${fileUrlOrKey}`,
@@ -695,8 +703,9 @@ export function extractKeyFromS3Url(fileUrlOrKey: string): string {
       return '';
     }
 
-    logger.debug(`[extractKeyFromS3Url] fileUrlOrKey: ${fileUrlOrKey}, Extracted key: ${pathname}`);
-    return pathname;
+    const key = decodeS3UrlKey(pathname);
+    logger.debug(`[extractKeyFromS3Url] fileUrlOrKey: ${fileUrlOrKey}, Extracted key: ${key}`);
+    return key;
   } catch (error) {
     if (fileUrlOrKey.startsWith('http://') || fileUrlOrKey.startsWith('https://')) {
       logger.error(


### PR DESCRIPTION
## Summary

Closes #15688.

S3-backed attachments with URL-encoded characters in their object keys can upload successfully but fail when LibreChat later reads them. `extractKeyFromS3Url` currently passes the encoded pathname (for example, `%C4%99` or `%20`) to the S3 SDK, which expects the decoded object key and returns `NoSuchKey`.

This change:

- URL-decodes keys in endpoint-based path-style, AWS path-style, and virtual-hosted/fallback URL branches;
- decodes exactly once, preserving literal percent sequences encoded as `%25`;
- safely preserves the original key if a URL contains a malformed percent escape;
- leaves raw non-URL keys unchanged;
- verifies that `getS3FileStream` passes the decoded key to `GetObjectCommand`.

A related patch was previously proposed in #13375, but it was closed without merge and did not include regression tests.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

```text
npx jest src/storage/s3/__tests__/crud.test.ts --runInBand --coverage=false
PASS: 102 tests

npx eslint packages/api/src/storage/s3/crud.ts packages/api/src/storage/s3/__tests__/crud.test.ts
PASS

npx prettier --check packages/api/src/storage/s3/crud.ts packages/api/src/storage/s3/__tests__/crud.test.ts
PASS

npm run build:api
PASS
```

### Test Configuration

- Node.js v24.18.0
- npm 11.16.0
- Linux

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Targeted local unit tests pass with my changes
