### PR TITLE
🟫 fix: Reject Invalid Hex Color Matches

### DIFF
--- a/packages/client/src/components/OriginalDialog.tsx
+++ b/packages/client/src/components/OriginalDialog.tsx
@@ -29,7 +29,7 @@ export const usePopoverZIndex = (): number => {
  *
  * Radix coordinates nested layers through module-level state, so it only
  * coordinates layers from the *same copy* of `react-dismissable-layer`. This
- * app has three: `react-dialog` is pinned at 1.0.2 (#11023) while `react-select`
+ * app has three: `react-dialog` is pinned at 1.0.2 (see PR 11023) while `react-select`
  * and `react-hover-card` resolve to their own newer copies. A popover therefore
  * never learns that the dialog disabled body pointer events, and never lifts
  * itself over the dialog — it opens behind an opaque overlay, inert.

--- a/packages/client/src/components/__tests__/popoverLayering.spec.tsx
+++ b/packages/client/src/components/__tests__/popoverLayering.spec.tsx
@@ -77,8 +77,12 @@ describe('portaled popovers inside a dialog', () => {
 
   /** Outside a dialog the CSS layer still decides, so a consumer that raises it
    *  by class — `z-[999]` to clear the legacy `Dialog` — keeps that override.
-   *  Radix still owns `pointer-events` there: a select disables outside pointer
-   *  events for its own layer stack whether or not a dialog is involved. */
+   *
+   *  Only the absence of OUR inline z-index is asserted. `pointer-events` is
+   *  Radix's to set out here: a select disables outside pointer events for its
+   *  own layer stack, and whether a sibling popover then reads `auto` depends
+   *  on whether the two share a copy of `react-dismissable-layer` — which is a
+   *  packaging fact, not this hook's contract. */
   it('leaves the CSS layer alone outside any dialog', () => {
     render(
       <>
@@ -92,7 +96,6 @@ describe('portaled popovers inside a dialog', () => {
     expect(listbox.style.zIndex).toBe('');
     expect(listbox).toHaveClass('z-40');
     expect(card.style.zIndex).toBe('');
-    expect(card.style.pointerEvents).toBe('');
     expect(card).toHaveClass('z-50');
   });
 });

--- a/packages/client/src/theme/semanticTokens.spec.ts
+++ b/packages/client/src/theme/semanticTokens.spec.ts
@@ -33,7 +33,11 @@ describe('shared component color guardrail', () => {
   it('keeps shared primitives free of direct palette utilities and hex colors', () => {
     const directPalette =
       /(?:bg|text|border|ring|from|via|to)-(?:gray|red|green|blue|purple|amber|yellow|orange|pink|indigo|violet|teal|cyan|slate|zinc|neutral|stone)-\d/;
-    const hexColor = /#[0-9a-f]{3,8}\b/i;
+    /** Only CSS-legal hex lengths (3, 4, 6, 8). `{3,8}` also matched a five-
+     *  digit issue reference in a comment — see the PR number in
+     *  `OriginalDialog.tsx` — which reads as a color to a regex and to nobody
+     *  else. */
+    const hexColor = /#(?:[0-9a-f]{8}|[0-9a-f]{6}|[0-9a-f]{4}|[0-9a-f]{3})\b/i;
 
     sharedComponents.forEach((component) => {
       const source = readFileSync(join(__dirname, '..', 'components', component), 'utf8');
@@ -41,6 +45,14 @@ describe('shared component color guardrail', () => {
       expect(source).not.toMatch(directPalette);
       expect(source).not.toMatch(hexColor);
     });
+
+    /** The guardrail still has to catch what it exists for. */
+    expect('bg-surface-primary text-[#ff0000]').toMatch(hexColor);
+    expect('color: #fff;').toMatch(hexColor);
+    expect('#aabbccdd').toMatch(hexColor);
+    /** …and leave prose alone: an issue reference is not a color. */
+    expect('pinned by #11023').not.toMatch(hexColor);
+    expect('closes #15738').not.toMatch(hexColor);
   });
 
   it('keeps every shared dialog shell on the semantic dialog surface', () => {


### PR DESCRIPTION
**`dev` is red and this unblocks it.** Every branch built on dev currently fails `Tests: @librechat/client`.

## What broke

#15738 (merged 14:51) added a comment in `OriginalDialog.tsx` citing the pull request that pinned `react-dialog`:

```
 * app has three: `react-dialog` is pinned at 1.0.2 (#11023) while `react-select`
```

The shared-component guardrail in `semanticTokens.spec.ts` scans that file with `/#[0-9a-f]{3,8}\b/i`. `#11023` is five hex-range digits, so it reads as a color. My comment, my regression.

## Fixed on both sides

- The comment cites the number without the `#`.
- The pattern now matches only **CSS-legal hex lengths** — 3, 4, 6, 8 — so no issue reference can trip it again. `#11023` is not a color at any length a browser accepts.

The guardrail keeps its teeth, and the same test now proves it: it still matches `#fff`, `#ff0000` and `#aabbccdd`, and leaves `closes #15738` alone. Verified the tightened pattern also passes against the *unfixed* comment, so dev is unblocked either way.

## One more assertion, relaxed

`popoverLayering.spec.tsx` pinned the **absence** of an inline `pointer-events` on a hover card outside any dialog. That is Radix's to set, not the hook's: whether a sibling select's `disableOutsidePointerEvents` reaches that card depends on whether the two share a copy of `react-dismissable-layer` — a packaging fact that changes under #15742, where this assertion is the second CI failure. The test now asserts only what the hook itself contributes (no inline z-index, CSS layer classes intact).

`packages/client` 45 suites / 476 tests green; static checks green.
