### PR TITLE
🏠 fix: Keep MCP Caches Fresh on Demand

### DIFF
--- a/client/src/Providers/AgentPanelContext.tsx
+++ b/client/src/Providers/AgentPanelContext.tsx
@@ -19,6 +19,7 @@ import {
   useMCPToolsQuery,
 } from '~/data-provider';
 import { isMCPServerReadyForAgent } from '~/components/MCP/mcpServerUtils';
+import { useMCPRefresh } from '~/hooks/MCP/useMCPRefresh';
 import { Panel, isEphemeralAgent } from '~/common';
 import store from '~/store';
 
@@ -63,6 +64,15 @@ export function AgentPanelProvider({ children }: { children: React.ReactNode }) 
   /** The tools query keeps its own warmup gate: the servers list resolving
    * alone must not pull the heavier tools request ahead of its stagger. */
   const mcpToolsReady = useCatalogReady('mcpTools');
+  useMCPRefresh({
+    enabled:
+      panelVisible &&
+      mcpToolsReady &&
+      !isEphemeralAgent(agent_id) &&
+      !isLoading &&
+      availableMCPServers.length > 0,
+    tools: true,
+  });
   const { data: mcpData, isFetching: mcpToolsFetching } = useMCPToolsQuery({
     enabled:
       mcpToolsReady &&

--- a/client/src/components/Chat/Input/MCPSelect.tsx
+++ b/client/src/components/Chat/Input/MCPSelect.tsx
@@ -6,6 +6,7 @@ import { TooltipAnchor, composerControlClasses } from '@librechat/client';
 import MCPServerMenuItem from '~/components/MCP/MCPServerMenuItem';
 import MCPConfigDialog from '~/components/MCP/MCPConfigDialog';
 import StackedMCPIcons from '~/components/MCP/StackedMCPIcons';
+import { useMCPRefresh } from '~/hooks/MCP/useMCPRefresh';
 import { useHasAccess, useLocalize } from '~/hooks';
 import { useBadgeRowContext } from '~/Providers';
 import { cn } from '~/utils';
@@ -18,6 +19,9 @@ function MCPSelectContent() {
   const menuStore = Ariakit.useMenuStore({ focusLoop: true });
   const isOpen = menuStore.useState('open');
   const configDialogOpen = manager?.getConfigDialogProps()?.isOpen === true;
+  useMCPRefresh({
+    enabled: (isOpen || configDialogOpen) && (manager?.availableMCPServers.length ?? 0) > 0,
+  });
 
   /**
    * The menu closes with the dialog it launched. Ariakit only takes Escape for

--- a/client/src/components/Chat/Input/MCPSubMenu.tsx
+++ b/client/src/components/Chat/Input/MCPSubMenu.tsx
@@ -4,6 +4,7 @@ import { ChevronRight } from 'lucide-react';
 import { MCPIcon, PinIcon } from '@librechat/client';
 import MCPServerMenuItem from '~/components/MCP/MCPServerMenuItem';
 import MCPConfigDialog from '~/components/MCP/MCPConfigDialog';
+import { useMCPRefresh } from '~/hooks/MCP/useMCPRefresh';
 import { useBadgeRowContext } from '~/Providers';
 import { useLocalize } from '~/hooks';
 import { cn } from '~/utils';
@@ -22,6 +23,13 @@ const MCPSubMenu = React.forwardRef<HTMLButtonElement, MCPSubMenuProps>(
       focusLoop: true,
       showTimeout: 100,
       placement: 'right',
+    });
+
+    const isOpen = menuStore.useState('open');
+    const configDialogOpen = mcpServerManager?.getConfigDialogProps()?.isOpen === true;
+    useMCPRefresh({
+      enabled:
+        (isOpen || configDialogOpen) && (mcpServerManager?.selectableServers.length ?? 0) > 0,
     });
 
     if (!mcpServerManager) {

--- a/client/src/components/Chat/Input/__tests__/MCPSelect.spec.tsx
+++ b/client/src/components/Chat/Input/__tests__/MCPSelect.spec.tsx
@@ -14,6 +14,7 @@ const defaultMcpServerManager = {
     { serverName: 'server-a', config: { title: 'Server A' } },
     { serverName: 'server-b', config: { title: 'Server B' } },
   ],
+  availableMCPServers: [{ serverName: 'server-a' }, { serverName: 'server-b' }],
   connectionStatus: {},
   isInitializing: () => false,
   getConfigDialogProps: () => null,
@@ -23,6 +24,12 @@ const defaultMcpServerManager = {
 
 let mockCanUseMcp = true;
 let mockMcpServerManager = { ...defaultMcpServerManager };
+
+const mockMCPRefresh = jest.fn();
+
+jest.mock('~/hooks/MCP/useMCPRefresh', () => ({
+  useMCPRefresh: (options: { enabled: boolean; tools?: boolean }) => mockMCPRefresh(options),
+}));
 
 jest.mock('~/Providers', () => ({
   useBadgeRowContext: () => ({
@@ -69,6 +76,7 @@ describe('MCPSelect', () => {
 
   it('renders the menu button', () => {
     render(<MCPSelect />);
+    expect(mockMCPRefresh).toHaveBeenLastCalledWith({ enabled: false });
     expect(screen.getByRole('button', { name: /MCP Servers/i })).toHaveClass(
       'h-theme-control',
       'min-w-theme-control',
@@ -83,6 +91,7 @@ describe('MCPSelect', () => {
 
     await user.click(screen.getByRole('button', { name: /MCP Servers/i }));
 
+    expect(mockMCPRefresh).toHaveBeenLastCalledWith({ enabled: true });
     const menu = screen.getByRole('menu', { name: /com_ui_mcp_servers/i });
     expect(menu).toBeVisible();
     expect(within(menu).getByRole('menuitemcheckbox', { name: /Server A/i })).toBeInTheDocument();

--- a/client/src/components/Chat/Input/__tests__/MCPSubMenu.spec.tsx
+++ b/client/src/components/Chat/Input/__tests__/MCPSubMenu.spec.tsx
@@ -1,11 +1,16 @@
 import React from 'react';
 import * as Ariakit from '@ariakit/react';
 import userEvent from '@testing-library/user-event';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, within, waitFor } from '@testing-library/react';
 import MCPSubMenu from '../MCPSubMenu';
 
 const mockToggleServerSelection = jest.fn();
 const mockSetIsPinned = jest.fn();
+const mockMCPRefresh = jest.fn();
+
+jest.mock('~/hooks/MCP/useMCPRefresh', () => ({
+  useMCPRefresh: (options: { enabled: boolean }) => mockMCPRefresh(options),
+}));
 
 const defaultMcpServerManager = {
   isPinned: true,
@@ -85,6 +90,7 @@ describe('MCPSubMenu', () => {
 
   it('renders the submenu trigger with default placeholder', () => {
     renderSubMenu();
+    expect(mockMCPRefresh).toHaveBeenLastCalledWith({ enabled: false });
     expect(screen.getByText('MCP Servers')).toBeInTheDocument();
   });
 
@@ -94,16 +100,20 @@ describe('MCPSubMenu', () => {
     expect(screen.queryByText('MCP Servers')).not.toBeInTheDocument();
   });
 
-  it('opens submenu and shows real server items', async () => {
+  it('refreshes the unpinned submenu while open and stops on close', async () => {
     const user = userEvent.setup();
+    mockMcpServerManager = { ...defaultMcpServerManager, isPinned: false };
     renderSubMenu();
 
     await user.click(screen.getByText('MCP Servers'));
 
+    expect(mockMCPRefresh).toHaveBeenLastCalledWith({ enabled: true });
     const menu = screen.getByRole('menu', { name: /com_ui_mcp_servers/i });
     expect(menu).toBeVisible();
     expect(within(menu).getByRole('menuitemcheckbox', { name: /Server A/i })).toBeInTheDocument();
     expect(within(menu).getByRole('menuitemcheckbox', { name: /Server B/i })).toBeInTheDocument();
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(mockMCPRefresh).toHaveBeenLastCalledWith({ enabled: false }));
   });
 
   it('keeps menu open after toggling a server item', async () => {

--- a/client/src/components/MCP/ServerInitializationSection.spec.tsx
+++ b/client/src/components/MCP/ServerInitializationSection.spec.tsx
@@ -7,6 +7,12 @@ import ServerInitializationSection from './ServerInitializationSection';
 const mockInitializeServer = jest.fn();
 const mockConnectionStatus = jest.fn((): MCPServerStatus | undefined => undefined);
 
+const mockMCPRefresh = jest.fn();
+
+jest.mock('~/hooks/MCP/useMCPRefresh', () => ({
+  useMCPRefresh: (options: { enabled: boolean; tools?: boolean }) => mockMCPRefresh(options),
+}));
+
 jest.mock('~/hooks', () => ({
   useLocalize: () => (key: string) => key,
   useMCPConnectionStatus: () => ({

--- a/client/src/components/MCP/ServerInitializationSection.tsx
+++ b/client/src/components/MCP/ServerInitializationSection.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { RefreshCw, Trash2 } from 'lucide-react';
 import { Button, Spinner } from '@librechat/client';
 import { useLocalize, useMCPServerManager, useMCPConnectionStatus } from '~/hooks';
+import { useMCPRefresh } from '~/hooks/MCP/useMCPRefresh';
 
 interface ServerInitializationSectionProps {
   sidePanel?: boolean;
@@ -36,6 +37,8 @@ export default function ServerInitializationSection({
   const { connectionStatus } = useMCPConnectionStatus({
     enabled: !!availableMCPServers && availableMCPServers.length > 0,
   });
+
+  useMCPRefresh({ enabled: availableMCPServers.length > 0 });
 
   const serverStatus = connectionStatus?.[serverName];
   const isConnected = serverStatus?.connectionState === 'connected';

--- a/client/src/components/SidePanel/Agents/Tools/ItemDialog/__tests__/McpSection.spec.tsx
+++ b/client/src/components/SidePanel/Agents/Tools/ItemDialog/__tests__/McpSection.spec.tsx
@@ -27,6 +27,12 @@ const mockLocalize = jest.fn((key: string, values?: Record<number, string>) =>
   key === 'com_nav_mcp_status_connecting' ? `${values?.[0]} - Connecting` : key,
 );
 
+const mockMCPRefresh = jest.fn();
+
+jest.mock('~/hooks/MCP/useMCPRefresh', () => ({
+  useMCPRefresh: (options: { enabled: boolean; tools?: boolean }) => mockMCPRefresh(options),
+}));
+
 jest.mock('react-hook-form', () => ({
   useFormContext: () => ({ control: {}, setValue: mockSetValue, getValues: mockGetValues }),
   useWatch: ({ name }: { name: string }) => {

--- a/client/src/components/SidePanel/Agents/Tools/ItemDialog/sections/McpSection.tsx
+++ b/client/src/components/SidePanel/Agents/Tools/ItemDialog/sections/McpSection.tsx
@@ -26,6 +26,7 @@ import { getStatusColor, getStatusTextKey } from '~/components/MCP/mcpServerUtil
 import MCPServerStatusIcon from '~/components/MCP/MCPServerStatusIcon';
 import MCPConfigDialog from '~/components/MCP/MCPConfigDialog';
 import McpOAuthDialog from '~/components/MCP/McpOAuthDialog';
+import { useMCPRefresh } from '~/hooks/MCP/useMCPRefresh';
 import { useAgentPanelContext } from '~/Providers';
 import { getIconForItem } from '../../items/icons';
 import OptionToggle from '../../../OptionToggle';
@@ -79,6 +80,7 @@ export default function McpSection({ item }: Props) {
   const [prevReadyForAgent, setPrevReadyForAgent] = useState(false);
   const [autoSelectPending, setAutoSelectPending] = useState(false);
   const { mcpServersMap, mcpToolsLoading } = useAgentPanelContext();
+  useMCPRefresh({ enabled: true, tools: true });
   const { agentsConfig } = useGetAgentsConfig();
   const {
     codeEnabled,

--- a/client/src/components/SidePanel/MCPBuilder/MCPBuilderPanel.tsx
+++ b/client/src/components/SidePanel/MCPBuilder/MCPBuilderPanel.tsx
@@ -14,6 +14,7 @@ import {
 import MCPConfigDialog from '~/components/MCP/MCPConfigDialog';
 import { PanelFooter, PanelContent } from '~/components/ui';
 import MCPServerCardSkeleton from './MCPServerCardSkeleton';
+import { useMCPRefresh } from '~/hooks/MCP/useMCPRefresh';
 import MCPAdminSettings from './MCPAdminSettings';
 import MCPServerDialog from './MCPServerDialog';
 import MCPServerList from './MCPServerList';
@@ -35,6 +36,7 @@ export default function MCPBuilderPanel() {
   const { user } = useAuthContext();
   const { availableMCPServers, isLoading, getServerStatusIconProps, getConfigDialogProps } =
     useMCPServerManager();
+  useMCPRefresh({ enabled: panelVisible && !isLoading && availableMCPServers.length > 0 });
 
   const hasCreateAccess = useHasAccess({
     permissionType: PermissionTypes.MCP_SERVERS,

--- a/client/src/data-provider/MCP/__tests__/freshness.spec.tsx
+++ b/client/src/data-provider/MCP/__tests__/freshness.spec.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { QueryKeys, dataService } from 'librechat-data-provider';
+import {
+  QueryClient,
+  QueryClientProvider,
+  focusManager,
+  onlineManager,
+} from '@tanstack/react-query';
+import type { MCPServersResponse, MCPConnectionStatusResponse } from 'librechat-data-provider';
+import { useMCPConnectionStatusQuery } from '../../Tools/queries';
+import { useMCPToolsQuery } from '../queries';
+
+jest.mock('librechat-data-provider', () => {
+  const actual =
+    jest.requireActual<typeof import('librechat-data-provider')>('librechat-data-provider');
+  return { ...actual, dataService: { ...actual.dataService } };
+});
+
+const catalog: MCPServersResponse = { servers: {} };
+const connected: MCPConnectionStatusResponse = {
+  success: true,
+  connectionStatus: { test: { requiresOAuth: false, connectionState: 'connected' } },
+};
+const disconnected: MCPConnectionStatusResponse = {
+  success: true,
+  connectionStatus: { test: { requiresOAuth: false, connectionState: 'disconnected' } },
+};
+const changedCatalog: MCPServersResponse = {
+  servers: {
+    test: { name: 'test', icon: '', authenticated: true, authConfig: [], tools: [] },
+  },
+};
+
+function useCatalogQueries(enabled = true) {
+  useMCPToolsQuery({ enabled });
+  useMCPConnectionStatusQuery({ enabled });
+}
+
+describe('MCP cache freshness', () => {
+  let client: QueryClient;
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    focusManager.setFocused(true);
+    onlineManager.setOnline(true);
+    client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    client.setQueryData([QueryKeys.mcpTools], catalog);
+    client.setQueryData([QueryKeys.mcpConnectionStatus], connected);
+    jest.spyOn(dataService, 'getMCPTools').mockResolvedValue(changedCatalog);
+    jest.spyOn(dataService, 'getMCPConnectionStatus').mockResolvedValue(disconnected);
+  });
+
+  afterEach(() => {
+    client.clear();
+    focusManager.setFocused(undefined);
+    onlineManager.setOnline(true);
+    jest.useRealTimers();
+  });
+
+  it('reconciles server-side changes at bounded intervals without sending messages', async () => {
+    const { rerender, unmount } = renderHook(() => useCatalogQueries(), { wrapper });
+    rerender();
+    expect(dataService.getMCPTools).not.toHaveBeenCalled();
+    expect(dataService.getMCPConnectionStatus).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(30_000);
+    });
+    expect(dataService.getMCPConnectionStatus).toHaveBeenCalledTimes(1);
+    expect(client.getQueryData([QueryKeys.mcpConnectionStatus])).toEqual(disconnected);
+    expect(dataService.getMCPTools).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(270_000);
+    });
+    expect(dataService.getMCPTools).toHaveBeenCalledTimes(1);
+    expect(client.getQueryData([QueryKeys.mcpTools])).toEqual(changedCatalog);
+    unmount();
+  });
+
+  it('does not poll while the browser is hidden and refreshes stale data on focus', async () => {
+    focusManager.setFocused(false);
+    const { unmount } = renderHook(() => useCatalogQueries(), { wrapper });
+    await act(async () => {
+      jest.advanceTimersByTime(300_001);
+    });
+    expect(dataService.getMCPTools).not.toHaveBeenCalled();
+    expect(dataService.getMCPConnectionStatus).not.toHaveBeenCalled();
+
+    await act(async () => {
+      focusManager.setFocused(true);
+    });
+    expect(dataService.getMCPTools).toHaveBeenCalledTimes(1);
+    expect(dataService.getMCPConnectionStatus).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it.each(['mount', 'reconnect'] as const)('refreshes stale data on %s', async (event) => {
+    jest.advanceTimersByTime(300_001);
+    if (event === 'reconnect') {
+      onlineManager.setOnline(false);
+    }
+    const { unmount } = renderHook(() => useCatalogQueries(), { wrapper });
+    await act(async () => {
+      onlineManager.setOnline(true);
+    });
+    expect(dataService.getMCPTools).toHaveBeenCalledTimes(1);
+    expect(dataService.getMCPConnectionStatus).toHaveBeenCalledTimes(1);
+    expect(client.getQueryData([QueryKeys.mcpTools])).toEqual(changedCatalog);
+    expect(client.getQueryData([QueryKeys.mcpConnectionStatus])).toEqual(disconnected);
+    unmount();
+  });
+
+  it('keeps disabled queries idle across polling, focus, and reconnect', async () => {
+    const { unmount } = renderHook(() => useCatalogQueries(false), { wrapper });
+    await act(async () => {
+      jest.advanceTimersByTime(600_000);
+      focusManager.setFocused(false);
+      focusManager.setFocused(true);
+      onlineManager.setOnline(false);
+      onlineManager.setOnline(true);
+    });
+    expect(dataService.getMCPTools).not.toHaveBeenCalled();
+    expect(dataService.getMCPConnectionStatus).not.toHaveBeenCalled();
+    unmount();
+  });
+});

--- a/client/src/data-provider/MCP/__tests__/freshness.spec.tsx
+++ b/client/src/data-provider/MCP/__tests__/freshness.spec.tsx
@@ -117,6 +117,45 @@ describe('MCP cache freshness', () => {
     unmount();
   });
 
+  it('shares the polling cadence across staggered surfaces and keeps polling after one closes', async () => {
+    mockRefreshConfig.toolsRefreshInterval = 60_000;
+    const { rerender, unmount } = renderHook(
+      ({ panel, dialog }) => {
+        useMCPRefresh({ enabled: panel, tools: true });
+        useMCPRefresh({ enabled: dialog, tools: true });
+      },
+      { wrapper, initialProps: { panel: true, dialog: false } },
+    );
+    await act(async () => {
+      jest.advanceTimersByTime(5_000);
+    });
+    rerender({ panel: true, dialog: true });
+    await act(async () => {
+      jest.advanceTimersByTime(25_000);
+    });
+    expect(dataService.getMCPConnectionStatus).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      jest.advanceTimersByTime(5_000);
+    });
+    expect(dataService.getMCPConnectionStatus).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      jest.advanceTimersByTime(25_000);
+    });
+    expect(dataService.getMCPConnectionStatus).toHaveBeenCalledTimes(2);
+    expect(dataService.getMCPTools).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      jest.advanceTimersByTime(5_000);
+    });
+    expect(dataService.getMCPConnectionStatus).toHaveBeenCalledTimes(2);
+    expect(dataService.getMCPTools).toHaveBeenCalledTimes(1);
+    rerender({ panel: false, dialog: true });
+    await act(async () => {
+      jest.advanceTimersByTime(25_000);
+    });
+    expect(dataService.getMCPConnectionStatus).toHaveBeenCalledTimes(3);
+    unmount();
+  });
+
   it('honors configured polling intervals and zero to disable', async () => {
     mockRefreshConfig.statusRefreshInterval = 60_000;
     mockRefreshConfig.toolsRefreshInterval = 0;

--- a/client/src/data-provider/MCP/__tests__/freshness.spec.tsx
+++ b/client/src/data-provider/MCP/__tests__/freshness.spec.tsx
@@ -9,6 +9,7 @@ import {
 } from '@tanstack/react-query';
 import type { MCPServersResponse, MCPConnectionStatusResponse } from 'librechat-data-provider';
 import { useMCPConnectionStatusQuery } from '../../Tools/queries';
+import { useMCPRefresh } from '~/hooks/MCP/useMCPRefresh';
 import { useMCPToolsQuery } from '../queries';
 
 jest.mock('librechat-data-provider', () => {
@@ -16,6 +17,12 @@ jest.mock('librechat-data-provider', () => {
     jest.requireActual<typeof import('librechat-data-provider')>('librechat-data-provider');
   return { ...actual, dataService: { ...actual.dataService } };
 });
+
+const mockRefreshConfig = { statusRefreshInterval: 30_000, toolsRefreshInterval: 300_000 };
+
+jest.mock('~/data-provider/Endpoints/queries', () => ({
+  useGetStartupConfig: () => ({ data: { interface: { mcpServers: mockRefreshConfig } } }),
+}));
 
 const catalog: MCPServersResponse = { servers: {} };
 const connected: MCPConnectionStatusResponse = {
@@ -33,8 +40,7 @@ const changedCatalog: MCPServersResponse = {
 };
 
 function useCatalogQueries(enabled = true) {
-  useMCPToolsQuery({ enabled });
-  useMCPConnectionStatusQuery({ enabled });
+  useMCPRefresh({ enabled, tools: true });
 }
 
 describe('MCP cache freshness', () => {
@@ -45,6 +51,8 @@ describe('MCP cache freshness', () => {
 
   beforeEach(() => {
     jest.useFakeTimers();
+    mockRefreshConfig.statusRefreshInterval = 30_000;
+    mockRefreshConfig.toolsRefreshInterval = 300_000;
     focusManager.setFocused(true);
     onlineManager.setOnline(true);
     client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -59,6 +67,73 @@ describe('MCP cache freshness', () => {
     focusManager.setFocused(undefined);
     onlineManager.setOnline(true);
     jest.useRealTimers();
+  });
+
+  it('keeps always-mounted cache observers free of polling', async () => {
+    const { unmount } = renderHook(
+      () => {
+        useMCPToolsQuery();
+        useMCPConnectionStatusQuery();
+      },
+      { wrapper },
+    );
+    await act(async () => {
+      jest.advanceTimersByTime(600_000);
+    });
+    expect(dataService.getMCPTools).not.toHaveBeenCalled();
+    expect(dataService.getMCPConnectionStatus).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('starts polling when a surface opens and stops when it closes', async () => {
+    const { rerender, unmount } = renderHook(
+      ({ visible }) => {
+        useMCPToolsQuery();
+        useMCPConnectionStatusQuery();
+        useMCPRefresh({ enabled: visible, tools: true });
+      },
+      { wrapper, initialProps: { visible: false } },
+    );
+    await act(async () => {
+      jest.advanceTimersByTime(600_000);
+    });
+    expect(dataService.getMCPTools).not.toHaveBeenCalled();
+    expect(dataService.getMCPConnectionStatus).not.toHaveBeenCalled();
+    await act(async () => {
+      rerender({ visible: true });
+    });
+    expect(dataService.getMCPTools).toHaveBeenCalledTimes(1);
+    expect(dataService.getMCPConnectionStatus).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      jest.advanceTimersByTime(30_000);
+    });
+    expect(dataService.getMCPConnectionStatus).toHaveBeenCalledTimes(2);
+    rerender({ visible: false });
+    await act(async () => {
+      jest.advanceTimersByTime(600_000);
+    });
+    expect(dataService.getMCPTools).toHaveBeenCalledTimes(1);
+    expect(dataService.getMCPConnectionStatus).toHaveBeenCalledTimes(2);
+    unmount();
+  });
+
+  it('honors configured polling intervals and zero to disable', async () => {
+    mockRefreshConfig.statusRefreshInterval = 60_000;
+    mockRefreshConfig.toolsRefreshInterval = 0;
+    const { unmount } = renderHook(() => useCatalogQueries(), { wrapper });
+    await act(async () => {
+      jest.advanceTimersByTime(30_000);
+    });
+    expect(dataService.getMCPConnectionStatus).not.toHaveBeenCalled();
+    await act(async () => {
+      jest.advanceTimersByTime(30_000);
+    });
+    expect(dataService.getMCPConnectionStatus).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      jest.advanceTimersByTime(300_000);
+    });
+    expect(dataService.getMCPTools).not.toHaveBeenCalled();
+    unmount();
   });
 
   it('reconciles server-side changes at bounded intervals without sending messages', async () => {

--- a/client/src/data-provider/MCP/queries.ts
+++ b/client/src/data-provider/MCP/queries.ts
@@ -38,8 +38,7 @@ export const useMCPToolsQuery = <TData = t.MCPServersResponse>(
       refetchOnReconnect: true,
       refetchOnMount: true,
       staleTime: 5 * 60 * 1000,
-      /** Backend list_changed notifications do not reach the browser cache. */
-      refetchInterval: 5 * 60 * 1000,
+      refetchInterval: false,
       refetchIntervalInBackground: false,
       ...config,
     },

--- a/client/src/data-provider/MCP/queries.ts
+++ b/client/src/data-provider/MCP/queries.ts
@@ -1,5 +1,5 @@
-import { useQuery, UseQueryOptions, QueryObserverResult } from '@tanstack/react-query';
 import { QueryKeys, dataService } from 'librechat-data-provider';
+import { useQuery, UseQueryOptions, QueryObserverResult } from '@tanstack/react-query';
 import type * as t from 'librechat-data-provider';
 
 /**
@@ -34,10 +34,13 @@ export const useMCPToolsQuery = <TData = t.MCPServersResponse>(
     [QueryKeys.mcpTools],
     () => dataService.getMCPTools(),
     {
-      refetchOnWindowFocus: false,
-      refetchOnReconnect: false,
-      refetchOnMount: false,
-      staleTime: 5 * 60 * 1000, // 5 minutes
+      refetchOnWindowFocus: true,
+      refetchOnReconnect: true,
+      refetchOnMount: true,
+      staleTime: 5 * 60 * 1000,
+      /** Backend list_changed notifications do not reach the browser cache. */
+      refetchInterval: 5 * 60 * 1000,
+      refetchIntervalInBackground: false,
       ...config,
     },
   );

--- a/client/src/data-provider/Tools/queries.ts
+++ b/client/src/data-provider/Tools/queries.ts
@@ -48,10 +48,13 @@ export const useMCPConnectionStatusQuery = (
     [QueryKeys.mcpConnectionStatus],
     () => dataService.getMCPConnectionStatus(),
     {
-      refetchOnWindowFocus: false,
-      refetchOnReconnect: false,
-      refetchOnMount: false,
+      refetchOnWindowFocus: true,
+      refetchOnReconnect: true,
+      refetchOnMount: true,
       staleTime: 10000, // 10 seconds
+      /** Reconcile idle sweeps and failures that happen without a client mutation. */
+      refetchInterval: 30 * 1000,
+      refetchIntervalInBackground: false,
       ...config,
     },
   );

--- a/client/src/data-provider/Tools/queries.ts
+++ b/client/src/data-provider/Tools/queries.ts
@@ -52,8 +52,7 @@ export const useMCPConnectionStatusQuery = (
       refetchOnReconnect: true,
       refetchOnMount: true,
       staleTime: 10000, // 10 seconds
-      /** Reconcile idle sweeps and failures that happen without a client mutation. */
-      refetchInterval: 30 * 1000,
+      refetchInterval: false,
       refetchIntervalInBackground: false,
       ...config,
     },

--- a/client/src/hooks/MCP/useMCPRefresh.ts
+++ b/client/src/hooks/MCP/useMCPRefresh.ts
@@ -1,0 +1,21 @@
+import { mcpRefreshDefaults } from 'librechat-data-provider';
+import { useMCPConnectionStatusQuery } from '~/data-provider/Tools/queries';
+import { useGetStartupConfig } from '~/data-provider/Endpoints/queries';
+import { useMCPToolsQuery } from '~/data-provider/MCP/queries';
+
+/** Reconcile server-side MCP changes only while a consuming UI is visible. */
+export function useMCPRefresh({ enabled, tools = false }: { enabled: boolean; tools?: boolean }) {
+  const { data: startupConfig } = useGetStartupConfig();
+  const config = startupConfig?.interface?.mcpServers;
+  const statusInterval = config?.statusRefreshInterval ?? mcpRefreshDefaults.statusRefreshInterval;
+  const toolsInterval = config?.toolsRefreshInterval ?? mcpRefreshDefaults.toolsRefreshInterval;
+
+  useMCPConnectionStatusQuery({
+    enabled,
+    refetchInterval: enabled && statusInterval > 0 ? statusInterval : false,
+  });
+  useMCPToolsQuery({
+    enabled: enabled && tools,
+    refetchInterval: enabled && tools && toolsInterval > 0 ? toolsInterval : false,
+  });
+}

--- a/client/src/hooks/SSE/useEventHandlers.ts
+++ b/client/src/hooks/SSE/useEventHandlers.ts
@@ -601,8 +601,6 @@ export default function useEventHandlers({
 
   const createdHandler = useCallback(
     (data: TResData, submission: EventSubmission) => {
-      queryClient.invalidateQueries([QueryKeys.mcpConnectionStatus]);
-      queryClient.invalidateQueries([QueryKeys.mcpTools]);
       const { messages, userMessage, isRegenerate = false, isTemporary = false } = submission;
       /**
        * The spread carries `manualSkills` through from

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -266,6 +266,9 @@ interface:
   #   public: true # Allows users to toggle "share with everyone" for their links. Whether anonymous access is permitted is controlled by ALLOW_SHARED_LINKS_PUBLIC.
   #   snapshotFiles: true # Snapshot files referenced by a shared chat so viewers can preview/download them via the link. Enabled by default; the SHARED_LINKS_SNAPSHOT_FILES env var overrides this.
   # mcpServers:
+  #   # Poll only while MCP controls are visible, in milliseconds (0 disables polling).
+  #   toolsRefreshInterval: 300000
+  #   statusRefreshInterval: 30000
   # Controls user permissions for MCP (Model Context Protocol) server management
   # - use: Allow users to use configured MCP servers
   # - create: Allow users to create and manage new MCP servers

--- a/packages/data-provider/src/config.spec.ts
+++ b/packages/data-provider/src/config.spec.ts
@@ -1154,3 +1154,25 @@ describe('bedrockModels defaults', () => {
     expect(bedrockModels).not.toContain('anthropic.claude-opus-5');
   });
 });
+
+describe('MCP UI refresh configuration', () => {
+  it('preserves configured intervals, including zero to disable polling', () => {
+    const result = configSchema.parse({
+      version: '1.3.5',
+      interface: { mcpServers: { toolsRefreshInterval: 0, statusRefreshInterval: 60_000 } },
+    });
+    expect(result.interface?.mcpServers).toMatchObject({
+      toolsRefreshInterval: 0,
+      statusRefreshInterval: 60_000,
+    });
+  });
+
+  it.each([-1, 1.5, 2_147_483_648])('rejects invalid timer intervals: %s', (interval) => {
+    expect(
+      configSchema.safeParse({
+        version: '1.3.5',
+        interface: { mcpServers: { statusRefreshInterval: interval } },
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1789,8 +1789,16 @@ export type TTermsOfService = z.infer<typeof termsOfServiceSchema>;
 const localizedStringSchema = z.union([z.string(), z.record(z.string())]);
 export type LocalizedString = z.infer<typeof localizedStringSchema>;
 
+export const mcpRefreshDefaults = {
+  toolsRefreshInterval: 5 * 60 * 1000,
+  statusRefreshInterval: 30 * 1000,
+};
+
 const mcpServersSchema = z
   .object({
+    /** Foreground polling intervals in milliseconds; 0 disables polling. */
+    toolsRefreshInterval: z.number().int().nonnegative().max(2_147_483_647).optional(),
+    statusRefreshInterval: z.number().int().nonnegative().max(2_147_483_647).optional(),
     placeholder: z.string().optional(),
     use: z.boolean().optional(),
     create: z.boolean().optional(),


### PR DESCRIPTION
## Summary

I removed per-message MCP cache invalidation and added refreshes owned by visible MCP controls, keeping tools and connection status current without refetching on every assistant response or polling idle chat tabs.

- Stop invalidating `mcpTools` and `mcpConnectionStatus` on SSE `created` events, including regenerated responses.
- Refresh stale data on focus, reconnect, and mount; preserve immediate refreshes for MCP server mutations, initialization, and OAuth handling.
- Poll through `useMCPRefresh` only while MCP panels, menus, or dialogs are visible, with background-tab polling disabled. Startup and navigation observers do not poll.
- Configure visible-control polling under `interface.mcpServers.toolsRefreshInterval` and `statusRefreshInterval` in milliseconds; defaults are five minutes and 30 seconds, and `0` disables polling.
- Cover cache reconciliation, hidden tabs, disabled queries, open/close transitions, staggered observers, configuration validation, and pinned/unpinned menu wiring.

Fixes #15757.

## How it works

```text
SSE created → update chat messages (no MCP invalidation)
Visible MCP control → useMCPRefresh → shared React Query caches
Closed control → polling disabled
MCP mutation / OAuth completion → immediate cache invalidation
```

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Passed 18 focused cache/submenu tests, including the unpinned open/close path and staggered observers; earlier validation also passed the MCP manager and 38 MCP section/initialization UI tests.
- Passed 185 configuration tests and `npx tsc --noEmit` in `packages/data-provider`.
- Passed scoped ESLint and `git diff --check`.
- Used a local Jest module mapping to the current data-provider source because installed workspace links point to a different checkout.
- Attempted the MCP menu suite: seven cases are blocked by the reused shared package missing `composerControlClasses`. The SSE handler suite is blocked by missing `lucide`.
- Ran client `npx tsc --noEmit`; the reused installation has missing modules and mismatched package types. Local Lighthouse preparation is blocked by missing `@tsdown/css`. CI verifies the complete dependency set.

Suggested browser verification: send several unrelated messages and regenerate a response; confirm `created` does not trigger MCP catalog/status requests. Keep all MCP controls closed and verify there is no periodic polling. Open an MCP control and verify server-side changes reconcile; close it and verify polling stops. Test custom intervals and `0`, then initialize/authenticate a server and verify its cache still refreshes immediately.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] I have written tests demonstrating that my changes are effective or that my feature works
