### PR TITLE
🏠 fix: Preserve Stateful Deployment Default

### DIFF
--- a/packages/api/src/agents/execution.spec.ts
+++ b/packages/api/src/agents/execution.spec.ts
@@ -311,6 +311,32 @@ describe('resolveCodeExecutionContext', () => {
     expect(context.baseUrl).toBe('https://bridge.example/v1');
   });
 
+  it('uses the stateful deployment when configured environments have no default', () => {
+    process.env.LIBRECHAT_CODE_BASEURL_STATEFUL = 'http://code-stateful.test/v1';
+    const context = resolveCodeExecutionContext({
+      statefulSessions: true,
+      environments: [
+        {
+          id: 'personal-vm',
+          name: 'Personal VM',
+          type: 'attached',
+          baseURL: 'https://bridge.example/v1',
+          owner: 'principal',
+          workerId: 'personal-worker',
+        },
+      ],
+      userId: 'user-1',
+    });
+
+    expect(context).toEqual(
+      expect.objectContaining({
+        baseUrl: 'http://code-stateful.test/v1',
+        environmentId: undefined,
+        runtimeSessionHint: 'v2:user:b5729fb0e3ca12e7a61ff6857b99d98e',
+      }),
+    );
+  });
+
   it('fails closed when an agent references an unknown configured environment', () => {
     expect(() =>
       resolveCodeExecutionContext({

--- a/packages/api/src/code/config.spec.ts
+++ b/packages/api/src/code/config.spec.ts
@@ -54,7 +54,11 @@ describe('mergeAccessibleCodeEnvironments', () => {
 
     expect(result).not.toBe(appConfig);
     expect(result.endpoints?.agents?.statefulCodeSessions?.environments).toEqual([
-      expect.objectContaining({ id: 'deployment-vm', baseURL: 'https://deployment.example' }),
+      expect.objectContaining({
+        id: 'deployment-vm',
+        baseURL: 'https://deployment.example',
+        default: true,
+      }),
       expect.objectContaining({ id: 'personal-vm', baseURL: 'https://deployment.example' }),
     ]);
     expect(appConfig.endpoints?.agents?.statefulCodeSessions?.environments).toHaveLength(1);
@@ -348,7 +352,16 @@ describe('mergeAccessibleCodeEnvironments', () => {
     ]);
   });
 
-  test('defaults to an executable principal environment after a pairing-only control plane', async () => {
+  test.each([
+    ['preserves the configured stateful deployment', 'https://stateful.example/v1', undefined],
+    ['uses the principal environment without a stateful deployment', undefined, true],
+  ])('%s after a pairing-only control plane', async (_name, statefulURL, expectedDefault) => {
+    const originalStatefulURL = process.env.LIBRECHAT_CODE_BASEURL_STATEFUL;
+    if (statefulURL == null) {
+      delete process.env.LIBRECHAT_CODE_BASEURL_STATEFUL;
+    } else {
+      process.env.LIBRECHAT_CODE_BASEURL_STATEFUL = statefulURL;
+    }
     const pairingOnly = {
       id: 'self-service',
       name: 'Self-service',
@@ -366,32 +379,40 @@ describe('mergeAccessibleCodeEnvironments', () => {
       },
     } as unknown as AppConfig;
 
-    const result = await mergeAccessibleCodeEnvironments({
-      appConfig,
-      deploymentConfig: appConfig,
-      actor: { userId: '68b2f0c498f24c1e78fa0001', role: 'USER', idOnTheSource: null },
-      registry: {
-        listRegisteredIds: jest.fn().mockResolvedValue(['personal-vm']),
-        listAccessibleConfigurations: jest.fn().mockResolvedValue([
-          {
-            id: 'personal-vm',
-            name: 'Personal VM',
-            type: 'attached',
-            baseURL: 'https://persisted.example',
-            controlPlaneId: 'self-service',
-            owner: 'principal',
-            workerId: 'personal-worker',
-          },
-        ]),
-      },
-    });
+    try {
+      const result = await mergeAccessibleCodeEnvironments({
+        appConfig,
+        deploymentConfig: appConfig,
+        actor: { userId: '68b2f0c498f24c1e78fa0001', role: 'USER', idOnTheSource: null },
+        registry: {
+          listRegisteredIds: jest.fn().mockResolvedValue(['personal-vm']),
+          listAccessibleConfigurations: jest.fn().mockResolvedValue([
+            {
+              id: 'personal-vm',
+              name: 'Personal VM',
+              type: 'attached',
+              baseURL: 'https://persisted.example',
+              controlPlaneId: 'self-service',
+              owner: 'principal',
+              workerId: 'personal-worker',
+            },
+          ]),
+        },
+      });
 
-    const environments = result.endpoints?.agents?.statefulCodeSessions?.environments;
-    expect(environments?.find((environment) => environment.id === 'self-service')?.default).toBe(
-      false,
-    );
-    expect(environments?.find((environment) => environment.id === 'personal-vm')?.default).toBe(
-      true,
-    );
+      const environments = result.endpoints?.agents?.statefulCodeSessions?.environments;
+      expect(environments?.find((environment) => environment.id === 'self-service')?.default).toBe(
+        false,
+      );
+      expect(environments?.find((environment) => environment.id === 'personal-vm')?.default).toBe(
+        expectedDefault,
+      );
+    } finally {
+      if (originalStatefulURL == null) {
+        delete process.env.LIBRECHAT_CODE_BASEURL_STATEFUL;
+      } else {
+        process.env.LIBRECHAT_CODE_BASEURL_STATEFUL = originalStatefulURL;
+      }
+    }
   });
 });

--- a/packages/api/src/code/config.ts
+++ b/packages/api/src/code/config.ts
@@ -161,7 +161,11 @@ export async function mergeAccessibleCodeEnvironments({
         environment.default === true,
     )
   ) {
-    const defaultIndex = mergedEnvironments.findIndex(isExecutableCodeEnvironment);
+    const defaultIndex = mergedEnvironments.findIndex(
+      (environment) =>
+        isExecutableCodeEnvironment(environment) &&
+        (environment.owner !== 'principal' || !process.env.LIBRECHAT_CODE_BASEURL_STATEFUL?.trim()),
+    );
     if (defaultIndex >= 0) {
       mergedEnvironments = mergedEnvironments.map((environment, index) =>
         index === defaultIndex ? { ...environment, default: true as const } : environment,


### PR DESCRIPTION
A paired personal code worker was silently promoted to the default execution environment when a deployment exposed only a pairing control plane. Agents that retained “Deployment default” then moved from the deployment's `LIBRECHAT_CODE_BASEURL_STATEFUL` route and `v2` session namespace to the user's machine and a `v3` environment namespace.

This change preserves `LIBRECHAT_CODE_BASEURL_STATEFUL` ahead of automatic principal-worker promotion. Personal workers remain available when explicitly selected, administrator-provided principal defaults remain honored, and personal-only installations still promote an available worker when no deployment stateful endpoint exists.

Validation:

- `npx jest src/code/config.spec.ts src/agents/execution.spec.ts --runInBand` (37 tests)
- `npx tsc --noEmit` in `packages/api`
- `npm run static-checks -- --against origin/dev`
- `npm run lighthouse` completed all builds; the browser run could not bind because another local process was already using port 3080
