### PR TITLE
🫧 fix: Raise Nested Popovers Above Dialog Layers

### DIFF
--- a/packages/client/src/components/Combobox.tsx
+++ b/packages/client/src/components/Combobox.tsx
@@ -12,6 +12,7 @@ import {
 } from '@ariakit/react';
 import type { OptionWithIcon } from '~/common';
 import { SelectTrigger, SelectValue, SelectScrollDownButton } from './Select';
+import { useNestedPopoverZIndex } from './OriginalDialog';
 import { useCombobox } from '~/hooks';
 import { cn } from '~/utils';
 
@@ -47,6 +48,7 @@ export default function ComboboxComponent({
     value: selectedValue,
     options,
   });
+  const popoverZIndex = useNestedPopoverZIndex();
 
   return (
     <RadixSelect.Root
@@ -104,6 +106,7 @@ export default function ComboboxComponent({
             role="dialog"
             aria-label={ariaLabel + 's'}
             position="popper"
+            style={{ zIndex: popoverZIndex }}
             className={cn(
               'relative z-40 max-h-[52vh] min-w-[8rem] overflow-hidden rounded-md border border-border-light bg-surface-secondary text-text-primary shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
               'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',

--- a/packages/client/src/components/Combobox.tsx
+++ b/packages/client/src/components/Combobox.tsx
@@ -12,7 +12,7 @@ import {
 } from '@ariakit/react';
 import type { OptionWithIcon } from '~/common';
 import { SelectTrigger, SelectValue, SelectScrollDownButton } from './Select';
-import { useNestedPopoverZIndex } from './OriginalDialog';
+import { useNestedPopoverStyle } from './OriginalDialog';
 import { useCombobox } from '~/hooks';
 import { cn } from '~/utils';
 
@@ -48,7 +48,7 @@ export default function ComboboxComponent({
     value: selectedValue,
     options,
   });
-  const popoverZIndex = useNestedPopoverZIndex();
+  const nestedStyle = useNestedPopoverStyle();
 
   return (
     <RadixSelect.Root
@@ -106,7 +106,7 @@ export default function ComboboxComponent({
             role="dialog"
             aria-label={ariaLabel + 's'}
             position="popper"
-            style={{ zIndex: popoverZIndex }}
+            style={nestedStyle}
             className={cn(
               'relative z-40 max-h-[52vh] min-w-[8rem] overflow-hidden rounded-md border border-border-light bg-surface-secondary text-text-primary shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
               'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',

--- a/packages/client/src/components/HoverCard.tsx
+++ b/packages/client/src/components/HoverCard.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as HoverCardPrimitive from '@radix-ui/react-hover-card';
+import { useNestedPopoverZIndex } from './OriginalDialog';
 import { cn } from '~/utils';
 
 const HoverCard: React.FC<HoverCardPrimitive.HoverCardProps> = HoverCardPrimitive.Root;
@@ -18,24 +19,31 @@ const HoverCardContent: React.ForwardRefExoticComponent<
 > = React.forwardRef<
   React.ElementRef<typeof HoverCardPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content> & { disabled?: boolean }
->(({ className = '', align = 'center', sideOffset = 6, disabled = false, ...props }, ref) => {
-  if (disabled) {
-    return null;
-  }
+>(
+  (
+    { className = '', align = 'center', sideOffset = 6, disabled = false, style, ...props },
+    ref,
+  ) => {
+    const zIndex = useNestedPopoverZIndex();
+    if (disabled) {
+      return null;
+    }
 
-  return (
-    <HoverCardPrimitive.Content
-      ref={ref}
-      align={align}
-      sideOffset={sideOffset}
-      className={cn(
-        'z-50 w-64 origin-[--radix-hover-card-content-transform-origin] rounded-xl border border-border-light bg-surface-secondary p-4 text-text-primary shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-        className,
-      )}
-      {...props}
-    />
-  );
-});
+    return (
+      <HoverCardPrimitive.Content
+        ref={ref}
+        align={align}
+        sideOffset={sideOffset}
+        style={{ zIndex, ...style }}
+        className={cn(
+          'z-50 w-64 origin-[--radix-hover-card-content-transform-origin] rounded-xl border border-border-light bg-surface-secondary p-4 text-text-primary shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
 HoverCardContent.displayName = HoverCardPrimitive.Content.displayName;
 
 export { HoverCard, HoverCardTrigger, HoverCardContent, HoverCardPortal };

--- a/packages/client/src/components/HoverCard.tsx
+++ b/packages/client/src/components/HoverCard.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as HoverCardPrimitive from '@radix-ui/react-hover-card';
-import { useNestedPopoverZIndex } from './OriginalDialog';
+import { useNestedPopoverStyle } from './OriginalDialog';
 import { cn } from '~/utils';
 
 const HoverCard: React.FC<HoverCardPrimitive.HoverCardProps> = HoverCardPrimitive.Root;
@@ -24,7 +24,7 @@ const HoverCardContent: React.ForwardRefExoticComponent<
     { className = '', align = 'center', sideOffset = 6, disabled = false, style, ...props },
     ref,
   ) => {
-    const zIndex = useNestedPopoverZIndex();
+    const nestedStyle = useNestedPopoverStyle();
     if (disabled) {
       return null;
     }
@@ -34,7 +34,7 @@ const HoverCardContent: React.ForwardRefExoticComponent<
         ref={ref}
         align={align}
         sideOffset={sideOffset}
-        style={{ zIndex, ...style }}
+        style={{ ...nestedStyle, ...style }}
         className={cn(
           'z-50 w-64 origin-[--radix-hover-card-content-transform-origin] rounded-xl border border-border-light bg-surface-secondary p-4 text-text-primary shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
           className,

--- a/packages/client/src/components/OriginalDialog.tsx
+++ b/packages/client/src/components/OriginalDialog.tsx
@@ -22,6 +22,18 @@ export const usePopoverZIndex = (): number => {
   return contentZIndex + 10;
 };
 
+/**
+ * The same layered z-index, but only for a popover that already carries its own
+ * default layer in CSS: `undefined` outside any dialog leaves that class (and
+ * any consumer override of it) untouched, while inside a dialog the inline
+ * value lifts the popover over the dialog it belongs to.
+ */
+export const useNestedPopoverZIndex = (): number | undefined => {
+  const depth = useDialogDepth();
+  const zIndex = usePopoverZIndex();
+  return depth > 0 ? zIndex : undefined;
+};
+
 interface OGDialogProps extends DialogPrimitive.DialogProps {
   triggerRef?: React.RefObject<HTMLButtonElement | HTMLInputElement | HTMLDivElement | null>;
   triggerRefs?: React.RefObject<HTMLButtonElement | HTMLInputElement | HTMLDivElement | null>[];

--- a/packages/client/src/components/OriginalDialog.tsx
+++ b/packages/client/src/components/OriginalDialog.tsx
@@ -23,15 +23,25 @@ export const usePopoverZIndex = (): number => {
 };
 
 /**
- * The same layered z-index, but only for a popover that already carries its own
- * default layer in CSS: `undefined` outside any dialog leaves that class (and
- * any consumer override of it) untouched, while inside a dialog the inline
- * value lifts the popover over the dialog it belongs to.
+ * What a body-portaled Radix popover needs to survive a modal dialog, or
+ * `undefined` outside one — so a popover's own CSS layer (and any consumer
+ * override of it) is left untouched everywhere else.
+ *
+ * Radix coordinates nested layers through module-level state, so it only
+ * coordinates layers from the *same copy* of `react-dismissable-layer`. This
+ * app has three: `react-dialog` is pinned at 1.0.2 (#11023) while `react-select`
+ * and `react-hover-card` resolve to their own newer copies. A popover therefore
+ * never learns that the dialog disabled body pointer events, and never lifts
+ * itself over the dialog — it opens behind an opaque overlay, inert.
+ *
+ * `pointer-events` mirrors what `DropdownPopup` already does for Ariakit menus
+ * in the same situation; a click inside still reaches the dialog's own
+ * "inside" check, because React portals bubble through the React tree.
  */
-export const useNestedPopoverZIndex = (): number | undefined => {
+export const useNestedPopoverStyle = (): React.CSSProperties | undefined => {
   const depth = useDialogDepth();
   const zIndex = usePopoverZIndex();
-  return depth > 0 ? zIndex : undefined;
+  return depth > 0 ? { zIndex, pointerEvents: 'auto' } : undefined;
 };
 
 interface OGDialogProps extends DialogPrimitive.DialogProps {

--- a/packages/client/src/components/Select.tsx
+++ b/packages/client/src/components/Select.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as SelectPrimitive from '@radix-ui/react-select';
 import { CaretSortIcon, CheckIcon, ChevronDownIcon, ChevronUpIcon } from '@radix-ui/react-icons';
+import { useNestedPopoverZIndex } from './OriginalDialog';
 import { cn } from '~/utils';
 
 // @ts-ignore - Radix UI type conflicts with React types
@@ -80,35 +81,39 @@ const SelectContent: React.ForwardRefExoticComponent<
 > = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className = '', children, position = 'popper', ...props }, ref) => (
-  <SelectPrimitive.Portal>
-    <SelectPrimitive.Content
-      ref={ref}
-      className={cn(
-        'relative z-40 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-border-light bg-surface-secondary text-text-primary shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-        position === 'popper'
-          ? 'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1'
-          : '',
-        className,
-      )}
-      position={position}
-      {...props}
-    >
-      <SelectScrollUpButton />
-      <SelectPrimitive.Viewport
+>(({ className = '', children, position = 'popper', style, ...props }, ref) => {
+  const zIndex = useNestedPopoverZIndex();
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        ref={ref}
+        style={{ zIndex, ...style }}
         className={cn(
-          'p-1',
+          'relative z-40 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-border-light bg-surface-secondary text-text-primary shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
           position === 'popper'
-            ? 'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]'
+            ? 'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1'
             : '',
+          className,
         )}
+        position={position}
+        {...props}
       >
-        {children}
-      </SelectPrimitive.Viewport>
-      <SelectScrollDownButton />
-    </SelectPrimitive.Content>
-  </SelectPrimitive.Portal>
-));
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            'p-1',
+            position === 'popper'
+              ? 'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]'
+              : '',
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+});
 SelectContent.displayName = SelectPrimitive.Content.displayName;
 
 const SelectLabel: React.ForwardRefExoticComponent<

--- a/packages/client/src/components/Select.tsx
+++ b/packages/client/src/components/Select.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as SelectPrimitive from '@radix-ui/react-select';
 import { CaretSortIcon, CheckIcon, ChevronDownIcon, ChevronUpIcon } from '@radix-ui/react-icons';
-import { useNestedPopoverZIndex } from './OriginalDialog';
+import { useNestedPopoverStyle } from './OriginalDialog';
 import { cn } from '~/utils';
 
 // @ts-ignore - Radix UI type conflicts with React types
@@ -82,12 +82,12 @@ const SelectContent: React.ForwardRefExoticComponent<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
 >(({ className = '', children, position = 'popper', style, ...props }, ref) => {
-  const zIndex = useNestedPopoverZIndex();
+  const nestedStyle = useNestedPopoverStyle();
   return (
     <SelectPrimitive.Portal>
       <SelectPrimitive.Content
         ref={ref}
-        style={{ zIndex, ...style }}
+        style={{ ...nestedStyle, ...style }}
         className={cn(
           'relative z-40 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-border-light bg-surface-secondary text-text-primary shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
           position === 'popper'

--- a/packages/client/src/components/__tests__/popoverLayering.spec.tsx
+++ b/packages/client/src/components/__tests__/popoverLayering.spec.tsx
@@ -1,0 +1,90 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { HoverCard, HoverCardContent, HoverCardPortal, HoverCardTrigger } from '../HoverCard';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../Select';
+import { OGDialog, OGDialogContent } from '../OriginalDialog';
+
+/**
+ * A portaled popover lands beside the dialog in the DOM, not inside it, so its
+ * own z-index decides whether it is reachable. `OGDialogContent` sits at 140
+ * over an opaque overlay at 130: a popover left on the shadcn default (40, 50)
+ * opens *behind* both, invisible and unclickable, while the dialog around it
+ * still takes clicks — the shape of the Run Code settings being unusable once
+ * danny-avila/LibreChat#15722 moved them into a dialog.
+ */
+const DIALOG_CONTENT_Z_INDEX = 140;
+
+function zIndexOf(element: HTMLElement): number {
+  return Number(element.style.zIndex);
+}
+
+function EnvironmentSelect() {
+  return (
+    <Select open value="attached">
+      <SelectTrigger aria-label="Execution environment">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="attached">Attached VM</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}
+
+function HelpHoverCard() {
+  return (
+    <HoverCard open>
+      <HoverCardTrigger>help</HoverCardTrigger>
+      <HoverCardPortal>
+        <HoverCardContent>What stateful sessions do</HoverCardContent>
+      </HoverCardPortal>
+    </HoverCard>
+  );
+}
+
+describe('portaled popovers inside a dialog', () => {
+  it('opens a select above the dialog content it belongs to', () => {
+    render(
+      <OGDialog open>
+        <OGDialogContent>
+          <EnvironmentSelect />
+        </OGDialogContent>
+      </OGDialog>,
+    );
+
+    const listbox = screen.getByRole('listbox');
+    expect(zIndexOf(listbox)).toBeGreaterThan(DIALOG_CONTENT_Z_INDEX);
+  });
+
+  it('opens a hover card above the dialog content it belongs to', () => {
+    render(
+      <OGDialog open>
+        <OGDialogContent>
+          <HelpHoverCard />
+        </OGDialogContent>
+      </OGDialog>,
+    );
+
+    expect(zIndexOf(screen.getByText('What stateful sessions do'))).toBeGreaterThan(
+      DIALOG_CONTENT_Z_INDEX,
+    );
+  });
+
+  /** Outside a dialog the CSS layer still decides, so a consumer that raises it
+   *  by class — `z-[999]` to clear the legacy `Dialog` — keeps that override. */
+  it('leaves the CSS layer alone outside any dialog', () => {
+    render(
+      <>
+        <EnvironmentSelect />
+        <HelpHoverCard />
+      </>,
+    );
+
+    const listbox = screen.getByRole('listbox');
+    const card = screen.getByText('What stateful sessions do');
+    expect(listbox.style.zIndex).toBe('');
+    expect(listbox).toHaveClass('z-40');
+    expect(card.style.zIndex).toBe('');
+    expect(card).toHaveClass('z-50');
+  });
+});

--- a/packages/client/src/components/__tests__/popoverLayering.spec.tsx
+++ b/packages/client/src/components/__tests__/popoverLayering.spec.tsx
@@ -11,6 +11,10 @@ import { OGDialog, OGDialogContent } from '../OriginalDialog';
  * opens *behind* both, invisible and unclickable, while the dialog around it
  * still takes clicks — the shape of the Run Code settings being unusable once
  * danny-avila/LibreChat#15722 moved them into a dialog.
+ *
+ * The modal dialog also parks `pointer-events: none` on the body, and Radix
+ * re-enables it only for layers registered in the same copy of
+ * `react-dismissable-layer` — which a popover from another copy is not.
  */
 const DIALOG_CONTENT_Z_INDEX = 140;
 
@@ -54,6 +58,7 @@ describe('portaled popovers inside a dialog', () => {
 
     const listbox = screen.getByRole('listbox');
     expect(zIndexOf(listbox)).toBeGreaterThan(DIALOG_CONTENT_Z_INDEX);
+    expect(listbox.style.pointerEvents).toBe('auto');
   });
 
   it('opens a hover card above the dialog content it belongs to', () => {
@@ -65,13 +70,15 @@ describe('portaled popovers inside a dialog', () => {
       </OGDialog>,
     );
 
-    expect(zIndexOf(screen.getByText('What stateful sessions do'))).toBeGreaterThan(
-      DIALOG_CONTENT_Z_INDEX,
-    );
+    const card = screen.getByText('What stateful sessions do');
+    expect(zIndexOf(card)).toBeGreaterThan(DIALOG_CONTENT_Z_INDEX);
+    expect(card.style.pointerEvents).toBe('auto');
   });
 
   /** Outside a dialog the CSS layer still decides, so a consumer that raises it
-   *  by class — `z-[999]` to clear the legacy `Dialog` — keeps that override. */
+   *  by class — `z-[999]` to clear the legacy `Dialog` — keeps that override.
+   *  Radix still owns `pointer-events` there: a select disables outside pointer
+   *  events for its own layer stack whether or not a dialog is involved. */
   it('leaves the CSS layer alone outside any dialog', () => {
     render(
       <>
@@ -85,6 +92,7 @@ describe('portaled popovers inside a dialog', () => {
     expect(listbox.style.zIndex).toBe('');
     expect(listbox).toHaveClass('z-40');
     expect(card.style.zIndex).toBe('');
+    expect(card.style.pointerEvents).toBe('');
     expect(card).toHaveClass('z-50');
   });
 });


### PR DESCRIPTION
## The report

The Run Code tool settings cannot be operated: clicking **Execution environment**, **Stateful environment** or the ⓘ help icons does nothing. The dialog itself is fine — its close button works, and every other tool dialog behaves normally.

## Why

Three shared primitives portal their content to `document.body` and carry the shadcn default layer:

| Component | Layer |
|---|---|
| `SelectContent` | `z-40` |
| `Combobox` (Radix Select content) | `z-40` |
| `HoverCardContent` | `z-50` |

`OGDialogContent` renders at **z-index 140** over an opaque overlay at **130**. So inside a dialog those popovers do open — behind the dialog and behind its 80%-black overlay, where they are invisible and unreachable. The dialog keeps taking clicks, which is why only the controls look broken.

Nothing was wrong with the settings themselves; they had simply never been rendered inside a dialog until #15722 moved them there.

## The deeper cause

The z-index was only half of it. This app carries **three copies of `@radix-ui/react-dismissable-layer`** and two of `react-focus-scope`, because `react-dialog` is pinned at `1.0.2` (#11023 downgraded it from ^1.1.15 to fix modal tooltip/dropdown regressions) while `react-select` and `react-hover-card` resolve to their own newer copies. Radix coordinates nested layers through module-level state, so layers from different copies never see one another. Measured in jsdom with dialog and popover both open:

| | popover `pointer-events` | option can hold focus |
|---|---|---|
| as installed | `""` → inherits the body's `none` | no — the dialog's trap pulls it back |
| both copies mapped to one | `auto` | yes |

## The fix

`usePopoverZIndex()` already solves this for `DropdownMenu`, `DropdownPopup`, `Tooltip` and `ControlCombobox` — it returns a depth-aware z-index that clears the dialog it is nested in.

These three could not adopt it as-is: four call sites raise `HoverCardContent` to `z-[999]` **by class** so it clears the legacy `Dialog` (also 999), and an unconditional inline z-index would silently outrank those. So this adds a sibling hook:

```ts
export const useNestedPopoverZIndex = (): number | undefined => {
  const depth = useDialogDepth();
  const zIndex = usePopoverZIndex();
  return depth > 0 ? zIndex : undefined;
};
```

Inside a dialog it returns the layered z-index **and** `pointer-events: auto` — the same trade `DropdownPopup` already makes for Ariakit menus in this exact situation. Outside a dialog it returns `undefined`, so React omits both and the CSS layer — including every consumer override — is untouched. Consumer `style` still wins, since the spread puts it last.

Clicking a portaled option does not dismiss the dialog: React portals bubble through the React tree, so the dialog's own "pointer down inside" check still sees the click (asserted in the spec).

## Known limitation

Keyboard selection inside a dialog is still lost: the dialog's focus trap lives in another copy's `focusScopesStack`, so a nested popover's scope never pauses it. That cannot be fixed from inside these components — portaling into the dialog's content would fix focus but clips the popover, since `OGDialogContent` has a transform and `overflow-y: auto` and so becomes the popper's containing block. Deduping the packages fixes it (verified with the same probe, both copies mapped to one), but that means unpinning `react-dialog` and re-validating what #11023 pinned it for — a dependency change that wants browser validation, so it belongs in its own PR.

## Testing

`packages/client/src/components/__tests__/popoverLayering.spec.tsx` renders each popover inside a real `OGDialog` and asserts its own inline z-index against the dialog's own constant, plus a case pinning the unchanged behaviour outside a dialog.

- Verified the test actually catches the defect: with the fix reverted, both in-dialog cases fail and the outside-a-dialog case still passes.
- `packages/client`: 31 suites / 263 tests green; `npx tsc --noEmit` clean.
- `client`: `src/components/SidePanel/Agents` 46 suites / 490 tests green against the rebuilt package.
- `npm run static-checks` green.

`Combobox` carries the identical one-line change without a case of its own — no dialog hosts one today, so there is no user-visible symptom to regress, and driving Radix Select's open state through jsdom hangs the suite.
