### PR TITLE
📎 feat: Single-Click Attach Mode with Configurable Default Target

### DIFF
--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -41,10 +41,10 @@ import {
 import { useSharePointFileHandlingNoChatContext } from '~/hooks/Files/useSharePointFileHandling';
 import { useShortcutAriaKey, useShortcutHint } from '~/hooks/useKeyboardShortcuts';
 import { SharePointPickerDialog } from '~/components/SharePoint';
+import { cn, resolveSingleAttachTarget } from '~/utils';
 import { useGetStartupConfig } from '~/data-provider';
 import { ephemeralAgentByConvoId } from '~/store';
 import { MenuItemProps } from '~/common';
-import { cn } from '~/utils';
 
 type FileUploadType =
   | 'image'
@@ -135,6 +135,57 @@ const AttachFileMenu = ({
     ephemeralAgent,
   );
 
+  /** Which provider upload path applies: decides the picker filter and the menu label. */
+  const providerUpload = useMemo(() => {
+    let currentProvider = provider || endpoint;
+
+    // This will be removed in a future PR to formally normalize Providers comparisons to be case insensitive
+    if (currentProvider?.toLowerCase() === Providers.OPENROUTER) {
+      currentProvider = Providers.OPENROUTER;
+    }
+
+    const isAzureWithResponsesApi =
+      (currentProvider === EModelEndpoint.azureOpenAI ||
+        endpointType === EModelEndpoint.azureOpenAI) &&
+      useResponsesApi === true;
+
+    const documentsSupported =
+      isDocumentSupportedProvider(endpointType) ||
+      isDocumentSupportedProvider(currentProvider) ||
+      isAzureWithResponsesApi;
+
+    let fileType: FileUploadType = 'image';
+    if (documentsSupported) {
+      fileType = 'image_document';
+      if (currentProvider === Providers.GOOGLE || currentProvider === Providers.OPENROUTER) {
+        fileType = 'image_document_video_audio';
+      } else if (currentProvider === Providers.BEDROCK || endpointType === EModelEndpoint.bedrock) {
+        fileType = 'image_document_extended';
+      }
+    }
+    return { documentsSupported, fileType };
+  }, [provider, endpoint, endpointType, useResponsesApi]);
+
+  /** `interface.attachFileMode: 'single'`: one click sends files to a fixed destination, no menu. */
+  const singleTarget = useMemo(
+    () =>
+      resolveSingleAttachTarget(startupConfig?.interface, {
+        codeEnabled: capabilities.codeEnabled,
+        contextEnabled: capabilities.contextEnabled,
+        fileSearchEnabled: capabilities.fileSearchEnabled,
+        codeAllowedByAgent,
+        fileSearchAllowedByAgent,
+      }),
+    [
+      startupConfig?.interface,
+      capabilities.codeEnabled,
+      capabilities.contextEnabled,
+      capabilities.fileSearchEnabled,
+      codeAllowedByAgent,
+      fileSearchAllowedByAgent,
+    ],
+  );
+
   const handleUploadClick = useCallback(
     (fileType?: FileUploadType) => {
       if (!inputRef.current) {
@@ -177,37 +228,12 @@ const AttachFileMenu = ({
     const createMenuItems = (onAction: (fileType?: FileUploadType) => void) => {
       const items: MenuItemProps[] = [];
 
-      let currentProvider = provider || endpoint;
-
-      // This will be removed in a future PR to formally normalize Providers comparisons to be case insensitive
-      if (currentProvider?.toLowerCase() === Providers.OPENROUTER) {
-        currentProvider = Providers.OPENROUTER;
-      }
-
-      const isAzureWithResponsesApi =
-        (currentProvider === EModelEndpoint.azureOpenAI ||
-          endpointType === EModelEndpoint.azureOpenAI) &&
-        useResponsesApi === true;
-
-      if (
-        isDocumentSupportedProvider(endpointType) ||
-        isDocumentSupportedProvider(currentProvider) ||
-        isAzureWithResponsesApi
-      ) {
+      if (providerUpload.documentsSupported) {
         items.push({
           label: localize('com_ui_upload_provider'),
           onClick: () => {
             setToolResource(undefined);
-            let fileType: Exclude<FileUploadType, 'image' | 'document'> = 'image_document';
-            if (currentProvider === Providers.GOOGLE || currentProvider === Providers.OPENROUTER) {
-              fileType = 'image_document_video_audio';
-            } else if (
-              currentProvider === Providers.BEDROCK ||
-              endpointType === EModelEndpoint.bedrock
-            ) {
-              fileType = 'image_document_extended';
-            }
-            onAction(fileType);
+            onAction(providerUpload.fileType);
           },
           icon: <FileImageIcon className="icon-md" />,
         });
@@ -216,7 +242,7 @@ const AttachFileMenu = ({
           label: localize('com_ui_upload_image_input'),
           onClick: () => {
             setToolResource(undefined);
-            onAction('image');
+            onAction(providerUpload.fileType);
           },
           icon: <ImageUpIcon className="icon-md" />,
         });
@@ -285,11 +311,8 @@ const AttachFileMenu = ({
     return localItems;
   }, [
     localize,
-    endpoint,
-    provider,
-    endpointType,
     capabilities,
-    useResponsesApi,
+    providerUpload,
     handleUploadClick,
     setEphemeralAgent,
     sharePointEnabled,
@@ -297,6 +320,48 @@ const AttachFileMenu = ({
     fileSearchAllowedByAgent,
     setIsSharePointDialogOpen,
   ]);
+
+  const handleSingleAttach = useCallback(() => {
+    if (singleTarget == null) {
+      return;
+    }
+    const { target } = singleTarget;
+    toolResourceRef.current = target;
+    if (target === EToolResources.execute_code || target === EToolResources.file_search) {
+      setEphemeralAgent((prev) => ({
+        ...prev,
+        [target]: true,
+      }));
+    }
+    handleUploadClick(target === undefined ? providerUpload.fileType : undefined);
+  }, [singleTarget, providerUpload.fileType, handleUploadClick, setEphemeralAgent]);
+
+  const triggerClassName =
+    'flex size-theme-control items-center justify-center rounded-theme-control-round p-1 transition-colors duration-theme-fast hover:bg-surface-composer-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-primary focus-visible:ring-opacity-50';
+
+  /** Single-click mode: a plain button that opens the file picker for the configured destination. */
+  const singleTrigger = (
+    <TooltipAnchor
+      render={
+        <button
+          type="button"
+          disabled={isUploadDisabled}
+          id="attach-file-menu-button"
+          aria-label={localize('com_sidepanel_attach_files')}
+          aria-keyshortcuts={uploadFileAriaKey}
+          onClick={handleSingleAttach}
+          className={triggerClassName}
+        >
+          <div className="flex w-full items-center justify-center gap-2">
+            <AttachmentIcon />
+          </div>
+        </button>
+      }
+      id="attach-file-menu-button"
+      description={uploadFileTooltip}
+      disabled={isUploadDisabled}
+    />
+  );
 
   const menuTrigger = (
     <TooltipAnchor
@@ -306,10 +371,7 @@ const AttachFileMenu = ({
           id="attach-file-menu-button"
           aria-label="Attach File Options"
           aria-keyshortcuts={uploadFileAriaKey}
-          className={cn(
-            'flex size-theme-control items-center justify-center rounded-theme-control-round p-1 transition-colors duration-theme-fast hover:bg-surface-composer-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-primary focus-visible:ring-opacity-50',
-            isPopoverActive && 'bg-surface-composer-hover',
-          )}
+          className={cn(triggerClassName, isPopoverActive && 'bg-surface-composer-hover')}
         >
           <div className="flex w-full items-center justify-center gap-2">
             <AttachmentIcon />
@@ -339,18 +401,22 @@ const AttachFileMenu = ({
           toolResourceRef.current = undefined;
         }}
       >
-        <DropdownPopup
-          menuId="attach-file-menu"
-          className="overflow-visible"
-          isOpen={isPopoverActive}
-          setIsOpen={setIsPopoverActive}
-          modal={false}
-          portal={true}
-          unmountOnHide={true}
-          trigger={menuTrigger}
-          items={dropdownItems}
-          iconClassName="mr-0"
-        />
+        {singleTarget != null ? (
+          singleTrigger
+        ) : (
+          <DropdownPopup
+            menuId="attach-file-menu"
+            className="overflow-visible"
+            isOpen={isPopoverActive}
+            setIsOpen={setIsPopoverActive}
+            modal={false}
+            portal={true}
+            unmountOnHide={true}
+            trigger={menuTrigger}
+            items={dropdownItems}
+            iconClassName="mr-0"
+          />
+        )}
       </FileUpload>
       <SharePointPickerDialog
         isOpen={isSharePointDialogOpen}

--- a/client/src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx
@@ -399,6 +399,117 @@ describe('AttachFileMenu', () => {
     });
   });
 
+  describe('single-click attach mode (interface.attachFileMode: single)', () => {
+    /** Captures the picker's accept filter and fires a change so the resource ref is observed. */
+    function stubPicker(file: File, onClick?: (accept: string) => void) {
+      const originalClick = HTMLInputElement.prototype.click;
+      HTMLInputElement.prototype.click = function click() {
+        onClick?.(this.accept);
+        Object.defineProperty(this, 'files', { configurable: true, value: [file] });
+        fireEvent.change(this);
+      };
+      return () => {
+        HTMLInputElement.prototype.click = originalClick;
+      };
+    }
+
+    function setupSingle(
+      interfaceConfig: Record<string, unknown>,
+      permissions: { codeAllowedByAgent?: boolean; fileSearchAllowedByAgent?: boolean } = {},
+    ) {
+      setupMocks();
+      mockUseGetStartupConfig.mockReturnValue({
+        data: { sharePointFilePickerEnabled: false, interface: interfaceConfig },
+      });
+      mockUseAgentCapabilities.mockReturnValue({
+        contextEnabled: true,
+        fileSearchEnabled: true,
+        codeEnabled: true,
+      });
+      mockUseAgentToolPermissions.mockReturnValue({
+        fileSearchAllowedByAgent: permissions.fileSearchAllowedByAgent ?? true,
+        codeAllowedByAgent: permissions.codeAllowedByAgent ?? true,
+        provider: undefined,
+      });
+    }
+
+    it('opens the picker for the code environment with one click and no menu', () => {
+      setupSingle({ attachFileMode: 'single' });
+      const handleFileChange = jest.fn();
+      mockUseFileHandlingNoChatContext.mockReturnValue({ handleFileChange });
+      const clicks: string[] = [];
+      const restore = stubPicker(new File(['data'], 'data.csv', { type: 'text/csv' }), (accept) =>
+        clicks.push(accept),
+      );
+
+      try {
+        renderMenu({ endpointType: EModelEndpoint.agents });
+        expect(screen.queryByRole('button', { name: /attach file options/i })).toBeNull();
+        expect(screen.queryByTestId('dropdown-popup')).toBeNull();
+        fireEvent.click(screen.getByRole('button', { name: 'Attach Files' }));
+      } finally {
+        restore();
+      }
+
+      expect(clicks).toEqual(['']);
+      expect(screen.queryByTestId('dropdown-menu')).toBeNull();
+      expect(handleFileChange).toHaveBeenCalledTimes(1);
+      expect(handleFileChange).toHaveBeenCalledWith(
+        expect.any(Object),
+        EToolResources.execute_code,
+      );
+    });
+
+    it('sends files to the provider path with its picker filter when that is the target', () => {
+      setupSingle({ attachFileMode: 'single', attachFileDefaultTarget: 'provider' });
+      const handleFileChange = jest.fn();
+      mockUseFileHandlingNoChatContext.mockReturnValue({ handleFileChange });
+      const clicks: string[] = [];
+      const restore = stubPicker(new File(['img'], 'cat.png', { type: 'image/png' }), (accept) =>
+        clicks.push(accept),
+      );
+
+      try {
+        renderMenu({ endpointType: EModelEndpoint.agents });
+        fireEvent.click(screen.getByRole('button', { name: 'Attach Files' }));
+      } finally {
+        restore();
+      }
+
+      /** Agents without a resolved provider only take images, like the "Upload Image" entry. */
+      expect(clicks).toEqual(['image/*,.heif,.heic']);
+      expect(handleFileChange).toHaveBeenCalledWith(expect.any(Object), undefined);
+    });
+
+    it('falls back to the menu when the target is not available to the agent', () => {
+      setupSingle({ attachFileMode: 'single' }, { codeAllowedByAgent: false });
+
+      renderMenu({ endpointType: EModelEndpoint.openAI });
+
+      expect(screen.queryByRole('button', { name: 'Attach Files' })).toBeNull();
+      openMenu();
+      expect(screen.getByText('Upload to Provider')).toBeInTheDocument();
+      expect(screen.queryByText('Upload to Code Environment')).not.toBeInTheDocument();
+    });
+
+    it('keeps the menu in the default mode even when a target is configured', () => {
+      setupSingle({ attachFileDefaultTarget: 'execute_code' });
+
+      renderMenu({ endpointType: EModelEndpoint.openAI });
+
+      openMenu();
+      expect(screen.getByText('Upload to Code Environment')).toBeInTheDocument();
+    });
+
+    it('respects the disabled prop in single-click mode', () => {
+      setupSingle({ attachFileMode: 'single' });
+
+      renderMenu({ disabled: true, endpointType: EModelEndpoint.agents });
+
+      expect(screen.getByRole('button', { name: 'Attach Files' })).toBeDisabled();
+    });
+  });
+
   describe('SharePoint Integration', () => {
     it('shows SharePoint option when enabled', () => {
       setupMocks();

--- a/client/src/hooks/Files/useDragHelpers.ts
+++ b/client/src/hooks/Files/useDragHelpers.ts
@@ -29,19 +29,21 @@ export default function useDragHelpers() {
     [conversation?.endpoint],
   );
 
-  const { getOptions } = useUploadOptions();
+  const { getOptions, singleTarget } = useUploadOptions();
   const routeFiles = useFileUploadRouter();
   const { openModal } = useUploadModalContext();
 
   /** Use refs to avoid re-creating the drop handler */
   const conversationRef = useRef(conversation);
   const getOptionsRef = useRef(getOptions);
+  const singleTargetRef = useRef(singleTarget);
   const routeFilesRef = useRef(routeFiles);
   const openModalRef = useRef(openModal);
   const isAssistantsRef = useRef(isAssistants);
 
   conversationRef.current = conversation;
   getOptionsRef.current = getOptions;
+  singleTargetRef.current = singleTarget;
   routeFilesRef.current = routeFiles;
   openModalRef.current = openModal;
   isAssistantsRef.current = isAssistants;
@@ -82,6 +84,13 @@ export default function useDragHelpers() {
       const options = getOptionsRef.current(item.files);
       if (options.length === 0) {
         showToast({ message: localize('com_error_files_unsupported'), status: 'error' });
+        return;
+      }
+      /** Single-click attach mode: the configured destination takes the drop without a chooser,
+       * as long as these files can go there. */
+      const singleTarget = singleTargetRef.current;
+      if (singleTarget != null && options.includes(singleTarget.target)) {
+        routeFilesRef.current(item.files, singleTarget.target);
         return;
       }
       if (options.length === 1) {

--- a/client/src/hooks/Files/useUploadOptions.ts
+++ b/client/src/hooks/Files/useUploadOptions.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
 import {
   Tools,
@@ -9,11 +9,11 @@ import {
 } from 'librechat-data-provider';
 import type { EToolResources } from 'librechat-data-provider';
 import useAgentToolPermissions from '~/hooks/Agents/useAgentToolPermissions';
+import { getViableUploadOptions, resolveSingleAttachTarget } from '~/utils';
+import { useGetFileConfig, useGetStartupConfig } from '~/data-provider';
 import useAgentCapabilities from '~/hooks/Agents/useAgentCapabilities';
 import useGetAgentsConfig from '~/hooks/Agents/useGetAgentsConfig';
-import { useGetFileConfig } from '~/data-provider';
 import { ephemeralAgentByConvoId } from '~/store';
-import { getViableUploadOptions } from '~/utils';
 import { useDragDropContext } from '~/Providers';
 import { isEphemeralAgent } from '~/common';
 
@@ -30,6 +30,7 @@ export default function useUploadOptions() {
     ephemeralAgentByConvoId(conversationId ?? Constants.NEW_CONVO),
   );
   const { provider, tools } = useAgentToolPermissions(agentId, ephemeralAgent);
+  const { data: startupConfig } = useGetStartupConfig();
   const {
     data: fileConfig = null,
     isError: isFileConfigError,
@@ -48,6 +49,27 @@ export default function useUploadOptions() {
   const isSavedAgent = agentId != null && agentId !== '' && !isEphemeralAgent(agentId);
   const fileSearchAllowedByAgent = !isSavedAgent || (tools?.includes(Tools.file_search) ?? false);
   const codeAllowedByAgent = !isSavedAgent || (tools?.includes(Tools.execute_code) ?? false);
+
+  /** `interface.attachFileMode: 'single'` routes drops and pastes to one destination without asking. */
+  const interfaceConfig = startupConfig?.interface;
+  const singleTarget = useMemo(
+    () =>
+      resolveSingleAttachTarget(interfaceConfig, {
+        fileSearchEnabled: capabilities.fileSearchEnabled,
+        codeEnabled: capabilities.codeEnabled,
+        contextEnabled: capabilities.contextEnabled,
+        fileSearchAllowedByAgent,
+        codeAllowedByAgent,
+      }),
+    [
+      interfaceConfig,
+      capabilities.fileSearchEnabled,
+      capabilities.codeEnabled,
+      capabilities.contextEnabled,
+      fileSearchAllowedByAgent,
+      codeAllowedByAgent,
+    ],
+  );
 
   const endpointFileConfig = getEndpointFileConfig({ fileConfig, endpoint, endpointType });
   const uploadsDisabled = endpointFileConfig.disabled === true;
@@ -83,5 +105,5 @@ export default function useUploadOptions() {
     ],
   );
 
-  return { getOptions, uploadsDisabled, isConfigPending };
+  return { getOptions, uploadsDisabled, isConfigPending, singleTarget };
 }

--- a/client/src/hooks/Input/useTextarea.spec.tsx
+++ b/client/src/hooks/Input/useTextarea.spec.tsx
@@ -14,7 +14,9 @@ const mockForceResize = jest.fn();
 const mockInsertTextAtCursor = jest.fn();
 const mockResolvePastedTextFile = jest.fn();
 const mockRouteFiles = jest.fn();
-const mockGetUploadOptions = jest.fn(() => [EToolResources.context]);
+const mockGetUploadOptions = jest.fn((): (EToolResources | undefined)[] => [
+  EToolResources.context,
+]);
 const mockSetFilesLoading = jest.fn();
 const mockShowToast = jest.fn();
 const mockOpenModal = jest.fn();
@@ -29,6 +31,7 @@ let useTextarea: typeof import('./useTextarea').default;
 let mockIndex = 0;
 let mockIsSubmitting = false;
 let mockIsUploadConfigPending = false;
+let mockSingleTarget: { target: EToolResources | undefined } | null = null;
 let mockConversation: { endpoint: string; conversationId?: string } = {
   endpoint: 'openAI',
   conversationId: 'convo-1',
@@ -102,6 +105,7 @@ jest.mock('~/hooks/Files/useUploadOptions', () => ({
     getOptions: mockGetUploadOptions,
     uploadsDisabled: false,
     isConfigPending: mockIsUploadConfigPending,
+    singleTarget: mockSingleTarget,
   })),
 }));
 
@@ -178,6 +182,7 @@ describe('useTextarea long-paste fallback', () => {
     mockIndex = 0;
     mockIsSubmitting = false;
     mockIsUploadConfigPending = false;
+    mockSingleTarget = null;
     mockConversation = { endpoint: 'openAI', conversationId: 'convo-1' };
     mockGetUploadOptions.mockReturnValue([EToolResources.context]);
     mockSetValue.mockReset();
@@ -860,6 +865,40 @@ describe('useTextarea long-paste fallback', () => {
     expect(consoleError).toHaveBeenCalledWith('clipboard file routing error', error);
     expect(mockInsertTextAtCursor).not.toHaveBeenCalled();
     consoleError.mockRestore();
+  });
+
+  it('routes pasted files to the single attach target instead of opening the chooser', async () => {
+    mockSingleTarget = { target: EToolResources.execute_code };
+    mockGetUploadOptions.mockReturnValue([undefined, EToolResources.execute_code]);
+    mockRouteFiles.mockResolvedValueOnce(true);
+    const { result } = renderTextareaHook();
+    const event = createPasteEvent([new File(['x'], 'data.csv', { type: 'text/csv' })]);
+
+    act(() =>
+      result.current.handlePaste(event as unknown as React.ClipboardEvent<HTMLTextAreaElement>),
+    );
+
+    await waitFor(() => expect(mockRouteFiles).toHaveBeenCalled());
+    expect(mockRouteFiles).toHaveBeenCalledWith(
+      expect.any(Array),
+      EToolResources.execute_code,
+      undefined,
+    );
+    expect(mockOpenModal).not.toHaveBeenCalled();
+  });
+
+  it('opens the chooser for pasted files the single attach target cannot take', async () => {
+    mockSingleTarget = { target: EToolResources.execute_code };
+    mockGetUploadOptions.mockReturnValue([undefined, EToolResources.context]);
+    const { result } = renderTextareaHook();
+    const event = createPasteEvent([new File(['x'], 'photo.png', { type: 'image/png' })]);
+
+    act(() =>
+      result.current.handlePaste(event as unknown as React.ClipboardEvent<HTMLTextAreaElement>),
+    );
+
+    await waitFor(() => expect(mockOpenModal).toHaveBeenCalled());
+    expect(mockRouteFiles).not.toHaveBeenCalled();
   });
 
   it('routes a paste to context while the file config is still pending', async () => {

--- a/client/src/hooks/Input/useTextarea.ts
+++ b/client/src/hooks/Input/useTextarea.ts
@@ -75,6 +75,7 @@ export default function useTextarea({
     getOptions: getUploadOptions,
     uploadsDisabled,
     isConfigPending: isUploadConfigPending,
+    singleTarget: singleAttachTarget,
   } = useUploadOptions();
   const routeFiles = useFileUploadRouter();
   const { openModal } = useUploadModalContext();
@@ -350,13 +351,25 @@ export default function useTextarea({
         }
 
         const usePreferred = preferred != null && options.includes(preferred);
-        if (!usePreferred && options.length > 1) {
+        /** Single-click attach mode: a caller's explicit destination still wins, otherwise the
+         * configured target takes the paste without a chooser when these files can go there. */
+        const useSingleTarget =
+          !usePreferred &&
+          singleAttachTarget != null &&
+          options.includes(singleAttachTarget.target);
+        if (!usePreferred && !useSingleTarget && options.length > 1) {
           setFilesLoading(false);
           openModal(clipboardFiles);
           return false;
         }
 
-        return await upload(usePreferred ? preferred : options[0]);
+        let destination = options[0];
+        if (usePreferred) {
+          destination = preferred;
+        } else if (useSingleTarget) {
+          destination = singleAttachTarget.target;
+        }
+        return await upload(destination);
       } catch (error) {
         console.error('clipboard file routing error', error);
         setFilesLoading(false);
@@ -372,6 +385,7 @@ export default function useTextarea({
       setFilesLoading,
       getUploadOptions,
       isUploadConfigPending,
+      singleAttachTarget,
     ],
   );
 

--- a/client/src/utils/__tests__/resolveSingleAttachTarget.spec.ts
+++ b/client/src/utils/__tests__/resolveSingleAttachTarget.spec.ts
@@ -1,0 +1,69 @@
+import { EToolResources } from 'librechat-data-provider';
+import { resolveSingleAttachTarget, type AttachTargetContext } from '../files';
+
+const ctx = (over: Partial<AttachTargetContext> = {}): AttachTargetContext => ({
+  fileSearchEnabled: true,
+  codeEnabled: true,
+  contextEnabled: true,
+  fileSearchAllowedByAgent: true,
+  codeAllowedByAgent: true,
+  ...over,
+});
+
+describe('resolveSingleAttachTarget', () => {
+  it('keeps the menu when the mode is unset or "menu"', () => {
+    expect(resolveSingleAttachTarget(undefined, ctx())).toBeNull();
+    expect(resolveSingleAttachTarget({}, ctx())).toBeNull();
+    expect(resolveSingleAttachTarget({ attachFileMode: 'menu' }, ctx())).toBeNull();
+    expect(
+      resolveSingleAttachTarget(
+        { attachFileMode: 'menu', attachFileDefaultTarget: 'execute_code' },
+        ctx(),
+      ),
+    ).toBeNull();
+  });
+
+  it('defaults the single target to the code environment', () => {
+    expect(resolveSingleAttachTarget({ attachFileMode: 'single' }, ctx())).toEqual({
+      target: EToolResources.execute_code,
+    });
+  });
+
+  it('falls back to the menu when the code environment is not available to the agent', () => {
+    expect(
+      resolveSingleAttachTarget({ attachFileMode: 'single' }, ctx({ codeEnabled: false })),
+    ).toBeNull();
+    expect(
+      resolveSingleAttachTarget({ attachFileMode: 'single' }, ctx({ codeAllowedByAgent: false })),
+    ).toBeNull();
+  });
+
+  it('maps the provider target to the undefined tool resource', () => {
+    expect(
+      resolveSingleAttachTarget(
+        { attachFileMode: 'single', attachFileDefaultTarget: 'provider' },
+        ctx({ codeEnabled: false, contextEnabled: false, fileSearchEnabled: false }),
+      ),
+    ).toEqual({ target: undefined });
+  });
+
+  it('honors the context and file search targets only when they are available', () => {
+    const single = (attachFileDefaultTarget: 'context' | 'file_search') => ({
+      attachFileMode: 'single' as const,
+      attachFileDefaultTarget,
+    });
+    expect(resolveSingleAttachTarget(single('context'), ctx())).toEqual({
+      target: EToolResources.context,
+    });
+    expect(resolveSingleAttachTarget(single('context'), ctx({ contextEnabled: false }))).toBeNull();
+    expect(resolveSingleAttachTarget(single('file_search'), ctx())).toEqual({
+      target: EToolResources.file_search,
+    });
+    expect(
+      resolveSingleAttachTarget(single('file_search'), ctx({ fileSearchAllowedByAgent: false })),
+    ).toBeNull();
+    expect(
+      resolveSingleAttachTarget(single('file_search'), ctx({ fileSearchEnabled: false })),
+    ).toBeNull();
+  });
+});

--- a/client/src/utils/files.ts
+++ b/client/src/utils/files.ts
@@ -28,6 +28,7 @@ import type {
   FileConfig,
   FileSources,
   RegexLike,
+  TInterfaceConfig,
 } from 'librechat-data-provider';
 import type { QueryClient } from '@tanstack/react-query';
 import type { ExtendedFile } from '~/common';
@@ -592,6 +593,49 @@ export const getViableUploadOptions = (
     options.push(EToolResources.context);
   }
   return options;
+};
+
+export type AttachTargetContext = Pick<
+  UploadOptionContext,
+  | 'fileSearchEnabled'
+  | 'codeEnabled'
+  | 'contextEnabled'
+  | 'fileSearchAllowedByAgent'
+  | 'codeAllowedByAgent'
+>;
+
+/** The one destination `attachFileMode: 'single'` sends files to; `undefined` is the provider. */
+export type SingleAttachTarget = { target: EToolResources | undefined };
+
+/**
+ * Resolves the fixed upload destination for `interface.attachFileMode: 'single'`, or `null` when
+ * the attach button should keep offering the menu: the mode is not `single`, or the configured
+ * `attachFileDefaultTarget` (default `execute_code`) is not available to the current agent —
+ * the capability is off, or a saved agent does not carry the tool. `provider` maps to the
+ * `undefined` tool resource the provider upload path uses.
+ */
+export const resolveSingleAttachTarget = (
+  interfaceConfig: Pick<TInterfaceConfig, 'attachFileMode' | 'attachFileDefaultTarget'> | undefined,
+  ctx: AttachTargetContext,
+): SingleAttachTarget | null => {
+  if (interfaceConfig?.attachFileMode !== 'single') {
+    return null;
+  }
+  switch (interfaceConfig.attachFileDefaultTarget ?? 'execute_code') {
+    case 'provider':
+      return { target: undefined };
+    case 'context':
+      return ctx.contextEnabled ? { target: EToolResources.context } : null;
+    case 'file_search':
+      return ctx.fileSearchEnabled && ctx.fileSearchAllowedByAgent
+        ? { target: EToolResources.file_search }
+        : null;
+    case 'execute_code':
+    default:
+      return ctx.codeEnabled && ctx.codeAllowedByAgent
+        ? { target: EToolResources.execute_code }
+        : null;
+  }
 };
 
 /**

--- a/packages/data-provider/specs/config-schemas.spec.ts
+++ b/packages/data-provider/specs/config-schemas.spec.ts
@@ -1432,6 +1432,30 @@ describe('interfaceSchema', () => {
 
     expect(result.defaultPinnedTools).toBeUndefined();
   });
+
+  it('accepts the single-click attach mode with a target', () => {
+    const result = interfaceSchema.parse({
+      attachFileMode: 'single',
+      attachFileDefaultTarget: 'execute_code',
+    });
+
+    expect(result.attachFileMode).toBe('single');
+    expect(result.attachFileDefaultTarget).toBe('execute_code');
+  });
+
+  it('leaves the attach mode and target undefined when not provided (menu behavior)', () => {
+    const result = interfaceSchema.parse({ modelSelect: true });
+
+    expect(result.attachFileMode).toBeUndefined();
+    expect(result.attachFileDefaultTarget).toBeUndefined();
+  });
+
+  it.each([[{ attachFileMode: 'popup' }], [{ attachFileDefaultTarget: 'artifacts' }]])(
+    'rejects unknown attach mode or target %j',
+    (value) => {
+      expect(interfaceSchema.safeParse(value).success).toBe(false);
+    },
+  );
 });
 
 describe('summarizationTriggerSchema', () => {

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1855,6 +1855,16 @@ export const interfaceSchema = z
     fileCitations: z.boolean().optional(),
     /** Tool keys (and `'mcp'` or an MCP server name) pinned to the prompt bar by default */
     defaultPinnedTools: z.array(z.string()).optional(),
+    /** How the composer's attach-file button behaves. `menu` (default) opens a dropdown of every
+     *  upload destination; `single` skips it and sends files straight to `attachFileDefaultTarget`
+     *  with one click. Drag-and-drop and paste follow the same target. Falls back to the menu when
+     *  that target is not available for the current agent. */
+    attachFileMode: z.enum(['menu', 'single']).optional(),
+    /** Upload destination for `attachFileMode: 'single'` (default `execute_code`). `provider` hands
+     *  the file to the model provider directly, like the "Upload to Provider" menu entry. */
+    attachFileDefaultTarget: z
+      .enum(['execute_code', 'provider', 'context', 'file_search'])
+      .optional(),
     buildInfo: z.boolean().optional(),
     remoteAgents: z
       .object({
@@ -1980,6 +1990,8 @@ export const interfaceSchema = z
   });
 
 export type TInterfaceConfig = z.infer<typeof interfaceSchema>;
+export type TAttachFileMode = NonNullable<TInterfaceConfig['attachFileMode']>;
+export type TAttachFileTarget = NonNullable<TInterfaceConfig['attachFileDefaultTarget']>;
 export type TBalanceConfig = z.infer<typeof balanceSchema>;
 export type TTransactionsConfig = z.infer<typeof transactionsSchema>;
 

--- a/packages/data-schemas/src/app/interface.spec.ts
+++ b/packages/data-schemas/src/app/interface.spec.ts
@@ -224,6 +224,33 @@ describe('loadDefaultInterface', () => {
     expect(interfaceConfig?.defaultPinnedTools).toEqual(['artifacts', 'execute_code', 'mcp']);
   });
 
+  it('passes through the configured attach-file mode and target', async () => {
+    const config: Partial<TCustomConfig> = {
+      interface: {
+        attachFileMode: 'single',
+        attachFileDefaultTarget: 'provider',
+      },
+    };
+
+    const interfaceConfig = await loadDefaultInterface({
+      config,
+      configDefaults: getConfigDefaults(),
+    });
+
+    expect(interfaceConfig?.attachFileMode).toBe('single');
+    expect(interfaceConfig?.attachFileDefaultTarget).toBe('provider');
+  });
+
+  it('omits the attach-file mode and target when not explicitly configured', async () => {
+    const interfaceConfig = await loadDefaultInterface({
+      config: {},
+      configDefaults: getConfigDefaults(),
+    });
+
+    expect(interfaceConfig).not.toHaveProperty('attachFileMode');
+    expect(interfaceConfig).not.toHaveProperty('attachFileDefaultTarget');
+  });
+
   it('omits default pinned tools when not explicitly configured', async () => {
     const interfaceConfig = await loadDefaultInterface({
       config: {},

--- a/packages/data-schemas/src/app/interface.ts
+++ b/packages/data-schemas/src/app/interface.ts
@@ -60,6 +60,8 @@ export async function loadDefaultInterface({
     fileSearch: interfaceConfig?.fileSearch,
     fileCitations: interfaceConfig?.fileCitations,
     defaultPinnedTools: interfaceConfig?.defaultPinnedTools,
+    attachFileMode: interfaceConfig?.attachFileMode,
+    attachFileDefaultTarget: interfaceConfig?.attachFileDefaultTarget,
     peoplePicker: interfaceConfig?.peoplePicker,
     marketplace: interfaceConfig?.marketplace,
     remoteAgents: interfaceConfig?.remoteAgents,


### PR DESCRIPTION
## Summary

Adds an opt-in `interface.attachFileMode: single` (default `menu`) with `interface.attachFileDefaultTarget` (`execute_code` default, or `provider` | `context` | `file_search`).

In `single` mode the composer's paperclip opens the file picker in one click and sends the files to the configured destination — no dropdown. Drag-and-drop and paste route to the same destination without the chooser whenever the dropped files can go there. If the target is not available to the current agent (capability off, or a saved agent without the tool), the button falls back to the regular menu, so nothing is lost. `menu` mode is byte-for-byte the current behavior.

Motivation: deployments that want every upload (images included) to land in one place — e.g. the Code Interpreter, whose files the model can view with `read_file` — currently ask users to pick between "Upload to Provider" and "Upload to Code Interpreter" on every attachment, which confuses non-technical users.

```yaml
interface:
  attachFileMode: single
  attachFileDefaultTarget: execute_code
```

- `librechat-data-provider`: schema keys + `TAttachFileMode` / `TAttachFileTarget`.
- `@librechat/data-schemas`: both keys pass through `loadDefaultInterface`.
- client: `resolveSingleAttachTarget` shared by `AttachFileMenu` and `useUploadOptions` (drop/paste); the provider picker filter is factored out of the menu items so both paths use the same accept list. The single-mode button keeps `#attach-file-menu-button`, so the upload keyboard shortcut still works. Note: the SharePoint picker is a menu entry, so it is only reachable in `menu` mode.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (`interface` config reference)

## Testing

- `packages/data-provider/specs/config-schemas.spec.ts`: accepts/rejects the new keys, undefined by default.
- `packages/data-schemas/src/app/interface.spec.ts`: pass-through / omission.
- `client/src/utils/__tests__/resolveSingleAttachTarget.spec.ts`: mode/target resolution and fallbacks.
- `client/src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx`: one click → picker with the code-environment resource, provider target with its accept filter, fallback to menu, default mode unchanged, disabled state.
- `client/src/hooks/Input/useTextarea.spec.tsx`: pasted files go to the single target; the chooser still opens when they cannot.
- Existing `DragDropModal.spec.tsx`, `ChatForm.attachments.spec.tsx`, `getViableUploadOptions.spec.ts` pass; `tsc --noEmit` clean.

### **Test Configuration**:

`interface.attachFileMode: single`, `attachFileDefaultTarget: execute_code`, agents endpoint with `execute_code` enabled.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] A pull request for updating the documentation has been submitted.
