### PR TITLE
🧰 feat: Move Code Settings Into Run Code

### DIFF
--- a/client/src/components/SidePanel/Agents/Advanced/AdvancedPanel.tsx
+++ b/client/src/components/SidePanel/Agents/Advanced/AdvancedPanel.tsx
@@ -1,11 +1,9 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { ChevronLeft, Check, Copy } from 'lucide-react';
-import { AgentCapabilities } from 'librechat-data-provider';
 import { Button, TooltipAnchor, labelVariants, useToastContext } from '@librechat/client';
 import type { AgentForm } from '~/common';
 import { useAgentPanelContext } from '~/Providers';
-import StatefulSessions from './StatefulSessions';
 import OrchestrationHub from './OrchestrationHub';
 import MaxAgentSteps from './MaxAgentSteps';
 import { groupHeadingClass } from './ui';
@@ -19,11 +17,7 @@ export default function AdvancedPanel() {
   const currentAgentId = watch('id');
   const [copied, setCopied] = useState(false);
 
-  const { agentsConfig, setActivePanel } = useAgentPanelContext();
-  const statefulSessionsEnabled = useMemo(
-    () => agentsConfig?.capabilities.includes(AgentCapabilities.stateful_code_sessions) ?? false,
-    [agentsConfig],
-  );
+  const { setActivePanel } = useAgentPanelContext();
 
   const handleCopyAgentId = async () => {
     if (!currentAgentId) return;
@@ -59,7 +53,6 @@ export default function AdvancedPanel() {
         <section className="flex flex-col gap-3">
           <span className={groupHeadingClass}>{localize('com_ui_essentials')}</span>
           <MaxAgentSteps />
-          {statefulSessionsEnabled && <StatefulSessions />}
         </section>
 
         <OrchestrationHub currentAgentId={currentAgentId} />

--- a/client/src/components/SidePanel/Agents/Code/Settings.tsx
+++ b/client/src/components/SidePanel/Agents/Code/Settings.tsx
@@ -34,7 +34,7 @@ const ENVIRONMENT_LABELS = {
 
 const DEPLOYMENT_DEFAULT_ENVIRONMENT = '__deployment_default__';
 
-export default function StatefulSessions() {
+export default function CodeSettings() {
   const localize = useLocalize();
   const { user } = useAuthContext();
   const { agentsConfig } = useGetAgentsConfig();
@@ -54,12 +54,17 @@ export default function StatefulSessions() {
   const codeEnvironmentId = watch('code_environment_id');
   const configuredEnvironments = agentsConfig?.statefulCodeSessions?.allowedEnvironments;
   const executionEnvironments = agentsConfig?.statefulCodeSessions?.environments ?? [];
+  const statefulSessionsAvailable =
+    agentsConfig?.capabilities.includes(AgentCapabilities.stateful_code_sessions) ?? false;
   const allowedEnvironments = resolveAllowedStatefulCodeEnvironments(configuredEnvironments);
   const effectiveExecutionEnvironment = codeEnvironmentId
     ? executionEnvironments.find((candidate) => candidate.id === codeEnvironmentId)
     : executionEnvironments.find((candidate) => candidate.default === true);
   const showGitIdentity =
-    codeEnabled && enabled && effectiveExecutionEnvironment?.type === 'attached';
+    statefulSessionsAvailable &&
+    codeEnabled &&
+    enabled &&
+    effectiveExecutionEnvironment?.type === 'attached';
   const releaseIdentity = useCallback(() => {
     const identity = getValues('git_identity');
     const empty = !identity?.name?.trim() && !identity?.email?.trim();
@@ -96,6 +101,10 @@ export default function StatefulSessions() {
       );
     }
   };
+
+  if (!statefulSessionsAvailable) {
+    return null;
+  }
 
   return (
     <div className="space-y-3">

--- a/client/src/components/SidePanel/Agents/Tools/ItemDialog/__tests__/BuiltinSection.spec.tsx
+++ b/client/src/components/SidePanel/Agents/Tools/ItemDialog/__tests__/BuiltinSection.spec.tsx
@@ -8,7 +8,15 @@ import BuiltinSection from '../sections/BuiltinSection';
 
 jest.mock('~/hooks', () => ({
   useLocalize: () => (key: string) => key,
-  useGetAgentsConfig: () => ({ agentsConfig: undefined }),
+  useAuthContext: () => ({ user: {} }),
+  useGetAgentsConfig: () => ({
+    agentsConfig: {
+      capabilities: ['stateful_code_sessions'],
+      statefulCodeSessions: {
+        environments: [{ id: 'byom', name: 'My machine', type: 'attached', default: true }],
+      },
+    },
+  }),
   useAgentCapabilities: () => ({ backgroundToolsEnabled: false }),
 }));
 jest.mock('~/data-provider', () => ({ useVerifyAgentToolAuth: () => ({ data: undefined }) }));
@@ -80,5 +88,21 @@ describe('BuiltinSection memory scope', () => {
   test('other builtins do not render the scope control', () => {
     renderSection('execute_code', { memory: true, memory_scope: MemoryScope.agent });
     expect(screen.queryByRole('checkbox', { name: 'com_agents_memory_scope' })).toBeNull();
+  });
+});
+
+describe('BuiltinSection Run Code settings', () => {
+  test('exposes stateful code configuration with the Run Code tool', () => {
+    renderSection('execute_code', {
+      execute_code: true,
+      stateful_code_sessions: true,
+      stateful_code_environment: 'user',
+    });
+
+    expect(screen.getByRole('switch', { name: 'com_ui_stateful_sessions' })).toBeChecked();
+    expect(screen.getByTestId('code-environment-id')).toBeInTheDocument();
+    expect(screen.getByTestId('stateful-code-environment')).toBeInTheDocument();
+    expect(screen.getByLabelText('com_ui_agent_git_name')).toBeInTheDocument();
+    expect(screen.getByLabelText('com_ui_agent_git_email')).toBeInTheDocument();
   });
 });

--- a/client/src/components/SidePanel/Agents/Tools/ItemDialog/sections/BuiltinSection.tsx
+++ b/client/src/components/SidePanel/Agents/Tools/ItemDialog/sections/BuiltinSection.tsx
@@ -6,6 +6,7 @@ import type { AgentForm, ExtendedFile } from '~/common';
 import type { BuiltinId } from '../../items/types';
 import { useVerifyAgentToolAuth } from '~/data-provider';
 import CodeBackground from '../../../Code/Background';
+import CodeSettings from '../../../Code/Settings';
 import SearchAction from '../../../Search/Action';
 import FileContext from '../../../FileContext';
 import FileSearch from '../../../FileSearch';
@@ -144,6 +145,7 @@ export default function BuiltinSection({
   if (builtinId === 'execute_code') {
     body = (
       <div className="flex flex-col gap-4">
+        <CodeSettings />
         <CodeBackground />
         <CodeFiles agent_id={agentId} files={codeFiles} />
       </div>

--- a/client/src/components/SidePanel/Agents/Tools/items/__tests__/configurable.spec.ts
+++ b/client/src/components/SidePanel/Agents/Tools/items/__tests__/configurable.spec.ts
@@ -6,15 +6,12 @@ const builtin = (id: string, extra: Record<string, unknown> = {}): AgentItem =>
   ({ kind: 'builtin', id, name: '', description: '', iconKey: id, ...extra }) as AgentItem;
 
 describe('hasConfigurableSettings', () => {
-  test('artifacts, file_search, context, and memory builtins are configurable', () => {
+  test('builtins with settings are configurable', () => {
     expect(hasConfigurableSettings(builtin('artifacts'))).toBe(true);
+    expect(hasConfigurableSettings(builtin('execute_code'))).toBe(true);
     expect(hasConfigurableSettings(builtin('file_search'))).toBe(true);
     expect(hasConfigurableSettings(builtin('context'))).toBe(true);
     expect(hasConfigurableSettings(builtin('memory'))).toBe(true);
-  });
-
-  test('execute_code builtin is not configurable', () => {
-    expect(hasConfigurableSettings(builtin('execute_code'))).toBe(false);
   });
 
   test('web_search is configurable only when auth is user-provided', () => {

--- a/client/src/components/SidePanel/Agents/Tools/items/configurable.ts
+++ b/client/src/components/SidePanel/Agents/Tools/items/configurable.ts
@@ -12,6 +12,7 @@ export function hasConfigurableSettings(item: AgentItem): boolean {
     case 'builtin':
       return (
         item.id === 'artifacts' ||
+        item.id === 'execute_code' ||
         item.id === 'file_search' ||
         item.id === 'context' ||
         item.id === 'memory' ||

--- a/client/src/components/SidePanel/Agents/__tests__/CodeSettings.spec.tsx
+++ b/client/src/components/SidePanel/Agents/__tests__/CodeSettings.spec.tsx
@@ -5,13 +5,14 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { AgentCapabilities } from 'librechat-data-provider';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import type { AgentForm } from '~/common';
-import StatefulSessions from '../Advanced/StatefulSessions';
+import CodeSettings from '../Code/Settings';
 
 jest.mock('~/hooks', () => ({
   useLocalize: () => (key: string) => key,
   useAuthContext: () => ({ user: {} }),
   useGetAgentsConfig: () => ({
     agentsConfig: {
+      capabilities: ['stateful_code_sessions'],
       statefulCodeSessions: {
         environments: [{ id: 'byom', name: 'My machine', type: 'attached', default: true }],
       },
@@ -20,7 +21,7 @@ jest.mock('~/hooks', () => ({
 }));
 
 function IdentityForm({ savedIdentity }: { savedIdentity?: AgentForm['git_identity'] }) {
-  const [advanced, setAdvanced] = useState(true);
+  const [dialogOpen, setDialogOpen] = useState(true);
   const methods = useForm<AgentForm>({
     mode: 'onChange',
     defaultValues: {
@@ -31,8 +32,8 @@ function IdentityForm({ savedIdentity }: { savedIdentity?: AgentForm['git_identi
   });
   return (
     <FormProvider {...methods}>
-      {advanced && <StatefulSessions />}
-      <button onClick={() => setAdvanced(!advanced)}>Toggle Advanced</button>
+      {dialogOpen && <CodeSettings />}
+      <button onClick={() => setDialogOpen(!dialogOpen)}>Toggle Dialog</button>
       <button onClick={() => methods.setValue(AgentCapabilities.execute_code, false)}>
         Disable code
       </button>
@@ -55,8 +56,8 @@ test.each(['', 'not-an-email'])(
       target: { value: email },
     });
     expect(await screen.findByRole('alert')).toBeInTheDocument();
-    fireEvent.click(screen.getByText('Toggle Advanced'));
-    fireEvent.click(screen.getByText('Toggle Advanced'));
+    fireEvent.click(screen.getByText('Toggle Dialog'));
+    fireEvent.click(screen.getByText('Toggle Dialog'));
     expect(screen.getByLabelText('com_ui_agent_git_name')).toHaveValue('Saved Agent');
     expect(screen.getByLabelText('com_ui_agent_git_email')).toHaveValue('saved@example.com');
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
@@ -77,7 +78,7 @@ test('clears cross-field errors when completing or clearing a Git identity', asy
   await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument());
 });
 
-test.each(['Disable code', 'Use managed', 'Disable sessions', 'Toggle Advanced'])(
+test.each(['Disable code', 'Use managed', 'Disable sessions', 'Toggle Dialog'])(
   'discards a partial identity when its controls disappear: %s',
   async (action) => {
     render(<IdentityForm />);
@@ -91,7 +92,7 @@ test.each(['Disable code', 'Use managed', 'Disable sessions', 'Toggle Advanced']
   },
 );
 
-test.each(['Disable code', 'Use managed', 'Disable sessions', 'Toggle Advanced'])(
+test.each(['Disable code', 'Use managed', 'Disable sessions', 'Toggle Dialog'])(
   'discards an invalid email when its controls disappear: %s',
   async (action) => {
     render(<IdentityForm />);
@@ -118,9 +119,9 @@ test.each([
   fireEvent.change(screen.getByLabelText('com_ui_agent_git_email'), {
     target: { value: identity.email },
   });
-  fireEvent.click(screen.getByText('Toggle Advanced'));
+  fireEvent.click(screen.getByText('Toggle Dialog'));
   expect(screen.getByTestId('identity')).toHaveTextContent(JSON.stringify(identity));
-  fireEvent.click(screen.getByText('Toggle Advanced'));
+  fireEvent.click(screen.getByText('Toggle Dialog'));
   expect(screen.getByLabelText('com_ui_agent_git_name')).toHaveValue(identity.name);
   expect(screen.getByLabelText('com_ui_agent_git_email')).toHaveValue(identity.email);
   fireEvent.change(screen.getByLabelText('com_ui_agent_git_email'), {


### PR DESCRIPTION
## Summary

I moved agent-owned stateful code configuration out of Advanced and into the Run Code tool dialog, where users naturally configure code behavior.

- Exposes the stateful-session toggle, execution environment, workspace scope, and attached-machine Git identity from Run Code settings.
- Marks Run Code as configurable so its settings action is available from the agent tool list.
- Preserves the existing agent form fields, validation, capability gating, and deployment restrictions without backend or schema changes.
- Keeps Advanced focused on general agent and orchestration settings.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- `cd client && ../node_modules/.bin/jest --runInBand --coverage=false src/components/SidePanel/Agents/Tools/items/__tests__/configurable.spec.ts src/components/SidePanel/Agents/Tools/ItemDialog/__tests__/BuiltinSection.spec.tsx src/components/SidePanel/Agents/__tests__/CodeSettings.spec.tsx`
- ESLint on the seven touched TypeScript/TSX files
- Prettier check on the seven touched TypeScript/TSX files
- `git diff --check`

### **Test Configuration**:

- macOS
- Node.js workspace dependencies from the current LibreChat development checkout

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
