### PR TITLE
🪫 fix: Gate Programmatic Bash on Stateful Worker Capabilities

### DIFF
--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -91,6 +91,7 @@ const {
   domainParser,
 } = require('./ActionService');
 const {
+  getAppConfig,
   getEndpointsConfig,
   getMCPServerTools,
   getCachedTools,
@@ -1291,6 +1292,7 @@ async function loadToolDefinitionsWrapper({
       codeExecutionEnabled,
       codeExecutionContext: resolvedCodeExecutionContext,
       codeEnvironments: appConfig?.endpoints?.agents?.statefulCodeSessions?.environments,
+      getAppConfig,
       provider: agent.provider,
       mcpServerNames,
       rawServerNames: mcpRawServerNames,
@@ -1383,6 +1385,7 @@ async function loadToolDefinitionsWrapper({
           codeExecutionEnabled,
           codeExecutionContext: resolvedCodeExecutionContext,
           codeEnvironments: appConfig?.endpoints?.agents?.statefulCodeSessions?.environments,
+          getAppConfig,
           provider: agent.provider,
           mcpServerNames,
           rawServerNames: mcpRawServerNames,
@@ -1744,6 +1747,7 @@ async function loadAgentTools({
       programmaticToolsEnabled,
       codeExecutionEnabled,
       codeEnvironments: appConfig?.endpoints?.agents?.statefulCodeSessions?.environments,
+      getAppConfig,
       authHeaders: () =>
         codeExecutionAuthHeaders(
           (bridgeWorkerId) => getCodeApiAuthHeaders(req, bridgeWorkerId),
@@ -2145,6 +2149,7 @@ async function loadToolsForExecution({
     (await supportsProgrammaticCodeExecution(
       codeExecutionContext,
       req.config?.endpoints?.agents?.statefulCodeSessions?.environments,
+      getAppConfig,
     ));
   if (canLoadPTC) {
     configurable.toolRegistry = toolRegistry;

--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -18,6 +18,7 @@ const {
   buildWebSearchContext,
   buildImageToolContext,
   buildToolClassification,
+  supportsProgrammaticCodeExecution,
   getMissingCustomUserVars,
   buildWebSearchDynamicContext,
   getCodeApiAuthHeaders,
@@ -1288,6 +1289,8 @@ async function loadToolDefinitionsWrapper({
       deferredToolsEnabled,
       programmaticToolsEnabled,
       codeExecutionEnabled,
+      codeExecutionContext: resolvedCodeExecutionContext,
+      codeEnvironments: appConfig?.endpoints?.agents?.statefulCodeSessions?.environments,
       provider: agent.provider,
       mcpServerNames,
       rawServerNames: mcpRawServerNames,
@@ -1378,6 +1381,8 @@ async function loadToolDefinitionsWrapper({
           deferredToolsEnabled,
           programmaticToolsEnabled,
           codeExecutionEnabled,
+          codeExecutionContext: resolvedCodeExecutionContext,
+          codeEnvironments: appConfig?.endpoints?.agents?.statefulCodeSessions?.environments,
           provider: agent.provider,
           mcpServerNames,
           rawServerNames: mcpRawServerNames,
@@ -1738,6 +1743,7 @@ async function loadAgentTools({
       deferredToolsEnabled,
       programmaticToolsEnabled,
       codeExecutionEnabled,
+      codeEnvironments: appConfig?.endpoints?.agents?.statefulCodeSessions?.environments,
       authHeaders: () =>
         codeExecutionAuthHeaders(
           (bridgeWorkerId) => getCodeApiAuthHeaders(req, bridgeWorkerId),
@@ -2133,7 +2139,14 @@ async function loadToolsForExecution({
     configurable.toolRegistry = toolRegistry;
   }
 
-  if (isPTC && toolRegistry) {
+  const canLoadPTC =
+    isPTC &&
+    toolRegistry != null &&
+    (await supportsProgrammaticCodeExecution(
+      codeExecutionContext,
+      req.config?.endpoints?.agents?.statefulCodeSessions?.environments,
+    ));
+  if (canLoadPTC) {
     configurable.toolRegistry = toolRegistry;
     try {
       /**
@@ -2218,7 +2231,7 @@ async function loadToolsForExecution({
   ]);
 
   let ptcOrchestratedToolNames = [];
-  if (isPTC && toolRegistry) {
+  if (canLoadPTC) {
     ptcOrchestratedToolNames = Array.from(toolRegistry.values())
       .filter(
         (toolDef) =>

--- a/api/server/services/__tests__/ToolService.spec.js
+++ b/api/server/services/__tests__/ToolService.spec.js
@@ -16,6 +16,7 @@ const {
 } = require('librechat-data-provider');
 
 const mockGetEndpointsConfig = jest.fn();
+const mockGetAppConfig = jest.fn();
 const mockGetMCPServerTools = jest.fn();
 const mockGetCachedTools = jest.fn();
 const mockSendEvent = jest.fn();
@@ -59,6 +60,7 @@ const mockPrimeSearchFiles = jest.fn().mockResolvedValue({});
 const mockPrimeCodeFiles = jest.fn().mockResolvedValue({});
 jest.mock('~/server/services/Config', () => ({
   getEndpointsConfig: (...args) => mockGetEndpointsConfig(...args),
+  getAppConfig: (...args) => mockGetAppConfig(...args),
   getMCPServerTools: (...args) => mockGetMCPServerTools(...args),
   getCachedTools: (...args) => mockGetCachedTools(...args),
 }));
@@ -3054,6 +3056,82 @@ describe('ToolService - Action Capability Gating', () => {
         Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
       );
     });
+
+    it.each([false, true])(
+      'loads attached PTC using deployment credentials only when statefulWorkspace=%s',
+      async (statefulWorkspace) => {
+        const capabilities = [
+          AgentCapabilities.tools,
+          AgentCapabilities.programmatic_tools,
+          AgentCapabilities.execute_code,
+          AgentCapabilities.stateful_code_sessions,
+        ];
+        const req = createMockReq(capabilities);
+        const environment = {
+          id: 'personal',
+          name: 'Personal',
+          type: 'attached',
+          owner: 'deployment',
+          baseURL: 'https://attached.example',
+          workerId: `worker-${statefulWorkspace}`,
+          pairing: {
+            workerId: `worker-${statefulWorkspace}`,
+            tokenEnv: 'TEST_PTC_DEPLOYMENT_TOKEN',
+          },
+        };
+        req.config.endpoints.agents.statefulCodeSessions = { environments: [environment] };
+        mockGetAppConfig.mockResolvedValueOnce({
+          endpoints: { agents: { statefulCodeSessions: { environments: [environment] } } },
+        });
+        mockGetEndpointsConfig.mockResolvedValue(createEndpointsConfig(capabilities));
+        mockResolveCodeExecutionContext.mockImplementationOnce(
+          jest.requireActual('@librechat/api').resolveCodeExecutionContext,
+        );
+        process.env.TEST_PTC_DEPLOYMENT_TOKEN = `deployment-token-${statefulWorkspace}`;
+        const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              protocolVersion: 1,
+              workerId: environment.workerId,
+              online: true,
+              ready: true,
+              leaseExpiresInMs: 45_000,
+              capabilities: { statefulWorkspace, sandboxProfile: 'native-srt', runtimes: ['bash'] },
+            }),
+          ),
+        );
+        try {
+          const result = await loadToolsForExecution({
+            req,
+            res: {},
+            agent: {
+              id: 'agent_ptc',
+              tools: [Tools.execute_code],
+              stateful_code_sessions: true,
+              code_environment_id: 'personal',
+            },
+            toolNames: [Constants.BASH_PROGRAMMATIC_TOOL_CALLING],
+            toolRegistry: new Map(),
+            actionsEnabled: false,
+          });
+          expect(
+            result.loadedTools.some(
+              (tool) => tool.name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
+            ),
+          ).toBe(statefulWorkspace);
+          expect(mockGetAppConfig).toHaveBeenCalledWith({ baseOnly: true });
+          expect(fetchSpy).toHaveBeenCalledWith(
+            `https://attached.example/bridge/workers/${environment.workerId}/status`,
+            expect.objectContaining({
+              headers: { Authorization: `Bearer deployment-token-${statefulWorkspace}` },
+            }),
+          );
+        } finally {
+          fetchSpy.mockRestore();
+          delete process.env.TEST_PTC_DEPLOYMENT_TOKEN;
+        }
+      },
+    );
 
     it('does not load PTC when programmatic tools capability is disabled', async () => {
       const capabilities = [AgentCapabilities.tools, AgentCapabilities.execute_code];

--- a/api/server/services/__tests__/ToolService.spec.js
+++ b/api/server/services/__tests__/ToolService.spec.js
@@ -3013,6 +3013,48 @@ describe('ToolService - Action Capability Gating', () => {
       );
     });
 
+    it('does not lazily load PTC for an attached worker without confirmed stateful support', async () => {
+      const capabilities = [
+        AgentCapabilities.tools,
+        AgentCapabilities.programmatic_tools,
+        AgentCapabilities.execute_code,
+        AgentCapabilities.stateful_code_sessions,
+      ];
+      const req = createMockReq(capabilities);
+      req.config.endpoints.agents.statefulCodeSessions = {
+        environments: [
+          {
+            id: 'personal',
+            name: 'Personal',
+            type: 'attached',
+            owner: 'deployment',
+            baseURL: 'https://attached.example',
+            workerId: 'worker',
+          },
+        ],
+      };
+      mockGetEndpointsConfig.mockResolvedValue(createEndpointsConfig(capabilities));
+      mockResolveCodeExecutionContext.mockImplementationOnce(
+        jest.requireActual('@librechat/api').resolveCodeExecutionContext,
+      );
+      const result = await loadToolsForExecution({
+        req,
+        res: {},
+        agent: {
+          id: 'agent_ptc',
+          tools: [Tools.execute_code],
+          stateful_code_sessions: true,
+          code_environment_id: 'personal',
+        },
+        toolNames: [Constants.BASH_PROGRAMMATIC_TOOL_CALLING],
+        toolRegistry: new Map(),
+        actionsEnabled: false,
+      });
+      expect(result.loadedTools.map((tool) => tool.name)).not.toContain(
+        Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
+      );
+    });
+
     it('does not load PTC when programmatic tools capability is disabled', async () => {
       const capabilities = [AgentCapabilities.tools, AgentCapabilities.execute_code];
       const req = createMockReq(capabilities);

--- a/api/server/services/__tests__/ToolService.spec.js
+++ b/api/server/services/__tests__/ToolService.spec.js
@@ -3057,9 +3057,13 @@ describe('ToolService - Action Capability Gating', () => {
       );
     });
 
-    it.each([false, true])(
-      'loads attached PTC using deployment credentials only when statefulWorkspace=%s',
-      async (statefulWorkspace) => {
+    it.each([
+      { statefulWorkspace: false, runtimes: ['bash'], supported: false },
+      { statefulWorkspace: true, runtimes: ['py'], supported: false },
+      { statefulWorkspace: true, runtimes: ['bash'], supported: true },
+    ])(
+      'loads attached PTC using deployment credentials: stateful=$statefulWorkspace runtimes=$runtimes',
+      async ({ statefulWorkspace, runtimes, supported }) => {
         const capabilities = [
           AgentCapabilities.tools,
           AgentCapabilities.programmatic_tools,
@@ -3073,9 +3077,9 @@ describe('ToolService - Action Capability Gating', () => {
           type: 'attached',
           owner: 'deployment',
           baseURL: 'https://attached.example',
-          workerId: `worker-${statefulWorkspace}`,
+          workerId: `worker-${statefulWorkspace}-${runtimes[0]}`,
           pairing: {
-            workerId: `worker-${statefulWorkspace}`,
+            workerId: `worker-${statefulWorkspace}-${runtimes[0]}`,
             tokenEnv: 'TEST_PTC_DEPLOYMENT_TOKEN',
           },
         };
@@ -3096,7 +3100,7 @@ describe('ToolService - Action Capability Gating', () => {
               online: true,
               ready: true,
               leaseExpiresInMs: 45_000,
-              capabilities: { statefulWorkspace, sandboxProfile: 'native-srt', runtimes: ['bash'] },
+              capabilities: { statefulWorkspace, sandboxProfile: 'native-srt', runtimes },
             }),
           ),
         );
@@ -3118,7 +3122,7 @@ describe('ToolService - Action Capability Gating', () => {
             result.loadedTools.some(
               (tool) => tool.name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
             ),
-          ).toBe(statefulWorkspace);
+          ).toBe(supported);
           expect(mockGetAppConfig).toHaveBeenCalledWith({ baseOnly: true });
           expect(fetchSpy).toHaveBeenCalledWith(
             `https://attached.example/bridge/workers/${environment.workerId}/status`,

--- a/packages/api/src/agents/execution.ts
+++ b/packages/api/src/agents/execution.ts
@@ -15,7 +15,10 @@ export const CODE_API_BRIDGE_WORKER_HEADER = 'X-LibreChat-Code-Worker-ID';
 export type CodeExecutionProfile = 'default' | 'stateful';
 export type CodeEnvironmentConfig = NonNullable<
   NonNullable<TAgentsEndpoint['statefulCodeSessions']>['environments']
->[number];
+>[number] & {
+  /** Server-resolved control plane for a principal-owned attached environment. */
+  controlPlaneId?: string;
+};
 
 export interface CodeExecutionContext {
   baseUrl: string;

--- a/packages/api/src/code/bridge.spec.ts
+++ b/packages/api/src/code/bridge.spec.ts
@@ -35,6 +35,7 @@ describe('getCodeBridgeWorkerStatus', () => {
       }),
     ).resolves.toEqual({
       status: 'ready',
+      statefulWorkspace: true,
       leaseExpiresInMs: 45_000,
       sandboxProfile: 'native-srt',
       runtimes: ['bash'],

--- a/packages/api/src/code/bridge.ts
+++ b/packages/api/src/code/bridge.ts
@@ -23,6 +23,7 @@ export type CodeBridgePairing = {
 export type CodeBridgeWorkerStatus = {
   status: 'offline' | 'starting' | 'ready';
   leaseExpiresInMs?: number;
+  statefulWorkspace?: boolean;
   sandboxProfile?: string;
   runtimes?: string[];
   operations?: string[];
@@ -199,6 +200,7 @@ export async function getCodeBridgeWorkerStatus({
       ready?: unknown;
       leaseExpiresInMs?: unknown;
       capabilities?: {
+        statefulWorkspace?: unknown;
         sandboxProfile?: unknown;
         runtimes?: unknown;
         workspaceTools?: { operations?: unknown };
@@ -228,7 +230,9 @@ export async function getCodeBridgeWorkerStatus({
       !validLease ||
       !validCapabilities ||
       !validRuntimes ||
-      !validOperations
+      !validOperations ||
+      (capabilities?.statefulWorkspace != null &&
+        typeof capabilities.statefulWorkspace !== 'boolean')
     ) {
       throw new CodeBridgeStatusError('invalid');
     }
@@ -238,6 +242,9 @@ export async function getCodeBridgeWorkerStatus({
     }
     return {
       status: workerStatus,
+      ...(typeof capabilities?.statefulWorkspace === 'boolean'
+        ? { statefulWorkspace: capabilities.statefulWorkspace }
+        : {}),
       ...(typeof status.leaseExpiresInMs !== 'number'
         ? {}
         : { leaseExpiresInMs: status.leaseExpiresInMs }),

--- a/packages/api/src/code/capabilities.spec.ts
+++ b/packages/api/src/code/capabilities.spec.ts
@@ -1,0 +1,88 @@
+import type { CodeExecutionContext, CodeEnvironmentConfig } from '~/agents/execution';
+import { supportsProgrammaticCodeExecution } from './capabilities';
+
+const context: CodeExecutionContext = {
+  baseUrl: 'https://bridge.example',
+  codeSessionKey: 'session',
+  executionProfile: 'stateful',
+  statefulSessions: true,
+  environmentId: 'personal',
+  environmentType: 'attached',
+  bridgeWorkerId: 'worker',
+};
+const environments: CodeEnvironmentConfig[] = [
+  {
+    id: 'personal',
+    name: 'Personal',
+    type: 'attached',
+    owner: 'principal',
+    baseURL: context.baseUrl,
+    workerId: 'worker',
+    controlPlaneId: 'control-plane',
+  },
+  {
+    id: 'control-plane',
+    name: 'Control plane',
+    type: 'attached',
+    owner: 'deployment',
+    baseURL: context.baseUrl,
+    pairing: { allowPrincipalWorkers: true, tokenEnv: 'TEST_CODE_CAPABILITY_TOKEN' },
+  },
+];
+
+describe('supportsProgrammaticCodeExecution', () => {
+  afterEach(() => {
+    delete process.env.TEST_CODE_CAPABILITY_TOKEN;
+  });
+
+  it.each([false, true, undefined])('requires explicit support: %s', async (statefulWorkspace) => {
+    process.env.TEST_CODE_CAPABILITY_TOKEN = `token-${statefulWorkspace}`;
+    const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          protocolVersion: 1,
+          workerId: 'worker',
+          online: true,
+          ready: true,
+          leaseExpiresInMs: 45_000,
+          capabilities: { statefulWorkspace, sandboxProfile: 'native-srt', runtimes: ['bash'] },
+        }),
+      ),
+    );
+    expect(await supportsProgrammaticCodeExecution(context, environments)).toBe(
+      statefulWorkspace === true,
+    );
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://bridge.example/bridge/workers/worker/status',
+      expect.objectContaining({ headers: { Authorization: `Bearer token-${statefulWorkspace}` } }),
+    );
+  });
+
+  it('disables PTC when discovery fails', async () => {
+    process.env.TEST_CODE_CAPABILITY_TOKEN = 'failed-token';
+    jest.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'));
+    expect(await supportsProgrammaticCodeExecution(context, environments)).toBe(false);
+  });
+
+  it('does not poll managed environments or environments without status credentials', async () => {
+    const fetchSpy = jest.spyOn(globalThis, 'fetch');
+    expect(
+      await supportsProgrammaticCodeExecution({ ...context, environmentType: 'managed' }),
+    ).toBe(true);
+    expect(await supportsProgrammaticCodeExecution()).toBe(true);
+    expect(await supportsProgrammaticCodeExecution(context, environments)).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not send credentials to a different execution route', async () => {
+    process.env.TEST_CODE_CAPABILITY_TOKEN = 'route-token';
+    const fetchSpy = jest.spyOn(globalThis, 'fetch');
+    expect(
+      await supportsProgrammaticCodeExecution(
+        { ...context, baseUrl: 'https://different.example' },
+        environments,
+      ),
+    ).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/code/capabilities.spec.ts
+++ b/packages/api/src/code/capabilities.spec.ts
@@ -70,6 +70,59 @@ describe('supportsProgrammaticCodeExecution', () => {
     );
   });
 
+  it.each([
+    { runtimes: [], supported: false },
+    { runtimes: ['py'], supported: false },
+    { runtimes: undefined, supported: false },
+    { runtimes: ['py', 'bash'], supported: true },
+  ])('requires advertised Bash support: $runtimes', async ({ runtimes, supported }) => {
+    process.env.TEST_CODE_CAPABILITY_TOKEN = `runtimes-${JSON.stringify(runtimes)}`;
+    jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          protocolVersion: 1,
+          workerId: 'worker',
+          online: true,
+          ready: true,
+          leaseExpiresInMs: 45_000,
+          capabilities: { statefulWorkspace: true, sandboxProfile: 'native-srt', runtimes },
+        }),
+      ),
+    );
+    expect(await supportsProgrammaticCodeExecution(context, environments, getAppConfig)).toBe(
+      supported,
+    );
+  });
+
+  it('refreshes worker capabilities after the cached status expires', async () => {
+    process.env.TEST_CODE_CAPABILITY_TOKEN = 'capability-transition-token';
+    const startedAt = Date.now();
+    const now = jest.spyOn(Date, 'now').mockReturnValue(startedAt);
+    const status = (runtimes: string[]) =>
+      new Response(
+        JSON.stringify({
+          protocolVersion: 1,
+          workerId: 'worker',
+          online: true,
+          ready: true,
+          leaseExpiresInMs: 45_000,
+          capabilities: { statefulWorkspace: true, sandboxProfile: 'native-srt', runtimes },
+        }),
+      );
+    const fetchSpy = jest
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(status(['bash']))
+      .mockResolvedValueOnce(status(['py']));
+    expect(await supportsProgrammaticCodeExecution(context, environments, getAppConfig)).toBe(true);
+    expect(await supportsProgrammaticCodeExecution(context, environments, getAppConfig)).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    now.mockReturnValue(startedAt + 2_001);
+    expect(await supportsProgrammaticCodeExecution(context, environments, getAppConfig)).toBe(
+      false,
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
   it('disables PTC when discovery fails', async () => {
     process.env.TEST_CODE_CAPABILITY_TOKEN = 'failed-token';
     jest.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'));
@@ -79,7 +132,9 @@ describe('supportsProgrammaticCodeExecution', () => {
   });
 
   it('does not poll managed environments or environments without status credentials', async () => {
-    const fetchSpy = jest.spyOn(globalThis, 'fetch');
+    const fetchSpy = jest
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new Error('Unexpected status request'));
     expect(
       await supportsProgrammaticCodeExecution({ ...context, environmentType: 'managed' }),
     ).toBe(true);
@@ -92,7 +147,9 @@ describe('supportsProgrammaticCodeExecution', () => {
 
   it('does not send credentials to a different execution route', async () => {
     process.env.TEST_CODE_CAPABILITY_TOKEN = 'route-token';
-    const fetchSpy = jest.spyOn(globalThis, 'fetch');
+    const fetchSpy = jest
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new Error('Unexpected status request'));
     expect(
       await supportsProgrammaticCodeExecution(
         { ...context, baseUrl: 'https://different.example' },
@@ -113,7 +170,9 @@ describe('supportsProgrammaticCodeExecution', () => {
         tokenEnv: 'TEST_PRIVATE_CAPABILITY_SECRET',
       },
     };
-    const fetchSpy = jest.spyOn(globalThis, 'fetch');
+    const fetchSpy = jest
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new Error('Unexpected status request'));
     expect(
       await supportsProgrammaticCodeExecution(
         {
@@ -164,7 +223,9 @@ describe('supportsProgrammaticCodeExecution', () => {
   });
 
   it('requires the control plane in effective config before reading deployment config', async () => {
-    const fetchSpy = jest.spyOn(globalThis, 'fetch');
+    const fetchSpy = jest
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new Error('Unexpected status request'));
     expect(await supportsProgrammaticCodeExecution(context, [environments[0]], getAppConfig)).toBe(
       false,
     );
@@ -173,7 +234,9 @@ describe('supportsProgrammaticCodeExecution', () => {
   });
 
   it('fails closed when deployment configuration cannot be loaded', async () => {
-    const fetchSpy = jest.spyOn(globalThis, 'fetch');
+    const fetchSpy = jest
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new Error('Unexpected status request'));
     expect(
       await supportsProgrammaticCodeExecution(context, environments, async () => {
         throw new Error('unavailable');

--- a/packages/api/src/code/capabilities.spec.ts
+++ b/packages/api/src/code/capabilities.spec.ts
@@ -1,3 +1,4 @@
+import type { AppConfig } from '@librechat/data-schemas';
 import type { CodeExecutionContext, CodeEnvironmentConfig } from '~/agents/execution';
 import { supportsProgrammaticCodeExecution } from './capabilities';
 
@@ -30,9 +31,19 @@ const environments: CodeEnvironmentConfig[] = [
   },
 ];
 
+const deploymentConfig = {
+  endpoints: { agents: { statefulCodeSessions: { environments: [environments[1]] } } },
+} as AppConfig;
+const getAppConfig = jest.fn(async () => deploymentConfig);
+
 describe('supportsProgrammaticCodeExecution', () => {
+  beforeEach(() => {
+    getAppConfig.mockClear();
+  });
+
   afterEach(() => {
     delete process.env.TEST_CODE_CAPABILITY_TOKEN;
+    delete process.env.TEST_PRIVATE_CAPABILITY_SECRET;
   });
 
   it.each([false, true, undefined])('requires explicit support: %s', async (statefulWorkspace) => {
@@ -49,9 +60,10 @@ describe('supportsProgrammaticCodeExecution', () => {
         }),
       ),
     );
-    expect(await supportsProgrammaticCodeExecution(context, environments)).toBe(
+    expect(await supportsProgrammaticCodeExecution(context, environments, getAppConfig)).toBe(
       statefulWorkspace === true,
     );
+    expect(getAppConfig).toHaveBeenCalledWith({ baseOnly: true });
     expect(fetchSpy).toHaveBeenCalledWith(
       'https://bridge.example/bridge/workers/worker/status',
       expect.objectContaining({ headers: { Authorization: `Bearer token-${statefulWorkspace}` } }),
@@ -61,7 +73,9 @@ describe('supportsProgrammaticCodeExecution', () => {
   it('disables PTC when discovery fails', async () => {
     process.env.TEST_CODE_CAPABILITY_TOKEN = 'failed-token';
     jest.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'));
-    expect(await supportsProgrammaticCodeExecution(context, environments)).toBe(false);
+    expect(await supportsProgrammaticCodeExecution(context, environments, getAppConfig)).toBe(
+      false,
+    );
   });
 
   it('does not poll managed environments or environments without status credentials', async () => {
@@ -70,7 +84,9 @@ describe('supportsProgrammaticCodeExecution', () => {
       await supportsProgrammaticCodeExecution({ ...context, environmentType: 'managed' }),
     ).toBe(true);
     expect(await supportsProgrammaticCodeExecution()).toBe(true);
-    expect(await supportsProgrammaticCodeExecution(context, environments)).toBe(false);
+    expect(await supportsProgrammaticCodeExecution(context, environments, getAppConfig)).toBe(
+      false,
+    );
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
@@ -81,7 +97,87 @@ describe('supportsProgrammaticCodeExecution', () => {
       await supportsProgrammaticCodeExecution(
         { ...context, baseUrl: 'https://different.example' },
         environments,
+        getAppConfig,
       ),
+    ).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+  it('rejects a deployment environment override that redirects a process secret', async () => {
+    process.env.TEST_PRIVATE_CAPABILITY_SECRET = 'must-not-leave-the-process';
+    const override: CodeEnvironmentConfig = {
+      ...environments[1],
+      baseURL: 'https://attacker.example',
+      pairing: {
+        workerId: 'worker',
+        allowPrincipalWorkers: false,
+        tokenEnv: 'TEST_PRIVATE_CAPABILITY_SECRET',
+      },
+    };
+    const fetchSpy = jest.spyOn(globalThis, 'fetch');
+    expect(
+      await supportsProgrammaticCodeExecution(
+        {
+          ...context,
+          environmentId: override.id,
+          baseUrl: override.baseURL,
+        },
+        [override],
+        getAppConfig,
+      ),
+    ).toBe(false);
+    expect(getAppConfig).toHaveBeenCalledWith({ baseOnly: true });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('uses only deployment credentials even if the effective control plane names another secret', async () => {
+    process.env.TEST_CODE_CAPABILITY_TOKEN = 'deployment-only-token';
+    process.env.TEST_PRIVATE_CAPABILITY_SECRET = 'must-not-leave-the-process';
+    const override: CodeEnvironmentConfig = {
+      ...environments[1],
+      baseURL: 'https://attacker.example',
+      pairing: { allowPrincipalWorkers: true, tokenEnv: 'TEST_PRIVATE_CAPABILITY_SECRET' },
+    };
+    const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          protocolVersion: 1,
+          workerId: 'worker',
+          online: true,
+          ready: true,
+          leaseExpiresInMs: 45_000,
+          capabilities: {
+            statefulWorkspace: true,
+            sandboxProfile: 'native-srt',
+            runtimes: ['bash'],
+          },
+        }),
+      ),
+    );
+    expect(
+      await supportsProgrammaticCodeExecution(context, [environments[0], override], getAppConfig),
+    ).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://bridge.example/bridge/workers/worker/status',
+      expect.objectContaining({ headers: { Authorization: 'Bearer deployment-only-token' } }),
+    );
+    expect(JSON.stringify(fetchSpy.mock.calls)).not.toContain('must-not-leave-the-process');
+  });
+
+  it('requires the control plane in effective config before reading deployment config', async () => {
+    const fetchSpy = jest.spyOn(globalThis, 'fetch');
+    expect(await supportsProgrammaticCodeExecution(context, [environments[0]], getAppConfig)).toBe(
+      false,
+    );
+    expect(getAppConfig).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when deployment configuration cannot be loaded', async () => {
+    const fetchSpy = jest.spyOn(globalThis, 'fetch');
+    expect(
+      await supportsProgrammaticCodeExecution(context, environments, async () => {
+        throw new Error('unavailable');
+      }),
     ).toBe(false);
     expect(fetchSpy).not.toHaveBeenCalled();
   });

--- a/packages/api/src/code/capabilities.ts
+++ b/packages/api/src/code/capabilities.ts
@@ -1,6 +1,9 @@
 import { logger } from '@librechat/data-schemas';
 import type { CodeEnvironmentConfig, CodeExecutionContext } from '~/agents/execution';
+import type { createAppConfigService } from '~/app/service';
 import { createCodeBridgeStatusPoller, readCodeBridgeSecret } from './bridge';
+
+export type CodeCapabilityConfigLoader = ReturnType<typeof createAppConfigService>['getAppConfig'];
 
 const pollWorkerStatus = createCodeBridgeStatusPoller();
 
@@ -8,28 +11,39 @@ const pollWorkerStatus = createCodeBridgeStatusPoller();
 export async function supportsProgrammaticCodeExecution(
   context?: CodeExecutionContext,
   environments?: readonly CodeEnvironmentConfig[],
+  getAppConfig?: CodeCapabilityConfigLoader,
 ): Promise<boolean> {
   if (context?.environmentType !== 'attached') return true;
   if (!context.bridgeWorkerId) return false;
   const selected = environments?.find((environment) => environment.id === context.environmentId);
-  const controlPlane = selected?.controlPlaneId
-    ? environments?.find((environment) => environment.id === selected.controlPlaneId)
-    : selected;
-  const tokenEnv = controlPlane?.pairing?.tokenEnv;
-  const token = tokenEnv == null ? undefined : readCodeBridgeSecret(tokenEnv)?.trim();
-  if (
-    !token ||
-    !controlPlane ||
-    controlPlane.type !== 'attached' ||
-    controlPlane.owner === 'principal'
-  )
-    return false;
-  if (controlPlane.baseURL.replace(/\/+$/, '') !== context.baseUrl.replace(/\/+$/, '')) {
-    return false;
-  }
+  const controlPlaneId = selected?.controlPlaneId ?? selected?.id;
+  const effectiveControlPlane = environments?.find(
+    (environment) =>
+      environment.id === controlPlaneId &&
+      environment.type === 'attached' &&
+      environment.owner === 'deployment',
+  );
+  if (!effectiveControlPlane || !getAppConfig) return false;
   try {
+    const deploymentConfig = await getAppConfig({ baseOnly: true });
+    const controlPlane =
+      deploymentConfig.endpoints?.agents?.statefulCodeSessions?.environments?.find(
+        (environment) =>
+          environment.id === controlPlaneId &&
+          environment.type === 'attached' &&
+          environment.owner === 'deployment',
+      );
+    if (
+      !controlPlane ||
+      controlPlane.baseURL.replace(/\/+$/, '') !== context.baseUrl.replace(/\/+$/, '')
+    ) {
+      return false;
+    }
+    const tokenEnv = controlPlane.pairing?.tokenEnv;
+    const token = tokenEnv == null ? undefined : readCodeBridgeSecret(tokenEnv)?.trim();
+    if (!token) return false;
     const status = await pollWorkerStatus({
-      baseURL: context.baseUrl,
+      baseURL: controlPlane.baseURL,
       workerId: context.bridgeWorkerId,
       token,
     });

--- a/packages/api/src/code/capabilities.ts
+++ b/packages/api/src/code/capabilities.ts
@@ -1,0 +1,41 @@
+import { logger } from '@librechat/data-schemas';
+import type { CodeEnvironmentConfig, CodeExecutionContext } from '~/agents/execution';
+import { createCodeBridgeStatusPoller, readCodeBridgeSecret } from './bridge';
+
+const pollWorkerStatus = createCodeBridgeStatusPoller();
+
+/** Attached workers must confirm the stateful workspace needed by programmatic Bash. */
+export async function supportsProgrammaticCodeExecution(
+  context?: CodeExecutionContext,
+  environments?: readonly CodeEnvironmentConfig[],
+): Promise<boolean> {
+  if (context?.environmentType !== 'attached') return true;
+  if (!context.bridgeWorkerId) return false;
+  const selected = environments?.find((environment) => environment.id === context.environmentId);
+  const controlPlane = selected?.controlPlaneId
+    ? environments?.find((environment) => environment.id === selected.controlPlaneId)
+    : selected;
+  const tokenEnv = controlPlane?.pairing?.tokenEnv;
+  const token = tokenEnv == null ? undefined : readCodeBridgeSecret(tokenEnv)?.trim();
+  if (
+    !token ||
+    !controlPlane ||
+    controlPlane.type !== 'attached' ||
+    controlPlane.owner === 'principal'
+  )
+    return false;
+  if (controlPlane.baseURL.replace(/\/+$/, '') !== context.baseUrl.replace(/\/+$/, '')) {
+    return false;
+  }
+  try {
+    const status = await pollWorkerStatus({
+      baseURL: context.baseUrl,
+      workerId: context.bridgeWorkerId,
+      token,
+    });
+    return status.status === 'ready' && status.statefulWorkspace === true;
+  } catch {
+    logger.warn('[codeCapabilities] Worker capabilities unavailable; programmatic Bash disabled');
+    return false;
+  }
+}

--- a/packages/api/src/code/capabilities.ts
+++ b/packages/api/src/code/capabilities.ts
@@ -7,7 +7,7 @@ export type CodeCapabilityConfigLoader = ReturnType<typeof createAppConfigServic
 
 const pollWorkerStatus = createCodeBridgeStatusPoller();
 
-/** Attached workers must confirm the stateful workspace needed by programmatic Bash. */
+/** Attached workers must confirm both a stateful workspace and the Bash runtime. */
 export async function supportsProgrammaticCodeExecution(
   context?: CodeExecutionContext,
   environments?: readonly CodeEnvironmentConfig[],
@@ -47,7 +47,11 @@ export async function supportsProgrammaticCodeExecution(
       workerId: context.bridgeWorkerId,
       token,
     });
-    return status.status === 'ready' && status.statefulWorkspace === true;
+    return (
+      status.status === 'ready' &&
+      status.statefulWorkspace === true &&
+      status.runtimes?.includes('bash') === true
+    );
   } catch {
     logger.warn('[codeCapabilities] Worker capabilities unavailable; programmatic Bash disabled');
     return false;

--- a/packages/api/src/code/config.spec.ts
+++ b/packages/api/src/code/config.spec.ts
@@ -401,6 +401,9 @@ describe('mergeAccessibleCodeEnvironments', () => {
       });
 
       const environments = result.endpoints?.agents?.statefulCodeSessions?.environments;
+      expect(environments?.find((environment) => environment.id === 'personal-vm')).toEqual(
+        expect.objectContaining({ controlPlaneId: 'self-service', baseURL: pairingOnly.baseURL }),
+      );
       expect(environments?.find((environment) => environment.id === 'self-service')?.default).toBe(
         false,
       );

--- a/packages/api/src/code/config.ts
+++ b/packages/api/src/code/config.ts
@@ -112,6 +112,7 @@ export async function mergeAccessibleCodeEnvironments({
       return [
         {
           ...environment,
+          controlPlaneId,
           baseURL: controlPlane.baseURL,
           configSchema: effectiveControlPlanes.get(controlPlaneId)?.configSchema,
         },

--- a/packages/api/src/code/index.ts
+++ b/packages/api/src/code/index.ts
@@ -5,3 +5,4 @@ export * from './bridge';
 export * from './lifecycle';
 export * from './workspace';
 export * from './command';
+export * from './capabilities';

--- a/packages/api/src/tools/classification.spec.ts
+++ b/packages/api/src/tools/classification.spec.ts
@@ -541,22 +541,29 @@ describe('classification.ts', () => {
       expect(result.additionalTools.length).toBe(0);
     });
 
-    it.each([false, true])(
-      'gates attached-worker PTC in definitionsOnly=%s',
-      async (definitionsOnly) => {
+    it.each(
+      [false, true].flatMap((definitionsOnly) => [
+        { definitionsOnly, statefulWorkspace: false, runtimes: ['bash'], supported: false },
+        { definitionsOnly, statefulWorkspace: true, runtimes: ['py'], supported: false },
+        { definitionsOnly, statefulWorkspace: true, runtimes: ['bash'], supported: true },
+      ]),
+    )(
+      'gates attached PTC: definitionsOnly=$definitionsOnly stateful=$statefulWorkspace runtimes=$runtimes',
+      async ({ definitionsOnly, statefulWorkspace, runtimes, supported }) => {
+        const workerId = `worker-${definitionsOnly}-${statefulWorkspace}-${runtimes[0]}`;
         process.env.TEST_CODE_CAPABILITY_TOKEN = 'capability-test-token';
         const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue(
           new Response(
             JSON.stringify({
               protocolVersion: 1,
-              workerId: `worker-${definitionsOnly}`,
+              workerId: workerId,
               online: true,
               ready: true,
               leaseExpiresInMs: 45_000,
               capabilities: {
-                statefulWorkspace: false,
+                statefulWorkspace,
                 sandboxProfile: 'native-srt',
-                runtimes: ['bash'],
+                runtimes,
               },
             }),
           ),
@@ -569,7 +576,7 @@ describe('classification.ts', () => {
             owner: 'deployment',
             baseURL: 'https://code.example',
             pairing: {
-              workerId: `worker-${definitionsOnly}`,
+              workerId: workerId,
               allowPrincipalWorkers: false,
               tokenEnv: 'TEST_CODE_CAPABILITY_TOKEN',
             },
@@ -594,17 +601,19 @@ describe('classification.ts', () => {
               statefulSessions: true,
               environmentType: 'attached',
               environmentId: 'attached',
-              bridgeWorkerId: `worker-${definitionsOnly}`,
+              bridgeWorkerId: workerId,
             },
             codeEnvironments,
             getAppConfig: jest.fn().mockResolvedValue({
               endpoints: { agents: { statefulCodeSessions: { environments: codeEnvironments } } },
             }),
           });
-          expect(result.toolDefinitions.some((d) => d.name === 'run_tools_with_bash')).toBe(false);
-          expect(result.toolRegistry?.has('run_tools_with_bash')).toBe(false);
+          expect(result.toolDefinitions.some((d) => d.name === 'run_tools_with_bash')).toBe(
+            supported,
+          );
+          expect(result.toolRegistry?.has('run_tools_with_bash')).toBe(supported);
           expect(result.additionalTools.some((tool) => tool.name === 'run_tools_with_bash')).toBe(
-            false,
+            supported && !definitionsOnly,
           );
           expect(result.hasDeferredTools).toBe(true);
           expect(result.toolRegistry?.get('tool1')?.allowed_callers).toEqual([

--- a/packages/api/src/tools/classification.spec.ts
+++ b/packages/api/src/tools/classification.spec.ts
@@ -540,6 +540,80 @@ describe('classification.ts', () => {
       expect(result.additionalTools.length).toBe(0);
     });
 
+    it.each([false, true])(
+      'gates attached-worker PTC in definitionsOnly=%s',
+      async (definitionsOnly) => {
+        process.env.TEST_CODE_CAPABILITY_TOKEN = 'capability-test-token';
+        const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              protocolVersion: 1,
+              workerId: `worker-${definitionsOnly}`,
+              online: true,
+              ready: true,
+              leaseExpiresInMs: 45_000,
+              capabilities: {
+                statefulWorkspace: false,
+                sandboxProfile: 'native-srt',
+                runtimes: ['bash'],
+              },
+            }),
+          ),
+        );
+        try {
+          const result = await buildToolClassification({
+            loadedTools: [createMCPTool('tool1')],
+            userId: 'user1',
+            agentId: 'agent1',
+            agentToolOptions: {
+              tool1: { allowed_callers: ['direct', 'code_execution'], defer_loading: true },
+            },
+            programmaticToolsEnabled: true,
+            codeExecutionEnabled: true,
+            deferredToolsEnabled: true,
+            definitionsOnly,
+            codeExecutionContext: {
+              baseUrl: 'https://code.example',
+              codeSessionKey: 'session',
+              executionProfile: 'stateful',
+              statefulSessions: true,
+              environmentType: 'attached',
+              environmentId: 'attached',
+              bridgeWorkerId: `worker-${definitionsOnly}`,
+            },
+            codeEnvironments: [
+              {
+                id: 'attached',
+                name: 'Attached',
+                type: 'attached',
+                owner: 'deployment',
+                baseURL: 'https://code.example',
+                pairing: {
+                  workerId: `worker-${definitionsOnly}`,
+                  allowPrincipalWorkers: false,
+                  tokenEnv: 'TEST_CODE_CAPABILITY_TOKEN',
+                },
+              },
+            ],
+          });
+          expect(result.toolDefinitions.some((d) => d.name === 'run_tools_with_bash')).toBe(false);
+          expect(result.toolRegistry?.has('run_tools_with_bash')).toBe(false);
+          expect(result.additionalTools.some((tool) => tool.name === 'run_tools_with_bash')).toBe(
+            false,
+          );
+          expect(result.hasDeferredTools).toBe(true);
+          expect(result.toolRegistry?.get('tool1')?.allowed_callers).toEqual([
+            'direct',
+            'code_execution',
+          ]);
+          expect(fetchSpy).toHaveBeenCalledTimes(1);
+        } finally {
+          fetchSpy.mockRestore();
+          delete process.env.TEST_CODE_CAPABILITY_TOKEN;
+        }
+      },
+    );
+
     it('should create bash PTC tool when capabilities allow programmatic tools', async () => {
       const loadedTools: GenericTool[] = [createMCPTool('tool1')];
 

--- a/packages/api/src/tools/classification.spec.ts
+++ b/packages/api/src/tools/classification.spec.ts
@@ -1,6 +1,7 @@
 import { Providers } from '@librechat/agents';
 import type { AgentToolOptions } from 'librechat-data-provider';
 import type { GenericTool } from '@librechat/agents';
+import type { CodeEnvironmentConfig } from '~/agents/execution';
 import type { LCToolRegistry } from './classification';
 import {
   buildToolRegistryFromAgentOptions,
@@ -560,6 +561,20 @@ describe('classification.ts', () => {
             }),
           ),
         );
+        const codeEnvironments: CodeEnvironmentConfig[] = [
+          {
+            id: 'attached',
+            name: 'Attached',
+            type: 'attached',
+            owner: 'deployment',
+            baseURL: 'https://code.example',
+            pairing: {
+              workerId: `worker-${definitionsOnly}`,
+              allowPrincipalWorkers: false,
+              tokenEnv: 'TEST_CODE_CAPABILITY_TOKEN',
+            },
+          },
+        ];
         try {
           const result = await buildToolClassification({
             loadedTools: [createMCPTool('tool1')],
@@ -581,20 +596,10 @@ describe('classification.ts', () => {
               environmentId: 'attached',
               bridgeWorkerId: `worker-${definitionsOnly}`,
             },
-            codeEnvironments: [
-              {
-                id: 'attached',
-                name: 'Attached',
-                type: 'attached',
-                owner: 'deployment',
-                baseURL: 'https://code.example',
-                pairing: {
-                  workerId: `worker-${definitionsOnly}`,
-                  allowPrincipalWorkers: false,
-                  tokenEnv: 'TEST_CODE_CAPABILITY_TOKEN',
-                },
-              },
-            ],
+            codeEnvironments,
+            getAppConfig: jest.fn().mockResolvedValue({
+              endpoints: { agents: { statefulCodeSessions: { environments: codeEnvironments } } },
+            }),
           });
           expect(result.toolDefinitions.some((d) => d.name === 'run_tools_with_bash')).toBe(false);
           expect(result.toolRegistry?.has('run_tools_with_bash')).toBe(false);

--- a/packages/api/src/tools/classification.ts
+++ b/packages/api/src/tools/classification.ts
@@ -22,7 +22,8 @@ import type {
   LCTool,
 } from '@librechat/agents';
 import type { AgentToolOptions } from 'librechat-data-provider';
-import type { CodeExecutionContext } from '~/agents/execution';
+import type { CodeEnvironmentConfig, CodeExecutionContext } from '~/agents/execution';
+import { supportsProgrammaticCodeExecution } from '~/code/capabilities';
 import { sanitizeGeminiSchema } from '~/mcp/zod';
 
 export type { LCTool, LCToolRegistry, AllowedCaller, JsonSchemaType };
@@ -280,6 +281,7 @@ export interface BuildToolClassificationParams {
   authHeaders?: () => Promise<Record<string, string>> | Record<string, string>;
   /** Trusted Code API route selected for the executing agent. */
   codeExecutionContext?: CodeExecutionContext;
+  codeEnvironments?: readonly CodeEnvironmentConfig[];
 }
 
 /** Result from building tool classification */
@@ -351,6 +353,7 @@ export async function buildToolClassification(
     codeExecutionEnabled = false,
     authHeaders,
     codeExecutionContext,
+    codeEnvironments,
   } = params;
   const isGoogle = provider === Providers.GOOGLE || provider === Providers.VERTEXAI;
   const additionalTools: GenericTool[] = [];
@@ -380,7 +383,10 @@ export async function buildToolClassification(
    * Only enable tool search if the agent has deferred tools AND the capability is enabled.
    */
   const hasProgrammaticTools =
-    programmaticToolsEnabled && codeExecutionEnabled && agentHasProgrammaticTools(toolRegistry);
+    programmaticToolsEnabled &&
+    codeExecutionEnabled &&
+    agentHasProgrammaticTools(toolRegistry) &&
+    (await supportsProgrammaticCodeExecution(codeExecutionContext, codeEnvironments));
   const hasDeferredTools = deferredToolsEnabled && agentHasDeferredTools(toolRegistry);
 
   /** Clear defer_loading if capability disabled */

--- a/packages/api/src/tools/classification.ts
+++ b/packages/api/src/tools/classification.ts
@@ -23,6 +23,7 @@ import type {
 } from '@librechat/agents';
 import type { AgentToolOptions } from 'librechat-data-provider';
 import type { CodeEnvironmentConfig, CodeExecutionContext } from '~/agents/execution';
+import type { CodeCapabilityConfigLoader } from '~/code/capabilities';
 import { supportsProgrammaticCodeExecution } from '~/code/capabilities';
 import { sanitizeGeminiSchema } from '~/mcp/zod';
 
@@ -282,6 +283,7 @@ export interface BuildToolClassificationParams {
   /** Trusted Code API route selected for the executing agent. */
   codeExecutionContext?: CodeExecutionContext;
   codeEnvironments?: readonly CodeEnvironmentConfig[];
+  getAppConfig?: CodeCapabilityConfigLoader;
 }
 
 /** Result from building tool classification */
@@ -354,6 +356,7 @@ export async function buildToolClassification(
     authHeaders,
     codeExecutionContext,
     codeEnvironments,
+    getAppConfig,
   } = params;
   const isGoogle = provider === Providers.GOOGLE || provider === Providers.VERTEXAI;
   const additionalTools: GenericTool[] = [];
@@ -386,7 +389,7 @@ export async function buildToolClassification(
     programmaticToolsEnabled &&
     codeExecutionEnabled &&
     agentHasProgrammaticTools(toolRegistry) &&
-    (await supportsProgrammaticCodeExecution(codeExecutionContext, codeEnvironments));
+    (await supportsProgrammaticCodeExecution(codeExecutionContext, codeEnvironments, getAppConfig));
   const hasDeferredTools = deferredToolsEnabled && agentHasDeferredTools(toolRegistry);
 
   /** Clear defer_loading if capability disabled */

--- a/packages/api/src/tools/definitions.spec.ts
+++ b/packages/api/src/tools/definitions.spec.ts
@@ -407,6 +407,37 @@ describe('definitions.ts', () => {
         expect(result.toolRegistry.has('run_tools_with_bash')).toBe(false);
       });
 
+      it('passes the selected attached environment into definitions-only classification', async () => {
+        mockGetOrFetchMCPServerTools.mockResolvedValueOnce(serverTools);
+        const result = await loadToolDefinitions(
+          {
+            userId: 'user-123',
+            agentId: 'agent-123',
+            tools: [mcpToolName],
+            toolOptions: { [mcpToolName]: { allowed_callers: ['code_execution'] } },
+            programmaticToolsEnabled: true,
+            codeExecutionEnabled: true,
+            codeExecutionContext: {
+              baseUrl: 'https://code.example',
+              codeSessionKey: 'session',
+              executionProfile: 'stateful',
+              statefulSessions: true,
+              environmentType: 'attached',
+              environmentId: 'attached',
+              bridgeWorkerId: 'worker',
+            },
+          },
+          {
+            getOrFetchMCPServerTools: mockGetOrFetchMCPServerTools,
+            isBuiltInTool: mockIsBuiltInTool,
+          },
+        );
+        expect(
+          result.toolDefinitions.some((definition) => definition.name === 'run_tools_with_bash'),
+        ).toBe(false);
+        expect(result.toolRegistry.has('run_tools_with_bash')).toBe(false);
+      });
+
       it('adds Bash PTC definitions when code and programmatic capabilities are enabled', async () => {
         mockGetOrFetchMCPServerTools.mockResolvedValueOnce(serverTools);
 

--- a/packages/api/src/tools/definitions.ts
+++ b/packages/api/src/tools/definitions.ts
@@ -17,6 +17,7 @@ import {
 import type { LCToolRegistry, JsonSchemaType, LCTool, GenericTool } from '@librechat/agents';
 import type { AgentToolOptions } from 'librechat-data-provider';
 import type { CodeEnvironmentConfig, CodeExecutionContext } from '~/agents/execution';
+import type { CodeCapabilityConfigLoader } from '~/code/capabilities';
 import type { MCPToolAlias, ToolDefinition } from './classification';
 import { resolveJsonSchemaRefs, normalizeJsonSchema, sanitizeGeminiSchema } from '~/mcp/zod';
 import { buildToolClassification } from './classification';
@@ -52,6 +53,7 @@ export interface LoadToolDefinitionsParams {
   codeExecutionEnabled?: boolean;
   codeExecutionContext?: CodeExecutionContext;
   codeEnvironments?: readonly CodeEnvironmentConfig[];
+  getAppConfig?: CodeCapabilityConfigLoader;
   /** Agent provider — Gemini/Vertex tool schemas get union-flattened for compatibility */
   provider?: Providers;
   /** Configured server names, used to resolve the tool-key boundary exactly */
@@ -132,6 +134,7 @@ export async function loadToolDefinitions(
     codeExecutionEnabled = false,
     codeExecutionContext,
     codeEnvironments,
+    getAppConfig,
     provider,
     mcpServerNames,
     rawServerNames,
@@ -370,6 +373,7 @@ export async function loadToolDefinitions(
     codeExecutionEnabled,
     codeExecutionContext,
     codeEnvironments,
+    getAppConfig,
     definitionsOnly: true,
     agentToolOptions: toolOptions,
   });

--- a/packages/api/src/tools/definitions.ts
+++ b/packages/api/src/tools/definitions.ts
@@ -16,6 +16,7 @@ import {
 } from 'librechat-data-provider';
 import type { LCToolRegistry, JsonSchemaType, LCTool, GenericTool } from '@librechat/agents';
 import type { AgentToolOptions } from 'librechat-data-provider';
+import type { CodeEnvironmentConfig, CodeExecutionContext } from '~/agents/execution';
 import type { MCPToolAlias, ToolDefinition } from './classification';
 import { resolveJsonSchemaRefs, normalizeJsonSchema, sanitizeGeminiSchema } from '~/mcp/zod';
 import { buildToolClassification } from './classification';
@@ -49,6 +50,8 @@ export interface LoadToolDefinitionsParams {
   programmaticToolsEnabled?: boolean;
   /** Whether code execution is enabled and requested by this agent */
   codeExecutionEnabled?: boolean;
+  codeExecutionContext?: CodeExecutionContext;
+  codeEnvironments?: readonly CodeEnvironmentConfig[];
   /** Agent provider — Gemini/Vertex tool schemas get union-flattened for compatibility */
   provider?: Providers;
   /** Configured server names, used to resolve the tool-key boundary exactly */
@@ -127,6 +130,8 @@ export async function loadToolDefinitions(
     deferredToolsEnabled = false,
     programmaticToolsEnabled = false,
     codeExecutionEnabled = false,
+    codeExecutionContext,
+    codeEnvironments,
     provider,
     mcpServerNames,
     rawServerNames,
@@ -363,6 +368,8 @@ export async function loadToolDefinitions(
     deferredToolsEnabled,
     programmaticToolsEnabled,
     codeExecutionEnabled,
+    codeExecutionContext,
+    codeEnvironments,
     definitionsOnly: true,
     agentToolOptions: toolOptions,
   });


### PR DESCRIPTION
## Summary

I prevent `run_tools_with_bash` from being advertised or instantiated for attached workers that do not confirm stateful-workspace support, avoiding permanent Code API failures and repeated model retries.

- Preserve and validate the worker's `statefulWorkspace` capability in bridge status responses.
- Require a ready attached worker with `statefulWorkspace: true` and an advertised Bash runtime before exposing programmatic Bash in eager and definitions-only loading, including definition reloads after OAuth.
- Recheck capabilities before lazy PTC instantiation and reuse the result when resolving programmatic tools.
- Authorize the control plane against effective config, then resolve polling credentials and destination exclusively from YAML deployment config using `getAppConfig({ baseOnly: true })`.
- Reuse the bounded, credential-scoped status poller and retain the authorized control-plane reference for principal-owned environments, without adding database reads.
- Omit PTC when attached-worker capabilities or status credentials are unavailable, while preserving workspace tools, direct tool policies, and managed/default environment behavior.

Native SRT can continue advertising `statefulWorkspace: false`; this change does not enable stateful workspaces or change runtime isolation defaults. Attached environments now need successful status discovery to expose PTC. The companion agents PR, https://github.com/danny-avila/agents/pull/535, improves permanent-error classification independently; this gating change works with the currently declared agents version.

Execution-identity check: the Code API execution-error log interpolates optional body `user_id`, which PTC does not send. The execution handler separately requires an authenticated principal and derives execution identity from it. LibreChat threads Code API auth headers through this path and uses the authenticated user ID as JWT `sub`. Thus `User ID: undefined` is expected for that legacy log field and is not evidence that execution identity is unset. This is a source-level finding, not a verification of the deployed revision; the Code API log should use the resolved principal/identity instead.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Run bridge, capability, environment-merge, classification, and definitions specs in `packages/api`: 114 tests passed.
- Run `src/auth/codeapi.spec.ts` in `packages/api`: 18 tests passed.
- Run `server/services/__tests__/ToolService.spec.js` in `api`: 133 tests passed.
- Run `npx tsc --noEmit` in `packages/api`: passed after rebuilding local workspace declarations.
- Build data-provider, data-schemas, and API workspaces: passed.
- Run `npm run static-checks -- --against origin/dev`: all affected checks passed, including ESLint, Prettier, import order, and circular dependencies.
- Attempt `npm run lighthouse`: frontend preparation stopped because the local dependency tree lacks `@vitejs/plugin-react`; browser audits did not run.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
