### PR TITLE
🛫 feat: Enable Full Access for BYOM Coding

### DIFF
--- a/client/src/components/Chat/Input/CodeApprovalMenu.tsx
+++ b/client/src/components/Chat/Input/CodeApprovalMenu.tsx
@@ -1,4 +1,4 @@
-import { ShieldCheck, Hand } from 'lucide-react';
+import { ShieldCheck, ShieldAlert, Hand } from 'lucide-react';
 import {
   Button,
   DropdownMenu,
@@ -32,7 +32,14 @@ export default function CodeApprovalMenu({
   const labels: Record<CodeApprovalMode, string> = {
     ask: localize('com_ui_code_approval_ask'),
     acceptEdits: localize('com_ui_code_approval_accept_edits'),
+    fullAccess: localize('com_ui_code_approval_full_access'),
   };
+  const descriptions: Record<CodeApprovalMode, string> = {
+    ask: localize('com_ui_code_approval_ask_description'),
+    acceptEdits: localize('com_ui_code_approval_accept_edits_description'),
+    fullAccess: localize('com_ui_code_approval_full_access_description'),
+  };
+  const ModeIcon = { ask: Hand, acceptEdits: ShieldCheck, fullAccess: ShieldAlert }[selected];
 
   return (
     <DropdownMenu>
@@ -46,7 +53,7 @@ export default function CodeApprovalMenu({
           className="h-8 gap-1.5 rounded-full px-2 text-text-secondary"
           data-testid="code-approval-mode"
         >
-          {selected === 'ask' ? <Hand aria-hidden="true" /> : <ShieldCheck aria-hidden="true" />}
+          <ModeIcon aria-hidden="true" />
           <span>{labels[selected]}</span>
         </Button>
       </DropdownMenuTrigger>
@@ -67,13 +74,7 @@ export default function CodeApprovalMenu({
             <DropdownMenuRadioItem key={mode} value={mode}>
               <div>
                 <div>{labels[mode]}</div>
-                <div className="text-xs text-text-tertiary">
-                  {localize(
-                    mode === 'ask'
-                      ? 'com_ui_code_approval_ask_description'
-                      : 'com_ui_code_approval_accept_edits_description',
-                  )}
-                </div>
+                <div className="text-xs text-text-tertiary">{descriptions[mode]}</div>
               </div>
             </DropdownMenuRadioItem>
           ))}

--- a/client/src/components/Chat/Input/__tests__/CodeApprovalMenu.spec.tsx
+++ b/client/src/components/Chat/Input/__tests__/CodeApprovalMenu.spec.tsx
@@ -56,4 +56,26 @@ describe('CodeApprovalMenu', () => {
     );
     expect(screen.queryByTestId('code-approval-mode')).not.toBeInTheDocument();
   });
+
+  test('selects full access on the conversation with sandbox scope explained', async () => {
+    mockUseCodeApprovalMode.mockReturnValue({
+      available: true,
+      modes: ['ask', 'acceptEdits', 'fullAccess'],
+      selected: 'ask',
+    });
+    render(
+      <CodeApprovalMenu
+        conversation={conversation}
+        setConversation={mockSetConversation}
+        disabled={false}
+      />,
+    );
+    await userEvent.click(screen.getByTestId('code-approval-mode'));
+    expect(screen.getByText('com_ui_code_approval_full_access_description')).toBeInTheDocument();
+    await userEvent.click(screen.getByText('com_ui_code_approval_full_access'));
+    expect(mockSetConversation.mock.calls[0][0](conversation)).toEqual({
+      ...conversation,
+      codeApprovalMode: 'fullAccess',
+    });
+  });
 });

--- a/client/src/hooks/Agents/__tests__/useCodeApprovalMode.test.ts
+++ b/client/src/hooks/Agents/__tests__/useCodeApprovalMode.test.ts
@@ -120,6 +120,49 @@ describe('useCodeApprovalMode', () => {
     },
   );
 
+  test.each(['agent-1', 'agent-2'])(
+    'waits for unresolved root %s before full access',
+    (missingId) => {
+      const permissions = {
+        fileWrite: { allowed: ['ask', 'allow'], default: 'ask' },
+        commandExecution: { allowed: ['ask', 'allow'], default: 'ask' },
+      };
+      mockUseGetAgentsConfig.mockReturnValue({
+        agentsConfig: {
+          statefulCodeSessions: {
+            approvalsEnabled: true,
+            approvalModes: ['ask', 'acceptEdits', 'fullAccess'],
+            environments: [{ id: 'mac', type: 'attached', configSchema: { permissions } }],
+          },
+        },
+      });
+      let loaded = false;
+      mockUseAgentToolPermissions.mockImplementation((id?: string) => ({
+        agent:
+          id === missingId && !loaded
+            ? undefined
+            : {
+                id,
+                tools: ['execute_code'],
+                stateful_code_sessions: true,
+                code_environment_id: 'mac',
+              },
+      }));
+      const { result, rerender } = renderHook(() =>
+        useCodeApprovalMode(
+          { ...conversation, codeApprovalMode: 'fullAccess' },
+          { ...conversation, agent_id: 'agent-2' },
+        ),
+      );
+      expect(result.current.modes).not.toContain('fullAccess');
+      expect(result.current.selected).toBe('ask');
+      loaded = true;
+      rerender();
+      expect(result.current.modes).toContain('fullAccess');
+      expect(result.current.selected).toBe('fullAccess');
+    },
+  );
+
   test('falls back to ask when a saved mode is no longer permitted', () => {
     mockUseGetAgentsConfig.mockReturnValue({
       agentsConfig: {

--- a/client/src/hooks/Agents/__tests__/useCodeApprovalMode.test.ts
+++ b/client/src/hooks/Agents/__tests__/useCodeApprovalMode.test.ts
@@ -68,6 +68,58 @@ describe('useCodeApprovalMode', () => {
     });
   });
 
+  test.each(['permitted', 'restricted', 'missing'])(
+    'full access requires every reachable machine: %s',
+    (policy) => {
+      const permissions = {
+        fileWrite: { allowed: ['ask', 'allow'], default: 'ask' },
+        commandExecution: { allowed: ['ask', 'allow'], default: 'ask' },
+      };
+      mockUseAgentToolPermissions.mockReturnValue({
+        agent: {
+          id: 'agent-1',
+          tools: ['execute_code'],
+          stateful_code_sessions: true,
+          code_environment_id: 'mac',
+          subagents: { enabled: true, agent_ids: ['child'] },
+        },
+      });
+      mockUseAgentsMapContext.mockReturnValue(
+        policy === 'missing'
+          ? {}
+          : {
+              child: {
+                id: 'child',
+                tools: ['execute_code'],
+                stateful_code_sessions: true,
+                code_environment_id: 'child-machine',
+              },
+            },
+      );
+      mockUseGetAgentsConfig.mockReturnValue({
+        agentsConfig: {
+          statefulCodeSessions: {
+            approvalsEnabled: true,
+            approvalModes: ['ask', 'acceptEdits', 'fullAccess'],
+            environments: [
+              { id: 'mac', type: 'attached', configSchema: { permissions } },
+              {
+                id: 'child-machine',
+                type: 'attached',
+                configSchema: { permissions: policy === 'permitted' ? permissions : {} },
+              },
+            ],
+          },
+        },
+      });
+      const { result } = renderHook(() =>
+        useCodeApprovalMode({ ...conversation, codeApprovalMode: 'fullAccess' }),
+      );
+      expect(result.current.modes.includes('fullAccess')).toBe(policy === 'permitted');
+      expect(result.current.selected).toBe(policy === 'permitted' ? 'fullAccess' : 'ask');
+    },
+  );
+
   test('falls back to ask when a saved mode is no longer permitted', () => {
     mockUseGetAgentsConfig.mockReturnValue({
       agentsConfig: {

--- a/client/src/hooks/Agents/useCodeApprovalMode.ts
+++ b/client/src/hooks/Agents/useCodeApprovalMode.ts
@@ -28,8 +28,12 @@ export default function useCodeApprovalMode(
     | undefined;
   const environments = statefulCodeSessions?.environments;
   const reachable = useMemo(
-    () => collectReachableAgents([primaryAgent, addedAgent], agentsMap),
-    [addedAgent, agentsMap, primaryAgent],
+    () =>
+      collectReachableAgents([primaryAgent, addedAgent], agentsMap, [
+        conversation?.agent_id,
+        addedConversation?.agent_id,
+      ]),
+    [addedAgent, agentsMap, primaryAgent, conversation?.agent_id, addedConversation?.agent_id],
   );
   const codeEnvironments = useMemo(
     () =>
@@ -102,12 +106,15 @@ function findExecutionEnvironment(
 
 function collectReachableAgents(
   roots: Array<Agent | undefined>,
-  agentsMap?: TAgentsMap,
+  agentsMap: TAgentsMap | undefined,
+  expectedRootIds: Array<string | undefined | null>,
 ): { agents: Agent[]; complete: boolean } {
   const pending = roots.filter((agent): agent is Agent => agent != null);
   const visited = new Set<string>();
   const agents: Agent[] = [];
-  let complete = true;
+  let complete = expectedRootIds.every(
+    (id) => id == null || roots.some((agent) => agent?.id === id),
+  );
   while (pending.length > 0) {
     const agent = pending.pop();
     if (agent == null || visited.has(agent.id)) continue;

--- a/client/src/hooks/Agents/useCodeApprovalMode.ts
+++ b/client/src/hooks/Agents/useCodeApprovalMode.ts
@@ -27,18 +27,26 @@ export default function useCodeApprovalMode(
     | TConfig['statefulCodeSessions']
     | undefined;
   const environments = statefulCodeSessions?.environments;
-  const attachedEnvironments = useMemo(
+  const reachable = useMemo(
+    () => collectReachableAgents([primaryAgent, addedAgent], agentsMap),
+    [addedAgent, agentsMap, primaryAgent],
+  );
+  const codeEnvironments = useMemo(
     () =>
-      collectReachableAgents([primaryAgent, addedAgent], agentsMap)
+      reachable.agents
         .filter(
           (agent) =>
             agent.stateful_code_sessions === true && agent.tools?.includes(Tools.execute_code),
         )
-        .map((agent) => findExecutionEnvironment(agent, environments))
-        .filter(
-          (environment): environment is TPublicCodeEnvironment => environment?.type === 'attached',
-        ),
-    [addedAgent, agentsMap, environments, primaryAgent],
+        .map((agent) => findExecutionEnvironment(agent, environments)),
+    [environments, reachable],
+  );
+  const attachedEnvironments = useMemo(
+    () =>
+      codeEnvironments.filter(
+        (environment): environment is TPublicCodeEnvironment => environment?.type === 'attached',
+      ),
+    [codeEnvironments],
   );
   const supported =
     (conversation?.endpointType ?? conversation?.endpoint) === EModelEndpoint.agents &&
@@ -49,6 +57,10 @@ export default function useCodeApprovalMode(
   const modes = useMemo(() => {
     if (!available) return [];
     const allowed = new Set<CodeApprovalMode>(endpointModes?.includes('ask') ? ['ask'] : []);
+    let fullAccessAllowed =
+      endpointModes?.includes('fullAccess') === true &&
+      reachable.complete &&
+      codeEnvironments.every((environment) => environment != null);
     for (const environment of attachedEnvironments) {
       const environmentModes = getAllowedCodeApprovalModes({
         environment: 'attached',
@@ -59,9 +71,11 @@ export default function useCodeApprovalMode(
       if (endpointModes?.includes('acceptEdits') && environmentModes.includes('acceptEdits')) {
         allowed.add('acceptEdits');
       }
+      fullAccessAllowed &&= environmentModes.includes('fullAccess');
     }
+    if (fullAccessAllowed) allowed.add('fullAccess');
     return CODE_APPROVAL_MODES.filter((mode) => allowed.has(mode));
-  }, [attachedEnvironments, available, endpointModes]);
+  }, [attachedEnvironments, available, codeEnvironments, endpointModes, reachable.complete]);
   const requested = conversation?.codeApprovalMode ?? 'ask';
   /**
    * Fail closed while agent/environment metadata is incomplete. An affirmative
@@ -86,10 +100,14 @@ function findExecutionEnvironment(
     : environments?.find((candidate) => candidate.default === true);
 }
 
-function collectReachableAgents(roots: Array<Agent | undefined>, agentsMap?: TAgentsMap): Agent[] {
+function collectReachableAgents(
+  roots: Array<Agent | undefined>,
+  agentsMap?: TAgentsMap,
+): { agents: Agent[]; complete: boolean } {
   const pending = roots.filter((agent): agent is Agent => agent != null);
   const visited = new Set<string>();
   const agents: Agent[] = [];
+  let complete = true;
   while (pending.length > 0) {
     const agent = pending.pop();
     if (agent == null || visited.has(agent.id)) continue;
@@ -107,7 +125,8 @@ function collectReachableAgents(roots: Array<Agent | undefined>, agentsMap?: TAg
     for (const id of ids) {
       const candidate = agentsMap?.[id];
       if (candidate != null) pending.push(candidate);
+      else complete = false;
     }
   }
-  return agents;
+  return { agents, complete };
 }

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -4,6 +4,8 @@
   "com_ui_code_approval_ask_description": "Ask before editing files or running commands",
   "com_ui_code_approval_accept_edits": "Accept edits",
   "com_ui_code_approval_accept_edits_description": "Allow file edits; continue asking before commands",
+  "com_ui_code_approval_full_access": "Full access",
+  "com_ui_code_approval_full_access_description": "Allow file edits and commands on your machine without asking. Sandbox limits and required approvals still apply.",
   "com_ui_review_action": "Review 1 action",
   "com_ui_review_actions": "Review {{0}} actions",
   "com_ui_review_run_command": "Run command",

--- a/e2e/byom/README.md
+++ b/e2e/byom/README.md
@@ -40,6 +40,8 @@ do not relax that policy to make the test pass.
 6. Rejected creation leaves no file, and creation has no side effect before approval.
 7. Selecting worker B does not expose worker A's file; B's write leaves A unchanged.
 8. Stopping B produces a persisted tool failure, not success or fallback to A.
+9. Selecting **Full access** runs commands and physically creates a file without
+   approval prompts, survives reload, and can switch back to **Ask before changes**.
 
 Assertions inspect **tool outputs**, not echoed arguments or the model's final prose.
 The default hosted Code API URL is deliberately pointed at an invalid local route,
@@ -52,7 +54,8 @@ and workspaces. Ports are dynamically assigned, not the usual development ports.
 Listeners are loopback-only. No existing database, launchd worker, pairing, or project
 directory is reused. Children receive an allowlisted environment; checkout `.env`
 keys are neutralized. Mutations default to real UI approval; the test explicitly selects
-**Accept edits** for one file edit, while commands remain approval-gated and reads are allowed.
+**Accept edits** for one file edit, then **Full access** for unattended commands and
+file creation. Returning to **Ask before changes** restores approval prompts.
 
 The command stops its children on success, failure, SIGINT, and SIGTERM. The private
 temporary run directory is printed and retained for debugging; it contains test-only

--- a/e2e/byom/model.cjs
+++ b/e2e/byom/model.cjs
@@ -14,6 +14,10 @@ module.exports = (run, context) => {
       { path: 'workspace/proof.txt', old_text: 'native-original', new_text: 'native-edited' },
     ],
     read: ['read_file', { path: 'workspace/proof.txt' }],
+    fullCreate: [
+      'create_file',
+      { path: 'workspace/unattended.txt', content: 'native-unattended', overwrite: false },
+    ],
     reject: [
       'create_file',
       { path: 'workspace/rejected.txt', content: 'must-not-exist', overwrite: false },

--- a/e2e/byom/native.spec.ts
+++ b/e2e/byom/native.spec.ts
@@ -41,7 +41,7 @@ test('native BYOM saves, persists, isolates workers, and fails closed', async ({
   const cli = process.env.BYOM_CODE_CLI!;
   const workers: Worker[] = [];
   let selectedWorker: Worker;
-  let selectedApprovalMode: 'ask' | 'acceptEdits' = 'ask';
+  let selectedApprovalMode: 'ask' | 'acceptEdits' | 'fullAccess' = 'ask';
   const password = `Acceptance-${randomUUID()}`;
   const email = `native-${randomUUID()}@example.com`;
   const registered = await page.request.post('/api/auth/register', {
@@ -219,14 +219,19 @@ test('native BYOM saves, persists, isolates workers, and fails closed', async ({
     return outputs.join('\n');
   }
 
-  async function selectApprovalMode(mode: 'Ask before changes' | 'Accept edits') {
+  async function selectApprovalMode(mode: 'Ask before changes' | 'Accept edits' | 'Full access') {
     const selector = page.getByTestId('code-approval-mode');
     await expect(selector).toBeVisible();
     await selector.click();
     await expect(selector).toHaveAttribute('aria-expanded', 'true');
     await page.getByRole('menuitemradio', { name: new RegExp(`^${mode}`) }).click();
     await expect(selector).toContainText(mode, { timeout: 10_000 });
-    selectedApprovalMode = mode === 'Accept edits' ? 'acceptEdits' : 'ask';
+    const modes = {
+      'Full access': 'fullAccess',
+      'Accept edits': 'acceptEdits',
+      'Ask before changes': 'ask',
+    } as const;
+    selectedApprovalMode = modes[mode];
   }
 
   try {
@@ -242,6 +247,13 @@ test('native BYOM saves, persists, isolates workers, and fails closed', async ({
     expect(await turn('read')).toContain('native-edited');
     /** Accept edits does not weaken command execution approval. */
     expect(await turn('command', 'Approve')).toContain('native-command-ok');
+    await selectApprovalMode('Full access');
+    expect(await turn('command')).toContain('native-command-ok');
+    await turn('fullCreate');
+    expect(await readFile(path.join(a.root, 'unattended.txt'), 'utf8')).toBe('native-unattended');
+    await page.reload();
+    await expect(page.getByTestId('code-approval-mode')).toContainText('Full access');
+    expect(await turn('command')).toContain('native-command-ok');
     await selectApprovalMode('Ask before changes');
     expect(await turn('reject', 'Reject')).toMatch(/blocked|reject|denied|declined/i);
     expect(await readdir(a.root)).not.toContain('rejected.txt');
@@ -266,6 +278,9 @@ test('native BYOM saves, persists, isolates workers, and fails closed', async ({
         physicalCreate: true,
         acceptEditsWithoutPrompt: true,
         commandsStillRequireApproval: true,
+        fullAccessCommandsWithoutPrompt: true,
+        fullAccessWritesWithoutPrompt: true,
+        fullAccessSurvivesReload: true,
         crossTurnEdit: true,
         rejectedWriteAbsent: true,
         twoWorkerIsolation: true,

--- a/e2e/byom/run.mjs
+++ b/e2e/byom/run.mjs
@@ -175,7 +175,7 @@ try {
               configSchema: {
                 permissions: {
                   fileWrite: { allowed: ['ask', 'allow'], default: 'ask' },
-                  commandExecution: { allowed: ['ask'], default: 'ask' },
+                  commandExecution: { allowed: ['ask', 'allow'], default: 'ask' },
                 },
               },
             },

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -628,6 +628,10 @@ endpoints:
   #               allowed: [allow, ask, deny]
   #               default: ask
   #             commandExecution:
+  #               # Add allow to offer Full access in the chat composer. Both
+  #               # permission categories must permit allow; defaults can stay ask.
+  #               # Full access skips routine code prompts within the worker sandbox.
+  #               # Explicit endpoint ask/deny rules and hooks still apply.
   #               allowed: [ask, deny]
   #               default: ask
   #         pairing:

--- a/packages/api/src/agents/hitl/byom.spec.ts
+++ b/packages/api/src/agents/hitl/byom.spec.ts
@@ -13,6 +13,95 @@ import { canAgentGraphPause } from './admission';
 
 const signal = new AbortController().signal;
 
+const fullAccessSettings: AttachedCodeEnvironmentPolicySettings = {
+  configSchema: {
+    permissions: {
+      fileWrite: { allowed: ['allow', 'ask', 'deny'], default: 'ask' },
+      commandExecution: { allowed: ['allow', 'ask', 'deny'], default: 'ask' },
+    },
+  },
+};
+
+describe('full access', () => {
+  test('allows native writes and commands while preserving mandatory skill review', async () => {
+    const settings = new Map([['attached-agent', fullAccessSettings]]);
+    const mode = resolveAttachedCodeApprovalMode('fullAccess', settings);
+    const hook = createAttachedCodeEnvironmentPolicyHook(new Set(settings.keys()), settings, mode);
+    for (const toolName of ['create_file', 'edit_file', 'bash_tool', 'execute_code']) {
+      await expect(
+        hook(
+          {
+            toolName,
+            executingAgentId: 'attached-agent',
+            toolInput: { path: 'output.txt' },
+          } as never,
+          signal,
+        ),
+      ).resolves.toEqual({ decision: 'allow' });
+    }
+    await expect(
+      hook(
+        {
+          toolName: 'create_file',
+          executingAgentId: 'attached-agent',
+          toolInput: { path: 'skills/reviewer/SKILL.md' },
+        } as never,
+        signal,
+      ),
+    ).resolves.toMatchObject({ decision: 'ask' });
+    await expect(hook({ toolName: 'bash_tool' } as never, signal)).resolves.toMatchObject({
+      decision: 'deny',
+    });
+    await expect(
+      hook({ toolName: 'mcp_example', executingAgentId: 'attached-agent' } as never, signal),
+    ).resolves.toEqual({});
+  });
+
+  test.each([false, true])(
+    'rejects restrictive siblings regardless of traversal order: %s',
+    (reverse) => {
+      const entries: Array<[string, AttachedCodeEnvironmentPolicySettings]> = [
+        ['permissive', fullAccessSettings],
+        [
+          'restricted',
+          { configSchema: { permissions: { fileWrite: { allowed: ['ask'], default: 'ask' } } } },
+        ],
+      ];
+      expect(() =>
+        resolveAttachedCodeApprovalMode(
+          'fullAccess',
+          new Map(reverse ? entries.reverse() : entries),
+        ),
+      ).toThrow('not permitted');
+    },
+  );
+
+  test('rechecks changed and newly discovered machine restrictions before execution', async () => {
+    const settings = new Map([['attached-agent', fullAccessSettings]]);
+    const attachedIds = new Set(settings.keys());
+    const hook = createAttachedCodeEnvironmentPolicyHook(
+      attachedIds,
+      settings,
+      resolveAttachedCodeApprovalMode('fullAccess', settings),
+    );
+    settings.set('attached-agent', {
+      ...fullAccessSettings,
+      settings: { permissions: { commandExecution: 'deny' } },
+    });
+    await expect(
+      hook({ toolName: 'bash_tool', executingAgentId: 'attached-agent' } as never, signal),
+    ).resolves.toMatchObject({ decision: 'deny' });
+    attachedIds.add('lazy-agent');
+    settings.set('lazy-agent', {});
+    await expect(
+      hook({ toolName: 'bash_tool', executingAgentId: 'lazy-agent' } as never, signal),
+    ).resolves.toMatchObject({ decision: 'ask' });
+    expect(() => resolveAttachedCodeApprovalMode('fullAccess', settings, false)).toThrow(
+      'not permitted',
+    );
+  });
+});
+
 test('identifies every built-in tool that can touch a stateful code target', () => {
   for (const toolName of [
     'read_file',

--- a/packages/api/src/agents/hitl/byom.ts
+++ b/packages/api/src/agents/hitl/byom.ts
@@ -238,6 +238,8 @@ export function resolveAttachedCodeApprovalMode(
         settings: policy.settings,
       });
     } catch (error) {
+      /** Unattended execution requires every known target to permit the mode. */
+      if (requested === 'fullAccess') throw error;
       rejection = error as Error;
     }
   }

--- a/packages/api/src/agents/hitl/runtime.spec.ts
+++ b/packages/api/src/agents/hitl/runtime.spec.ts
@@ -5,6 +5,63 @@ import { resolveToolApprovalPolicy } from './policy';
 import { buildHITLRunWiring } from './runtime';
 
 describe('buildHITLRunWiring', () => {
+  test.each([
+    ['ask', 'bash_tool', 'ask'],
+    ['deny', 'bash_tool', 'deny'],
+    ['allow', 'bash_tool', 'allow'],
+    ['allow', 'mcp:github:create_issue', 'ask'],
+  ] as const)(
+    'full access preserves endpoint %s rules for %s',
+    async (rule, toolName, expected) => {
+      const settings = new Map([
+        [
+          'attached-agent',
+          {
+            configSchema: {
+              permissions: {
+                fileWrite: {
+                  allowed: ['ask', 'allow'] as Array<'ask' | 'allow'>,
+                  default: 'ask' as const,
+                },
+                commandExecution: {
+                  allowed: ['ask', 'allow'] as Array<'ask' | 'allow'>,
+                  default: 'ask' as const,
+                },
+              },
+            },
+          },
+        ],
+      ]);
+      const wiring = buildHITLRunWiring(
+        { enabled: true, mode: 'default', [rule]: ['bash_tool'] },
+        {},
+        [],
+        [
+          {
+            hook: createAttachedCodeEnvironmentPolicyHook(
+              new Set(settings.keys()),
+              settings,
+              'fullAccess',
+            ),
+          },
+        ],
+      );
+      const result = await executeHooks({
+        registry: wiring!.hooks,
+        matchQuery: toolName,
+        input: {
+          hook_event_name: 'PreToolUse',
+          runId: 'full-access-policy',
+          toolName,
+          toolInput: {},
+          toolUseId: 'tool-code',
+          executingAgentId: 'attached-agent',
+        },
+      });
+      expect(result.decision).toBe(expected);
+    },
+  );
+
   test('returns undefined when HITL is disabled (the default)', () => {
     expect(buildHITLRunWiring(undefined)).toBeUndefined();
     expect(buildHITLRunWiring({})).toBeUndefined();

--- a/packages/api/src/endpoints/config/endpoints.spec.ts
+++ b/packages/api/src/endpoints/config/endpoints.spec.ts
@@ -274,7 +274,7 @@ describe('createEndpointsConfigService', () => {
       expect(result?.[EModelEndpoint.agents]?.statefulCodeSessions).toEqual({
         allowedEnvironments: ['user'],
         approvalsEnabled: true,
-        approvalModes: ['ask', 'acceptEdits'],
+        approvalModes: ['ask', 'acceptEdits', 'fullAccess'],
         environments: [],
       });
     });
@@ -283,7 +283,7 @@ describe('createEndpointsConfigService', () => {
       [{ enabled: true }, ['ask']],
       [{ enabled: true, mode: 'default' }, ['ask']],
       [{ enabled: true, mode: 'dontAsk' }, ['ask']],
-      [{ enabled: true, mode: 'bypass' }, ['ask', 'acceptEdits']],
+      [{ enabled: true, mode: 'bypass' }, ['ask', 'acceptEdits', 'fullAccess']],
     ])('exposes approval modes allowed by endpoint policy %p', async (toolApproval, expected) => {
       const deps = createMockDeps({
         loadDefaultEndpointsConfig: jest.fn().mockResolvedValue({

--- a/packages/data-provider/src/code/approval.spec.ts
+++ b/packages/data-provider/src/code/approval.spec.ts
@@ -97,7 +97,7 @@ describe('conversation code approval constraints', () => {
     ).toEqual(['ask']);
   });
 
-  test.each(['autoApprove', 'bypass', 'fullAccess', '', {}, ['ask'], true, 1])(
+  test.each(['autoApprove', 'bypass', 'invalidMode', '', {}, ['ask'], true, 1])(
     'rejects invalid request state: %j',
     (value) => {
       expect(() => resolveCodeApprovalMode(value, constraints)).toThrow(CodeApprovalModeError);
@@ -107,7 +107,7 @@ describe('conversation code approval constraints', () => {
   test('rejects an unvalidated runtime mode before permission lookup', () => {
     expect(() =>
       resolveCodePermissionDecision({
-        mode: 'fullAccess' as never,
+        mode: 'invalidMode' as never,
         category: 'fileWrite',
         decision: 'ask',
       }),
@@ -124,6 +124,24 @@ describe('conversation code approval constraints', () => {
   test.each(CODE_APPROVAL_MODES)('preserves deny under %s', (mode) => {
     for (const category of ['fileWrite', 'commandExecution'] as const) {
       expect(resolveCodePermissionDecision({ mode, category, decision: 'deny' })).toBe('deny');
+    }
+  });
+
+  test('full access allows commands and file writes only with both machine grants', () => {
+    const mode = resolveCodeApprovalMode('fullAccess', constraints);
+    for (const category of ['fileWrite', 'commandExecution'] as const) {
+      expect(resolveCodePermissionDecision({ mode, category, decision: 'ask' })).toBe('allow');
+      expect(() =>
+        resolveCodeApprovalMode('fullAccess', {
+          ...constraints,
+          configSchema: {
+            permissions: {
+              ...constraints.configSchema?.permissions,
+              [category]: { allowed: ['ask'], default: 'ask' },
+            },
+          },
+        }),
+      ).toThrow(CodeApprovalModeError);
     }
   });
 

--- a/packages/data-provider/src/code/approval.ts
+++ b/packages/data-provider/src/code/approval.ts
@@ -4,7 +4,7 @@ import type {
   CodeEnvironmentUserSettings,
 } from '../config';
 
-export const CODE_APPROVAL_MODES = ['ask', 'acceptEdits'] as const;
+export const CODE_APPROVAL_MODES = ['ask', 'acceptEdits', 'fullAccess'] as const;
 export type CodeApprovalMode = (typeof CODE_APPROVAL_MODES)[number];
 
 type CodePermissions = Required<NonNullable<CodeEnvironmentUserSettings['permissions']>>;
@@ -12,6 +12,7 @@ type CodePermissions = Required<NonNullable<CodeEnvironmentUserSettings['permiss
 const MODE_PERMISSIONS: Record<CodeApprovalMode, CodePermissions> = {
   ask: { fileWrite: 'ask', commandExecution: 'ask' },
   acceptEdits: { fileWrite: 'allow', commandExecution: 'ask' },
+  fullAccess: { fileWrite: 'allow', commandExecution: 'allow' },
 };
 
 export type CodeApprovalConstraints = {


### PR DESCRIPTION
## Summary

BYOM users can accept file edits but must still approve every command. I added **Full access** to the composer so a conversation can edit files and run commands unattended within its machine's existing sandbox.

- Require both file-write and command-execution `allow` grants from every known attached environment before offering or admitting Full access.
- Keep administrator rules, machine denies, mandatory skill approvals, and per-tool checks authoritative, including newly resolved subagents.
- Persist the selection through the existing conversation and approval-resume contract; retain Ask before changes as the default.
- Preserve existing Accept edits behavior and leave unrelated tool policies unchanged.
- Extend the native BYOM browser acceptance test to physically create a file and run commands without prompts, reload, and restore Ask before changes.
- Document how operators expose command-execution permission; Full access does not expand filesystem, networking, credential, or sandbox access.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Passed 109 focused tests: portable approval policy, BYOM hooks, endpoint mode projection, SDK hook composition, mode availability/loading transitions, and composer selection.
- Passed data-provider, backend, and client TypeScript checks; scoped ESLint, formatting, and import checks.
- Built the frontend and affected runtime packages.
- Passed the real native BYOM acceptance test with isolated MongoDB, Redis, LibreChat, Code API, and two outbound SRT workers on dynamically allocated non-default ports. Verified unattended commands, physical file creation, reload, restored approval prompts, worker isolation, and offline failure.
- CodeGraph selection was unavailable (authenticated endpoint returned 401); local tests were selected through inspected source dependencies. Full suites remain delegated to CI.

### Test Configuration

Node 24.16.0, macOS native SRT, deterministic model fixture, real bridge and worker execution. Run `BYOM_CODE_REPO=/path/to/built/code-interpreter node e2e/byom/run.mjs` after building LibreChat. No new SDK or Code API release is required.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules
