### PR TITLE
🧘 fix: Settle Stale Response Parts

### DIFF
--- a/client/src/components/Chat/Messages/Content/ContentParts.tsx
+++ b/client/src/components/Chat/Messages/Content/ContentParts.tsx
@@ -165,6 +165,13 @@ const PartWithContext = memo(function PartWithContext({
     [messageId, conversationId, idx, nextType, isSubmitting, isLatestMessage],
   );
 
+  /** Being last WITHIN a body is not being last in the message: activity
+   *  phases split one response into several bodies, so every settled phase has
+   *  a trailing part too. Only the body that holds the message's cursor can
+   *  own a live part — otherwise a phase from minutes ago keeps its reasoning
+   *  shimmering and its peek scrolling while later phases stream. */
+  const holdsCursor = isLastPart && isLast;
+
   return (
     <MessageContext.Provider value={contextValue}>
       <Part
@@ -173,8 +180,8 @@ const PartWithContext = memo(function PartWithContext({
         isSubmitting={isSubmitting}
         key={`part-${messageId}-${getPartKeyIndex(part, idx)}`}
         isCreatedByUser={isCreatedByUser}
-        isLast={isLastPart}
-        showCursor={isLastPart && isLast}
+        isLast={holdsCursor}
+        showCursor={holdsCursor}
         hideAttachments={hideAttachments}
         onToolExpand={onToolExpand}
       />
@@ -1053,8 +1060,9 @@ const ContentPartsBody = memo(function ContentPartsBody({
                *  mark its group as last or nothing holds the streaming
                *  cursor until the next delta. */
               isLast={
-                group.parts.some((p) => p.idx === lastContentIdx) ||
-                group.labelPart?.idx === lastContentIdx
+                isLast &&
+                (group.parts.some((p) => p.idx === lastContentIdx) ||
+                  group.labelPart?.idx === lastContentIdx)
               }
               renderPart={renderGroupedPart}
               lastContentIdx={lastContentIdx}

--- a/client/src/components/Chat/Messages/Content/ToolCallGroup.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCallGroup.tsx
@@ -20,6 +20,7 @@ import {
 } from '~/utils';
 import { useLocalize, useExpandCollapse, scheduleMessageContentLayoutReconcile } from '~/hooks';
 import { parseBackgroundHandle, splitBackgroundAttachments } from './Parts/handle';
+import { ASK_USER_QUESTION, getSubmittedAskAnswer } from '~/utils/approval';
 import { mapAttachments, filterAttachmentsForPart } from '~/utils/map';
 import { ToolAuthWarning, ToolAuthWarningContext } from './auth';
 import { useMCPIconMap, useMCPServerNames } from '~/hooks/MCP';
@@ -28,7 +29,6 @@ import { AttachmentGroup, ReasoningCompact } from './Parts';
 import { isMemoryFailureOutput } from './Parts/MemoryCall';
 import { isError, StackedToolIcons } from './ToolOutput';
 import { isBashProgrammaticToolCall } from './routing';
-import { ASK_USER_QUESTION } from '~/utils/approval';
 import SearchVerticals from './verticals';
 import { ROW_GLYPH_SLOT } from './rows';
 import store from '~/store';
@@ -368,10 +368,41 @@ export default function ToolCallGroup({
    *  tools: ask_user_question") with a question glyph. */
   const allAskQuestions =
     activitySummary.askQuestionCount > 0 && activitySummary.askQuestionCount === count;
+  /**
+   * An answered question is the group's completion proof. The `tool_call`
+   * part carries no output until the turn finalizes, so `allCompleted` stays
+   * false and the header read "Asking 1 question" for the rest of the turn,
+   * long after the user answered. Position cannot settle it either: a LIVE
+   * pause appends its interactive card after this group, so the group is not
+   * the message's last part precisely while the question is open.
+   *
+   * The locally-recorded answer is the same fallback the durable record card
+   * uses — the streaming handler's message copy can overwrite the optimistic
+   * output stamp mid-stream, and only this survives it.
+   */
+  const askQuestionsAnswered = useMemo(
+    () =>
+      parts.every(({ part }) => {
+        if (part.type !== ContentTypes.TOOL_CALL) {
+          return true;
+        }
+        const toolCall = part[ContentTypes.TOOL_CALL] as
+          | { name?: string; id?: string; output?: string | null }
+          | undefined;
+        if (toolCall?.name !== ASK_USER_QUESTION) {
+          return true;
+        }
+        return (
+          (toolCall.output?.length ?? 0) > 0 || getSubmittedAskAnswer(toolCall.id) !== undefined
+        );
+      }),
+    [parts],
+  );
   /** Past tense once the turn is settled — matches the Asking/Asked record
    *  card. While a multi-question turn streams, the still-open question's
    *  tool_call part has no output yet, so keep the present tense. */
-  const askQuestionsDone = allAskQuestions && (allCompleted || !isSubmitting);
+  const askQuestionsDone =
+    allAskQuestions && (allCompleted || !isSubmitting || askQuestionsAnswered);
 
   /** For a single-tool group, lead with the tool's own (capitalized) label
    *  instead of the generic "Used 1 tool: name", which reads awkwardly. */

--- a/client/src/components/Chat/Messages/Content/ToolCallGroup.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCallGroup.tsx
@@ -401,8 +401,13 @@ export default function ToolCallGroup({
   /** Past tense once the turn is settled — matches the Asking/Asked record
    *  card. While a multi-question turn streams, the still-open question's
    *  tool_call part has no output yet, so keep the present tense. */
-  const askQuestionsDone =
-    allAskQuestions && (allCompleted || !isSubmitting || askQuestionsAnswered);
+  const groupDone = allCompleted || !isSubmitting;
+  const askQuestionsDone = allAskQuestions && (groupDone || askQuestionsAnswered);
+
+  /** One verdict for the header's tense, its glyph and its icon animation —
+   *  they read as a single control, so a group whose label already says
+   *  "Asked 1 question" must not keep pulsing beside it. */
+  const isGroupLive = allAskQuestions ? !askQuestionsDone : !groupDone;
 
   /** For a single-tool group, lead with the tool's own (capitalized) label
    *  instead of the generic "Used 1 tool: name", which reads awkwardly. */
@@ -517,7 +522,6 @@ export default function ToolCallGroup({
 
   const searchCount = activitySummary.webSearchCount + activitySummary.fileSearchCount;
   const searchesOnly = count > 0 && searchCount === count;
-  const groupDone = allCompleted || !isSubmitting;
 
   /** Outcome-first header verb. Homogeneous searches, subagents, and questions
    *  read as the activity the assistant performed. Mixed implementation-level
@@ -633,7 +637,7 @@ export default function ToolCallGroup({
             className={cn(
               ROW_GLYPH_SLOT,
               'text-text-secondary',
-              !allCompleted && isSubmitting && 'animate-pulse text-text-primary',
+              isGroupLive && 'animate-pulse text-text-primary',
             )}
             aria-hidden="true"
           >
@@ -645,7 +649,7 @@ export default function ToolCallGroup({
               toolNames={iconToolNames}
               mcpIconMap={mcpIconMap}
               maxIcons={4}
-              isAnimating={!allCompleted && isSubmitting}
+              isAnimating={isGroupLive}
             />
           </div>
         )}

--- a/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
@@ -135,15 +135,18 @@ jest.mock('../Part', () => ({
     part,
     idx,
     showCursor,
+    isLast,
   }: {
     part: TMessageContentParts;
     idx: number;
     showCursor?: boolean;
+    isLast?: boolean;
   }) => (
     <div
       data-testid={`real-part-${part.type}`}
       data-index={idx}
       data-show-cursor={String(showCursor === true)}
+      data-is-last={String(isLast === true)}
     />
   ),
 }));
@@ -509,6 +512,48 @@ describe('ContentParts — activity phase state', () => {
     const textParts = screen.getAllByTestId(`real-part-${ContentTypes.TEXT}`);
     expect(textParts[0]).toHaveAttribute('data-show-cursor', 'true');
     expect(textParts[1]).toHaveAttribute('data-show-cursor', 'false');
+  });
+
+  /** Activity phases split one response into several bodies, and every settled
+   *  body has a trailing part. Only the body holding the message's cursor may
+   *  own a live one — otherwise a phase that finished minutes ago keeps its
+   *  reasoning shimmering while later phases stream. */
+  it("leaves an earlier phase's trailing part settled while a later part streams", () => {
+    const think = {
+      type: ContentTypes.THINK,
+      think: 'weighing the options',
+    } as unknown as TMessageContentParts;
+    const phase = {
+      type: ContentTypes.ACTIVITY_LABEL,
+      [ContentTypes.ACTIVITY_LABEL]: 'Mapped the schema',
+      activity_label_type: 'phase',
+      activity_start_index: 0,
+      activity_end_index: 1,
+      activity_count: 1,
+      pending: false,
+    } as unknown as TMessageContentParts;
+    render(
+      <ContentParts
+        {...baseProps}
+        content={[
+          think,
+          phase,
+          { type: ContentTypes.TEXT, text: 'Good — schema mapped.' } as TMessageContentParts,
+        ]}
+        isLast
+        isSubmitting
+        isLatestMessage
+      />,
+    );
+
+    expect(screen.getByTestId(`real-part-${ContentTypes.THINK}`)).toHaveAttribute(
+      'data-is-last',
+      'false',
+    );
+    expect(screen.getByTestId(`real-part-${ContentTypes.TEXT}`)).toHaveAttribute(
+      'data-is-last',
+      'true',
+    );
   });
 
   it('renders a completion-appended parent before the final root text', () => {

--- a/client/src/components/Chat/Messages/Content/__tests__/ToolCallGroup.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ToolCallGroup.test.tsx
@@ -991,6 +991,7 @@ describe('ToolCallGroup image hoisting', () => {
     });
 
     expect(screen.getByRole('button', { name: 'Asking 2 questions' })).toBeInTheDocument();
+    expect(screen.getByTestId('question-icon').parentElement).toHaveClass('animate-pulse');
   });
 
   it('uses a singular completed label for one question grouped with reasoning', () => {
@@ -1018,6 +1019,8 @@ describe('ToolCallGroup image hoisting', () => {
     });
 
     expect(screen.getByRole('button', { name: 'Asked 1 question' })).toBeInTheDocument();
+    /** The glyph reads as part of the same control, so it settles with it. */
+    expect(screen.getByTestId('question-icon').parentElement).not.toHaveClass('animate-pulse');
   });
 
   it('keeps the active label while one question of a batch is unanswered', () => {

--- a/client/src/components/Chat/Messages/Content/__tests__/ToolCallGroup.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ToolCallGroup.test.tsx
@@ -112,8 +112,12 @@ jest.mock('lucide-react', () => ({
   TriangleAlert: () => <span>{'warning'}</span>,
 }));
 
+const mockSubmittedAskAnswers = new Map<string, string>();
+
 jest.mock('~/utils/approval', () => ({
   ASK_USER_QUESTION: 'ask_user_question',
+  getSubmittedAskAnswer: (toolCallId?: string) =>
+    toolCallId != null ? mockSubmittedAskAnswers.get(toolCallId) : undefined,
 }));
 
 jest.mock('~/utils', () => ({
@@ -271,6 +275,7 @@ describe('ToolCallGroup image hoisting', () => {
   beforeEach(() => {
     mockScheduleMessageContentLayoutReconcile.mockClear();
     mockMCPServerNames.length = 0;
+    mockSubmittedAskAnswers.clear();
   });
 
   it('renders an AttachmentGroup outside the collapsible container with all attachments', () => {
@@ -996,6 +1001,37 @@ describe('ToolCallGroup image hoisting', () => {
     });
 
     expect(screen.getByRole('button', { name: 'Asked 1 question' })).toBeInTheDocument();
+  });
+
+  /** The `tool_call` part carries no output until the turn finalizes, so a group
+   *  the user already answered kept reading "Asking 1 question" for the rest of
+   *  the turn. Position cannot settle it: a live pause appends its interactive
+   *  card AFTER this group, so the group is not the last part exactly while the
+   *  question is open. */
+  it('settles the question label once the answer is recorded locally', () => {
+    mockSubmittedAskAnswers.set('q1', 'Option A');
+    renderGroup({
+      ...baseProps,
+      isSubmitting: true,
+      parts: [{ part: makePart('q1', '', 'ask_user_question'), idx: 0 }],
+      lastContentIdx: 0,
+    });
+
+    expect(screen.getByRole('button', { name: 'Asked 1 question' })).toBeInTheDocument();
+  });
+
+  it('keeps the active label while one question of a batch is unanswered', () => {
+    mockSubmittedAskAnswers.set('q1', 'Option A');
+    renderGroup({
+      ...baseProps,
+      isSubmitting: true,
+      parts: [
+        { part: makePart('q1', '', 'ask_user_question'), idx: 0 },
+        { part: makePart('q2', '', 'ask_user_question'), idx: 1 },
+      ],
+    });
+
+    expect(screen.getByRole('button', { name: 'Asking 2 questions' })).toBeInTheDocument();
   });
 
   it('uses a singular active label for one question grouped with reasoning', () => {


### PR DESCRIPTION
Two live treatments outlive what they are reporting on: a reasoning block keeps shimmering with its thought peek scrolling, and a question group keeps reading "Asking 1 question" — both long after the response moved past them.

## Reasoning

Activity phases split one response into several bodies. `PartWithContext` handed `Part` the **per-body** `isLastPart` as `isLast`, while `showCursor` was correctly that AND'd with the body-level `isLast`:

```tsx
isLast={isLastPart}
showCursor={isLastPart && isLast}
```

So every settled phase's trailing part claimed to be the live one, and `Reasoning` shimmers (and renders its streaming peek) on `isSubmitting && isLast`. Both props now carry the same verdict — this part holds the message's cursor. The grouped and parallel-lane paths already AND'd the two (`isLast && idx === lastContentIdx`, `isLastInColumn && isLastContent`), so only the phase path changes; `ToolCallGroup`'s own `isLast` prop gets the same treatment so a non-tail segment's group is not marked live either.

## Questions

`ask_user_question` writes no output onto its `tool_call` part until the turn finalizes, so `allCompleted` stays false and the header holds the present tense for the rest of the turn.

Position cannot settle this one, and the tests said so: **a live pause appends its interactive card AFTER the group**, so the group is not the message's last part exactly while the question is open. My first attempt gated the label on `!isLast` and three existing label tests failed — correctly.

The answer itself is the signal, read through the same locally-recorded fallback the durable record card uses (`getSubmittedAskAnswer`), because the streaming handler's message copy can overwrite the optimistic output stamp mid-stream.

## One more, from auditing the rest of the class

The header's glyph and stacked icons pulsed on their own `!allCompleted && isSubmitting`, so with the label fixed an answered group would have read "Asked 1 question" while still pulsing beside it. Label, glyph and icon animation now read one `isGroupLive` verdict.

Everything else in message content is gated on a per-part signal that does settle, so nothing further needed changing:

| Treatment | Gate | Settles because |
|---|---|---|
| `Summary` "Summarizing…" | its own `summarizing` flag | the part carries the flag |
| Interim skill cards | `hasRealContent` | flips on the first real part |
| `SubagentCall` pulse | progress status / `runStepStatus` | the child reports terminal state |
| Tool cards (`ExecuteCode`, `ReadFileCall`, `MemoryCall`, `SkillCall`, `CodeAnalyze`, `PtcToolTrace`) | `resolveToolCallPhase` | `runStepStatus` wins when emitted |
| Text cursor / `EmptyText` | `showCursor` | already the cursor-holding verdict |

The one standing caveat is documented in `ToolCall.tsx`: where an endpoint emits no `on_run_step_closed`, `resolveToolCallPhase` falls back to a whole-message `isSubmitting` inference that cannot tell which step stopped. That is the same shape of imprecision, but position cannot fix it either — parallel lanes legitimately run while later parts stream — so it needs a per-step signal rather than a heuristic.

## Testing

- `ContentParts.test.tsx`: an earlier phase's trailing `think` part must report `isLast: false` while a later part streams. The `Part` mock now exposes `isLast` alongside `showCursor`.
- `ToolCallGroup.test.tsx`: the label settles once an answer is recorded locally (and its glyph stops pulsing), and both stay active while one question of a batch is unanswered.
- Both new tests verified to fail with their fix reverted.
- `client` 323 suites / 3204 tests green, `tsc --noEmit` clean, static checks green.
