### PR TITLE
🧍 fix: Accommodate BYOM Queue and Execution Budgets

### DIFF
--- a/packages/api/src/code/workspace.spec.ts
+++ b/packages/api/src/code/workspace.spec.ts
@@ -1,7 +1,55 @@
+import type { WorkspaceToolRequest } from './workspace';
 import type { CodeBridgeFetch } from './bridge';
 import { executeWorkspaceTool } from './workspace';
 
 describe('executeWorkspaceTool', () => {
+  test.each<[WorkspaceToolRequest, number]>([
+    [
+      { protocolVersion: 1, operation: 'read_file', workspaceId: 'primary', path: 'README.md' },
+      65_000,
+    ],
+    [
+      {
+        protocolVersion: 1,
+        operation: 'execute_command',
+        workspaceId: 'primary',
+        command: 'echo ready',
+      },
+      70_000,
+    ],
+    [
+      {
+        protocolVersion: 1,
+        operation: 'execute_command',
+        workspaceId: 'primary',
+        command: 'echo ready',
+        timeoutMs: 300_000,
+      },
+      340_000,
+    ],
+  ])('allows admission, execution and delivery time for %j', async (request, budget) => {
+    const timeout = jest.spyOn(AbortSignal, 'timeout');
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ error: 'Older server deadline exceeded', code: 'ASSIGNMENT_EXPIRED' }),
+          { status: 504 },
+        ),
+      );
+    await expect(
+      executeWorkspaceTool({
+        baseURL: 'https://code.example.com/v1',
+        authHeaders: {},
+        request,
+        fetchImpl,
+      }),
+    ).rejects.toMatchObject({ upstreamStatus: 504 });
+    expect(timeout).toHaveBeenCalledWith(budget);
+    expect(fetchImpl.mock.calls[0][1].body).toBe(JSON.stringify(request));
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
   test('sends an authenticated bounded read to the selected attached worker', async () => {
     const fetchImpl = jest.fn().mockResolvedValue(
       new Response(

--- a/packages/api/src/code/workspace.ts
+++ b/packages/api/src/code/workspace.ts
@@ -17,6 +17,9 @@ const DEFAULT_COMMAND_OUTPUT_BYTES = 256 * 1024;
 const MAX_COMMAND_OUTPUT_BYTES = 1024 * 1024;
 const MAX_COMMAND_SIGNAL_LENGTH = 32;
 const WORKSPACE_COMMAND_TRANSPORT_GRACE_MS = 5_000;
+/** Matches Code API's bounded admission wait and command settlement allowance. */
+const WORKSPACE_QUEUE_TIMEOUT_MS = 30_000;
+const WORKSPACE_COMMAND_SETTLEMENT_GRACE_MS = 5_000;
 const MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
 const MAX_ERROR_BODY_BYTES = 4096;
 const ERROR_BODY_TIMEOUT_MS = 1000;
@@ -653,8 +656,11 @@ function isValidResult(
 }
 
 function getWorkspaceToolTimeoutMs(request: WorkspaceToolRequest): number {
-  if (request.operation !== 'execute_command') return WORKSPACE_TOOL_TIMEOUT_MS;
-  return (request.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS) + WORKSPACE_COMMAND_TRANSPORT_GRACE_MS;
+  const executionBudgetMs =
+    request.operation === 'execute_command'
+      ? (request.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS) + WORKSPACE_COMMAND_SETTLEMENT_GRACE_MS
+      : WORKSPACE_TOOL_TIMEOUT_MS;
+  return WORKSPACE_QUEUE_TIMEOUT_MS + executionBudgetMs + WORKSPACE_COMMAND_TRANSPORT_GRACE_MS;
 }
 
 export async function executeWorkspaceTool({


### PR DESCRIPTION
## Summary

I increased workspace-tool HTTP deadlines to accommodate Code API's bounded queue wait, execution/settlement budget, and response delivery. A command waiting for a busy BYOM worker can finish without LibreChat prematurely disconnecting.

- Allow 65 seconds for reads, 70 seconds for default commands, and 340 seconds for five-minute commands.
- Preserve caller cancellation, request validation, wire format, and upstream errors without automatically retrying mutations.
- Cover compatibility with older Code API servers returning an earlier deadline error.

The companion Code API change https://github.com/LibreChat-AI/code-interpreter/pull/161 separates admission and execution budgets. Either PR can land first; the full behavior requires both updates. Existing workers need no deadline-protocol update.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Passed seven focused budget and cancellation tests in `packages/api/src/code/workspace.spec.ts`.
- Passed scoped ESLint, formatting, import sorting, and `git diff --check`.
- Ran the API workspace typecheck; local shared-package declarations are stale, producing unrelated approval/retention/schedule type errors. Full checks with clean dependency builds are left to CI.
- Confirmed the same local typecheck diagnostics occur on untouched `origin/dev` at `fd229fe478`.
- Verified a third queued caller receives HTTP 504 on queue expiry without being executed, while the first two commands complete.
- Passed an isolated live probe using this client, the Code API router, real Redis and native SRT under Node. Two simultaneous commands returned their expected output in 5.06 seconds with fresh post-queue execution budgets. Used ephemeral ports 55864/55869, fixture authentication and a lease/settlement harness; this is not deployed browser/full-worker E2E. Deployment remains deferred.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
