### PR TITLE
🔒 fix: Read and Serve azure_blob Files from Private Containers

### DIFF
--- a/api/server/routes/static.js
+++ b/api/server/routes/static.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { isEnabled } = require('@librechat/api');
+const { createAzureBlobImageHandler } = require('~/server/services/Files/Azure/serveImage');
 const staticCache = require('../utils/staticCache');
 const paths = require('~/config/paths');
 
@@ -7,5 +8,8 @@ const skipGzipScan = !isEnabled(process.env.ENABLE_IMAGE_OUTPUT_GZIP_SCAN);
 
 const router = express.Router();
 router.use(staticCache(paths.imageOutput, { skipGzipScan }));
+/** Private `azure_blob` containers store `/images/...` paths the browser cannot fetch from Blob
+ * Storage directly; anything the static middleware did not find on disk is looked up there. */
+router.use(createAzureBlobImageHandler());
 
 module.exports = router;

--- a/api/server/services/Files/Azure/__tests__/crud.spec.js
+++ b/api/server/services/Files/Azure/__tests__/crud.spec.js
@@ -1,0 +1,201 @@
+const { Readable } = require('stream');
+
+jest.mock('axios', () => jest.fn());
+jest.mock('node-fetch', () => jest.fn());
+jest.mock('@librechat/data-schemas', () => ({
+  logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock('@librechat/api', () => ({
+  deleteRagFile: jest.fn(),
+  assertRemoteFileURL: jest.fn((url) => url),
+  getAzureContainerClient: jest.fn(),
+  getRemoteFileFetchMaxBytes: jest.fn(() => 1024),
+  getRemoteFileFetchTimeoutMs: jest.fn(() => 1000),
+  assertRemoteFileContentLength: jest.fn(),
+}));
+
+const axios = require('axios');
+const { getAzureContainerClient } = require('@librechat/api');
+const {
+  getAzureURL,
+  getAzureBlobPath,
+  saveBufferToAzure,
+  getAzureFileStream,
+  deleteFileFromAzure,
+} = require('../crud');
+
+const ACCOUNT_URL = 'https://acct.blob.core.windows.net';
+const CONTAINER = 'ai-chat-uploads';
+
+function mockContainer() {
+  const blobClient = {
+    download: jest.fn(),
+  };
+  const blockBlobClient = {
+    url: '',
+    uploadData: jest.fn(),
+    delete: jest.fn(),
+  };
+  const containerClient = {
+    createIfNotExists: jest.fn(),
+    getBlobClient: jest.fn(() => blobClient),
+    getBlockBlobClient: jest.fn((blobPath) => {
+      blockBlobClient.url = `${ACCOUNT_URL}/${CONTAINER}/${blobPath}`;
+      return blockBlobClient;
+    }),
+  };
+  getAzureContainerClient.mockResolvedValue(containerClient);
+  return { containerClient, blobClient, blockBlobClient };
+}
+
+describe('Azure Blob crud – private vs public containers', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.AZURE_CONTAINER_NAME = CONTAINER;
+    delete process.env.AZURE_STORAGE_PUBLIC_ACCESS;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  describe('getAzureBlobPath', () => {
+    it('resolves the blob path from an absolute blob URL (query stripped, container prefix removed)', () => {
+      expect(
+        getAzureBlobPath(
+          `${ACCOUNT_URL}/${CONTAINER}/images/user1/avatar.png?manual=true`,
+          CONTAINER,
+        ),
+      ).toBe('images/user1/avatar.png');
+    });
+
+    it('resolves the blob path from a root-relative stored path', () => {
+      expect(getAzureBlobPath('/images/user1/file.png', CONTAINER)).toBe('images/user1/file.png');
+    });
+
+    it('rejects URLs from another container and traversal segments', () => {
+      expect(() => getAzureBlobPath(`${ACCOUNT_URL}/other/images/u/f.png`, CONTAINER)).toThrow(
+        /not in container/,
+      );
+      expect(() => getAzureBlobPath('/images/../secrets', CONTAINER)).toThrow(/Invalid/);
+      expect(() => getAzureBlobPath('', CONTAINER)).toThrow(/Invalid/);
+    });
+  });
+
+  describe('getAzureFileStream', () => {
+    it('fetches the blob anonymously when the container is public (default)', async () => {
+      const stream = Readable.from(['x']);
+      axios.mockResolvedValue({ data: stream });
+      const { blobClient } = mockContainer();
+      const url = `${ACCOUNT_URL}/${CONTAINER}/images/user1/file.png`;
+
+      const result = await getAzureFileStream({}, url);
+
+      expect(result).toBe(stream);
+      expect(axios).toHaveBeenCalledWith({ method: 'get', url, responseType: 'stream' });
+      expect(blobClient.download).not.toHaveBeenCalled();
+    });
+
+    it('downloads through the authenticated client when the container is private', async () => {
+      process.env.AZURE_STORAGE_PUBLIC_ACCESS = 'false';
+      const stream = Readable.from(['x']);
+      const { containerClient, blobClient } = mockContainer();
+      blobClient.download.mockResolvedValue({ readableStreamBody: stream });
+
+      const result = await getAzureFileStream(
+        {},
+        `${ACCOUNT_URL}/${CONTAINER}/images/user1/file.png`,
+      );
+
+      expect(result).toBe(stream);
+      expect(axios).not.toHaveBeenCalled();
+      expect(getAzureContainerClient).toHaveBeenCalledWith(CONTAINER);
+      expect(containerClient.getBlobClient).toHaveBeenCalledWith('images/user1/file.png');
+    });
+
+    it('accepts the root-relative path stored for private blobs', async () => {
+      process.env.AZURE_STORAGE_PUBLIC_ACCESS = 'false';
+      const stream = Readable.from(['x']);
+      const { containerClient, blobClient } = mockContainer();
+      blobClient.download.mockResolvedValue({ readableStreamBody: stream });
+
+      await expect(getAzureFileStream({}, '/images/user1/file.png')).resolves.toBe(stream);
+      expect(containerClient.getBlobClient).toHaveBeenCalledWith('images/user1/file.png');
+    });
+
+    it('rethrows download errors in private mode', async () => {
+      process.env.AZURE_STORAGE_PUBLIC_ACCESS = 'false';
+      const { blobClient } = mockContainer();
+      blobClient.download.mockRejectedValue(Object.assign(new Error('nope'), { statusCode: 404 }));
+
+      await expect(getAzureFileStream({}, '/images/user1/missing.png')).rejects.toThrow('nope');
+    });
+
+    it('fails when the Azure client is not initialized in private mode', async () => {
+      process.env.AZURE_STORAGE_PUBLIC_ACCESS = 'false';
+      getAzureContainerClient.mockResolvedValue(null);
+
+      await expect(getAzureFileStream({}, '/images/user1/file.png')).rejects.toThrow(
+        /not initialized/,
+      );
+    });
+  });
+
+  describe('stored file paths', () => {
+    it('returns the blob URL and requests public blob access when the container is public', async () => {
+      const { containerClient } = mockContainer();
+
+      const result = await saveBufferToAzure({
+        userId: 'user1',
+        buffer: Buffer.from('data'),
+        fileName: 'file.png',
+      });
+
+      expect(result).toBe(`${ACCOUNT_URL}/${CONTAINER}/images/user1/file.png`);
+      expect(containerClient.createIfNotExists).toHaveBeenCalledWith({ access: 'blob' });
+    });
+
+    it('returns a root-relative /images path served by the app when the container is private', async () => {
+      process.env.AZURE_STORAGE_PUBLIC_ACCESS = 'false';
+      const { containerClient } = mockContainer();
+
+      const result = await saveBufferToAzure({
+        userId: 'user1',
+        buffer: Buffer.from('data'),
+        fileName: 'file.png',
+      });
+
+      expect(result).toBe('/images/user1/file.png');
+      expect(containerClient.createIfNotExists).toHaveBeenCalledWith({ access: undefined });
+      await expect(getAzureURL({ userId: 'user1', fileName: 'file.png' })).resolves.toBe(
+        '/images/user1/file.png',
+      );
+    });
+  });
+
+  describe('deleteFileFromAzure', () => {
+    it('deletes by blob path for both stored path shapes', async () => {
+      const req = { user: { id: 'user1' } };
+      const { containerClient, blockBlobClient } = mockContainer();
+
+      await deleteFileFromAzure(req, {
+        filepath: `${ACCOUNT_URL}/${CONTAINER}/images/user1/a.png`,
+      });
+      await deleteFileFromAzure(req, { filepath: '/images/user1/b.png' });
+
+      expect(containerClient.getBlockBlobClient).toHaveBeenNthCalledWith(1, 'images/user1/a.png');
+      expect(containerClient.getBlockBlobClient).toHaveBeenNthCalledWith(2, 'images/user1/b.png');
+      expect(blockBlobClient.delete).toHaveBeenCalledTimes(2);
+    });
+
+    it("refuses to delete a blob outside the user's directory", async () => {
+      const { blockBlobClient } = mockContainer();
+
+      await expect(
+        deleteFileFromAzure({ user: { id: 'user1' } }, { filepath: '/images/user2/c.png' }),
+      ).rejects.toThrow('User ID not found in blob path');
+      expect(blockBlobClient.delete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/api/server/services/Files/Azure/__tests__/serveImage.spec.js
+++ b/api/server/services/Files/Azure/__tests__/serveImage.spec.js
@@ -1,0 +1,166 @@
+const { Readable, PassThrough } = require('stream');
+
+jest.mock('@librechat/data-schemas', () => ({
+  logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock('@librechat/api', () => ({
+  deleteRagFile: jest.fn(),
+  getAzureContainerClient: jest.fn(),
+  assertRemoteFileURL: jest.fn(),
+  getRemoteFileFetchMaxBytes: jest.fn(),
+  getRemoteFileFetchTimeoutMs: jest.fn(),
+  assertRemoteFileContentLength: jest.fn(),
+}));
+jest.mock('~/server/services/Config', () => ({ getAppConfig: jest.fn() }));
+jest.mock('~/server/utils/getFileStrategy', () => ({ getFileStrategy: jest.fn() }));
+
+const { FileSources } = require('librechat-data-provider');
+const { createAzureBlobImageHandler } = require('../serveImage');
+
+function makeRes() {
+  const res = new PassThrough();
+  res.headers = {};
+  res.setHeader = jest.fn((name, value) => {
+    res.headers[name] = value;
+  });
+  res.status = jest.fn(() => res);
+  const end = res.end.bind(res);
+  res.end = jest.fn((...args) => end(...args));
+  return res;
+}
+
+function setup({ publicAccess = false, strategy = FileSources.azure_blob, download } = {}) {
+  const blobClient = { download: jest.fn(download) };
+  const containerClient = { getBlobClient: jest.fn(() => blobClient) };
+  const deps = {
+    isPublicAccess: () => publicAccess,
+    getAppConfig: jest.fn(async () => ({ fileStrategy: strategy })),
+    getFileStrategy: jest.fn((appConfig) => appConfig.fileStrategy),
+    getAzureContainerClient: jest.fn(async () => containerClient),
+  };
+  return { handler: createAzureBlobImageHandler(deps), deps, containerClient, blobClient };
+}
+
+describe('createAzureBlobImageHandler', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.AZURE_CONTAINER_NAME = 'ai-chat-uploads';
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('streams a private blob under /images/{ownerId}/{filename} with private cache headers', async () => {
+    const body = Readable.from([Buffer.from('png-bytes')]);
+    const { handler, deps, containerClient } = setup({
+      download: async () => ({
+        readableStreamBody: body,
+        contentType: 'image/png',
+        contentLength: 9,
+      }),
+    });
+    const res = makeRes();
+    const next = jest.fn();
+    const chunks = [];
+    res.on('data', (chunk) => chunks.push(chunk));
+    const finished = new Promise((resolve) => res.on('end', resolve));
+
+    await handler({ method: 'GET', path: '/0123456789abcdef01234567/img.png' }, res, next);
+    await finished;
+
+    expect(next).not.toHaveBeenCalled();
+    expect(deps.getAzureContainerClient).toHaveBeenCalledWith('ai-chat-uploads');
+    expect(containerClient.getBlobClient).toHaveBeenCalledWith(
+      'images/0123456789abcdef01234567/img.png',
+    );
+    expect(res.headers['Content-Type']).toBe('image/png');
+    expect(res.headers['Content-Length']).toBe('9');
+    expect(res.headers['Cache-Control']).toBe('private, no-store');
+    expect(Buffer.concat(chunks).toString()).toBe('png-bytes');
+  });
+
+  it('falls back to the extension when the blob has no content type', async () => {
+    const { handler } = setup({
+      download: async () => ({ readableStreamBody: Readable.from([Buffer.from('x')]) }),
+    });
+    const res = makeRes();
+
+    await handler({ method: 'GET', path: '/user1/photo.webp' }, res, jest.fn());
+
+    expect(res.headers['Content-Type']).toBe('image/webp');
+  });
+
+  it('passes through when the container is public', async () => {
+    const { handler, deps } = setup({ publicAccess: true });
+    const next = jest.fn();
+
+    await handler({ method: 'GET', path: '/user1/img.png' }, makeRes(), next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(deps.getAppConfig).not.toHaveBeenCalled();
+  });
+
+  it('passes through when images are not stored with the azure_blob strategy', async () => {
+    const { handler, deps } = setup({ strategy: FileSources.local });
+    const next = jest.fn();
+
+    await handler({ method: 'GET', path: '/user1/img.png' }, makeRes(), next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(deps.getAzureContainerClient).not.toHaveBeenCalled();
+  });
+
+  it('passes through when the blob does not exist', async () => {
+    const { handler } = setup({
+      download: async () => {
+        throw Object.assign(new Error('BlobNotFound'), { statusCode: 404 });
+      },
+    });
+    const next = jest.fn();
+
+    await handler({ method: 'GET', path: '/user1/missing.png' }, makeRes(), next);
+
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('forwards other storage errors to the error handler', async () => {
+    const error = Object.assign(new Error('AuthorizationFailure'), { statusCode: 403 });
+    const { handler } = setup({
+      download: async () => {
+        throw error;
+      },
+    });
+    const next = jest.fn();
+
+    await handler({ method: 'GET', path: '/user1/img.png' }, makeRes(), next);
+
+    expect(next).toHaveBeenCalledWith(error);
+  });
+
+  it.each([
+    ['nested path', '/user1/sub/img.png'],
+    ['traversal', '/../img.png'],
+    ['encoded traversal', '/user1/%2e%2e'],
+    ['missing filename', '/user1'],
+  ])('passes through malformed image paths (%s)', async (_label, path) => {
+    const { handler, deps } = setup();
+    const next = jest.fn();
+
+    await handler({ method: 'GET', path }, makeRes(), next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(deps.getAzureContainerClient).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-GET requests', async () => {
+    const { handler, deps } = setup();
+    const next = jest.fn();
+
+    await handler({ method: 'POST', path: '/user1/img.png' }, makeRes(), next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(deps.getAppConfig).not.toHaveBeenCalled();
+  });
+});

--- a/api/server/services/Files/Azure/crud.js
+++ b/api/server/services/Files/Azure/crud.js
@@ -14,7 +14,65 @@ const {
 } = require('@librechat/api');
 
 const defaultBasePath = 'images';
-const { AZURE_STORAGE_PUBLIC_ACCESS = 'true', AZURE_CONTAINER_NAME = 'files' } = process.env;
+
+/**
+ * Whether the container is configured for anonymous (public) blob access.
+ * Read per call so a process can be reconfigured without a restart (and so tests can toggle it).
+ * @returns {boolean}
+ */
+function isAzurePublicAccess() {
+  return (process.env.AZURE_STORAGE_PUBLIC_ACCESS ?? 'true').toLowerCase() === 'true';
+}
+
+/** @returns {string} The configured container name (defaults to `files`). */
+function getAzureContainerName() {
+  return process.env.AZURE_CONTAINER_NAME || 'files';
+}
+
+/**
+ * Resolves the blob path (`{basePath}/{userId}/{fileName}`) from a stored file path.
+ *
+ * Public containers store the absolute blob URL (`https://{account}.blob.core.windows.net/{container}/{path}`);
+ * private containers store a root-relative path (`/{path}`) that the app serves itself, because the
+ * browser cannot fetch a private blob directly. Both shapes resolve to the same blob path.
+ *
+ * @param {string} fileURL - Absolute blob URL or root-relative stored path.
+ * @param {string} [containerName] - The container the blob lives in.
+ * @returns {string} The blob path within the container.
+ */
+function getAzureBlobPath(fileURL, containerName = getAzureContainerName()) {
+  if (typeof fileURL !== 'string' || fileURL.length === 0) {
+    throw new Error('Invalid Azure blob file path');
+  }
+  let pathname = fileURL;
+  if (/^https?:\/\//i.test(fileURL)) {
+    pathname = decodeURIComponent(new URL(fileURL).pathname);
+    const containerPrefix = `/${containerName}/`;
+    if (!pathname.startsWith(containerPrefix)) {
+      throw new Error(`Blob URL is not in container "${containerName}"`);
+    }
+    pathname = pathname.slice(containerPrefix.length);
+  } else {
+    pathname = pathname.split(/[?#]/, 1)[0].replace(/^\/+/, '');
+  }
+  if (pathname.length === 0 || pathname.split('/').some((segment) => segment === '..')) {
+    throw new Error('Invalid Azure blob file path');
+  }
+  return pathname;
+}
+
+/**
+ * The file path stored for (and handed to) clients. Public containers expose the blob URL directly;
+ * private containers expose the root-relative `/{blobPath}` served by the app (`/images/...`), so the
+ * download goes through the app's identity instead of an anonymous request the container would refuse.
+ *
+ * @param {import('@azure/storage-blob').BlockBlobClient} blockBlobClient
+ * @param {string} blobPath
+ * @returns {string}
+ */
+function getAzureStoredPath(blockBlobClient, blobPath) {
+  return isAzurePublicAccess() ? blockBlobClient.url : `/${blobPath}`;
+}
 
 /**
  * Uploads a buffer to Azure Blob Storage.
@@ -38,13 +96,13 @@ async function saveBufferToAzure({
 }) {
   try {
     const containerClient = await getAzureContainerClient(containerName);
-    const access = AZURE_STORAGE_PUBLIC_ACCESS?.toLowerCase() === 'true' ? 'blob' : undefined;
+    const access = isAzurePublicAccess() ? 'blob' : undefined;
     // Create the container if it doesn't exist. This is done per operation.
     await containerClient.createIfNotExists({ access });
     const blobPath = `${basePath}/${userId}/${fileName}`;
     const blockBlobClient = containerClient.getBlockBlobClient(blobPath);
     await blockBlobClient.uploadData(buffer);
-    return blockBlobClient.url;
+    return getAzureStoredPath(blockBlobClient, blobPath);
   } catch (error) {
     logger.error('[saveBufferToAzure] Error uploading buffer:', error);
     throw error;
@@ -106,7 +164,7 @@ async function getAzureURL({ fileName, basePath = defaultBasePath, userId, conta
     const containerClient = await getAzureContainerClient(containerName);
     const blobPath = userId ? `${basePath}/${userId}/${fileName}` : `${basePath}/${fileName}`;
     const blockBlobClient = containerClient.getBlockBlobClient(blobPath);
-    return blockBlobClient.url;
+    return getAzureStoredPath(blockBlobClient, blobPath);
   } catch (error) {
     logger.error('[getAzureURL] Error retrieving blob URL:', error);
     throw error;
@@ -124,8 +182,9 @@ async function deleteFileFromAzure(req, file) {
   await deleteRagFile({ userId: req.user.id, file });
 
   try {
-    const containerClient = await getAzureContainerClient(AZURE_CONTAINER_NAME);
-    const blobPath = file.filepath.split(`${AZURE_CONTAINER_NAME}/`)[1];
+    const containerName = getAzureContainerName();
+    const containerClient = await getAzureContainerClient(containerName);
+    const blobPath = getAzureBlobPath(file.filepath, containerName);
     if (!blobPath.includes(req.user.id)) {
       throw new Error('User ID not found in blob path');
     }
@@ -162,7 +221,7 @@ async function streamFileToAzure({
 }) {
   try {
     const containerClient = await getAzureContainerClient(containerName);
-    const access = AZURE_STORAGE_PUBLIC_ACCESS?.toLowerCase() === 'true' ? 'blob' : undefined;
+    const access = isAzurePublicAccess() ? 'blob' : undefined;
 
     // Create the container if it doesn't exist
     await containerClient.createIfNotExists({ access });
@@ -193,7 +252,7 @@ async function streamFileToAzure({
       },
     );
 
-    return blockBlobClient.url;
+    return getAzureStoredPath(blockBlobClient, blobPath);
   } catch (error) {
     logger.error('[streamFileToAzure] Error streaming file:', error);
     throw error;
@@ -246,18 +305,35 @@ async function uploadFileToAzure({
 /**
  * Retrieves a readable stream for a blob from Azure Blob Storage.
  *
+ * Public containers are fetched anonymously by URL. Private containers (`AZURE_STORAGE_PUBLIC_ACCESS`
+ * not `true`) are read through the authenticated client (connection string or managed identity),
+ * since an anonymous request to a private container is refused (404).
+ *
  * @param {object} _req - The Express request object.
- * @param {string} fileURL - The URL of the blob.
- * @returns {Promise<ReadableStream>} A readable stream of the blob.
+ * @param {string} fileURL - The stored file path: the blob URL, or the root-relative path of a private blob.
+ * @returns {Promise<NodeJS.ReadableStream>} A readable stream of the blob.
  */
 async function getAzureFileStream(_req, fileURL) {
   try {
-    const response = await axios({
-      method: 'get',
-      url: fileURL,
-      responseType: 'stream',
-    });
-    return response.data;
+    if (isAzurePublicAccess()) {
+      const response = await axios({
+        method: 'get',
+        url: fileURL,
+        responseType: 'stream',
+      });
+      return response.data;
+    }
+    const containerName = getAzureContainerName();
+    const containerClient = await getAzureContainerClient(containerName);
+    if (!containerClient) {
+      throw new Error('Azure Blob Service is not initialized');
+    }
+    const blobClient = containerClient.getBlobClient(getAzureBlobPath(fileURL, containerName));
+    const response = await blobClient.download();
+    if (!response.readableStreamBody) {
+      throw new Error('Azure blob download returned no stream body');
+    }
+    return response.readableStreamBody;
   } catch (error) {
     logger.error('[getAzureFileStream] Error getting blob stream:', error);
     throw error;
@@ -268,7 +344,10 @@ module.exports = {
   saveBufferToAzure,
   saveURLToAzure,
   getAzureURL,
+  getAzureBlobPath,
+  isAzurePublicAccess,
   deleteFileFromAzure,
   uploadFileToAzure,
   getAzureFileStream,
+  getAzureContainerName,
 };

--- a/api/server/services/Files/Azure/index.js
+++ b/api/server/services/Files/Azure/index.js
@@ -1,7 +1,9 @@
 const crud = require('./crud');
 const images = require('./images');
+const serveImage = require('./serveImage');
 
 module.exports = {
   ...crud,
   ...images,
+  ...serveImage,
 };

--- a/api/server/services/Files/Azure/serveImage.js
+++ b/api/server/services/Files/Azure/serveImage.js
@@ -1,0 +1,101 @@
+const mime = require('mime');
+const { logger } = require('@librechat/data-schemas');
+const { FileSources } = require('librechat-data-provider');
+const { getAzureContainerClient } = require('@librechat/api');
+const { getFileStrategy } = require('~/server/utils/getFileStrategy');
+const { getAppConfig } = require('~/server/services/Config');
+const { isAzurePublicAccess, getAzureContainerName } = require('./crud');
+
+/** `/{ownerId}/{filename}` below the `/images/` mount – the shape the app stores for private blobs. */
+const IMAGE_PATH_PATTERN = /^\/([^/\\]+)\/([^/\\]+)$/;
+
+/**
+ * Creates the `/images/` fallback that streams images out of a private Azure Blob container.
+ *
+ * With `AZURE_STORAGE_PUBLIC_ACCESS` not `true`, the `azure_blob` strategy stores root-relative
+ * `/images/{userId}/{fileName}` paths instead of blob URLs (a browser cannot read a private blob
+ * anonymously). Those paths land on the same `/images/` route the local strategy serves from disk;
+ * this handler runs after the static middleware and answers from Blob Storage with the app's own
+ * credential. It steps aside (`next()`) whenever the request is not for a private Azure image, so
+ * every other configuration keeps its current behavior. Authorization stays where it is for the
+ * local strategy too: the `/images/` route's image-authorization middleware (`secureImageLinks`).
+ *
+ * @param {Object} [deps]
+ * @param {() => Promise<object>} [deps.getAppConfig]
+ * @param {typeof getFileStrategy} [deps.getFileStrategy]
+ * @param {typeof getAzureContainerClient} [deps.getAzureContainerClient]
+ * @param {() => boolean} [deps.isPublicAccess]
+ * @returns {import('express').RequestHandler}
+ */
+function createAzureBlobImageHandler(deps = {}) {
+  const resolveAppConfig = deps.getAppConfig ?? getAppConfig;
+  const resolveStrategy = deps.getFileStrategy ?? getFileStrategy;
+  const resolveContainerClient = deps.getAzureContainerClient ?? getAzureContainerClient;
+  const isPublicAccess = deps.isPublicAccess ?? isAzurePublicAccess;
+
+  return async function serveAzureBlobImage(req, res, next) {
+    if ((req.method !== 'GET' && req.method !== 'HEAD') || isPublicAccess()) {
+      return next();
+    }
+
+    let decodedPath;
+    try {
+      decodedPath = decodeURIComponent(req.path);
+    } catch {
+      return next();
+    }
+    const match = decodedPath.match(IMAGE_PATH_PATTERN);
+    if (!match || match[1] === '..' || match[2] === '..' || decodedPath.includes('\0')) {
+      return next();
+    }
+
+    try {
+      const appConfig = await resolveAppConfig();
+      const usesAzure =
+        resolveStrategy(appConfig, { isImage: true }) === FileSources.azure_blob ||
+        resolveStrategy(appConfig, { isAvatar: true }) === FileSources.azure_blob;
+      if (!usesAzure) {
+        return next();
+      }
+
+      const containerClient = await resolveContainerClient(getAzureContainerName());
+      if (!containerClient) {
+        return next();
+      }
+
+      const blobPath = `images${decodedPath}`;
+      const download = await containerClient.getBlobClient(blobPath).download();
+      if (!download.readableStreamBody) {
+        return next();
+      }
+
+      res.setHeader(
+        'Content-Type',
+        download.contentType || mime.getType(blobPath) || 'application/octet-stream',
+      );
+      if (download.contentLength != null) {
+        res.setHeader('Content-Length', String(download.contentLength));
+      }
+      /** Served per-request under the app's identity: never let a shared cache keep a copy. */
+      res.setHeader('Cache-Control', 'private, no-store');
+      res.setHeader('Vary', 'Cookie');
+      if (req.method === 'HEAD') {
+        download.readableStreamBody.destroy?.();
+        return res.status(200).end();
+      }
+      download.readableStreamBody.on('error', (error) => {
+        logger.error('[serveAzureBlobImage] Stream error:', error);
+        res.destroy(error);
+      });
+      download.readableStreamBody.pipe(res);
+    } catch (error) {
+      if (error?.statusCode === 404) {
+        return next();
+      }
+      logger.error('[serveAzureBlobImage] Error serving blob:', error);
+      return next(error);
+    }
+  };
+}
+
+module.exports = { createAzureBlobImageHandler };


### PR DESCRIPTION
## Summary

With `fileStrategy: azure_blob` and `AZURE_STORAGE_PUBLIC_ACCESS=false`, the container is created without anonymous access, but the strategy still:

- downloaded blobs with a plain `axios` GET (`getAzureFileStream`) → `404` from Azure, so agents could not read uploaded images and the download/share routes failed;
- stored the raw blob URL as `filepath`, which the browser cannot load from a private container either.

This makes private containers work with the credential `initializeAzureBlobService` already sets up (connection string or `DefaultAzureCredential` / managed identity):

- `getAzureFileStream` downloads through the authenticated `BlobClient` when the container is private; public containers keep the anonymous fetch.
- Private mode stores root-relative `/images/{userId}/{fileName}` paths (the same shape the local strategy uses) instead of blob URLs, so the client keeps working unchanged through the `/images/` route.
- The `/images/` route gets a fallback after the static middleware that streams the blob from the private container (`Cache-Control: private, no-store`). It steps aside (`next()`) for public containers, other strategies, unknown blobs and malformed paths, so existing setups are unaffected. Authorization stays with the route's existing image-authorization middleware (`secureImageLinks`), exactly as for local images.
- Blob paths are resolved from either stored shape (absolute URL or root-relative path) for download and delete, so files uploaded while the container was public keep working.

Public containers (the default, `AZURE_STORAGE_PUBLIC_ACCESS` unset or `true`) behave exactly as before.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- New `api/server/services/Files/Azure/__tests__/crud.spec.js`: public → axios path, private → authenticated `BlobClient.download()`, root-relative path resolution, error propagation, uninitialized client, stored path shape per mode, delete for both path shapes and cross-user refusal.
- New `api/server/services/Files/Azure/__tests__/serveImage.spec.js`: streams a private blob with headers, extension MIME fallback, pass-through for public / non-azure / 404 / malformed paths / non-GET, other storage errors forwarded.
- Existing `api/server/routes/files/files.test.js`, `process.spec.js`, `skills.test.js` pass.
- Manually against a private container with managed-identity auth (`AZURE_STORAGE_ACCOUNT_NAME`, `AZURE_CONTAINER_NAME`, `AZURE_STORAGE_PUBLIC_ACCESS=false`): uploaded image visible in chat and readable by the agent, download link works.

### **Test Configuration**:

`fileStrategy: "azure_blob"`, `AZURE_STORAGE_PUBLIC_ACCESS=false`, `AZURE_STORAGE_ACCOUNT_NAME` set (managed identity, no connection string), `secureImageLinks: true`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] A pull request for updating the documentation has been submitted (will follow: note under `azure_blob` that private containers are supported).

