### PR TITLE
🏰 fix: Enforce Platform Grants for Code Workers

### DIFF
--- a/api/server/routes/admin/code.js
+++ b/api/server/routes/admin/code.js
@@ -7,7 +7,10 @@ const { requireJwtAuth } = require('~/server/middleware');
 
 const router = express.Router();
 const requireAdminAccess = requireCapability(SystemCapabilities.ACCESS_ADMIN);
-const requireCodeEnvironmentManage = requireCapability(SystemCapabilities.MANAGE_CODE_ENVIRONMENTS);
+const requireCodeEnvironmentManage = requireCapability(
+  SystemCapabilities.MANAGE_CODE_ENVIRONMENTS,
+  { platformOnly: true },
+);
 const handlers = createAdminCodeEnvironmentHandlers({ getAppConfig });
 
 router.use(requireJwtAuth, requireAdminAccess, requireCodeEnvironmentManage);

--- a/api/server/routes/admin/code.test.js
+++ b/api/server/routes/admin/code.test.js
@@ -70,5 +70,10 @@ describe('admin code environment routes', () => {
     expect(response.body).toEqual({ operation, environmentId: 'attached-vm' });
     expect(middlewareCalls).toEqual(['jwt', 'access:admin', 'manage:code_environments']);
     expect(mockHandlers[handlerName]).toHaveBeenCalledTimes(1);
+    if (path === 'pairings') {
+      expect(mockRequireCapability).toHaveBeenCalledWith('manage:code_environments', {
+        platformOnly: true,
+      });
+    }
   });
 });

--- a/packages/api/src/middleware/capabilities.spec.ts
+++ b/packages/api/src/middleware/capabilities.spec.ts
@@ -149,6 +149,49 @@ describe('generateCapabilityCheck', () => {
       expect(statusMock).not.toHaveBeenCalled();
     });
 
+    it('omits tenant scope for platform-only capability checks', async () => {
+      mockReq.user = {
+        id: 'user-123',
+        role: 'ADMIN',
+        tenantId: 'tenant-1',
+      } as ServerRequest['user'];
+      mockGetUserPrincipals.mockResolvedValue(adminPrincipals);
+      mockHasCapabilityForPrincipals.mockResolvedValue(true);
+
+      const middleware = requireCapability(SystemCapabilities.MANAGE_CODE_ENVIRONMENTS, {
+        platformOnly: true,
+      });
+      await middleware(mockReq as ServerRequest, mockRes as Response, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+      expect(mockHasCapabilityForPrincipals).toHaveBeenCalledWith(
+        expect.objectContaining({
+          capability: SystemCapabilities.MANAGE_CODE_ENVIRONMENTS,
+          tenantId: undefined,
+        }),
+      );
+    });
+
+    it('rejects a tenant-only grant for a platform-only capability check', async () => {
+      mockReq.user = {
+        id: 'user-123',
+        role: 'ADMIN',
+        tenantId: 'tenant-1',
+      } as ServerRequest['user'];
+      mockGetUserPrincipals.mockResolvedValue(adminPrincipals);
+      mockHasCapabilityForPrincipals.mockImplementation(({ tenantId }) =>
+        Promise.resolve(tenantId === 'tenant-1'),
+      );
+
+      const middleware = requireCapability(SystemCapabilities.MANAGE_CODE_ENVIRONMENTS, {
+        platformOnly: true,
+      });
+      await middleware(mockReq as ServerRequest, mockRes as Response, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(statusMock).toHaveBeenCalledWith(403);
+    });
+
     it('returns 403 when user lacks the capability', async () => {
       mockReq.user = { id: 'user-456', role: 'USER' } as ServerRequest['user'];
       mockGetUserPrincipals.mockResolvedValue(userPrincipals);

--- a/packages/api/src/middleware/capabilities.spec.ts
+++ b/packages/api/src/middleware/capabilities.spec.ts
@@ -5,8 +5,9 @@ import {
   readConfigCapability,
 } from '@librechat/data-schemas';
 import type { Response } from 'express';
+import type { CapabilityUser } from './capabilities';
 import type { ServerRequest } from '~/types/http';
-import { generateCapabilityCheck } from './capabilities';
+import { capabilityContextMiddleware, generateCapabilityCheck } from './capabilities';
 
 jest.mock('@librechat/data-schemas', () => ({
   ...jest.requireActual('@librechat/data-schemas'),
@@ -164,12 +165,11 @@ describe('generateCapabilityCheck', () => {
       await middleware(mockReq as ServerRequest, mockRes as Response, mockNext);
 
       expect(mockNext).toHaveBeenCalled();
-      expect(mockHasCapabilityForPrincipals).toHaveBeenCalledWith(
-        expect.objectContaining({
-          capability: SystemCapabilities.MANAGE_CODE_ENVIRONMENTS,
-          tenantId: undefined,
-        }),
-      );
+      expect(mockHasCapabilityForPrincipals).toHaveBeenCalledWith({
+        capability: SystemCapabilities.MANAGE_CODE_ENVIRONMENTS,
+        principals: [adminPrincipals[0]],
+        tenantId: undefined,
+      });
     });
 
     it('rejects a tenant-only grant for a platform-only capability check', async () => {
@@ -190,6 +190,35 @@ describe('generateCapabilityCheck', () => {
 
       expect(mockNext).not.toHaveBeenCalled();
       expect(statusMock).toHaveBeenCalledWith(403);
+    });
+
+    it('reuses tenant principal resolution across tenant and platform checks', async () => {
+      mockReq.user = {
+        id: 'user-123',
+        role: 'ADMIN',
+        tenantId: 'tenant-1',
+      } as ServerRequest['user'];
+      mockGetUserPrincipals.mockResolvedValue(adminPrincipals);
+      mockHasCapabilityForPrincipals.mockResolvedValue(true);
+
+      await new Promise<void>((resolve, reject) => {
+        capabilityContextMiddleware(mockReq as ServerRequest, mockRes as Response, () => {
+          void (async () => {
+            try {
+              await hasCapability(mockReq.user as CapabilityUser, SystemCapabilities.ACCESS_ADMIN);
+              const middleware = requireCapability(SystemCapabilities.MANAGE_CODE_ENVIRONMENTS, {
+                platformOnly: true,
+              });
+              await middleware(mockReq as ServerRequest, mockRes as Response, mockNext);
+              resolve();
+            } catch (error) {
+              reject(error);
+            }
+          })();
+        });
+      });
+
+      expect(mockGetUserPrincipals).toHaveBeenCalledTimes(1);
     });
 
     it('returns 403 when user lacks the capability', async () => {

--- a/packages/api/src/middleware/capabilities.ts
+++ b/packages/api/src/middleware/capabilities.ts
@@ -61,6 +61,7 @@ export type HasCapabilityFn = (
 
 export type RequireCapabilityFn = (
   capability: SystemCapability,
+  options?: { platformOnly?: boolean },
 ) => (req: ServerRequest, res: Response, next: NextFunction) => Promise<void>;
 
 export type HasConfigCapabilityFn = (
@@ -265,7 +266,10 @@ export function generateCapabilityCheck(deps: CapabilityDeps): {
     return hasCapability(user, sectionCap);
   }
 
-  function requireCapability(capability: SystemCapability) {
+  function requireCapability(
+    capability: SystemCapability,
+    { platformOnly = false }: { platformOnly?: boolean } = {},
+  ) {
     return async (req: ServerRequest, res: Response, next: NextFunction) => {
       try {
         if (!req.user) {
@@ -282,7 +286,7 @@ export function generateCapabilityCheck(deps: CapabilityDeps): {
         const user: CapabilityUser = {
           id,
           role: req.user.role ?? '',
-          tenantId: (req.user as CapabilityUser).tenantId,
+          ...(platformOnly ? {} : { tenantId: (req.user as CapabilityUser).tenantId }),
           idOnTheSource: req.user.idOnTheSource ?? null,
         };
 

--- a/packages/api/src/middleware/capabilities.ts
+++ b/packages/api/src/middleware/capabilities.ts
@@ -1,5 +1,6 @@
 import { isMainThread } from 'node:worker_threads';
 import { AsyncLocalStorage } from 'node:async_hooks';
+import { PrincipalType } from 'librechat-data-provider';
 import {
   logger,
   configCapability,
@@ -215,6 +216,7 @@ export function generateCapabilityCheck(deps: CapabilityDeps): {
   async function hasCapability(
     user: CapabilityUser,
     capability: SystemCapability,
+    { platformOnly = false }: { platformOnly?: boolean } = {},
   ): Promise<boolean> {
     if (!isMainThread && !workerWarned) {
       workerWarned = true;
@@ -227,17 +229,21 @@ export function generateCapabilityCheck(deps: CapabilityDeps): {
 
     const store = capabilityStore.getStore();
 
-    const resultKey = `${user.id}:${user.tenantId ?? ''}:${capability}`;
+    const resultKey = `${user.id}:${user.tenantId ?? ''}:${capability}:${platformOnly ? 'platform' : 'tenant'}`;
     const cached = store?.results.get(resultKey);
     if (cached !== undefined) {
       return cached;
     }
 
-    const principals = await resolvePrincipals(user);
+    const resolvedPrincipals = await resolvePrincipals(user);
+    const principals =
+      platformOnly && user.tenantId
+        ? resolvedPrincipals.filter(({ principalType }) => principalType === PrincipalType.USER)
+        : resolvedPrincipals;
     const result = await hasCapabilityForPrincipals({
       principals,
       capability,
-      tenantId: user.tenantId,
+      tenantId: platformOnly ? undefined : user.tenantId,
     });
     store?.results.set(resultKey, result);
     return result;
@@ -286,11 +292,11 @@ export function generateCapabilityCheck(deps: CapabilityDeps): {
         const user: CapabilityUser = {
           id,
           role: req.user.role ?? '',
-          ...(platformOnly ? {} : { tenantId: (req.user as CapabilityUser).tenantId }),
+          tenantId: (req.user as CapabilityUser).tenantId,
           idOnTheSource: req.user.idOnTheSource ?? null,
         };
 
-        if (await hasCapability(user, capability)) {
+        if (await hasCapability(user, capability, { platformOnly })) {
           next();
           return;
         }


### PR DESCRIPTION
## Summary

I closed the tenant-to-platform authorization gap on deployment-owned code-worker pairing and revocation.

- Added an explicit `platformOnly` option to capability middleware while preserving existing tenant-aware behavior by default.
- Required a platform-scoped `manage:code_environments` grant for deployment worker enrollment and revocation routes.
- Added regression coverage proving tenant-only grants are rejected when a platform-only check is requested.
- Kept JWT and administrator-access checks unchanged and preserved all existing route behavior for authorized platform operators.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `packages/api/src/middleware/capabilities.spec.ts`: 14 focused tests passed.
- `api/server/routes/admin/code.test.js`: 2 focused tests passed.
- Scoped ESLint, import sorting, Prettier, and `git diff --check` passed.
- The complete `packages/api` typecheck was attempted, but the reused local dependency build is stale relative to current `dev` and reports unrelated missing exports across existing files; the touched TypeScript compiled through the focused Jest suite. CI will run against a clean dependency build.

### **Test Configuration**:

- macOS
- Node.js v24.16.0

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas where necessary
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.