### PR TITLE
🧵 test: Type BYOM Cancellation Mock

### DIFF
--- a/packages/api/src/agents/handlers.spec.ts
+++ b/packages/api/src/agents/handlers.spec.ts
@@ -463,7 +463,9 @@ describe('createToolExecuteHandler', () => {
       foregroundController.abort();
       const tool = {
         name: 'child_tool',
-        invoke: jest.fn(async () => ({ content: 'done' })),
+        invoke: jest.fn(async (_args: unknown, _config: Record<string, unknown>) => ({
+          content: 'done',
+        })),
       };
       const loadTools: ToolExecuteOptions['loadTools'] = jest.fn(async () => ({
         loadedTools: [tool] as never[],


### PR DESCRIPTION
## Summary

I fixed the TypeScript failure introduced by the merged BYOM foreground-cancellation regression test.

- Give the detached-child tool mock the same two-argument invocation shape used by runtime tools.
- Preserve the assertion that the detached child receives its own abort signal.
- Avoid changing production cancellation behavior.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npm exec -- jest src/agents/handlers.spec.ts --runInBand --coverage=false` from `packages/api` (190 tests passed).
- Ran `npm exec -- eslint src/agents/handlers.spec.ts` from `packages/api`.
- Ran `npx tsc --noEmit -p packages/api/tsconfig.json`; the reported `handlers.spec.ts:487` errors are resolved. The remaining local errors come from stale built workspace dependencies, so CI is authoritative for the coherent monorepo typecheck.

### **Test Configuration**:

- macOS
- Node.js 24.16.0
- Branch based on `origin/dev` at `b207530ff5`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
