### PR TITLE
🔢 fix: Normalize PDF Citation Page Numbers

### DIFF
--- a/api/app/clients/tools/util/fileSearch.js
+++ b/api/app/clients/tools/util/fileSearch.js
@@ -167,7 +167,10 @@ const createFileSearchTool = async ({
             content: docInfo.page_content,
             distance,
             file_id: result.file_id,
-            page: docInfo.metadata.page || null,
+            page:
+              Number.isInteger(docInfo.metadata.page) && docInfo.metadata.page >= 0
+                ? docInfo.metadata.page + 1
+                : null,
           })),
         )
         .sort((a, b) => a.distance - b.distance)

--- a/api/test/app/clients/tools/util/fileSearch.test.js
+++ b/api/test/app/clients/tools/util/fileSearch.test.js
@@ -110,6 +110,34 @@ describe('fileSearch.js - tuple return validation', () => {
   });
 
   describe('success cases should return tuple with artifact object', () => {
+    it.each([
+      [0, [1]],
+      [2, [3]],
+      [undefined, []],
+      [null, []],
+      [-1, []],
+      [1.5, []],
+      ['2', []],
+    ])('maps RAG page index %s to citation pages %j', async (page, pages) => {
+      generateShortLivedToken.mockReturnValue('mock-jwt-token');
+      axios.post.mockResolvedValue({
+        data: [
+          [{ page_content: 'Synthetic passage', metadata: { source: '/test.pdf', page } }, 0.2],
+        ],
+      });
+
+      const fileSearchTool = await createFileSearchTool({
+        userId: 'user1',
+        files: [{ file_id: 'file-123', filename: 'test.pdf' }],
+        fileCitations: true,
+      });
+      const [, artifact] = await fileSearchTool.func({ query: 'Synthetic page check' });
+      const source = artifact.file_search.sources[0];
+
+      expect(source.pages).toEqual(pages);
+      expect(source.pageRelevance).toEqual(pages.length ? { [pages[0]]: expect.any(Number) } : {});
+    });
+
     it('should return tuple with formatted results and sources artifact', async () => {
       generateShortLivedToken.mockReturnValue('mock-jwt-token');
 
@@ -118,14 +146,14 @@ describe('fileSearch.js - tuple return validation', () => {
           [
             {
               page_content: 'This is test content from the document',
-              metadata: { source: '/path/to/test.pdf', page: 1 },
+              metadata: { source: '/path/to/test.pdf', page: 0 },
             },
             0.2,
           ],
           [
             {
               page_content: 'Additional relevant content',
-              metadata: { source: '/path/to/test.pdf', page: 2 },
+              metadata: { source: '/path/to/test.pdf', page: 1 },
             },
             0.35,
           ],


### PR DESCRIPTION
## Summary

File-search results use zero-based PDF page metadata, but citations currently discard page 0 and show later page indices directly. Normalize valid non-negative integer indices before constructing citation `pages` and `pageRelevance`: page 0 becomes page 1, and page 2 becomes page 3. Missing or invalid metadata leaves page information empty.

Related issue: #15730.

## Change Type

- [x] Bug fix

## Testing

- All 17 tests in `api/test/app/clients/tools/util/fileSearch.test.js` pass (`cd api && npx jest test/app/clients/tools/util/fileSearch.test.js --runInBand`).
- Negative control: the updated tests fail in six cases against unchanged dev, including first and later PDF pages.
- Affected static checks pass: ESLint, Prettier, import sorting and circular dependencies.
- Production frontend and shared-package build completed as part of `npm run lighthouse`.
- Lighthouse passed using `npm run lighthouse:run` with the completed production build, isolated MongoDB, and the harness's 250 ms/query delay. All three runs rendered the seeded transcript. Medians: LCP 3474 ms (limit 4500), CLS 0.0388 (limit 0.1), TBT 84.1 ms (limit 500).

Test environment: Node.js 24.18.0, dev base `f50c40e2f583b03262d600299e94e85411785fe3`. Playwright's required headless shell was installed in a temporary directory, and `CHROME_PATH` selected an available isolated Chromium executable for Lighthouse. Only legacy JavaScript source and its existing Jest test are changed; the affected static-check runner reports no TypeScript gate for this diff.

## Checklist

- [x] Self-reviewed the two-file diff
- [x] Followed project formatting and import-order checks
- [x] Added a failing regression and verified it passes with the fix
- [x] Local targeted unit tests pass
- [x] Lighthouse measurement completed
