### PR TITLE
🧷 fix: Keep Ref Cleanup and Hold Consumer Handlers to the Frontmost Dialog

### DIFF
--- a/packages/client/src/components/OriginalDialog.tsx
+++ b/packages/client/src/components/OriginalDialog.tsx
@@ -177,11 +177,24 @@ const DialogContent: React.ForwardRefExoticComponent<
     const composedRef = React.useCallback(
       (node: HTMLDivElement | null) => {
         contentRef.current = node;
-        if (typeof ref === 'function') {
-          ref(node);
-        } else if (ref) {
-          (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+        if (typeof ref !== 'function') {
+          if (ref) {
+            (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+          }
+          return undefined;
         }
+        /** React 19 lets a callback ref return a teardown, and swallowing it
+         *  here would strand a consumer's observers and listeners on a replaced
+         *  node. Only a real function is passed on: React 18 warns about any
+         *  other return value. */
+        const cleanup: unknown = ref(node);
+        if (typeof cleanup !== 'function') {
+          return undefined;
+        }
+        return () => {
+          contentRef.current = null;
+          (cleanup as () => void)();
+        };
       },
       [ref],
     );
@@ -217,13 +230,6 @@ const DialogContent: React.ForwardRefExoticComponent<
         if (escapeBelongsToPopup(ownerDocument)) {
           return;
         }
-        /** The consumer's own `onEscapeKeyDown` never ran: Radix only calls it
-         *  for the highest layer, which the toast is. Give it the say it would
-         *  have had, so a dialog that refuses to close on Escape still does. */
-        propsOnEscapeKeyDown?.(event);
-        if (event.defaultPrevented) {
-          return;
-        }
         /** Radix Toast's own `li`. Matched whatever its `data-state`, because a
          *  toast that has begun closing keeps its dismissable layer registered
          *  until the exit animation ends — and that layer is what takes the
@@ -251,6 +257,19 @@ const DialogContent: React.ForwardRefExoticComponent<
           null,
         );
         if (frontmost !== content) {
+          return;
+        }
+        /** Only now, with this dialog established as the one the Escape belongs
+         *  to. Every mounted dialog runs this listener, and calling a consumer's
+         *  handler from the ones underneath would fire their side effects for
+         *  someone else's keystroke — and a `preventDefault()` there would stop
+         *  the frontmost dialog from closing at all.
+         *
+         *  The consumer's own `onEscapeKeyDown` never ran: Radix calls it only
+         *  for the highest layer, which the toast is. Give it the say it would
+         *  have had, so a dialog that refuses to close on Escape still does. */
+        propsOnEscapeKeyDown?.(event);
+        if (event.defaultPrevented) {
           return;
         }
         escapeFallbackRef.current?.click();

--- a/packages/client/src/components/__tests__/dialogToastEscape.spec.tsx
+++ b/packages/client/src/components/__tests__/dialogToastEscape.spec.tsx
@@ -125,6 +125,38 @@ describe('dialog Escape', () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  /** Every mounted dialog runs the fallback listener, so one underneath must not
+   *  fire its consumer's Escape handler for a keystroke that belongs to the
+   *  dialog above it. */
+  it("does not run a lower dialog's Escape handler for the frontmost dialog", async () => {
+    const lowerEscape = jest.fn();
+    const upperOpenChange = jest.fn();
+    render(
+      <RadixToast.Provider>
+        <OGDialog open>
+          <OGDialogContent onEscapeKeyDown={lowerEscape}>
+            <button type="button">lower</button>
+          </OGDialogContent>
+        </OGDialog>
+        <OGDialog open onOpenChange={upperOpenChange}>
+          <OGDialogContent style={{ zIndex: 300 }}>
+            <button type="button">upper</button>
+          </OGDialogContent>
+        </OGDialog>
+        <RadixToast.Root open duration={Infinity} className="toast-root">
+          <RadixToast.Description>Saved</RadixToast.Description>
+        </RadixToast.Root>
+        <RadixToast.Viewport />
+      </RadixToast.Provider>,
+    );
+
+    screen.getByText('upper').focus();
+    await userEvent.keyboard('{Escape}');
+
+    expect(lowerEscape).not.toHaveBeenCalled();
+    expect(upperOpenChange).toHaveBeenCalledWith(false);
+  });
+
   /** A dialog that carries its z-index in a class — `ImagePreview` is
    *  `z-[250]` — still outranks this one, so Escape there must not close the
    *  dialog underneath it. */


### PR DESCRIPTION
Two findings from the final codex round on #15742, which merged before they landed. Both are real; the third report was the same ref finding filed three times.

## Callback-ref cleanup was swallowed

The ref wrapper `OGDialogContent` gained in #15742 discards a callback ref's return value:

```tsx
if (typeof ref === 'function') { ref(node); }    // return value dropped
```

Under the React 19 peer range a consumer's teardown then never runs when the node is replaced or unmounted, stranding whatever it attached — the direct forwarding it replaced had no such gap. The cleanup is passed on now, and only when it really is a function, because React 18 warns about any other return value from a ref callback.

## The consumer's Escape handler ran from dialogs it did not belong to

The fallback called `onEscapeKeyDown` before establishing that this dialog was the one the Escape belonged to. **Every** mounted dialog runs that document listener, so a dialog underneath fired its consumer's handler for someone else's keystroke — and a `preventDefault()` there would have stopped the frontmost dialog from closing at all, since the lower dialog's listener registers first and runs first. The call now happens after the frontmost check, so only the dialog that will actually close consults its consumer.

## Testing

- `does not run a lower dialog's Escape handler for the frontmost dialog` — verified to fail without the fix.
- The ref cleanup has no test: React 18 ignores a returned function outright, so the repo's own test runtime cannot observe the behaviour. Flagging that rather than writing a test that would pass either way.
- `packages/client` 48 suites / 488 tests, typecheck and static checks clean.

## Not done, deliberately

The same round asked the fallback to consume the Escape so a visible toast survives. It cannot from where the fallback runs: Radix registers the toast's escape listener with `{ capture: true }` and the fallback is bubble-phase, so the toast is already dismissed by the time it executes. Measured with probes on both phases:

```
ORDER ["toast", "capture-probe", "dialog", "bubble-probe"]
```

Moving the fallback to capture to pre-empt it would cost the `defaultPrevented` check an earlier round asked for — a layer that answers the Escape can only be observed after capture — and would still be order-dependent. Losing a dialog's unsaved work is worse than losing a toast. Reasoning in full on #15742.
