### PR TITLE
⏱️ feat: Configurable Code API Request Timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -728,6 +728,10 @@ TTS_API_KEY=
 
 # LIBRECHAT_CODE_API_KEY=
 # LIBRECHAT_CODE_BASEURL=
+# Timeout in milliseconds for each Code API request (/exec, /upload, /download; default: 15000).
+# Raise it when the sandbox needs longer to start or to stage session files before a call returns;
+# keep it below any proxy timeout on the path, which would otherwise cut the request first.
+# LIBRECHAT_CODE_TIMEOUT_MS=15000
 # Current self-hosted Code Interpreter deployments use per-user LibreChat JWTs outside local mode.
 # Configure the matching public verifier on Code Interpreter; see:
 # https://www.librechat.ai/docs/features/code_interpreter#self-hosted-jwt-authentication

--- a/api/server/services/Files/Code/crud.js
+++ b/api/server/services/Files/Code/crud.js
@@ -2,6 +2,7 @@ const FormData = require('form-data');
 const { logger } = require('@librechat/data-schemas');
 const { getCodeBaseURL } = require('@librechat/agents');
 const { EModelEndpoint, getCodeEnvRefs } = require('librechat-data-provider');
+const { getCodeApiTimeoutMs } = require('./timeout');
 const {
   logAxiosError,
   appendCodeEnvFile,
@@ -56,7 +57,7 @@ async function getCodeOutputDownloadStream(fileIdentifier, identity, req, route 
       },
       httpAgent: codeServerHttpAgent,
       httpsAgent: codeServerHttpsAgent,
-      timeout: 15000,
+      timeout: getCodeApiTimeoutMs(),
     };
 
     const response = await axios(options);
@@ -144,7 +145,7 @@ async function deleteCodeEnvFile(req, file) {
         },
         httpAgent: codeServerHttpAgent,
         httpsAgent: codeServerHttpsAgent,
-        timeout: 15000,
+        timeout: getCodeApiTimeoutMs(),
       });
     } catch (error) {
       if (error.response?.status !== 404) {

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -55,6 +55,7 @@ const {
   getEndpointFileConfig,
 } = require('librechat-data-provider');
 const { filterFilesByAgentAccess } = require('~/server/services/Files/permissions');
+const { getCodeApiTimeoutMs } = require('~/server/services/Files/Code/timeout');
 const { createFile, getFiles, updateFile, claimCodeFile } = require('~/models');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { convertImage } = require('~/server/services/Files/images/convert');
@@ -240,7 +241,7 @@ const downloadCodeOutputBuffer = async ({
       },
       httpAgent: codeServerHttpAgent,
       httpsAgent: codeServerHttpsAgent,
-      timeout: 15000,
+      timeout: getCodeApiTimeoutMs(),
       ...(Number.isFinite(maxBytes) && maxBytes >= 0
         ? {
             maxContentLength: maxBytes,
@@ -1636,7 +1637,7 @@ async function readSandboxFile({
       },
       httpAgent: codeServerHttpAgent,
       httpsAgent: codeServerHttpsAgent,
-      timeout: 15000,
+      timeout: getCodeApiTimeoutMs(),
     });
   } catch (error) {
     logAxiosError({
@@ -2033,7 +2034,7 @@ async function execSandboxImageChunk({
           },
           httpAgent: codeServerHttpAgent,
           httpsAgent: codeServerHttpsAgent,
-          timeout: 15000,
+          timeout: getCodeApiTimeoutMs(),
         });
       },
     });
@@ -2126,7 +2127,7 @@ async function writeSandboxFile({
       },
       httpAgent: codeServerHttpAgent,
       httpsAgent: codeServerHttpsAgent,
-      timeout: 15000,
+      timeout: getCodeApiTimeoutMs(),
     });
     const result = response?.data ?? {};
     if (result.stderr && (result.stdout == null || result.stdout === '')) {

--- a/api/server/services/Files/Code/timeout.js
+++ b/api/server/services/Files/Code/timeout.js
@@ -1,0 +1,37 @@
+const { logger } = require('@librechat/data-schemas');
+
+/** Upstream default for every Code API request (`/exec`, `/upload`, `/download`). */
+const DEFAULT_CODE_API_TIMEOUT_MS = 15_000;
+
+let warnedValue;
+
+/**
+ * Request timeout for Code API calls, from `LIBRECHAT_CODE_TIMEOUT_MS`.
+ *
+ * Unset keeps the 15 s default. A deployment whose sandbox needs longer to start or to
+ * stage session files before a call returns can raise it; the value should stay below any
+ * proxy timeout on the path, which would otherwise cut the request first. A value that is
+ * not a positive integer falls back to the default and is logged once per distinct value,
+ * so a typo does not silently change behavior. Read per call so tests (and a config
+ * reload) see the current env.
+ *
+ * @returns {number} Timeout in milliseconds.
+ */
+function getCodeApiTimeoutMs() {
+  const raw = process.env.LIBRECHAT_CODE_TIMEOUT_MS?.trim();
+  if (raw == null || raw === '') {
+    return DEFAULT_CODE_API_TIMEOUT_MS;
+  }
+  if (!/^\d+$/.test(raw) || Number(raw) <= 0) {
+    if (warnedValue !== raw) {
+      warnedValue = raw;
+      logger.warn(
+        `[CodeAPI] LIBRECHAT_CODE_TIMEOUT_MS=${raw} is not a positive integer; using the default of ${DEFAULT_CODE_API_TIMEOUT_MS} ms`,
+      );
+    }
+    return DEFAULT_CODE_API_TIMEOUT_MS;
+  }
+  return Number(raw);
+}
+
+module.exports = { getCodeApiTimeoutMs, DEFAULT_CODE_API_TIMEOUT_MS };

--- a/api/server/services/Files/Code/timeout.spec.js
+++ b/api/server/services/Files/Code/timeout.spec.js
@@ -1,0 +1,54 @@
+jest.mock('@librechat/data-schemas', () => ({
+  logger: { warn: jest.fn() },
+}));
+
+describe('getCodeApiTimeoutMs', () => {
+  const originalValue = process.env.LIBRECHAT_CODE_TIMEOUT_MS;
+  let getCodeApiTimeoutMs;
+  let logger;
+
+  beforeEach(() => {
+    /** Fresh module per test so the warn-once guard starts clean; the logger mock is
+     * re-required alongside it, since resetModules gives the module a new instance. */
+    jest.resetModules();
+    ({ logger } = require('@librechat/data-schemas'));
+    ({ getCodeApiTimeoutMs } = require('./timeout'));
+  });
+
+  afterEach(() => {
+    if (originalValue === undefined) {
+      delete process.env.LIBRECHAT_CODE_TIMEOUT_MS;
+    } else {
+      process.env.LIBRECHAT_CODE_TIMEOUT_MS = originalValue;
+    }
+  });
+
+  it('returns the 15 s default when unset or blank', () => {
+    delete process.env.LIBRECHAT_CODE_TIMEOUT_MS;
+    expect(getCodeApiTimeoutMs()).toBe(15000);
+    process.env.LIBRECHAT_CODE_TIMEOUT_MS = '  ';
+    expect(getCodeApiTimeoutMs()).toBe(15000);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('returns the configured value', () => {
+    process.env.LIBRECHAT_CODE_TIMEOUT_MS = '60000';
+    expect(getCodeApiTimeoutMs()).toBe(60000);
+    process.env.LIBRECHAT_CODE_TIMEOUT_MS = ' 30000 ';
+    expect(getCodeApiTimeoutMs()).toBe(30000);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it.each([['abc'], ['0'], ['-1'], ['1.5e4'], ['15s']])(
+    'falls back to the default and warns once for the invalid value %j',
+    (value) => {
+      process.env.LIBRECHAT_CODE_TIMEOUT_MS = value;
+      expect(getCodeApiTimeoutMs()).toBe(15000);
+      expect(getCodeApiTimeoutMs()).toBe(15000);
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(`LIBRECHAT_CODE_TIMEOUT_MS=${value} is not a positive integer`),
+      );
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Every Code API call (`/exec`, `/upload`, `/download`) uses a hardcoded 15 s axios timeout, spread over six call sites in `api/server/services/Files/Code/process.js` and `crud.js`. A self-hosted sandbox that needs longer to start or to stage a session's files before a call returns hits that limit and `read_file` / file authoring fail with "Sandbox read failed", even though the runner would have answered a few seconds later.

This adds `LIBRECHAT_CODE_TIMEOUT_MS`:

- unset → the 15 s default, so behavior is unchanged out of the box;
- a positive integer sets the timeout for all six call sites (one helper, `getCodeApiTimeoutMs`, read per call);
- anything else falls back to the default and is logged once per distinct value;
- documented in `.env.example` next to `LIBRECHAT_CODE_BASEURL`, with the note that the value should stay below any proxy timeout on the path.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (env var reference)

## Testing

- New `api/server/services/Files/Code/timeout.spec.js`: default when unset/blank, configured value (with whitespace), invalid values (`abc`, `0`, `-1`, `1.5e4`, `15s`) fall back with a single warning.
- Existing `process.spec.js`, `crud.spec.js`, `preflight.spec.js`, `process-traversal.spec.js` pass (191 tests).
- Manually against a self-hosted Code API with `LIBRECHAT_CODE_TIMEOUT_MS=60000`: reads that previously timed out at 15 s complete.

### **Test Configuration**:

Self-hosted Code API; `LIBRECHAT_CODE_TIMEOUT_MS=60000`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] A pull request for updating the documentation has been submitted.

