### PR TITLE
🏁 style: Align Streaming Elapsed Reading With Footer Start

### DIFF
--- a/client/src/components/Chat/Messages/MessageParts.tsx
+++ b/client/src/components/Chat/Messages/MessageParts.tsx
@@ -127,6 +127,17 @@ function MessageParts(props: TMessageProps) {
           isEditing={edit}
           footer={
             <SubRow classes={cn(messageFooterClasses, isCreatedByUser && 'justify-end')}>
+              {/* The reading holds the column start: it takes over the slot the streaming
+                  dot vacates, so the retry navigation beside it — whose width the footer
+                  reserves whether or not hover has revealed it — must never push the
+                  timer inboard of that column. */}
+              {shouldShowElapsed({
+                isSubmitting,
+                isLatestMessage: messageId === latestMessageId,
+                isCreatedByUser,
+                siblingIdx,
+                siblingCount,
+              }) && <Elapsed index={index} />}
               {/* While the answer is generating every other action is withheld, which
                   would otherwise leave this counter sitting alone under a half-written
                   response. It reveals on hover there, like the actions it sits with. */}
@@ -138,13 +149,6 @@ function MessageParts(props: TMessageProps) {
                   isSubmitting && messageId === latestMessageId && revealOnRowHoverClasses,
                 )}
               />
-              {shouldShowElapsed({
-                isSubmitting,
-                isLatestMessage: messageId === latestMessageId,
-                isCreatedByUser,
-                siblingIdx,
-                siblingCount,
-              }) && <Elapsed index={index} />}
               <HoverButtons
                 index={index}
                 isEditing={edit}

--- a/client/src/components/Chat/Messages/__tests__/HoverActions.streaming.spec.tsx
+++ b/client/src/components/Chat/Messages/__tests__/HoverActions.streaming.spec.tsx
@@ -8,6 +8,7 @@ import { QueryClient, QueryClientProvider, useQueryClient } from '@tanstack/reac
 import { useLatestMessage, useLatestMessageId } from '~/hooks/Messages/useLatestMessage';
 import { ChatContext, MessagesViewProvider, useChatContext } from '~/Providers';
 import StructuredMessage from '~/components/Messages/MessageContent';
+import MessageParts from '~/components/Chat/Messages/MessageParts';
 import Message from '~/components/Chat/Messages/Message';
 import store from '~/store';
 
@@ -53,8 +54,10 @@ jest.mock('~/hooks', () => {
   const useMemoizedChatContext = jest.requireActual(
     '~/hooks/Messages/useMemoizedChatContext',
   ).default;
+  const useMessageHelpers = jest.requireActual('~/hooks/Messages/useMessageHelpers').default;
   return {
     useMessageProcess,
+    useMessageHelpers,
     useMemoizedChatContext,
     useContentMetadata: () => ({ hasParallelContent: false }),
     useAttachments: () => ({ attachments: [], searchResults: undefined }),
@@ -140,14 +143,18 @@ function createQueryClient() {
   });
 }
 
+type RowComponent = typeof Message;
+
 function DerivedStreamingRow({
   structured = false,
   submitting = true,
   siblingIdx = 1,
+  row,
 }: {
   structured?: boolean;
   submitting?: boolean;
   siblingIdx?: number;
+  row?: RowComponent;
 }) {
   const queryClient = useQueryClient();
   const latestMessage = useLatestMessage(0);
@@ -183,7 +190,7 @@ function DerivedStreamingRow({
     return null;
   }
 
-  const MessageComponent = structured ? StructuredMessage : Message;
+  const MessageComponent = row ?? (structured ? StructuredMessage : Message);
   return (
     <ChatContext.Provider value={chatContext}>
       <MessagesViewProvider>
@@ -200,7 +207,12 @@ function DerivedStreamingRow({
   );
 }
 
-function renderStreamingRow(structured = false, submitting = true, siblingIdx = 1) {
+function renderStreamingRow(
+  structured = false,
+  submitting = true,
+  siblingIdx = 1,
+  row?: RowComponent,
+) {
   const queryClient = createQueryClient();
   queryClient.setQueryData<TMessage[]>(
     [QueryKeys.messages, conversation.conversationId],
@@ -220,6 +232,7 @@ function renderStreamingRow(structured = false, submitting = true, siblingIdx = 
             structured={structured}
             submitting={submitting}
             siblingIdx={siblingIdx}
+            row={row}
           />
         </MemoryRouter>
       </RecoilRoot>
@@ -314,6 +327,26 @@ describe('streaming hover actions', () => {
     renderStreamingRow(structured);
 
     expect(screen.getByTestId('stream-elapsed')).toBeInTheDocument();
+  });
+
+  /**
+   * The retry navigation holds its width in the footer whether or not hover has
+   * revealed it, so a row with siblings would otherwise indent the timer past the
+   * column the streaming dot just vacated. The reading stays at the column start.
+   */
+  it.each([
+    ['a plain text', Message],
+    ['a structured', StructuredMessage],
+    ['a flat-thread', MessageParts],
+  ])('keeps the elapsed reading left-most in %s streaming footer', (_label, row) => {
+    renderStreamingRow(false, true, 1, row);
+
+    const timer = screen.getByTestId('stream-elapsed');
+    const footer = screen.getByRole('navigation', {
+      name: 'com_ui_sibling_navigation',
+    }).parentElement;
+
+    expect(footer?.firstElementChild).toContainElement(timer);
   });
 
   it('renders no elapsed timer once the row is not submitting', () => {

--- a/client/src/components/Chat/Messages/ui/MessageRender.tsx
+++ b/client/src/components/Chat/Messages/ui/MessageRender.tsx
@@ -173,6 +173,17 @@ const MessageRender = memo(function MessageRender({
       plain={wakeupDisplay != null && !edit}
       footer={
         <SubRow classes={cn(messageFooterClasses, msg.isCreatedByUser && 'justify-end')}>
+          {/* The reading holds the column start: it takes over the slot the streaming
+              dot vacates, so the retry navigation beside it — whose width the footer
+              reserves whether or not hover has revealed it — must never push the
+              timer inboard of that column. */}
+          {shouldShowElapsed({
+            isSubmitting,
+            isLatestMessage,
+            isCreatedByUser: msg.isCreatedByUser,
+            siblingIdx,
+            siblingCount,
+          }) && <Elapsed index={index} />}
           {/* A user turn is right-aligned, so its retry navigation belongs at the
               outer edge under the bubble rather than inboard of the actions.
 
@@ -188,13 +199,6 @@ const MessageRender = memo(function MessageRender({
               isSubmitting && isLatestMessage && revealOnRowHoverClasses,
             )}
           />
-          {shouldShowElapsed({
-            isSubmitting,
-            isLatestMessage,
-            isCreatedByUser: msg.isCreatedByUser,
-            siblingIdx,
-            siblingCount,
-          }) && <Elapsed index={index} />}
           <HoverButtons
             index={index}
             isEditing={edit}

--- a/client/src/components/Messages/ContentRender.tsx
+++ b/client/src/components/Messages/ContentRender.tsx
@@ -173,6 +173,17 @@ const ContentRender = memo(function ContentRender({
       isEditing={edit}
       footer={
         <SubRow classes={cn(messageFooterClasses, msg.isCreatedByUser && 'justify-end')}>
+          {/* The reading holds the column start: it takes over the slot the streaming
+              dot vacates, so the retry navigation beside it — whose width the footer
+              reserves whether or not hover has revealed it — must never push the
+              timer inboard of that column. */}
+          {shouldShowElapsed({
+            isSubmitting,
+            isLatestMessage,
+            isCreatedByUser: msg.isCreatedByUser,
+            siblingIdx,
+            siblingCount,
+          }) && <Elapsed index={index} />}
           {/* While the answer is generating every other action is withheld, which
               would otherwise leave this counter sitting alone under a half-written
               response. It reveals on hover there, like the actions it sits with. */}
@@ -182,13 +193,6 @@ const ContentRender = memo(function ContentRender({
             setSiblingIdx={setSiblingIdx}
             className={cn(isSubmitting && isLatestMessage && revealOnRowHoverClasses)}
           />
-          {shouldShowElapsed({
-            isSubmitting,
-            isLatestMessage,
-            isCreatedByUser: msg.isCreatedByUser,
-            siblingIdx,
-            siblingCount,
-          }) && <Elapsed index={index} />}
           <HoverButtons
             index={index}
             message={msg}


### PR DESCRIPTION
## Summary

The elapsed reading under a streaming response sat to the right of the retry navigation. That navigation reserves its width in the footer whether or not hover has revealed it, so on any response with siblings the timer rendered indented past the column the streaming dot had just vacated — the reading shifted inboard exactly when the row gained a sibling.

Rendering the reading ahead of the navigation puts it back on the column start that the streaming dot and the hover-button glyphs share (all inset `ps-1.5`/`p-1.5` from the column). It is a DOM move, not a `flex` `order` override, so the reading order matches what is seen and RTL follows the writing direction on its own. The change is applied in all three row renderers that own this footer — `MessageRender`, `ContentRender`, and `MessageParts` (the flat thread).

Nothing about visibility changes: `shouldShowElapsed` still gates the timer to the newest sibling position of the actively generating latest row, and the hover-only fade on the retry navigation is untouched.

## Testing

`HoverActions.streaming.spec.tsx` gains a footer-order case across all three renderers (the flat-thread renderer is newly exercised there, via the existing harness). Each of the three fails against the previous order and passes with the fix.

- `client`: `npx jest src/components/Chat/Messages/__tests__` — 10 suites, 195 tests passing
- `client`: `npx tsc --noEmit` — no diagnostics in the touched files
- `npx eslint` on the touched files — clean