### PR TITLE
feat: add Sora and Sora 2 to Azure OpenAI default models

### DIFF
--- a/packages/api/src/endpoints/models.spec.ts
+++ b/packages/api/src/endpoints/models.spec.ts
@@ -510,6 +510,13 @@ describe('getOpenAIModels', () => {
     expect(models).toEqual(expect.arrayContaining(['azure-model', 'azure-model-2']));
   });
 
+  it('returns Azure OpenAI defaults including Sora when azure flag is set', async () => {
+    delete process.env.AZURE_OPENAI_MODELS;
+    const models = await getOpenAIModels({ azure: true });
+    expect(models).toEqual(expect.arrayContaining(['sora', 'sora-2']));
+    expect(models).not.toContain('gpt-6-astra');
+  });
+
   it('returns `OPENAI_MODELS` with no flags (and fetch fails)', async () => {
     process.env.OPENAI_MODELS = 'openai-model,openai-model-2';
     const models = await getOpenAIModels({});

--- a/packages/api/src/endpoints/models.ts
+++ b/packages/api/src/endpoints/models.ts
@@ -403,7 +403,7 @@ export async function getOpenAIModels(opts: GetOpenAIModelsOptions = {}): Promis
   if (opts.assistants) {
     models = defaultModels[EModelEndpoint.assistants];
   } else if (opts.azure) {
-    models = defaultModels[EModelEndpoint.azureAssistants];
+    models = defaultModels[EModelEndpoint.azureOpenAI];
   }
 
   let key: string;

--- a/packages/data-provider/src/config.spec.ts
+++ b/packages/data-provider/src/config.spec.ts
@@ -3,7 +3,9 @@ import {
   allowedAddressesSchema,
   bedrockModels,
   configSchema,
+  defaultModels,
   excludedKeys,
+  initialModelsConfig,
   resolveEndpointType,
   webSearchSchema,
 } from './config';
@@ -19,6 +21,20 @@ const endpointsConfig: TEndpointsConfig = {
   'Some Endpoint': { type: EModelEndpoint.custom, userProvide: false, order: 9999 },
   Gemini: { type: EModelEndpoint.custom, userProvide: false, order: 9999 },
 };
+
+describe('Azure OpenAI Sora catalog', () => {
+  it('lists Sora video models on Azure OpenAI defaults, not first-party OpenAI', () => {
+    expect(defaultModels[EModelEndpoint.azureOpenAI]).toEqual(
+      expect.arrayContaining(['sora', 'sora-2']),
+    );
+    expect(initialModelsConfig[EModelEndpoint.azureOpenAI]).toEqual(
+      expect.arrayContaining(['sora', 'sora-2']),
+    );
+    expect(defaultModels[EModelEndpoint.openAI]).not.toContain('sora');
+    expect(defaultModels[EModelEndpoint.openAI]).not.toContain('sora-2');
+    expect(defaultModels[EModelEndpoint.azureAssistants]).not.toContain('sora');
+  });
+});
 
 describe('excludedKeys', () => {
   it.each([

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2932,6 +2932,15 @@ export const defaultModels = {
     'gpt-3.5-turbo-instruct-0914',
     'gpt-3.5-turbo-instruct',
   ],
+  [EModelEndpoint.azureOpenAI]: [
+    ...sharedOpenAIModels,
+    'chatgpt-4o-latest',
+    'gpt-4-vision-preview',
+    'gpt-3.5-turbo-instruct-0914',
+    'gpt-3.5-turbo-instruct',
+    'sora',
+    'sora-2',
+  ],
   [EModelEndpoint.bedrock]: bedrockModels,
 };
 
@@ -2941,22 +2950,12 @@ const fitlerAssistantModels = (str: string) => {
 
 const openAIModels = defaultModels[EModelEndpoint.openAI];
 
-/**
- * The OpenAI catalog without the models only the first-party OpenAI endpoint
- * can run. Azure OpenAI shares this list, but Astra is neither routed to the
- * Responses API nor given its request constraints there, and listing it first
- * would let it become the default selection.
- */
-const nonResponsesOnlyOpenAIModels = openAIModels.filter(
-  (model) => !responsesOnlyOpenAIModels.includes(model),
-);
-
 export const initialModelsConfig: TModelsConfig = {
   initial: [],
   [EModelEndpoint.openAI]: openAIModels,
   [EModelEndpoint.assistants]: openAIModels.filter(fitlerAssistantModels),
   [EModelEndpoint.agents]: openAIModels, // TODO: Add agent models (agentsModels)
-  [EModelEndpoint.azureOpenAI]: nonResponsesOnlyOpenAIModels,
+  [EModelEndpoint.azureOpenAI]: defaultModels[EModelEndpoint.azureOpenAI],
   [EModelEndpoint.google]: defaultModels[EModelEndpoint.google],
   [EModelEndpoint.anthropic]: defaultModels[EModelEndpoint.anthropic],
   [EModelEndpoint.bedrock]: defaultModels[EModelEndpoint.bedrock],


### PR DESCRIPTION
Fixes #7702

Azure OpenAI can serve Sora video models, but LibreChat's Azure default catalog did not list them, and `getOpenAIModels({ azure: true })` read the Assistants catalog instead of Azure OpenAI.

This change:

- Adds `sora` and `sora-2` to `defaultModels.azureOpenAI` / `initialModelsConfig.azureOpenAI`
- Leaves the first-party OpenAI and Azure Assistants catalogs unchanged
- Returns the Azure OpenAI catalog when the azure flag is set (still overridden by `AZURE_OPENAI_MODELS`)

`/claim #7702`
