### PR TITLE
🪡 fix: Thread Stop Into BYOM Commands

### DIFF
--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -402,6 +402,11 @@ const initializeClient = async ({
 
   const invokedSkillIdentities = new Map();
   const toolExecuteOptions = {
+    // Keep foreground cancellation owned by this request even when the agents
+    // SDK rebuilds a graph for approval resume. The SDK event's breaker signal
+    // is composed with this authoritative job signal by the handler.
+    runSignal: signal,
+    foregroundRunId: runtimeRequestBody?.messageId,
     loadTools: async (toolNames, agentId, _configurable, callerCapabilityProjection) => {
       const ctx = agentToolContexts.get(agentId) ?? {};
       logger.debug(`[ON_TOOL_EXECUTE] ctx found: ${!!ctx.userMCPAuthMap}, agent: ${ctx.agent?.id}`);

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -305,6 +305,22 @@ describe('initializeClient — processAgent ACL gate', () => {
     });
   });
 
+  it('binds foreground tool execution to the host-owned run signal', async () => {
+    mockInitializeAgent.mockResolvedValue(makePrimaryConfig([]));
+    const controller = new AbortController();
+
+    await initializeClient({
+      req: makeReq(),
+      res: {},
+      signal: controller.signal,
+      endpointOption: makeEndpointOption(),
+      requestBody: { messageId: 'response-1', conversationId: 'conv_1' },
+    });
+
+    expect(capturedToolExecuteOptions.runSignal).toBe(controller.signal);
+    expect(capturedToolExecuteOptions.foregroundRunId).toBe('response-1');
+  });
+
   it('propagates an expected-MCP-tools failure from the runtime tool loader', async () => {
     const toolError = Object.assign(new Error('Expected MCP tools are unavailable'), {
       code: 'AGENT_EXPECTED_MCP_TOOLS_UNAVAILABLE',

--- a/packages/api/src/agents/handlers.spec.ts
+++ b/packages/api/src/agents/handlers.spec.ts
@@ -386,11 +386,12 @@ describe('createToolExecuteHandler', () => {
       tool: { name: string; invoke: jest.Mock },
       request: Partial<ToolExecuteBatchRequest>,
       controller: AbortController,
+      options: Partial<ToolExecuteOptions> = {},
     ): Promise<ToolExecuteResult[]> {
       const loadTools: ToolExecuteOptions['loadTools'] = jest.fn(async () => ({
         loadedTools: [tool] as never[],
       }));
-      const handler = createToolExecuteHandler({ loadTools });
+      const handler = createToolExecuteHandler({ loadTools, ...options });
       return new Promise<ToolExecuteResult[]>((resolve, reject) => {
         handler.handle('on_tool_execute', {
           toolCalls: [{ id: 'call-1', name: tool.name, args: {} }] as ToolCallRequest[],
@@ -412,6 +413,79 @@ describe('createToolExecuteHandler', () => {
       expect(tool.invoke.mock.calls[0][1].signal).toBe(controller.signal);
       expect(results).toHaveLength(1);
       expect(results[0].status).toBe('error');
+    });
+
+    it('uses the host-owned run signal when an SDK event omits its signal', async () => {
+      const controller = new AbortController();
+      const tool = abortingTool();
+
+      const results = await runBatch(
+        tool,
+        { signal: undefined, metadata: { run_id: 'foreground-run' } },
+        controller,
+        {
+          runSignal: controller.signal,
+          foregroundRunId: 'foreground-run',
+        },
+      );
+
+      expect(tool.invoke.mock.calls[0][1].signal).toBe(controller.signal);
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe('error');
+    });
+
+    it('composes host cancellation with an SDK event circuit-breaker signal', async () => {
+      const controller = new AbortController();
+      const eventController = new AbortController();
+      const tool = abortingTool();
+
+      const results = await runBatch(
+        tool,
+        { signal: eventController.signal, metadata: { run_id: 'foreground-run' } },
+        controller,
+        {
+          runSignal: controller.signal,
+          foregroundRunId: 'foreground-run',
+        },
+      );
+
+      const invokedSignal = tool.invoke.mock.calls[0][1].signal as AbortSignal;
+      expect(invokedSignal).not.toBe(controller.signal);
+      expect(invokedSignal.aborted).toBe(true);
+      expect(eventController.signal.aborted).toBe(false);
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe('error');
+    });
+
+    it('does not bind a detached child run to the foreground host signal', async () => {
+      const foregroundController = new AbortController();
+      const childController = new AbortController();
+      foregroundController.abort();
+      const tool = {
+        name: 'child_tool',
+        invoke: jest.fn(async () => ({ content: 'done' })),
+      };
+      const loadTools: ToolExecuteOptions['loadTools'] = jest.fn(async () => ({
+        loadedTools: [tool] as never[],
+      }));
+      const handler = createToolExecuteHandler({
+        loadTools,
+        runSignal: foregroundController.signal,
+        foregroundRunId: 'foreground-run',
+      });
+
+      const [result] = await new Promise<ToolExecuteResult[]>((resolve, reject) => {
+        handler.handle('on_tool_execute', {
+          toolCalls: [{ id: 'call-1', name: tool.name, args: {} }] as ToolCallRequest[],
+          metadata: { run_id: 'detached-child-run' },
+          signal: childController.signal,
+          resolve,
+          reject,
+        } as ToolExecuteBatchRequest);
+      });
+
+      expect(tool.invoke.mock.calls[0][1].signal).toBe(childController.signal);
+      expect(result.status).toBe('success');
     });
 
     it('logs a cancelled tool call as debug rather than a tool error', async () => {

--- a/packages/api/src/agents/handlers.ts
+++ b/packages/api/src/agents/handlers.ts
@@ -221,6 +221,14 @@ export function createOwnedToolEndHandler(
 }
 
 export interface ToolExecuteOptions {
+  /**
+   * Host-owned signal for the foreground run. This is authoritative across
+   * graph reconstruction (including approval resume); the SDK event signal is
+   * composed with it below so circuit-breaker cancellation is preserved too.
+   */
+  runSignal?: AbortSignal;
+  /** Run id owned by `runSignal`; detached child runs carry a different id. */
+  foregroundRunId?: string;
   /** Loads tools by name, using agentId to look up agent-specific context */
   loadTools: (
     toolNames: string[],
@@ -5191,6 +5199,8 @@ function buildToolCallConfig(
 
 export function createToolExecuteHandler(options: ToolExecuteOptions): EventHandler {
   const {
+    runSignal: hostRunSignal,
+    foregroundRunId,
     loadTools,
     toolEndCallback,
     eventActorDetachedAction,
@@ -5209,10 +5219,26 @@ export function createToolExecuteHandler(options: ToolExecuteOptions): EventHand
         agentId,
         configurable,
         metadata,
-        signal: runSignal,
+        signal: eventRunSignal,
         resolve,
         reject,
       } = data;
+      let eventRunId: string | undefined;
+      if (typeof metadata?.run_id === 'string') {
+        eventRunId = metadata.run_id;
+      } else if (typeof configurable?.run_id === 'string') {
+        eventRunId = configurable.run_id;
+      }
+      const foregroundHostSignal =
+        foregroundRunId == null || eventRunId == null || eventRunId === foregroundRunId
+          ? hostRunSignal
+          : undefined;
+      const runSignal =
+        foregroundHostSignal != null &&
+        eventRunSignal != null &&
+        foregroundHostSignal !== eventRunSignal
+          ? AbortSignal.any([foregroundHostSignal, eventRunSignal])
+          : (foregroundHostSignal ?? eventRunSignal);
       const callerCapabilityProjection = resolveCallerCapabilityProjectionSnapshot(
         (
           data as ToolExecuteBatchRequest & {

--- a/packages/api/src/code/command.spec.ts
+++ b/packages/api/src/code/command.spec.ts
@@ -119,6 +119,46 @@ describe('createAttachedWorkspaceBashTool', () => {
     ).toBeUndefined();
   });
 
+  test('aborts an in-flight command without poisoning subsequent workspace reuse', async () => {
+    let requestCount = 0;
+    let markRequestStarted!: () => void;
+    const requestStarted = new Promise<void>((resolve) => {
+      markRequestStarted = resolve;
+    });
+    const fetchImpl: CodeBridgeFetch = jest.fn(async (_url, init) => {
+      requestCount += 1;
+      if (requestCount > 1) {
+        return commandResponse({ stdout: 'reused\n' });
+      }
+      markRequestStarted();
+      return await new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal as AbortSignal;
+        if (signal.aborted) {
+          reject(signal.reason);
+          return;
+        }
+        signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+      });
+    });
+    const bashTool = createAttachedWorkspaceBashTool({
+      baseUrl: 'https://code.example.com/v1',
+      authHeaders: () => ({}),
+      workspaceId: 'project-a',
+      fetchImpl,
+    });
+    const controller = new AbortController();
+
+    const cancelled = bashTool.invoke({ command: 'sleep 30' }, { signal: controller.signal });
+    await requestStarted;
+    controller.abort();
+
+    await expect(cancelled).rejects.toThrow('Aborted');
+    await expect(bashTool.invoke({ command: 'pwd' })).resolves.toBe(
+      'stdout:\nreused\n\n[exit code: 0]',
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
   test('preserves legacy positional args without interpolating shell metacharacters', async () => {
     const fetchImpl: CodeBridgeFetch = jest.fn(async () => commandResponse());
     const bashTool = createAttachedWorkspaceBashTool({


### PR DESCRIPTION
## Summary

I fixed foreground BYOM cancellation so Stop reaches active workspace tools during both fresh runs and approval-resumed runs, while preserving the agents SDK circuit breaker and independent detached execution.

- Bind the authoritative generation-job abort signal to the shared foreground tool handler during client initialization.
- Scope the host signal to the response run ID so detached child tasks retain their task-owned cancellation lifecycle.
- Compose the host-owned signal with the SDK event signal so approval reconstruction cannot detach tools from Stop and circuit-breaker cancellation still works.
- Forward the resolved signal through file provisioning, built-in workspace actions, dynamically loaded tools, `packages/api/src/code/command.ts`, and `executeWorkspaceTool`.
- Preserve timeout behavior as a separate bounded transport failure rather than treating Stop as a 30-second command timeout.
- Add regressions for missing/replaced SDK event signals, detached child isolation, command cancellation, and immediate workspace reuse after cancellation.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npm exec -- jest src/agents/handlers.spec.ts src/code/command.spec.ts --runInBand --coverage=false` from `packages/api` (197 tests passed).
- Ran focused ESLint checks for every changed source and test file in `packages/api` and `api`.
- Attempted the focused initializer suite; the local shared dependency build predates current `dev` and fails during module loading because `createCheckpointDeletionReclaimer` is absent. CI runs it against the branch's coherent workspace build.

### **Test Configuration**:

- macOS
- Node.js 24.16.0
- Branch based on `origin/dev` at `a8087ce454`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
