### PR TITLE
🪪 fix: Guard Null Avatar URLs in Social Login

### DIFF
--- a/api/strategies/process.js
+++ b/api/strategies/process.js
@@ -29,9 +29,9 @@ const handleExistingUser = async (oldUser, avatarUrl, appConfig, email) => {
   const hasManualFlag =
     typeof oldUser?.avatar === 'string' && oldUser.avatar.includes('?manual=true');
 
-  if (isLocal && (!oldUser?.avatar || !hasManualFlag)) {
+  if (avatarUrl && isLocal && (!oldUser?.avatar || !hasManualFlag)) {
     updatedAvatar = avatarUrl;
-  } else if (!isLocal && (!oldUser?.avatar || !hasManualFlag)) {
+  } else if (avatarUrl && !isLocal && (!oldUser?.avatar || !hasManualFlag)) {
     const userId = oldUser._id;
     const resizedBuffer = await resizeAvatar({
       userId,
@@ -102,7 +102,7 @@ const createSocialUser = async ({
   const fileStrategy = appConfig?.fileStrategy ?? process.env.CDN_PROVIDER;
   const isLocal = fileStrategy === FileSources.local;
 
-  if (!isLocal) {
+  if (avatarUrl && !isLocal) {
     const resizedBuffer = await resizeAvatar({
       userId: newUserId,
       input: avatarUrl,

--- a/api/strategies/process.test.js
+++ b/api/strategies/process.test.js
@@ -1,5 +1,5 @@
 const { FileSources } = require('librechat-data-provider');
-const { handleExistingUser } = require('./process');
+const { handleExistingUser, createSocialUser } = require('./process');
 
 jest.mock('~/server/services/Files/strategies', () => ({
   getStrategyFunctions: jest.fn(),
@@ -27,12 +27,51 @@ jest.mock('@librechat/api', () => ({
 
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { resizeAvatar } = require('~/server/services/Files/images/avatar');
-const { updateUser } = require('~/models');
+const { updateUser, createUser, getUserById } = require('~/models');
 
 describe('handleExistingUser', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     process.env.CDN_PROVIDER = FileSources.local;
+  });
+
+  it('should not process the avatar when the provider supplies no avatarUrl (local storage)', async () => {
+    const oldUser = {
+      _id: 'user123',
+      avatar: null,
+    };
+
+    await handleExistingUser(oldUser, null);
+
+    expect(resizeAvatar).not.toHaveBeenCalled();
+    expect(updateUser).not.toHaveBeenCalled();
+  });
+
+  it('should not process the avatar when the provider supplies no avatarUrl (non-local storage)', async () => {
+    process.env.CDN_PROVIDER = FileSources.s3;
+    const oldUser = {
+      _id: 'user123',
+      avatar: null,
+    };
+
+    await handleExistingUser(oldUser, undefined);
+
+    expect(resizeAvatar).not.toHaveBeenCalled();
+    expect(updateUser).not.toHaveBeenCalled();
+  });
+
+  it('should still update the email when the provider supplies no avatarUrl', async () => {
+    process.env.CDN_PROVIDER = FileSources.s3;
+    const oldUser = {
+      _id: 'user123',
+      avatar: null,
+      email: 'old@example.com',
+    };
+
+    await handleExistingUser(oldUser, null, undefined, 'new@example.com');
+
+    expect(resizeAvatar).not.toHaveBeenCalled();
+    expect(updateUser).toHaveBeenCalledWith('user123', { email: 'new@example.com' });
   });
 
   it('should handle null avatar without throwing error', async () => {
@@ -238,5 +277,31 @@ describe('handleExistingUser', () => {
     await handleExistingUser(oldUser, avatarUrl, {});
 
     expect(updateUser).not.toHaveBeenCalled();
+  });
+});
+
+describe('createSocialUser', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.CDN_PROVIDER = FileSources.s3;
+    createUser.mockResolvedValue('newUser123');
+    getUserById.mockResolvedValue({ _id: 'newUser123' });
+  });
+
+  it('should not process the avatar when the provider supplies no avatarUrl', async () => {
+    await createSocialUser({
+      email: 'user@privaterelay.appleid.com',
+      avatarUrl: null,
+      provider: 'apple',
+      providerKey: 'appleId',
+      providerId: 'apple-sub-123',
+      username: 'user',
+      name: 'User',
+      emailVerified: true,
+    });
+
+    expect(resizeAvatar).not.toHaveBeenCalled();
+    expect(updateUser).not.toHaveBeenCalled();
+    expect(getUserById).toHaveBeenCalledWith('newUser123');
   });
 });


### PR DESCRIPTION
## Summary

Social providers that do not return a profile picture cause sign-in to fail outright when a non-local file strategy is configured.

`handleExistingUser` and `createSocialUser` pass the incoming `avatarUrl` straight to `resizeAvatar`:

```js
} else if (!isLocal && (!oldUser?.avatar || !hasManualFlag)) {
  const resizedBuffer = await resizeAvatar({ userId, input: avatarUrl });
```

When `avatarUrl` is `null`, `resizeAvatar` throws `Invalid input type. Expected URL, Buffer, or File.` That rejection propagates into `socialLogin`, whose `catch` forwards it to the Passport callback — so authentication fails rather than the avatar simply being skipped.

Apple is affected by definition. `appleStrategy.js` sets:

```js
avatarUrl: null, // Apple does not provide an avatar URL
```

so every Apple sign-in hits this path when `fileStrategy` is anything other than `local` — both first-time sign-up via `createSocialUser`, and every subsequent login via `handleExistingUser`, because those accounts have `avatar: null` stored. Google or OIDC accounts without a picture reach the same code.

This guards the three call sites with `avatarUrl &&`, so a missing avatar skips avatar processing and leaves the rest of the sign-in flow untouched. When the guard skips both branches, `updatedAvatar` stays `false` and no avatar field is written, which is the pre-existing behaviour for accounts without a picture.

Related prior work:

- #8982 / #8993 fixed a null dereference on the **stored** `oldUser.avatar`; the **incoming** `avatarUrl` was left unguarded.
- #13422 established that avatar processing failures should not block sign-in for OpenID and SAML. This applies the same principle to the shared social login path.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added four regression tests to `api/strategies/process.test.js`, covering both functions:

- `handleExistingUser` with no `avatarUrl` under local storage
- `handleExistingUser` with no `avatarUrl` under non-local storage
- `handleExistingUser` still applying an email change when the avatar is absent
- a new `createSocialUser` block covering the first-time sign-up path

Verified the tests fail without the fix and pass with it:

```
# with the guard
Tests:       19 passed, 19 total

# with the guard reverted
Tests:       3 failed, 16 passed, 19 total
  ● handleExistingUser › should not process the avatar when the provider supplies no avatarUrl (non-local storage)
  ● handleExistingUser › should still update the email when the provider supplies no avatarUrl
  ● createSocialUser › should not process the avatar when the provider supplies no avatarUrl
```

Commands run:

- `npm ci`
- `npm run build:data-provider && npm run build:data-schemas && npm run build:api`
- `cd api && npx jest strategies/process.test.js`
- `npx eslint api/strategies/process.js api/strategies/process.test.js`
- `npx prettier --check api/strategies/process.js api/strategies/process.test.js`
- `git diff --check`

### **Test Configuration**:

- Node.js v24.16.0
- npm 11.6.2

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
