### PR TITLE
🛄 fix: Clear MCP Connection State Before Catalog Refresh

### DIFF
--- a/client/src/hooks/MCP/__tests__/useMCPServerManager.spec.tsx
+++ b/client/src/hooks/MCP/__tests__/useMCPServerManager.spec.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { Provider } from 'jotai';
+import { QueryKeys } from 'librechat-data-provider';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider, QueryObserver } from '@tanstack/react-query';
+import type { MCPReinitializeResponse } from 'librechat-data-provider';
+import { useMCPServerManager } from '../useMCPServerManager';
+
+const mockShowToast = jest.fn();
+const mockSetMCPValues = jest.fn();
+const mockReinitialize = jest.fn();
+
+jest.mock('@librechat/client', () => ({
+  useToastContext: () => ({ showToast: mockShowToast }),
+}));
+
+jest.mock('~/hooks', () => ({
+  useLocalize: () => (key: string) => key,
+  useHasAccess: () => true,
+  useCatalogReady: () => true,
+  useMCPSelect: () => ({ mcpValues: [], setMCPValues: mockSetMCPValues }),
+  useMCPConnectionStatus: () => ({ connectionStatus: {} }),
+}));
+
+jest.mock('~/data-provider', () => ({
+  useGetStartupConfig: () => ({ data: {} }),
+  useMCPServersQuery: () => ({ data: {}, isLoading: false }),
+}));
+
+jest.mock('librechat-data-provider/react-query', () => ({
+  useReinitializeMCPServerMutation: () => ({ mutateAsync: mockReinitialize }),
+  useCancelMCPOAuthMutation: () => ({}),
+  useUpdateUserPluginsMutation: () => ({}),
+  useGetAllEffectivePermissionsQuery: () => ({ data: {} }),
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('useMCPServerManager initialization', () => {
+  it.each(['success', 'error'])(
+    'finishes before a slow catalog refetch ends in %s',
+    async (outcome) => {
+      const connection = deferred<MCPReinitializeResponse>();
+      const catalog = deferred<string[]>();
+      mockReinitialize.mockReturnValue(connection.promise);
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, cacheTime: 0 } },
+        logger: { log: console.log, warn: console.warn, error: jest.fn() },
+      });
+      const catalogQuery = new QueryObserver(queryClient, {
+        queryKey: [QueryKeys.mcpTools],
+        queryFn: () => catalog.promise,
+        initialData: [],
+        staleTime: Infinity,
+      });
+      const unsubscribe = catalogQuery.subscribe(() => undefined);
+      const invalidate = jest.spyOn(queryClient, 'invalidateQueries');
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <Provider>
+          <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        </Provider>
+      );
+      const { result, unmount } = renderHook(() => useMCPServerManager(), { wrapper });
+      const initialized = jest.fn();
+
+      try {
+        act(() => {
+          void result.current.initializeServer('test-server').then(initialized);
+        });
+        expect(result.current.isInitializing('test-server')).toBe(true);
+        expect(mockShowToast).not.toHaveBeenCalled();
+
+        const response = { success: true, message: 'Connected', serverName: 'test-server' };
+        await act(async () => {
+          connection.resolve(response);
+        });
+
+        expect(queryClient.getQueryState([QueryKeys.mcpTools])?.fetchStatus).toBe('fetching');
+        expect(result.current.isInitializing('test-server')).toBe(false);
+        expect(initialized).toHaveBeenCalledWith(response);
+        expect(mockSetMCPValues).toHaveBeenCalledWith(['test-server']);
+        expect(mockShowToast).toHaveBeenCalledWith({
+          message: 'com_ui_mcp_initialized_success',
+          status: 'success',
+        });
+        for (const key of [
+          QueryKeys.mcpServers,
+          QueryKeys.mcpTools,
+          QueryKeys.mcpAuthValues,
+          QueryKeys.mcpConnectionStatus,
+        ]) {
+          expect(invalidate).toHaveBeenCalledWith([key]);
+        }
+
+        await act(async () => {
+          if (outcome === 'error') {
+            catalog.reject(new Error('Catalog unavailable'));
+          } else {
+            catalog.resolve(['test-tool']);
+          }
+        });
+        await waitFor(() => {
+          expect(queryClient.getQueryState([QueryKeys.mcpTools])?.fetchStatus).toBe('idle');
+        });
+        expect(result.current.isInitializing('test-server')).toBe(false);
+        expect(mockShowToast).toHaveBeenCalledTimes(1);
+      } finally {
+        catalog.resolve([]);
+        unmount();
+        unsubscribe();
+        queryClient.clear();
+      }
+    },
+  );
+});

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -506,12 +506,15 @@ export function useMCPServerManager({
 
           startServerPolling(serverName, response.flowId, response.oauthTimeout);
         } else {
-          await Promise.all([
+          cleanupServerState(serverName);
+          void Promise.all([
             queryClient.invalidateQueries([QueryKeys.mcpServers]),
             queryClient.invalidateQueries([QueryKeys.mcpTools]),
             queryClient.invalidateQueries([QueryKeys.mcpAuthValues]),
             queryClient.invalidateQueries([QueryKeys.mcpConnectionStatus]),
-          ]);
+          ]).catch((error) => {
+            console.error(`[MCP Manager] Failed to refresh queries for ${serverName}:`, error);
+          });
 
           showToast({
             message: localize('com_ui_mcp_initialized_success', { 0: serverName }),
@@ -522,8 +525,6 @@ export function useMCPServerManager({
           if (!currentValues.includes(serverName)) {
             setMCPValues([...currentValues, serverName]);
           }
-
-          cleanupServerState(serverName);
         }
         return response;
       } catch (error) {


### PR DESCRIPTION
## Summary

I fixed the MCP Connect spinner staying active after a successful connection while the tools catalog refreshes. Fixes #15737.

- Clear initialization state as soon as a non-OAuth connection succeeds.
- Refresh server, tools, auth values, and connection status queries in the background so selection, success feedback, and the initialization response are immediate.
- Log background refresh failures without reporting a successful connection as failed.
- Cover a pending active catalog refetch that subsequently succeeds or fails using a real React Query client and Jotai state.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Reproduced the regression before the fix: both new cases failed because initialization remained active after the connection response.
- Passed all 4 tests: `cd client && npx jest src/hooks/MCP/__tests__/useMCPServerManager.spec.tsx src/components/MCP/MCPServerStatusIcon.spec.tsx --runInBand --coverage=false`.
- Passed affected static checks: `npm run static-checks -- --against origin/dev`.
- Ran `cd client && npx tsc --noEmit`. Both the base code and final change produce the same 22 diagnostics outside the changed files with the reused local dependencies, including stale shared-package exports and code approval types. No new diagnostics were introduced; full typechecking remains blocked by those baseline errors.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
