### PR TITLE
✨ feat: Admin-Configurable Default Defer Loading for MCP Tools

### DIFF
--- a/client/src/components/SidePanel/Agents/Tools/ItemDialog/sections/McpSection.tsx
+++ b/client/src/components/SidePanel/Agents/Tools/ItemDialog/sections/McpSection.tsx
@@ -23,6 +23,7 @@ import {
 } from '~/hooks';
 import { matchesMcpServer, mcpAllToken, mcpServerToken } from '../../items/selectors';
 import { getStatusColor, getStatusTextKey } from '~/components/MCP/mcpServerUtils';
+import { withDefaultDeferredTools } from '~/hooks/Agents/useMCPToolOptions';
 import MCPServerStatusIcon from '~/components/MCP/MCPServerStatusIcon';
 import MCPConfigDialog from '~/components/MCP/MCPConfigDialog';
 import McpOAuthDialog from '~/components/MCP/McpOAuthDialog';
@@ -83,10 +84,11 @@ export default function McpSection({ item }: Props) {
   const {
     codeEnabled,
     deferredToolsEnabled,
+    defaultDeferLoadingEnabled,
     programmaticToolsEnabled,
     backgroundToolsEnabled,
     toolIntentsEnabled,
-  } = useAgentCapabilities(agentsConfig?.capabilities);
+  } = useAgentCapabilities(agentsConfig?.capabilities, agentsConfig?.defaultDeferLoading);
   const codeInterpreterSelected = useWatch({ control, name: AgentCapabilities.execute_code });
   const programmaticToolsAvailable =
     codeEnabled && programmaticToolsEnabled && codeInterpreterSelected === true;
@@ -391,7 +393,15 @@ export default function McpSection({ item }: Props) {
       return;
     }
     setAutoSelectPending(false);
-    updateFormTools(tools.map((t) => t.tool_id));
+    const toolIds = tools.map((t) => t.tool_id);
+    updateFormTools(toolIds);
+    /** Auto-selected MCP tools inherit the admin Defer Loading default; tools
+     * with an existing `tool_options` entry keep their prior choice. */
+    if (defaultDeferLoadingEnabled) {
+      setValue('tool_options', withDefaultDeferredTools(getValues('tool_options') ?? {}, toolIds), {
+        shouldDirty: true,
+      });
+    }
   }, [
     autoSelectPending,
     initConnectionDeferred,
@@ -401,6 +411,9 @@ export default function McpSection({ item }: Props) {
     updateFormTools,
     toggleRuntimeTools,
     isWildcardAttached,
+    defaultDeferLoadingEnabled,
+    getValues,
+    setValue,
   ]);
 
   /** Connect inline from this first dialog. Servers with custom user variables are

--- a/client/src/components/SidePanel/Agents/Tools/ToolsMarketplaceDialog.tsx
+++ b/client/src/components/SidePanel/Agents/Tools/ToolsMarketplaceDialog.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useCallback } from 'react';
 import { Search } from 'lucide-react';
 import { useFormContext } from 'react-hook-form';
-import { AgentCapabilities, removeCodeExecutionCaller } from 'librechat-data-provider';
+import { Constants, AgentCapabilities, removeCodeExecutionCaller } from 'librechat-data-provider';
 import {
   Input,
   OGDialog,
@@ -20,11 +20,12 @@ import {
   matchesMcpServer,
   mcpServerIds,
 } from './items/selectors';
+import { useLocalize, useToolFavorites, useAgentCapabilities, useGetAgentsConfig } from '~/hooks';
 import { useAgentFileEntries, useAgentItems, useUninstallToolCredentials } from './hooks';
+import { withDefaultDeferredTools } from '~/hooks/Agents/useMCPToolOptions';
 import { requiresFileManagerRemoval } from './items/capabilities';
 import AddMcpServerDialog from './ItemDialog/AddMcpServerDialog';
 import { computeToggleAction } from './items/mutations';
-import { useLocalize, useToolFavorites } from '~/hooks';
 import MarketplaceSidebar from './MarketplaceSidebar';
 import MarketplaceCatalog from './MarketplaceCatalog';
 import ItemDialog from './ItemDialog/ItemDialog';
@@ -55,6 +56,12 @@ export default function ToolsMarketplaceDialog({
   const { catalog, selected: selectedItems } = useAgentItems({ agentId });
 
   const { favoriteKeys, toggle: toggleFavorite } = useToolFavorites();
+
+  const { agentsConfig } = useGetAgentsConfig();
+  const { defaultDeferLoadingEnabled } = useAgentCapabilities(
+    agentsConfig?.capabilities,
+    agentsConfig?.defaultDeferLoading,
+  );
 
   const [view, setView] = useState<View>('marketplace');
   const [kind, setKind] = useState<Kind>('all');
@@ -111,6 +118,20 @@ export default function ToolsMarketplaceDialog({
     [catalog, search, kind, view, favoriteKeys],
   );
 
+  /** Applies the admin-configured Defer Loading default to freshly added MCP
+   * tools; tools with an existing `tool_options` entry are never rewritten. */
+  const applyDeferLoadingDefault = useCallback(
+    (toolIds: string[]) => {
+      if (!defaultDeferLoadingEnabled || toolIds.length === 0) {
+        return;
+      }
+      setValue('tool_options', withDefaultDeferredTools(getValues('tool_options') ?? {}, toolIds), {
+        shouldDirty: true,
+      });
+    },
+    [defaultDeferLoadingEnabled, getValues, setValue],
+  );
+
   const handleToggle = useCallback(
     (item: AgentItem) => {
       const selected = selectedIds.has(itemKey(item));
@@ -134,6 +155,9 @@ export default function ToolsMarketplaceDialog({
         case 'tool-add': {
           const current = (getValues('tools') ?? []) as string[];
           setValue('tools', Array.from(new Set([...current, patch.id])), { shouldDirty: true });
+          if (patch.id.includes(Constants.mcp_delimiter)) {
+            applyDeferLoadingDefault([patch.id]);
+          }
           break;
         }
         case 'tool-remove': {
@@ -157,6 +181,11 @@ export default function ToolsMarketplaceDialog({
             Array.from(new Set([...current, mcpServerToken(item.id), ...toolIds])),
             { shouldDirty: true },
           );
+          /** Request-scoped servers attach via the `mcp_all` wildcard, which is
+           * not a concrete tool and carries no per-tool options. */
+          if (item.server.requestScoped !== true) {
+            applyDeferLoadingDefault(toolIds);
+          }
           break;
         }
         case 'mcp-remove': {
@@ -175,7 +204,15 @@ export default function ToolsMarketplaceDialog({
           break;
       }
     },
-    [getValues, setValue, selectedIds, uninstallToolCredentials, catalog, fileCounts],
+    [
+      getValues,
+      setValue,
+      selectedIds,
+      uninstallToolCredentials,
+      catalog,
+      fileCounts,
+      applyDeferLoadingDefault,
+    ],
   );
 
   const handleCardClick = useCallback(

--- a/client/src/hooks/Agents/useAgentCapabilities.ts
+++ b/client/src/hooks/Agents/useAgentCapabilities.ts
@@ -13,6 +13,7 @@ interface AgentCapabilitiesResult {
   skillsEnabled: boolean;
   memoryEnabled: boolean;
   deferredToolsEnabled: boolean;
+  defaultDeferLoadingEnabled: boolean;
   programmaticToolsEnabled: boolean;
   backgroundToolsEnabled: boolean;
   toolIntentsEnabled: boolean;
@@ -20,6 +21,7 @@ interface AgentCapabilitiesResult {
 
 export default function useAgentCapabilities(
   capabilities: AgentCapabilities[] | undefined,
+  defaultDeferLoading?: boolean,
 ): AgentCapabilitiesResult {
   const toolsEnabled = useMemo(
     () => capabilities?.includes(AgentCapabilities.tools) ?? false,
@@ -76,6 +78,12 @@ export default function useAgentCapabilities(
     [capabilities],
   );
 
+  /** The admin default only applies when the per-tool toggle exists at all. */
+  const defaultDeferLoadingEnabled = useMemo(
+    () => deferredToolsEnabled && (defaultDeferLoading ?? false),
+    [deferredToolsEnabled, defaultDeferLoading],
+  );
+
   const programmaticToolsEnabled = useMemo(
     () => capabilities?.includes(AgentCapabilities.programmatic_tools) ?? false,
     [capabilities],
@@ -103,6 +111,7 @@ export default function useAgentCapabilities(
     webSearchEnabled,
     fileSearchEnabled,
     deferredToolsEnabled,
+    defaultDeferLoadingEnabled,
     programmaticToolsEnabled,
     backgroundToolsEnabled,
     toolIntentsEnabled,

--- a/client/src/hooks/Agents/useMCPToolOptions.ts
+++ b/client/src/hooks/Agents/useMCPToolOptions.ts
@@ -70,6 +70,27 @@ export function withBooleanOption(
 }
 
 /**
+ * Applies the admin-configured Defer Loading default to freshly added MCP
+ * tools: each tool WITHOUT an existing `tool_options` entry gets
+ * `defer_loading: true` written via {@link withBooleanOption} so the shape
+ * matches a manual toggle. Tools that already carry options are left alone —
+ * the default must never rewrite a prior per-tool choice.
+ */
+export function withDefaultDeferredTools(
+  options: AgentToolOptions,
+  toolIds: string[],
+): AgentToolOptions {
+  let updatedOptions = options;
+  for (const toolId of toolIds) {
+    if (updatedOptions[toolId] != null) {
+      continue;
+    }
+    updatedOptions = withBooleanOption(updatedOptions, toolId, 'defer_loading', true);
+  }
+  return updatedOptions;
+}
+
+/**
  * Counterpart of {@link withBooleanOption} for flags whose ABSENCE means
  * default-on (background-native code execution): enabling clears the entry so
  * the native default applies; disabling persists an explicit `false`, which a

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -572,6 +572,10 @@ endpoints:
   #   # Useful for large organizations where many department-specific skills may be available.
   #   skills:
   #     maxCatalogSkills: 20
+  #   # (optional) When true, MCP tools newly added to an agent in the Agent Builder
+  #   # default to "Defer Loading" ON. Users can still opt out per tool. Defaults to false.
+  #   # Only applies when the "deferred_tools" capability is enabled.
+  #   defaultDeferLoading: false
   #   # (optional) Agent Capabilities available to all users. Omit the ones you wish to exclude. Defaults to list below.
   #   capabilities: ["deferred_tools", "execute_code", "file_search", "web_search", "artifacts", "subagents", "actions", "context", "skills", "memory", "ask_user_question", "tools", "chain", "ocr"]
   #   # The following capabilities are opt-in and must be added explicitly:

--- a/packages/api/src/endpoints/config/endpoints.ts
+++ b/packages/api/src/endpoints/config/endpoints.ts
@@ -70,8 +70,14 @@ export function createEndpointsConfigService(deps: EndpointsConfigDeps): {
     }
 
     if (mergedConfig[EModelEndpoint.agents] && appConfig?.endpoints?.[EModelEndpoint.agents]) {
-      const { disableBuilder, capabilities, allowedProviders, statefulCodeSessions, maxSubagents } =
-        appConfig.endpoints[EModelEndpoint.agents];
+      const {
+        disableBuilder,
+        capabilities,
+        defaultDeferLoading,
+        allowedProviders,
+        statefulCodeSessions,
+        maxSubagents,
+      } = appConfig.endpoints[EModelEndpoint.agents];
       const clientStatefulCodeSessions = statefulCodeSessions
         ? {
             allowedEnvironments: statefulCodeSessions.allowedEnvironments,
@@ -99,6 +105,7 @@ export function createEndpointsConfigService(deps: EndpointsConfigDeps): {
         allowedProviders,
         disableBuilder,
         capabilities,
+        defaultDeferLoading,
         statefulCodeSessions: clientStatefulCodeSessions,
         maxSubagents,
       };

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1186,6 +1186,10 @@ export const agentsEndpointSchema = baseEndpointSchema
         .array(z.nativeEnum(AgentCapabilities))
         .optional()
         .default(defaultAgentCapabilities),
+      /** Opt-in: MCP tools newly added to an agent default to Defer Loading ON.
+       *  Users can still opt out per tool; only applies when the `deferred_tools`
+       *  capability is enabled. */
+      defaultDeferLoading: z.boolean().optional().default(false),
       /** Controls which workspace-sharing scopes users may select for stateful code sessions.
        *  Omit this block to preserve the legacy behavior of allowing every scope. */
       statefulCodeSessions: z
@@ -1353,6 +1357,7 @@ export const agentsEndpointSchema = baseEndpointSchema
   .default({
     disableBuilder: false,
     capabilities: defaultAgentCapabilities,
+    defaultDeferLoading: false,
     maxCitations: 30,
     maxCitationsPerFile: 7,
     minRelevanceScore: 0.45,


### PR DESCRIPTION
## Summary

Adds an opt-in admin setting, `endpoints.agents.defaultDeferLoading`, that makes **Defer Loading default to ON** for MCP tools when a user adds them to an agent in the Agent Builder, instead of requiring the toggle on every tool.

Implements #14004.

## Motivation

The `deferred_tools` capability only controls whether the Defer Loading toggle is *available* — it says nothing about its initial state. Today `tool_options[toolId].defer_loading` is never written at add time (absence = false), so every MCP tool loads its definition into context upfront unless users know to toggle Defer Loading per tool. For instances with many users or many MCP tools this means unnecessary context consumption and inconsistent agent behavior depending on how well-informed the agent creator is.

## Changes

- **`packages/data-provider/src/config.ts`** — new `defaultDeferLoading: z.boolean().optional().default(false)` on `agentsEndpointSchema` (with the schema-level default), so it validates from `librechat.yaml` and flows into `TAgentsEndpoint` via Zod inference.
- **`packages/api/src/endpoints/config/endpoints.ts`** — adds `defaultDeferLoading` to the client-facing agents config allowlist so the client can read it from the existing agents config endpoint.
- **`client/src/hooks/Agents/useAgentCapabilities.ts`** — derives `defaultDeferLoadingEnabled = deferredToolsEnabled && defaultDeferLoading`; the admin default only applies when the `deferred_tools` capability is enabled (otherwise the toggle doesn't exist).
- **`client/src/hooks/Agents/useMCPToolOptions.ts`** — new exported `withDefaultDeferredTools(options, toolIds)` helper that writes `defer_loading: true` via the existing `withBooleanOption` (same shape as a manual toggle) while **skipping any tool that already has a `tool_options` entry**.
- **`client/src/components/SidePanel/Agents/Tools/ToolsMarketplaceDialog.tsx`** — applies the default when MCP tools are added from the marketplace (guarded by the `mcp_delimiter` id convention; request-scoped servers are excluded since they attach via the `mcp_all` wildcard, which carries no per-tool options).
- **`client/src/components/SidePanel/Agents/Tools/ItemDialog/sections/McpSection.tsx`** — applies the default to tools auto-selected after an MCP server connects.
- **`librechat.example.yaml`** — documents the new key.

## Behavior

- Opt-in: defaults to `false`; instance behavior is unchanged unless the admin sets it.
- **Existing agents are unaffected** — the default is only applied at add time; read semantics (absence = false) are untouched, and loading an existing agent copies persisted `tool_options` verbatim.
- Per-tool user choice always wins — the default never rewrites a tool that already has options, and users can still opt out per tool or via the existing bulk "Defer all" toggle.
- No migrations, no new API routes, no runtime changes: the persisted model (`tool_options.defer_loading`) and the server-side deferred-tools machinery are consumed as-is.

## Configuration

```yaml
endpoints:
  agents:
    defaultDeferLoading: true   # opt-in, default false
```

## Verification

- `npx tsc --noEmit` clean in `packages/data-provider`, `client`, and the touched `packages/api` file
- Jest: 57/57 in `client` agent-hook suites (`useAgentCapabilities`, `useMCPToolOptions`), 17/17 in `packages/api` endpoints-config suite
- `npm run sort-imports` and pre-commit hooks (ESLint, Prettier, circular-dependency and package.json static checks) all pass