### PR TITLE
🧫 chore: Keep Jest Specs Out of Tool Discovery

### DIFF
--- a/api/app/clients/tools/structured/specs/AzureAISearch.spec.js
+++ b/api/app/clients/tools/structured/specs/AzureAISearch.spec.js
@@ -23,7 +23,7 @@ jest.mock(
   { virtual: true },
 );
 
-const AzureAISearch = require('./AzureAISearch');
+const AzureAISearch = require('../AzureAISearch');
 
 describe('AzureAISearch', () => {
   const requiredFields = {

--- a/api/app/clients/tools/structured/specs/StableDiffusion.spec.js
+++ b/api/app/clients/tools/structured/specs/StableDiffusion.spec.js
@@ -29,7 +29,7 @@ jest.mock('@librechat/api', () => ({
 }));
 jest.mock('~/config/paths', () => ({}), { virtual: true });
 
-const StableDiffusionAPI = require('./StableDiffusion');
+const StableDiffusionAPI = require('../StableDiffusion');
 
 describe('StableDiffusionAPI', () => {
   beforeEach(() => {

--- a/api/server/services/start/__tests__/tools.spec.js
+++ b/api/server/services/start/__tests__/tools.spec.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { loadAndFormatTools } = require('../tools');
+
+describe('loadAndFormatTools', () => {
+  let directory;
+
+  beforeEach(() => {
+    directory = fs.mkdtempSync(path.join(os.tmpdir(), 'librechat-tools-'));
+    const toolPath = require.resolve('@librechat/agents/langchain/tools');
+    fs.writeFileSync(
+      path.join(directory, 'Example.js'),
+      `const { Tool } = require(${JSON.stringify(toolPath)});
+      module.exports = class extends Tool {
+        constructor() {
+          super();
+          this.name = 'example';
+          this.description = 'Example tool';
+        }
+        async _call() { return 'example'; }
+      };`,
+    );
+    for (const file of ['Example.spec.js', 'Example.test.js']) {
+      fs.writeFileSync(
+        path.join(directory, file),
+        `require('fs').writeFileSync(${JSON.stringify(path.join(directory, `${file}.loaded`))}, 'loaded');
+        throw new Error('Test module must not execute during tool discovery');`,
+      );
+    }
+  });
+
+  afterEach(() => {
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  it.each([
+    { adminIncluded: [] },
+    { adminIncluded: ['Example.js', 'Example.spec.js', 'Example.test.js'] },
+  ])(
+    'skips test modules before execution with includedTools=$adminIncluded',
+    ({ adminIncluded }) => {
+      const tools = loadAndFormatTools({ directory, adminIncluded });
+
+      expect(tools.example.function.name).toBe('example');
+      expect(fs.existsSync(path.join(directory, 'Example.spec.js.loaded'))).toBe(false);
+      expect(fs.existsSync(path.join(directory, 'Example.test.js.loaded'))).toBe(false);
+    },
+  );
+});

--- a/api/server/services/start/tools.js
+++ b/api/server/services/start/tools.js
@@ -16,7 +16,7 @@ const { toolkits } = require('~/app/clients/tools/manifest');
 /**
  * Loads and formats tools from the specified tool directory.
  *
- * The directory is scanned for JavaScript files, excluding any files in the filter set.
+ * The directory is scanned for JavaScript files, excluding test files and any files in the filter set.
  * For each file, it attempts to load the file as a module and instantiate a class, if it's a subclass of `StructuredTool`.
  * Each tool instance is then formatted to be compatible with the OpenAI Assistant.
  * Additionally, instances of LangChain Tools are included in the result.
@@ -42,7 +42,11 @@ function loadAndFormatTools({ directory, adminFilter = [], adminIncluded = [] })
 
   for (const file of files) {
     const filePath = path.join(directory, file);
-    if (!file.endsWith('.js') || (filter.has(file) && included.size === 0)) {
+    if (
+      !file.endsWith('.js') ||
+      /\.(spec|test)\.js$/.test(file) ||
+      (filter.has(file) && included.size === 0)
+    ) {
       continue;
     }
 

--- a/api/server/services/start/tools.js
+++ b/api/server/services/start/tools.js
@@ -7,6 +7,7 @@ const { Tool } = require('@librechat/agents/langchain/tools');
 const { Tools, ImageVisionTool } = require('librechat-data-provider');
 const {
   getToolkitKey,
+  isToolModuleFile,
   oaiToolkit,
   geminiToolkit,
   createAskUserQuestionTool,
@@ -42,11 +43,7 @@ function loadAndFormatTools({ directory, adminFilter = [], adminIncluded = [] })
 
   for (const file of files) {
     const filePath = path.join(directory, file);
-    if (
-      !file.endsWith('.js') ||
-      /\.(spec|test)\.js$/.test(file) ||
-      (filter.has(file) && included.size === 0)
-    ) {
+    if (!isToolModuleFile(file) || (filter.has(file) && included.size === 0)) {
       continue;
     }
 

--- a/packages/api/src/tools/discovery.ts
+++ b/packages/api/src/tools/discovery.ts
@@ -1,0 +1,3 @@
+export function isToolModuleFile(filename: string): boolean {
+  return filename.endsWith('.js') && !/\.(spec|test)\.js$/.test(filename);
+}

--- a/packages/api/src/tools/index.ts
+++ b/packages/api/src/tools/index.ts
@@ -1,4 +1,5 @@
 export * from './format';
+export * from './discovery';
 export * from './protection';
 export * from './registry';
 export * from './toolkits';


### PR DESCRIPTION
## Summary

I fixed boot-time execution of Jest specs during structured tool discovery. Fixes #15758.

- Skip `.spec.js` and `.test.js` files before `require()`, even when listed in `includedTools`, using a TypeScript predicate exported from `@librechat/api`.
- Move Azure AI Search and Stable Diffusion specs into `structured/specs/` and update their imports.
- Verify that test-module side effects never execute while a valid tool still loads.

The discovery path is `loadAndFormatTools()` → `isToolModuleFile()` → `require()` for eligible modules. Test files stop at the predicate, before their module-level code can run.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Passed all 5 tests across the loader regression suite and both relocated specs using `cd api && npx jest --runInBand server/services/start/__tests__/tools.spec.js app/clients/tools/structured/specs/AzureAISearch.spec.js app/clients/tools/structured/specs/StableDiffusion.spec.js`.
- Confirmed both regression cases fail without the loader guard and pass after restoring it.
- Passed ESLint and Prettier on changed files, `git diff --check`, the `@librechat/api` build, and a focused strict TypeScript check for the predicate.
- Attempted `npm run lighthouse`; build preparation stopped at `tsdown: command not found`, before browser checks. Lighthouse passed in CI on the initial head; CI is rerunning for the updated head.

### **Test Configuration**:

I reused locally installed dependencies through worktree symlinks. For the latest focused Jest run, I mapped `@librechat/api` to this worktree’s rebuilt `packages/api/dist/index.cjs`. `npx tsc --noEmit` in `packages/api` reported errors outside the changed files with the reused dependency declarations (including missing upload-routing exports and schedule fields); CI must verify the full workspace gate. The legacy API workspace has no TypeScript configuration.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
