### PR TITLE
🖼️ feat: Configurable Inline Image Limit for Sandbox read_file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -763,6 +763,10 @@ TTS_API_KEY=
 # Bytes read per sandbox image window, overriding the size derived from the stdout budget above.
 # Prefer setting the budget; use this only to pin a window size exactly.
 # LIBRECHAT_CODE_IMAGE_CHUNK_BYTES=
+# Largest sandbox image `read_file` inlines for the model, in bytes (default: 1048576 / 1 MiB,
+# ceiling: 20971520 / 20 MiB). Larger images get a downscale hint instead. The image travels
+# base64-encoded inside the model request, so any proxy/body limit on that path must allow it.
+# SANDBOX_INLINE_IMAGE_MAX_BYTES=1048576
 
 #==================================================#
 #                        RAG                       #

--- a/packages/api/src/agents/handlers.spec.ts
+++ b/packages/api/src/agents/handlers.spec.ts
@@ -6991,6 +6991,97 @@ describe('createToolExecuteHandler', () => {
         expect(result.content).toContain('bash_tool');
       });
 
+      describe('SANDBOX_INLINE_IMAGE_MAX_BYTES', () => {
+        const originalValue = process.env.SANDBOX_INLINE_IMAGE_MAX_BYTES;
+        let warnSpy: jest.SpyInstance;
+
+        beforeEach(() => {
+          warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => logger);
+        });
+
+        afterEach(() => {
+          warnSpy.mockRestore();
+          if (originalValue === undefined) {
+            delete process.env.SANDBOX_INLINE_IMAGE_MAX_BYTES;
+          } else {
+            process.env.SANDBOX_INLINE_IMAGE_MAX_BYTES = originalValue;
+          }
+        });
+
+        async function readOversizeImage() {
+          const readSandboxImage = jest.fn(async () => ({
+            tooLarge: true as const,
+            bytes: 30_000_000,
+          }));
+          const handler = makeReadFileHandler({
+            codeEnvAvailable: true,
+            accessibleSkillIds: skillsInScope(),
+            readSandboxImage,
+          });
+          const [result] = await invokeHandler(handler, [
+            { id: 'call_limit', name: Constants.READ_FILE, args: { path: '/mnt/data/big.png' } },
+          ]);
+          return { result, readSandboxImage };
+        }
+
+        it('caps sandbox image reads at 1 MiB when unset', async () => {
+          delete process.env.SANDBOX_INLINE_IMAGE_MAX_BYTES;
+
+          const { result, readSandboxImage } = await readOversizeImage();
+
+          expect(readSandboxImage).toHaveBeenCalledWith(
+            expect.objectContaining({ maxBytes: 1_048_576 }),
+          );
+          expect(result.content).toContain('over the 1048576-byte inline limit');
+          expect(warnSpy).not.toHaveBeenCalled();
+        });
+
+        it('uses the configured cap for the read and names it in the over-limit message', async () => {
+          process.env.SANDBOX_INLINE_IMAGE_MAX_BYTES = '5242880';
+
+          const { result, readSandboxImage } = await readOversizeImage();
+
+          expect(readSandboxImage).toHaveBeenCalledWith(
+            expect.objectContaining({ maxBytes: 5_242_880 }),
+          );
+          expect(result.content).toContain('over the 5242880-byte inline limit');
+          expect(result.content).toContain('under 5242880 bytes');
+          expect(warnSpy).not.toHaveBeenCalled();
+        });
+
+        it.each([['lots'], ['0'], ['-5'], ['1.5e6']])(
+          'falls back to the default and warns on the invalid value %j',
+          async (value) => {
+            process.env.SANDBOX_INLINE_IMAGE_MAX_BYTES = value;
+
+            const { readSandboxImage } = await readOversizeImage();
+
+            expect(readSandboxImage).toHaveBeenCalledWith(
+              expect.objectContaining({ maxBytes: 1_048_576 }),
+            );
+            expect(warnSpy).toHaveBeenCalledWith(
+              expect.stringContaining(
+                `SANDBOX_INLINE_IMAGE_MAX_BYTES=${value} is not a positive integer`,
+              ),
+            );
+          },
+        );
+
+        it('clamps values above the 20 MiB ceiling and warns', async () => {
+          process.env.SANDBOX_INLINE_IMAGE_MAX_BYTES = '999999999';
+
+          const { result, readSandboxImage } = await readOversizeImage();
+
+          expect(readSandboxImage).toHaveBeenCalledWith(
+            expect.objectContaining({ maxBytes: 20_971_520 }),
+          );
+          expect(result.content).toContain('over the 20971520-byte inline limit');
+          expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining('exceeds the 20971520-byte ceiling'),
+          );
+        });
+      });
+
       it('reports a round-trip-bound image as unreadable inline, not oversize', async () => {
         /* Within the byte cap but needing more windowed `/exec` reads than
          * one call may spend on the Code API's execution limiter. Saying

--- a/packages/api/src/agents/handlers.ts
+++ b/packages/api/src/agents/handlers.ts
@@ -656,18 +656,63 @@ function truncateUtf8(value: string, maxBytes: number): string {
 }
 
 /**
- * Inline ceiling for images pulled out of the code-execution sandbox —
- * deliberately tighter than {@link MAX_BINARY_BYTES}, which governs the
- * skill-file path. The two differ because their transports differ: skill
- * files stream from storage, while sandbox bytes come back base64 over
- * `/exec` stdout, which the runner caps (`SANDBOX_OUTPUT_MAX_SIZE`). The
- * reader therefore windows the file, so cost scales in round-trips —
- * ~32 at this limit vs ~160 at 5MB. Nothing is lost by stopping here:
- * vision providers downsample to ~1.5-2k px regardless, so multi-MB
- * originals buy no fidelity, and anything larger degrades to the
- * `bash_tool` hint below.
+ * Default inline ceiling for images pulled out of the code-execution
+ * sandbox — deliberately tighter than {@link MAX_BINARY_BYTES}, which
+ * governs the skill-file path. The two differ because their transports
+ * differ: skill files stream from storage, while sandbox bytes come back
+ * base64 over `/exec` stdout, which the runner caps
+ * (`SANDBOX_OUTPUT_MAX_SIZE`). The reader therefore windows the file, so
+ * cost scales in round-trips — ~32 at this limit vs ~160 at 5MB. Nothing
+ * is lost by stopping here: vision providers downsample to ~1.5-2k px
+ * regardless, so multi-MB originals buy no fidelity, and anything larger
+ * degrades to the `bash_tool` hint below.
+ *
+ * Deployments whose sandbox returns larger windows (a bigger
+ * `SANDBOX_OUTPUT_MAX_SIZE`) and whose model request path accepts the
+ * resulting payload can raise it with `SANDBOX_INLINE_IMAGE_MAX_BYTES`,
+ * see {@link getSandboxInlineImageMaxBytes}.
  */
-const MAX_SANDBOX_INLINE_IMAGE_BYTES = 1024 * 1024;
+const DEFAULT_SANDBOX_INLINE_IMAGE_BYTES = 1024 * 1024;
+/** Hard upper bound for `SANDBOX_INLINE_IMAGE_MAX_BYTES`: the inlined image
+ *  travels base64-encoded inside the model request, and vision providers
+ *  reject images past ~20MB. */
+const MAX_SANDBOX_INLINE_IMAGE_BYTES_CEILING = 20 * 1024 * 1024;
+let warnedSandboxInlineImageLimit: string | undefined;
+
+/**
+ * Resolves the inline byte cap for sandbox images from
+ * `SANDBOX_INLINE_IMAGE_MAX_BYTES`. Unset means the
+ * {@link DEFAULT_SANDBOX_INLINE_IMAGE_BYTES} default; a value that is not a
+ * positive integer falls back to the default, one above
+ * {@link MAX_SANDBOX_INLINE_IMAGE_BYTES_CEILING} is clamped to it. Either
+ * correction is logged once per distinct value so a typo in the env does
+ * not silently change behavior. Read per call, so the same process picks up
+ * a changed env in tests and on config reload.
+ */
+export function getSandboxInlineImageMaxBytes(): number {
+  const raw = process.env.SANDBOX_INLINE_IMAGE_MAX_BYTES?.trim();
+  if (raw == null || raw === '') {
+    return DEFAULT_SANDBOX_INLINE_IMAGE_BYTES;
+  }
+  const warnOnce = (message: string) => {
+    if (warnedSandboxInlineImageLimit !== raw) {
+      warnedSandboxInlineImageLimit = raw;
+      logger.warn(`[read_file] SANDBOX_INLINE_IMAGE_MAX_BYTES=${raw} ${message}`);
+    }
+  };
+  if (!/^\d+$/.test(raw) || Number(raw) <= 0) {
+    warnOnce(
+      `is not a positive integer; using the default of ${DEFAULT_SANDBOX_INLINE_IMAGE_BYTES} bytes`,
+    );
+    return DEFAULT_SANDBOX_INLINE_IMAGE_BYTES;
+  }
+  const parsed = Number(raw);
+  if (parsed > MAX_SANDBOX_INLINE_IMAGE_BYTES_CEILING) {
+    warnOnce(`exceeds the ${MAX_SANDBOX_INLINE_IMAGE_BYTES_CEILING}-byte ceiling; clamping to it`);
+    return MAX_SANDBOX_INLINE_IMAGE_BYTES_CEILING;
+  }
+  return parsed;
+}
 const MAX_CACHE_BYTES = 512 * 1024;
 const MAX_AUTHORING_BYTES = 10 * 1024 * 1024;
 const MAX_TOOL_ERROR_MESSAGE_CHARS = 12_000;
@@ -2092,6 +2137,7 @@ async function handleSandboxImageRead(
   }
 
   const ctx = tc.codeSessionContext as SandboxSessionContext | undefined;
+  const inlineImageMaxBytes = getSandboxInlineImageMaxBytes();
   let read:
     | { base64: string; bytes: number }
     | { tooLarge: true; reason?: 'size' | 'round_trips'; bytes: number; inlineCeiling?: number }
@@ -2101,7 +2147,7 @@ async function handleSandboxImageRead(
       file_path: filePath,
       session_id: ctx?.session_id,
       files: ctx?.files,
-      maxBytes: MAX_SANDBOX_INLINE_IMAGE_BYTES,
+      maxBytes: inlineImageMaxBytes,
       ...codeExecutionRequestParams(codeExecutionContext),
       ...(req ? { req } : {}),
     });
@@ -2123,11 +2169,11 @@ async function handleSandboxImageRead(
     const ceiling =
       read.reason === 'round_trips' && read.inlineCeiling != null
         ? read.inlineCeiling
-        : MAX_SANDBOX_INLINE_IMAGE_BYTES;
+        : inlineImageMaxBytes;
     const overBudget =
       read.reason === 'round_trips'
         ? `more than this sandbox can return inline (about ${ceiling} bytes)`
-        : `over the ${MAX_SANDBOX_INLINE_IMAGE_BYTES}-byte inline limit`;
+        : `over the ${inlineImageMaxBytes}-byte inline limit`;
     return {
       toolCallId: tc.id,
       status: 'success',


### PR DESCRIPTION
## Summary

`read_file` inlines images from the code-execution sandbox for vision models only up to a fixed 1 MiB (`MAX_SANDBOX_INLINE_IMAGE_BYTES`); larger files come back as a "downscale it with `bash_tool`" hint, which costs the model another round-trip (5–10 s in our measurements) even though the image would be perfectly acceptable to the provider.

This adds `SANDBOX_INLINE_IMAGE_MAX_BYTES` so deployments whose sandbox returns larger stdout windows (a bigger `SANDBOX_OUTPUT_MAX_SIZE`) and whose model request path accepts the payload can raise the cap.

- Unset → the 1 MiB default, i.e. unchanged behavior.
- Values above 20 MiB are clamped to that ceiling (vision providers reject larger images); a value that is not a positive integer falls back to the default. Both corrections are logged once per distinct value.
- The over-limit message names the effective cap so the downscale target given to the model matches the configured limit.
- Documented in `.env.example` next to the sandbox stdout budget.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (env var reference)

## Testing

`packages/api/src/agents/handlers.spec.ts` (new `SANDBOX_INLINE_IMAGE_MAX_BYTES` block): default when unset, configured cap used for `readSandboxImage` and named in the message, invalid values (`lots`, `0`, `-5`, `1.5e6`) fall back with a warning, values above the ceiling are clamped with a warning. Full `handlers.spec.ts` passes (187 tests).

### **Test Configuration**:

`SANDBOX_INLINE_IMAGE_MAX_BYTES=5242880`, Code API behind a proxy with a 16 MiB request-body limit.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] A pull request for updating the documentation has been submitted.
