### PR TITLE
💠 style: Unify Code Approval With Composer Controls

### DIFF
--- a/client/src/components/Chat/Input/CodeApprovalMenu.tsx
+++ b/client/src/components/Chat/Input/CodeApprovalMenu.tsx
@@ -1,16 +1,39 @@
-import { ShieldCheck, ShieldAlert, Hand } from 'lucide-react';
-import {
-  Button,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuLabel,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuTrigger,
-} from '@librechat/client';
+import * as Ariakit from '@ariakit/react';
+import { TooltipAnchor, composerControlClasses } from '@librechat/client';
+import { Check, ChevronDown, FilePen, FileQuestionMark, FileTerminal } from 'lucide-react';
 import type { CodeApprovalMode, TConversation } from 'librechat-data-provider';
+import type { LucideIcon } from 'lucide-react';
 import type { SetterOrUpdater } from 'recoil';
+import type { TranslationKeys } from '~/hooks';
 import { useCodeApprovalMode, useLocalize } from '~/hooks';
+import { cn } from '~/utils';
+
+/** The modes answer one question — what may happen to the workspace without the
+ *  reader — so they share the document glyph and differ only in what is drawn on
+ *  it, escalating with what each mode permits: a question the reader answers, a
+ *  pen for writes that need no answer, a prompt for commands that need none
+ *  either. The shield stays with the pending review button, which sits in this
+ *  same row. */
+const modeOptions: Record<
+  CodeApprovalMode,
+  { icon: LucideIcon; label: TranslationKeys; description: TranslationKeys }
+> = {
+  ask: {
+    icon: FileQuestionMark,
+    label: 'com_ui_code_approval_ask',
+    description: 'com_ui_code_approval_ask_description',
+  },
+  acceptEdits: {
+    icon: FilePen,
+    label: 'com_ui_code_approval_accept_edits',
+    description: 'com_ui_code_approval_accept_edits_description',
+  },
+  fullAccess: {
+    icon: FileTerminal,
+    label: 'com_ui_code_approval_full_access',
+    description: 'com_ui_code_approval_full_access_description',
+  },
+};
 
 export default function CodeApprovalMenu({
   conversation,
@@ -25,61 +48,104 @@ export default function CodeApprovalMenu({
 }) {
   const localize = useLocalize();
   const { available, modes, selected } = useCodeApprovalMode(conversation, addedConversation);
+  const menuStore = Ariakit.useMenuStore({ focusLoop: true, placement: 'top-start' });
+  const isOpen = menuStore.useState('open');
 
   if (!available || selected == null) {
     return null;
   }
-  const labels: Record<CodeApprovalMode, string> = {
-    ask: localize('com_ui_code_approval_ask'),
-    acceptEdits: localize('com_ui_code_approval_accept_edits'),
-    fullAccess: localize('com_ui_code_approval_full_access'),
+
+  const selectMode = (mode: CodeApprovalMode) => {
+    if (!modes.includes(mode)) {
+      return;
+    }
+    setConversation((current) =>
+      current == null ? current : { ...current, codeApprovalMode: mode },
+    );
   };
-  const descriptions: Record<CodeApprovalMode, string> = {
-    ask: localize('com_ui_code_approval_ask_description'),
-    acceptEdits: localize('com_ui_code_approval_accept_edits_description'),
-    fullAccess: localize('com_ui_code_approval_full_access_description'),
-  };
-  const ModeIcon = { ask: Hand, acceptEdits: ShieldCheck, fullAccess: ShieldAlert }[selected];
+
+  const SelectedIcon = modeOptions[selected].icon;
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          disabled={disabled}
-          aria-label={localize('com_ui_code_approval_mode')}
-          className="h-8 gap-1.5 rounded-full px-2 text-text-secondary"
-          data-testid="code-approval-mode"
+    <Ariakit.MenuProvider store={menuStore}>
+      <TooltipAnchor
+        description={localize('com_ui_code_approval_mode')}
+        disabled={isOpen}
+        render={
+          <Ariakit.MenuButton
+            disabled={disabled}
+            data-testid="code-approval-mode"
+            aria-label={`${localize('com_ui_code_approval_mode')}: ${localize(
+              modeOptions[selected].label,
+            )}`}
+            className={cn(
+              composerControlClasses(),
+              'px-2.5 md:px-theme-normal',
+              isOpen && 'bg-surface-hover',
+              disabled && 'cursor-not-allowed opacity-50',
+            )}
+          />
+        }
+      >
+        <SelectedIcon className="size-4 shrink-0 text-text-secondary" aria-hidden="true" />
+        <span className="max-w-[12rem] truncate">{localize(modeOptions[selected].label)}</span>
+        <ChevronDown
+          className={cn(
+            'size-3 shrink-0 text-text-secondary transition-transform',
+            isOpen && 'rotate-180',
+          )}
+          aria-hidden="true"
+        />
+      </TooltipAnchor>
+      <Ariakit.Menu
+        portal={true}
+        gutter={8}
+        unmountOnHide={true}
+        className={cn(
+          'z-50 flex min-w-[280px] max-w-[min(320px,calc(100vw-2rem))] flex-col rounded-xl',
+          'border border-border-light bg-presentation p-1.5 shadow-lg',
+          'origin-bottom opacity-0 transition-[opacity,transform] duration-200 ease-out',
+          'data-[enter]:scale-100 data-[enter]:opacity-100',
+          'scale-95 data-[leave]:scale-95 data-[leave]:opacity-0',
+        )}
+      >
+        {/* Names the menu without adding an `h1` to the page outline. */}
+        <Ariakit.MenuHeading
+          render={<div />}
+          className="px-2.5 py-1.5 text-xs font-medium text-text-secondary"
         >
-          <ModeIcon aria-hidden="true" />
-          <span>{labels[selected]}</span>
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" side="top" className="w-72">
-        <DropdownMenuLabel>{localize('com_ui_code_approval_mode')}</DropdownMenuLabel>
-        <DropdownMenuRadioGroup
-          value={selected}
-          onValueChange={(value) => {
-            if (!modes.includes(value as CodeApprovalMode)) return;
-            setConversation((current) =>
-              current == null
-                ? current
-                : { ...current, codeApprovalMode: value as CodeApprovalMode },
-            );
-          }}
-        >
-          {modes.map((mode) => (
-            <DropdownMenuRadioItem key={mode} value={mode}>
-              <div>
-                <div>{labels[mode]}</div>
-                <div className="text-xs text-text-tertiary">{descriptions[mode]}</div>
+          {localize('com_ui_code_approval_mode')}
+        </Ariakit.MenuHeading>
+        {modes.map((mode) => {
+          const { icon: Icon, label, description } = modeOptions[mode];
+          const isSelected = mode === selected;
+          return (
+            <Ariakit.MenuItemRadio
+              key={mode}
+              name="codeApprovalMode"
+              value={mode}
+              checked={isSelected}
+              hideOnClick={true}
+              onChange={() => selectMode(mode)}
+              className={cn(
+                'group flex w-full cursor-pointer items-start gap-3 rounded-lg px-2.5 py-2',
+                'outline-none transition-colors duration-theme-fast',
+                'hover:bg-surface-hover data-[active-item]:bg-surface-hover',
+                isSelected && 'bg-surface-active-alt',
+              )}
+            >
+              <Icon className="mt-0.5 size-4 shrink-0 text-text-secondary" aria-hidden="true" />
+              <div className="min-w-0 flex-1 text-left">
+                <div className="text-sm font-medium text-text-primary">{localize(label)}</div>
+                <p className="text-xs text-text-secondary">{localize(description)}</p>
               </div>
-            </DropdownMenuRadioItem>
-          ))}
-        </DropdownMenuRadioGroup>
-      </DropdownMenuContent>
-    </DropdownMenu>
+              {isSelected && (
+                <Check className="mt-0.5 size-4 shrink-0 text-text-primary" aria-hidden="true" />
+              )}
+            </Ariakit.MenuItemRadio>
+          );
+        })}
+      </Ariakit.Menu>
+    </Ariakit.MenuProvider>
   );
 }

--- a/client/src/components/Chat/Input/MCPSelect.tsx
+++ b/client/src/components/Chat/Input/MCPSelect.tsx
@@ -1,8 +1,8 @@
 import React, { memo, useMemo } from 'react';
 import * as Ariakit from '@ariakit/react';
 import { ChevronDown } from 'lucide-react';
-import { TooltipAnchor } from '@librechat/client';
 import { PermissionTypes, Permissions } from 'librechat-data-provider';
+import { TooltipAnchor, composerControlClasses } from '@librechat/client';
 import MCPServerMenuItem from '~/components/MCP/MCPServerMenuItem';
 import MCPConfigDialog from '~/components/MCP/MCPConfigDialog';
 import StackedMCPIcons from '~/components/MCP/StackedMCPIcons';
@@ -72,11 +72,8 @@ function MCPSelectContent() {
           render={
             <Ariakit.MenuButton
               className={cn(
-                'group relative inline-flex items-center justify-center gap-theme-compact',
-                'border border-border-medium text-sm font-medium transition-all',
-                'h-theme-control min-w-theme-control rounded-theme-control-round bg-transparent px-2.5 shadow-sm',
-                'hover:bg-surface-hover hover:shadow-md active:shadow-inner',
-                'md:w-fit md:justify-start md:px-theme-normal',
+                composerControlClasses(),
+                'min-w-theme-control px-2.5 md:w-fit md:justify-start md:px-theme-normal',
                 isOpen && 'bg-surface-hover',
               )}
             />

--- a/client/src/components/Chat/Input/__tests__/CodeApprovalMenu.spec.tsx
+++ b/client/src/components/Chat/Input/__tests__/CodeApprovalMenu.spec.tsx
@@ -1,5 +1,5 @@
 import userEvent from '@testing-library/user-event';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import type { TConversation } from 'librechat-data-provider';
 import CodeApprovalMenu from '../CodeApprovalMenu';
 
@@ -28,7 +28,7 @@ describe('CodeApprovalMenu', () => {
     });
   });
 
-  test('defaults to ask and stores accept-edits on the conversation', async () => {
+  const renderMenu = () =>
     render(
       <CodeApprovalMenu
         conversation={conversation}
@@ -36,6 +36,9 @@ describe('CodeApprovalMenu', () => {
         disabled={false}
       />,
     );
+
+  test('defaults to ask and stores accept-edits on the conversation', async () => {
+    renderMenu();
 
     await userEvent.click(screen.getByTestId('code-approval-mode'));
     await userEvent.click(await screen.findByText('com_ui_code_approval_accept_edits'));
@@ -44,16 +47,53 @@ describe('CodeApprovalMenu', () => {
     expect(update(conversation)).toEqual({ ...conversation, codeApprovalMode: 'acceptEdits' });
   });
 
+  test('offers every mode as a radio and marks the selected one', async () => {
+    renderMenu();
+
+    const trigger = screen.getByTestId('code-approval-mode');
+    expect(trigger).toHaveTextContent('com_ui_code_approval_ask');
+    await userEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    const menu = await screen.findByRole('menu', { name: 'com_ui_code_approval_mode' });
+    expect(document.querySelector('h1')).toBeNull();
+    const options = within(menu).getAllByRole('menuitemradio');
+    expect(options).toHaveLength(2);
+    expect(options[0]).toHaveAttribute('aria-checked', 'true');
+    expect(options[0]).toHaveTextContent('com_ui_code_approval_ask_description');
+    expect(options[1]).toHaveAttribute('aria-checked', 'false');
+    expect(options[1]).toHaveTextContent('com_ui_code_approval_accept_edits_description');
+  });
+
+  test('draws the trigger from the shared composer control appearance', () => {
+    renderMenu();
+
+    expect(screen.getByTestId('code-approval-mode')).toHaveClass(
+      'h-theme-control',
+      'rounded-theme-control-round',
+      'gap-theme-compact',
+      'border-border-medium',
+    );
+  });
+
+  test('offers only the modes the conversation allows', async () => {
+    mockUseCodeApprovalMode.mockReturnValue({
+      available: true,
+      modes: ['ask'],
+      selected: 'ask',
+    });
+    renderMenu();
+
+    await userEvent.click(screen.getByTestId('code-approval-mode'));
+
+    const menu = await screen.findByRole('menu');
+    expect(within(menu).getAllByRole('menuitemradio')).toHaveLength(1);
+  });
+
   test('hides the control when code approvals are unavailable', () => {
     mockUseCodeApprovalMode.mockReturnValue({ available: false, modes: [] });
 
-    render(
-      <CodeApprovalMenu
-        conversation={conversation}
-        setConversation={mockSetConversation}
-        disabled={false}
-      />,
-    );
+    renderMenu();
     expect(screen.queryByTestId('code-approval-mode')).not.toBeInTheDocument();
   });
 
@@ -63,14 +103,10 @@ describe('CodeApprovalMenu', () => {
       modes: ['ask', 'acceptEdits', 'fullAccess'],
       selected: 'ask',
     });
-    render(
-      <CodeApprovalMenu
-        conversation={conversation}
-        setConversation={mockSetConversation}
-        disabled={false}
-      />,
-    );
+    renderMenu();
+
     await userEvent.click(screen.getByTestId('code-approval-mode'));
+    expect(within(await screen.findByRole('menu')).getAllByRole('menuitemradio')).toHaveLength(3);
     expect(screen.getByText('com_ui_code_approval_full_access_description')).toBeInTheDocument();
     await userEvent.click(screen.getByText('com_ui_code_approval_full_access'));
     expect(mockSetConversation.mock.calls[0][0](conversation)).toEqual({

--- a/client/src/components/Chat/Input/__tests__/MCPSelect.spec.tsx
+++ b/client/src/components/Chat/Input/__tests__/MCPSelect.spec.tsx
@@ -41,6 +41,8 @@ jest.mock('@librechat/client', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const R = require('react');
   return {
+    /** The real recipe, so the geometry assertions below cover shipped classes. */
+    composerControlClasses: jest.requireActual('@librechat/client').composerControlClasses,
     TooltipAnchor: ({
       children,
       render,

--- a/client/src/components/Chat/Input/__tests__/appearanceTokens.spec.ts
+++ b/client/src/components/Chat/Input/__tests__/appearanceTokens.spec.ts
@@ -13,7 +13,10 @@ const themedControls = [
   ],
   ['InterruptSteerButton.tsx', ['size-theme-control', 'rounded-theme-control-round']],
   ['AudioRecorder.tsx', ['size="theme"', 'shape="theme"']],
-  ['MCPSelect.tsx', ['h-theme-control', 'rounded-theme-control-round']],
+  /** Controls that draw their shape from `composerControlClasses()` prove it by
+   *  consuming the shared recipe; its own tokens are asserted where it lives. */
+  ['MCPSelect.tsx', ['composerControlClasses()', 'min-w-theme-control', 'md:px-theme-normal']],
+  ['CodeApprovalMenu.tsx', ['composerControlClasses()', 'md:px-theme-normal']],
   ['TokenUsage/index.tsx', ['size-theme-control', 'rounded-theme-control-round']],
   ['Files/AttachFile.tsx', ['size-theme-control', 'rounded-theme-control-round']],
   ['Files/AttachFileMenu.tsx', ['size-theme-control', 'rounded-theme-control-round']],

--- a/packages/client/src/components/CheckboxButton.spec.tsx
+++ b/packages/client/src/components/CheckboxButton.spec.tsx
@@ -7,7 +7,8 @@ describe('CheckboxButton', () => {
     render(<CheckboxButton label="Tools" icon={<span>icon</span>} />);
 
     expect(screen.getByRole('checkbox', { name: 'Tools' })).toHaveClass(
-      'size-theme-control',
+      'h-theme-control',
+      'w-theme-control',
       'rounded-theme-control-round',
       'gap-theme-compact',
       'p-theme-compact',

--- a/packages/client/src/components/CheckboxButton.tsx
+++ b/packages/client/src/components/CheckboxButton.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useEffect } from 'react';
 import { Checkbox, useStoreState, useCheckboxStore } from '@ariakit/react';
+import { composerControlClasses } from '~/utils/composer';
 import { cn } from '~/utils';
 
 const CheckboxButton: React.ForwardRefExoticComponent<
@@ -61,11 +62,8 @@ const CheckboxButton: React.ForwardRefExoticComponent<
       store={checkbox}
       onChange={onChange}
       className={cn(
-        // Base styling from MultiSelect's selectClassName
-        'group relative inline-flex items-center justify-center gap-theme-compact',
-        'rounded-theme-control-round border border-border-medium text-sm font-medium',
-        'size-theme-control max-w-fit p-theme-compact transition-all md:w-full md:px-theme-normal',
-        'bg-transparent shadow-sm hover:bg-surface-hover hover:shadow-md active:shadow-inner',
+        composerControlClasses(),
+        'w-theme-control max-w-fit p-theme-compact md:w-full md:px-theme-normal',
 
         // Checked state styling
         isChecked && isCheckedClassName && isCheckedClassName,

--- a/packages/client/src/utils/composer.spec.ts
+++ b/packages/client/src/utils/composer.spec.ts
@@ -1,0 +1,30 @@
+import { composerControlClasses, composerSurfaceClasses } from './composer';
+
+describe('composerSurfaceClasses', () => {
+  it('draws the composer surface from semantic roles', () => {
+    const classes = composerSurfaceClasses();
+
+    expect(classes).toContain('border-border-light');
+    expect(classes).toContain('bg-surface-chat');
+    expect(classes).toContain('text-text-primary');
+  });
+});
+
+describe('composerControlClasses', () => {
+  it('owns the geometry every labeled composer control shares', () => {
+    const classes = composerControlClasses();
+
+    expect(classes).toContain('h-theme-control');
+    expect(classes).toContain('rounded-theme-control-round');
+    expect(classes).toContain('gap-theme-compact');
+  });
+
+  it('draws its border and fills from semantic roles', () => {
+    const classes = composerControlClasses();
+
+    expect(classes).toContain('border-border-medium');
+    expect(classes).toContain('text-text-primary');
+    expect(classes).toContain('hover:bg-surface-hover');
+    expect(classes).not.toMatch(/#[0-9a-f]{3,6}|rgb\(|hsl\(/i);
+  });
+});

--- a/packages/client/src/utils/composer.ts
+++ b/packages/client/src/utils/composer.ts
@@ -17,3 +17,19 @@ export const composerSurfaceShadow = {
   blurred: 'shadow-md',
   within: 'shadow-md focus-within:shadow-lg',
 } as const;
+
+/**
+ * Shared appearance for a labeled control in the composer's action row — the
+ * capability checkboxes, the MCP selector, the code-approval selector. Border,
+ * radius, height, spacing and elevation are one decision here so a row of them
+ * reads as a single set of controls no matter which primitive each is built
+ * from. Width, responsive label collapsing and selected/open fills stay with
+ * each owner.
+ */
+export const composerControlClasses = (): string =>
+  cn(
+    'group relative inline-flex items-center justify-center gap-theme-compact',
+    'h-theme-control rounded-theme-control-round border border-border-medium',
+    'bg-transparent text-sm font-medium text-text-primary shadow-sm transition-all',
+    'hover:bg-surface-hover hover:shadow-md active:shadow-inner',
+  );


### PR DESCRIPTION
## Summary

The code approval selector shipped in #15703 was the only control in the chat composer built on the shadcn `DropdownMenu` primitives (used nowhere else in the chat UI): a borderless ghost button with a raised-hand icon sitting in a row of bordered composer pills, opening a menu of default radio dots with hand-styled item text. This rebuilds it on the composer's own components and theme roles, and moves the pill appearance the composer controls were each copying into one shared decision.

Rebased onto the three-mode selector from #15718, so `fullAccess` is styled with the rest.

## What changed

**The control now speaks the composer's menu language.** Ariakit menu + `TooltipAnchor`, matching its neighbour `MCPSelect`: a pill trigger with a rotating chevron, and a `bg-presentation` popover whose options carry an icon, a description and a check on the selected row — the same shape `ModelSpecItem` and `MCPServerMenuItem` already use.

**One source of truth for the composer pill.** `CheckboxButton` (every capability badge) and `MCPSelect` each carried their own copy of the same border / radius / height / spacing / elevation string. That decision now lives in `composerControlClasses()` beside the existing `composerSurfaceClasses()` in `@librechat/client`, and all three controls consume it. Width, responsive label collapsing and open/checked fills stay with each owner.

**Icons that escalate with the permission.** The raised hand and the two shields are gone. All three modes answer one question — what may happen to the workspace without the reader — so they share a document glyph and differ in what is drawn on it, in the order the modes loosen: a question mark for *Ask before changes*, a pen for *Accept edits* (writes need no answer), a prompt for *Full access* (commands need none either). The shield stays with the pending review button, which can sit in the same row.

Only semantic roles are used (`border-border-medium`, `bg-presentation`, `surface-hover`, `surface-active-alt`, `text-*`, `h-theme-control`, `rounded-theme-control-round`, `gap-theme-compact`), so both themes come out of the token system with no light/dark-specific values.

## Behaviour

Unchanged. The trigger keeps its `code-approval-mode` test id, its visible mode label and `aria-expanded`; the options stay `menuitemradio`; the stored `codeApprovalMode` and the fail-closed mode list from `useCodeApprovalMode` are untouched. The menu is now named by its own heading, rendered as a `div` so no `h1` is added to the page outline.

## Testing

- `client`: `CodeApprovalMenu.spec.tsx` extended (radio roles, `aria-checked`, menu naming, allowed-mode list, shared appearance) on top of #15718's full-access test; full `src/components/Chat/Input` run green (27 suites / 366 tests), `src/hooks/Agents` green.
- `packages/client`: new `utils/composer.spec.ts` pins the shared recipe's tokens and semantic roles; `CheckboxButton.spec.tsx` updated for the split geometry; all 32 suites / 271 tests green.
- `appearanceTokens.spec.ts` now asserts that `MCPSelect` and `CodeApprovalMenu` consume the shared recipe.
- `npx tsc --noEmit` clean in both `client` and `packages/client`.
- `npm run static-checks -- --against origin/dev` green (ESLint, Prettier, import sorting, package.json, circular deps).
- Rendered both themes in a Tailwind harness against the real config to confirm the chip matches the capability badges and all three options read correctly in light and dark.
