### PR TITLE
🪴 fix: Restore Native Workspace Selection

### DIFF
--- a/client/src/hooks/Agents/__tests__/useCodeWorkspace.test.tsx
+++ b/client/src/hooks/Agents/__tests__/useCodeWorkspace.test.tsx
@@ -119,14 +119,40 @@ describe('useCodeWorkspace', () => {
     expect(result.current.state).toBe('unavailable');
   });
 
-  it.each([false, undefined])('rejects non-stateful worker support: %s', (statefulWorkspace) => {
-    const statuses = mockStatus();
-    statuses[0].data.statefulWorkspace = statefulWorkspace;
-    const selection = { environmentId: 'personal-vm', workspaceId: 'project-a' };
-    const { result } = renderHook(() => useCodeWorkspace(conversation([selection])));
+  it.each([false, undefined])(
+    'selects native roots without runtime sessions: %s',
+    (statefulWorkspace) => {
+      const statuses = mockStatus();
+      statuses[0].data.statefulWorkspace = statefulWorkspace;
+      const selection = { environmentId: 'personal-vm', workspaceId: 'project-a' };
+      const { result } = renderHook(() => useCodeWorkspace(conversation([selection])));
+      expect(result.current.state).toBe('ready');
+      expect(result.current.selections).toEqual([selection]);
+      expect(result.current.resolveSelections([selection])).toEqual([selection]);
+    },
+  );
+
+  it('automatically selects a sole native root without runtime sessions', () => {
+    mockStatus()[0].data.statefulWorkspace = false;
+    const { result } = renderHook(() => useCodeWorkspace(conversation()));
+    expect(result.current.state).toBe('ready');
+    expect(result.current.selections).toEqual([
+      { environmentId: 'personal-vm', workspaceId: 'project-a' },
+    ]);
+  });
+
+  it.each(['offline', 'starting'])('rejects a native worker that is %s', (status) => {
+    Object.assign(mockStatus()[0].data, { status, statefulWorkspace: false });
+    const { result } = renderHook(() => useCodeWorkspace(conversation()));
     expect(result.current.state).toBe('unavailable');
     expect(result.current.selections).toBeUndefined();
-    expect(result.current.resolveSelections([selection])).toBeUndefined();
+  });
+
+  it('rejects a ready native worker without advertised roots', () => {
+    Object.assign(mockStatus()[0].data, { statefulWorkspace: false, workspaces: undefined });
+    const { result } = renderHook(() => useCodeWorkspace(conversation()));
+    expect(result.current.state).toBe('unsupported');
+    expect(result.current.selections).toBeUndefined();
   });
 
   it('requires an explicit choice when several workspaces are advertised', () => {

--- a/client/src/hooks/Agents/useCodeWorkspace.ts
+++ b/client/src/hooks/Agents/useCodeWorkspace.ts
@@ -70,12 +70,7 @@ function resolveEnvironmentSelection({
   stored?: CodeWorkspaceSelection;
   hasStoredSelections: boolean;
 }): CodeWorkspaceSelection | undefined {
-  if (
-    status?.status !== 'ready' ||
-    status.statefulWorkspace !== true ||
-    status.environmentId !== environment.id
-  )
-    return undefined;
+  if (status?.status !== 'ready' || status.environmentId !== environment.id) return undefined;
   if (stored != null && workspaces.some(({ id }) => id === stored.workspaceId)) {
     return { environmentId: environment.id, workspaceId: stored.workspaceId };
   }
@@ -160,7 +155,6 @@ export default function useCodeWorkspace(
     else if (
       status.isError ||
       status.data?.status !== 'ready' ||
-      status.data.statefulWorkspace !== true ||
       status.data.environmentId !== environment.id
     ) {
       state = 'unavailable';

--- a/packages/api/src/code/capabilities.spec.ts
+++ b/packages/api/src/code/capabilities.spec.ts
@@ -283,7 +283,7 @@ describe('resolveCodeExecutionWorkspaceContext', () => {
     delete process.env.TEST_CODE_CAPABILITY_TOKEN;
   });
 
-  function workspaceStatus(workspaces: unknown[]): Response {
+  function workspaceStatus(workspaces: unknown[], statefulWorkspace: boolean = true): Response {
     return new Response(
       JSON.stringify({
         protocolVersion: 1,
@@ -292,7 +292,7 @@ describe('resolveCodeExecutionWorkspaceContext', () => {
         ready: true,
         leaseExpiresInMs: 45_000,
         capabilities: {
-          statefulWorkspace: true,
+          statefulWorkspace,
           sandboxProfile: 'native-srt',
           runtimes: ['bash'],
           workspaceTools: {
@@ -332,6 +332,55 @@ describe('resolveCodeExecutionWorkspaceContext', () => {
       },
     });
   });
+
+  it('admits native workspace tools without enabling programmatic runtime execution', async () => {
+    jest
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(workspaceStatus([{ id: 'docs', operations: ['read_file'] }], false));
+    const resolved = await resolveCodeExecutionWorkspaceContext({
+      context,
+      requestedSelections: [{ environmentId: 'personal', workspaceId: 'docs' }],
+      environments,
+      getAppConfig,
+    });
+    expect(resolved.codeWorkspace).toEqual({
+      environmentId: 'personal',
+      workspaceId: 'docs',
+      operations: ['read_file'],
+    });
+    expect(await supportsProgrammaticCodeExecution(context, environments, getAppConfig)).toBe(
+      false,
+    );
+    expect(await supportsProgrammaticCodeExecution(resolved, environments, getAppConfig)).toBe(
+      false,
+    );
+  });
+
+  it.each([false, true])(
+    'fails closed without native workspace capabilities (ready: %s)',
+    async (ready) => {
+      jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            protocolVersion: 1,
+            workerId: 'worker',
+            online: true,
+            ready,
+            leaseExpiresInMs: 45_000,
+            capabilities: { statefulWorkspace: false, sandboxProfile: 'native-srt', runtimes: [] },
+          }),
+        ),
+      );
+      await expect(
+        resolveCodeExecutionWorkspaceContext({
+          context,
+          requestedSelections: [{ environmentId: 'personal', workspaceId: 'docs' }],
+          environments,
+          getAppConfig,
+        }),
+      ).rejects.toMatchObject({ reason: ready ? 'unsupported' : 'worker_unavailable' });
+    },
+  );
 
   it.each(['worker', 'replacement', undefined])(
     'pins deployment worker identity: %s',

--- a/packages/api/src/code/capabilities.ts
+++ b/packages/api/src/code/capabilities.ts
@@ -138,7 +138,8 @@ export async function resolveCodeExecutionWorkspaceContext({
     );
     throw new CodeWorkspaceSelectionError('worker_unavailable');
   }
-  if (status.status !== 'ready' || status.statefulWorkspace !== true) {
+  /** Named workspace tools enforce their roots independently of runtime sessions. */
+  if (status.status !== 'ready') {
     throw new CodeWorkspaceSelectionError('worker_unavailable');
   }
   if (!status.workspaces || !status.operations) {


### PR DESCRIPTION
## Summary

I fixed a regression from #15768 where a ready native BYOM worker appeared in the workspace picker but stayed unavailable and blocked Send. Named workspace selection now depends on the advertised workspace capabilities, not the separate stateful runtime-supervisor flag.

- Remove the runtime-session gate from both client selection checks and server workspace admission.
- Preserve worker readiness, environment authorization, exact workspace binding, per-root operation ceilings, and programmatic runtime restrictions.
- Cover automatic and saved native selections, unavailable workers, missing capabilities, and continued programmatic-execution denial.

## How it works

```diff
- status.status !== 'ready' || status.statefulWorkspace !== true
+ status.status !== 'ready'
```

This applies only to named-workspace admission. The worker independently resolves registered roots by workspace ID and confines file/command operations to those roots. `supportsProgrammaticCodeExecution` retains its runtime capability requirement and remains disabled for selected attached workspaces.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Passed 20 focused useCodeWorkspace hook tests and 29 capabilities tests.
- Passed scoped ESLint and formatting checks.
- Used current data-provider source mapping in local Jest runs because reused dependency builds predate workspace-selection exports. No test configuration changes are committed.
- Attempted client and packages/api `tsc --noEmit`; reused local dependency declarations report missing/new exports and unrelated type errors. Clean-install typechecking and broad suites run in CI.
- Codegraph selector token was unavailable; focused tests were source-selected, not graph-verified.
- Reproduced the picker failure live before the fix. Post-deployment live verification is pending.

### Test Configuration

Native workspace capability: ready, `statefulWorkspace: false`, advertised workspace descriptors and per-workspace operations. No worker configuration or dependency upgrade required.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
