### PR TITLE
🕓 style: Move the Queued-Message Hint Into a Hover Tooltip on the Clock Icon

### DIFF
--- a/client/src/components/Chat/Input/PendingSteerChips.tsx
+++ b/client/src/components/Chat/Input/PendingSteerChips.tsx
@@ -1,7 +1,7 @@
 import { memo, useMemo, useRef, useState, useCallback } from 'react';
 import { useAtomValue } from 'jotai';
 import { useRecoilValue } from 'recoil';
-import { useToastContext } from '@librechat/client';
+import { TooltipAnchor, useToastContext } from '@librechat/client';
 import {
   X,
   Zap,
@@ -74,6 +74,30 @@ function QuoteCount({ count, label }: { count: number; label: string }) {
       count={count}
       label={label}
     />
+  );
+}
+
+/**
+ * The one fact a queued row needs to convey ("did my message vanish?" it did
+ * not) rides the clock as a hover hint and its accessible name while a run is
+ * pending, instead of a caption row that costs composer height at rest.
+ */
+function QueuedIcon({ warning, hint }: { warning: boolean; hint?: string }) {
+  if (warning) {
+    return <TriangleAlert className="h-4 w-4 shrink-0 text-text-warning" aria-hidden="true" />;
+  }
+  if (!hint) {
+    return <Clock className={cn('h-4 w-4 shrink-0', QUEUE_ICON)} aria-hidden="true" />;
+  }
+  return (
+    <TooltipAnchor
+      description={hint}
+      role="img"
+      aria-label={hint}
+      className="flex shrink-0 cursor-help"
+    >
+      <Clock className={cn('h-4 w-4', QUEUE_ICON)} aria-hidden="true" />
+    </TooltipAnchor>
   );
 }
 
@@ -209,11 +233,10 @@ function QueuedRow({
 
   return (
     <div role="listitem" className={ROW_CLASS} data-testid="queued-message-row">
-      {isRejected || isUnconfirmed || isIndeterminate ? (
-        <TriangleAlert className="h-4 w-4 shrink-0 text-text-warning" aria-hidden="true" />
-      ) : (
-        <Clock className={cn('h-4 w-4 shrink-0', QUEUE_ICON)} aria-hidden="true" />
-      )}
+      <QueuedIcon
+        warning={isRejected || isUnconfirmed || isIndeterminate}
+        hint={steering.duringRunActive ? localize('com_ui_steer_queued_info') : undefined}
+      />
       <span className="min-w-0 flex-1 truncate" title={message.text}>
         {message.text}
       </span>
@@ -463,8 +486,6 @@ function PendingSteerChips({
 
   return (
     <div className="flex flex-col gap-1.5 px-2 pt-2" data-testid="pending-steer-chips">
-      {/* The list owns only listitem rows; the caption lives beside it so the
-       *  ARIA list structure stays valid for assistive tech. */}
       <div
         className="flex flex-col gap-1.5"
         role="list"
@@ -490,14 +511,6 @@ function PendingSteerChips({
           />
         ))}
       </div>
-      {/* One caption for the whole queued group: the single fact users need
-       *  ("did my message vanish?" it did not), shown only while a run is
-       *  actually pending — after it, rows drain or convert on their own. */}
-      {queued.length > 0 && steering.duringRunActive && (
-        <div className="px-3 text-xs text-text-secondary" data-testid="queued-caption">
-          {localize('com_ui_steer_queued_info')}
-        </div>
-      )}
     </div>
   );
 }

--- a/client/src/components/Chat/Input/PendingSteerChips.tsx
+++ b/client/src/components/Chat/Input/PendingSteerChips.tsx
@@ -80,7 +80,9 @@ function QuoteCount({ count, label }: { count: number; label: string }) {
 /**
  * The one fact a queued row needs to convey ("did my message vanish?" it did
  * not) rides the clock as a hover hint and its accessible name while a run is
- * pending, instead of a caption row that costs composer height at rest.
+ * pending, instead of a caption row that costs composer height at rest. The
+ * anchor is a tab stop with a visible ring so keyboard users reach the same
+ * hint: the tooltip opens on focus-visible as well as on hover.
  */
 function QueuedIcon({ warning, hint }: { warning: boolean; hint?: string }) {
   if (warning) {
@@ -94,7 +96,8 @@ function QueuedIcon({ warning, hint }: { warning: boolean; hint?: string }) {
       description={hint}
       role="img"
       aria-label={hint}
-      className="flex shrink-0 cursor-help"
+      tabIndex={0}
+      className="flex shrink-0 cursor-help rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-xheavy"
     >
       <Clock className={cn('h-4 w-4', QUEUE_ICON)} aria-hidden="true" />
     </TooltipAnchor>

--- a/client/src/components/Chat/Input/__tests__/PendingSteerChips.test.tsx
+++ b/client/src/components/Chat/Input/__tests__/PendingSteerChips.test.tsx
@@ -667,6 +667,17 @@ describe('PendingSteerChips — queued hint', () => {
     const clock = screen.getByRole('img', { name: hintName });
     fireEvent.mouseEnter(clock);
     fireEvent.mouseMove(clock);
+    /** Ariakit opens a hover tooltip on a timer; allow for a loaded CI shard. */
+    const tooltip = await screen.findByRole('tooltip', {}, { timeout: 4000 });
+    expect(tooltip).toHaveTextContent(hintName);
+  });
+
+  it('reaches the same hint from the keyboard: the clock is a tab stop and opens on focus', async () => {
+    const user = userEvent.setup();
+    renderChips([queuedItem], { steering: { duringRunActive: true } });
+    const clock = screen.getByRole('img', { name: hintName });
+    await user.tab();
+    expect(clock).toHaveFocus();
     const tooltip = await screen.findByRole('tooltip');
     expect(tooltip).toHaveTextContent(hintName);
   });

--- a/client/src/components/Chat/Input/__tests__/PendingSteerChips.test.tsx
+++ b/client/src/components/Chat/Input/__tests__/PendingSteerChips.test.tsx
@@ -666,9 +666,12 @@ describe('PendingSteerChips — queued hint', () => {
     renderChips([queuedItem], { steering: { duringRunActive: true } });
     const clock = screen.getByRole('img', { name: hintName });
     fireEvent.mouseEnter(clock);
-    fireEvent.mouseMove(clock);
-    /** Ariakit opens a hover tooltip on a timer; allow for a loaded CI shard. */
-    const tooltip = await screen.findByRole('tooltip', {}, { timeout: 4000 });
+    /** Ariakit only counts a pointer as moving when consecutive events differ
+     *  in screen coordinates (its NODE_ENV=test shortcut is off under CI's
+     *  NODE_ENV), and it opens the tooltip on a timer after that. */
+    fireEvent.mouseMove(clock, { screenX: 10, screenY: 10 });
+    fireEvent.mouseMove(clock, { screenX: 20, screenY: 20 });
+    const tooltip = await screen.findByRole('tooltip', {}, { timeout: 3000 });
     expect(tooltip).toHaveTextContent(hintName);
   });
 

--- a/client/src/components/Chat/Input/__tests__/PendingSteerChips.test.tsx
+++ b/client/src/components/Chat/Input/__tests__/PendingSteerChips.test.tsx
@@ -23,6 +23,7 @@ jest.mock('@librechat/client', () => {
   const { createSteerMorphIconMock } = jest.requireActual('~/../test/mockMorphIcon');
   return {
     useToastContext: () => ({ showToast: mockShowToast }),
+    TooltipAnchor: jest.requireActual('@librechat/client').TooltipAnchor,
     MorphIcon: createSteerMorphIconMock(),
   };
 });
@@ -653,34 +654,41 @@ describe('PendingSteerChips — queued interrupt-now', () => {
   );
 });
 
-describe('PendingSteerChips — queued caption', () => {
+describe('PendingSteerChips — queued hint', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   const queuedItem = { id: 'q1', text: 'follow up later', createdAt: 1 };
+  const hintName = 'com_ui_steer_queued_info';
 
-  it('explains when queued messages will send while a run is active', () => {
+  it('explains when a queued message will send as a hover hint on its clock icon', async () => {
     renderChips([queuedItem], { steering: { duringRunActive: true } });
-    expect(screen.getByTestId('queued-caption')).toHaveTextContent('com_ui_steer_queued_info');
+    const clock = screen.getByRole('img', { name: hintName });
+    fireEvent.mouseEnter(clock);
+    fireEvent.mouseMove(clock);
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent(hintName);
   });
 
-  it('renders one caption for the whole group, not one per row', () => {
+  it('renders no always-visible caption, so the hint costs no composer height at rest', () => {
+    renderChips([queuedItem], { steering: { duringRunActive: true } });
+    expect(screen.queryByText(hintName)).toBeNull();
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('keeps the hint inside each queued row as its icon, never as a stray child of the list', () => {
     renderChips([queuedItem, { id: 'q2', text: 'and another', createdAt: 2 }], {
       steering: { duringRunActive: true },
     });
-    expect(screen.getAllByTestId('queued-caption')).toHaveLength(1);
+    const rows = screen.getAllByTestId('queued-message-row');
+    const clocks = screen.getAllByRole('img', { name: hintName });
+    expect(clocks).toHaveLength(2);
+    rows.forEach((row, index) => expect(row).toContainElement(clocks[index]));
   });
 
-  it('keeps the caption beside the ARIA list, never as a non-listitem child of it', () => {
-    renderChips([queuedItem], { steering: { duringRunActive: true } });
-    const list = screen.getByRole('list', { name: 'com_ui_queued_messages' });
-    expect(list).not.toContainElement(screen.getByTestId('queued-caption'));
-    expect(list).toContainElement(screen.getByTestId('queued-message-row'));
-  });
-
-  it('omits the caption once the run is over, when rows drain on their own terms', () => {
+  it('omits the hint once the run is over, when rows drain on their own terms', () => {
     renderChips([queuedItem], { steering: { duringRunActive: false } });
-    expect(screen.queryByTestId('queued-caption')).toBeNull();
+    expect(screen.queryByRole('img', { name: hintName })).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

While a run is pending, every queued message showed a caption row beneath the chips: *"Sends when this response finishes."* It is one sentence of reassurance and it cost composer height for the whole time a run was active. The clock icon of each queued row now carries that sentence as a hover tooltip and as its accessible name, and the caption row is gone.

## Change

- `PendingSteerChips.tsx`: new `QueuedIcon` helper renders the warning triangle, the plain clock, or the clock wrapped in `TooltipAnchor` (`role="img"`, `aria-label` = the hint, `cursor-help`) while `steering.duringRunActive`. The group caption and its stale ARIA-structure comment are removed. No new locale keys; `com_ui_steer_queued_info` is reused.
- Accessibility: the hint stays exposed to assistive tech at rest through the icon's accessible name, so nothing that was readable before is lost. Mouse users get it on hover; keyboard users get it on focus: the clock is an explicit tab stop with the same focus-visible ring as the row's buttons, and Ariakit opens the tooltip on focus-visible.
- Behavior otherwise unchanged: warning states keep the triangle, and the hint disappears with the run exactly as the caption did.

## Tests

`PendingSteerChips.test.tsx` (the `@librechat/client` mock now passes the real `TooltipAnchor` through): hover on the clock shows the tooltip with the hint; tabbing to the clock focuses it and opens the same tooltip; no always-visible caption or mounted tooltip at rest; every queued row owns its own hinted icon inside the ARIA list; the hint is absent once the run is over. Mutation-checked: dropping the hint prop fails exactly the three hint tests (hover, keyboard, per-row).

Focused local runs only (codegraph d1 = this spec); CI owns the full suites.

## Trade-off

Touch devices have no hover, so on a phone the sentence is no longer visible at rest (it remains the icon's accessible name). That is the requested trade: the caption was spending composer height on every pending run for one reassurance, and the queued chip itself already says a message is waiting.
