### PR TITLE
🛑 fix: Preserve BYOM Foreground Cancellation Identity

### DIFF
--- a/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
+++ b/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
@@ -948,6 +948,9 @@ describe('ResumableAgentController resume metadata', () => {
     expect(initializeClient).toHaveBeenCalledWith(
       expect.objectContaining({ checkpointNamespace: '1000', jobCreatedAt: 1000 }),
     );
+    const [{ foregroundRunId, requestBody }] = initializeClient.mock.calls[0];
+    expect(foregroundRunId).toBe(requestBody.messageId);
+    expect(foregroundRunId).not.toBe(req.body.messageId);
     expect(req.turnStartedAt).toBe(1000);
     expect(mockGenerationJobManager.updateMetadata).not.toHaveBeenCalled();
     const startupMilestones = mockStartupTelemetry.mark.mock.calls.map(([milestone]) => milestone);

--- a/api/server/controllers/agents/__tests__/resume.spec.js
+++ b/api/server/controllers/agents/__tests__/resume.spec.js
@@ -428,20 +428,23 @@ describe('ResumeAgentController (POST /agents/chat/resume)', () => {
     });
 
     mockAddTitle = jest.fn().mockResolvedValue(undefined);
-    mockInitializeClient = jest.fn(async ({ req, checkpointNamespace, requestBody }) => {
-      // Capture the request state the controller seeds BEFORE reconstruction.
-      capturedInit = {
-        parentMessageId: req.body.parentMessageId,
-        files: req.body.files,
-        isTemporary: req.body.isTemporary,
-        turnStartedAt: req.turnStartedAt,
-        isScheduledFire: req._isScheduledFire,
-        timezone: req.body.timezone,
-        checkpointNamespace,
-        requestBody,
-      };
-      return { client: makeClient(), userMCPAuthMap: { server1: { token: 't' } } };
-    });
+    mockInitializeClient = jest.fn(
+      async ({ req, checkpointNamespace, foregroundRunId, requestBody }) => {
+        // Capture the request state the controller seeds BEFORE reconstruction.
+        capturedInit = {
+          parentMessageId: req.body.parentMessageId,
+          files: req.body.files,
+          isTemporary: req.body.isTemporary,
+          turnStartedAt: req.turnStartedAt,
+          isScheduledFire: req._isScheduledFire,
+          timezone: req.body.timezone,
+          checkpointNamespace,
+          foregroundRunId,
+          requestBody,
+        };
+        return { client: makeClient(), userMCPAuthMap: { server1: { token: 't' } } };
+      },
+    );
 
     app = express();
     app.use(express.json());
@@ -2799,6 +2802,7 @@ describe('ResumeAgentController (POST /agents/chat/resume)', () => {
         conversationId: CONVO_ID,
         parentMessageId: USER_MSG_ID,
       });
+      expect(capturedInit.foregroundRunId).toBe(RESPONSE_MSG_ID);
 
       expect(mockInitializeClient).toHaveBeenCalledTimes(1);
       const client = await mockInitializeClient.mock.results[0].value.then((r) => r.client);

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -1907,7 +1907,7 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
       signal: job.abortController.signal,
       jobCreatedAt,
       checkpointNamespace: job.metadata?.checkpointNamespace,
-      foregroundRunId: job.metadata.responseMessageId,
+      foregroundRunId: mcpRequestBody.messageId,
       requestBody: mcpRequestBody,
     });
     startupTelemetry?.mark('client_initialized');

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -1907,6 +1907,7 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
       signal: job.abortController.signal,
       jobCreatedAt,
       checkpointNamespace: job.metadata?.checkpointNamespace,
+      foregroundRunId: job.metadata.responseMessageId,
       requestBody: mcpRequestBody,
     });
     startupTelemetry?.mark('client_initialized');

--- a/api/server/controllers/agents/resume.js
+++ b/api/server/controllers/agents/resume.js
@@ -1815,6 +1815,14 @@ const ResumeAgentController = async (req, res, next, initializeClient, addTitle)
       );
     }
 
+    const mcpRequestBody =
+      job.metadata.mcpRequestBody ??
+      createMCPRuntimeRequestBody({
+        messageId: job.metadata.responseMessageId,
+        conversationId: streamId,
+        codeWorkspaces: req.body.codeWorkspaces ?? req.resolvedConversation?.codeWorkspaces,
+        parentMessageId: job.metadata.userMessage?.messageId ?? Constants.NO_PARENT,
+      });
     const result = await initializeClient({
       req,
       res,
@@ -1822,15 +1830,8 @@ const ResumeAgentController = async (req, res, next, initializeClient, addTitle)
       signal: job.abortController.signal,
       jobCreatedAt: job.createdAt,
       checkpointNamespace,
-      foregroundRunId: job.metadata.responseMessageId,
-      requestBody:
-        job.metadata.mcpRequestBody ??
-        createMCPRuntimeRequestBody({
-          messageId: job.metadata.responseMessageId,
-          conversationId: streamId,
-          codeWorkspaces: req.body.codeWorkspaces ?? req.resolvedConversation?.codeWorkspaces,
-          parentMessageId: job.metadata.userMessage?.messageId ?? Constants.NO_PARENT,
-        }),
+      foregroundRunId: mcpRequestBody.messageId,
+      requestBody: mcpRequestBody,
     });
     client = result.client;
 

--- a/api/server/controllers/agents/resume.js
+++ b/api/server/controllers/agents/resume.js
@@ -1822,6 +1822,7 @@ const ResumeAgentController = async (req, res, next, initializeClient, addTitle)
       signal: job.abortController.signal,
       jobCreatedAt: job.createdAt,
       checkpointNamespace,
+      foregroundRunId: job.metadata.responseMessageId,
       requestBody:
         job.metadata.mcpRequestBody ??
         createMCPRuntimeRequestBody({

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -165,6 +165,7 @@ function createToolLoader(
  * @param {Object} params.endpointOption
  * @param {number} [params.jobCreatedAt]
  * @param {string} [params.checkpointNamespace] Immutable saver-level generation scope
+ * @param {string} [params.foregroundRunId] Canonical response identity for foreground execution
  * @param {import('@librechat/api').MCPRuntimeRequestBody} [params.requestBody]
  */
 const initializeClient = async ({
@@ -174,6 +175,7 @@ const initializeClient = async ({
   endpointOption,
   jobCreatedAt,
   checkpointNamespace,
+  foregroundRunId,
   requestBody,
 }) => {
   if (!endpointOption) {
@@ -406,7 +408,7 @@ const initializeClient = async ({
     // SDK rebuilds a graph for approval resume. The SDK event's breaker signal
     // is composed with this authoritative job signal by the handler.
     runSignal: signal,
-    foregroundRunId: runtimeRequestBody?.messageId,
+    foregroundRunId,
     loadTools: async (toolNames, agentId, _configurable, callerCapabilityProjection) => {
       const ctx = agentToolContexts.get(agentId) ?? {};
       logger.debug(`[ON_TOOL_EXECUTE] ctx found: ${!!ctx.userMCPAuthMap}, agent: ${ctx.agent?.id}`);

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -308,12 +308,15 @@ describe('initializeClient — processAgent ACL gate', () => {
   it('binds foreground tool execution to the host-owned run signal', async () => {
     mockInitializeAgent.mockResolvedValue(makePrimaryConfig([]));
     const controller = new AbortController();
+    const req = makeReq();
+    req.body.messageId = 'user-message-1';
 
     await initializeClient({
-      req: makeReq(),
+      req,
       res: {},
       signal: controller.signal,
       endpointOption: makeEndpointOption(),
+      foregroundRunId: 'response-1',
       requestBody: { messageId: 'response-1', conversationId: 'conv_1' },
     });
 

--- a/packages/api/src/agents/handlers.spec.ts
+++ b/packages/api/src/agents/handlers.spec.ts
@@ -463,7 +463,9 @@ describe('createToolExecuteHandler', () => {
       foregroundController.abort();
       const tool = {
         name: 'child_tool',
-        invoke: jest.fn(async () => ({ content: 'done' })),
+        invoke: jest.fn(async (_args: unknown, _config: Record<string, unknown>) => ({
+          content: 'done',
+        })),
       };
       const loadTools: ToolExecuteOptions['loadTools'] = jest.fn(async () => ({
         loadedTools: [tool] as never[],
@@ -472,6 +474,38 @@ describe('createToolExecuteHandler', () => {
         loadTools,
         runSignal: foregroundController.signal,
         foregroundRunId: 'foreground-run',
+      });
+
+      const [result] = await new Promise<ToolExecuteResult[]>((resolve, reject) => {
+        handler.handle('on_tool_execute', {
+          toolCalls: [{ id: 'call-1', name: tool.name, args: {} }] as ToolCallRequest[],
+          metadata: { run_id: 'detached-child-run' },
+          signal: childController.signal,
+          resolve,
+          reject,
+        } as ToolExecuteBatchRequest);
+      });
+
+      expect(tool.invoke.mock.calls[0][1].signal).toBe(childController.signal);
+      expect(result.status).toBe('success');
+    });
+
+    it('does not bind a tagged child run when the foreground identity is unavailable', async () => {
+      const foregroundController = new AbortController();
+      const childController = new AbortController();
+      foregroundController.abort();
+      const tool = {
+        name: 'child_tool',
+        invoke: jest.fn(async (_args: unknown, _config: Record<string, unknown>) => ({
+          content: 'done',
+        })),
+      };
+      const loadTools: ToolExecuteOptions['loadTools'] = jest.fn(async () => ({
+        loadedTools: [tool] as never[],
+      }));
+      const handler = createToolExecuteHandler({
+        loadTools,
+        runSignal: foregroundController.signal,
       });
 
       const [result] = await new Promise<ToolExecuteResult[]>((resolve, reject) => {

--- a/packages/api/src/agents/handlers.ts
+++ b/packages/api/src/agents/handlers.ts
@@ -5230,9 +5230,7 @@ export function createToolExecuteHandler(options: ToolExecuteOptions): EventHand
         eventRunId = configurable.run_id;
       }
       const foregroundHostSignal =
-        foregroundRunId == null || eventRunId == null || eventRunId === foregroundRunId
-          ? hostRunSignal
-          : undefined;
+        eventRunId == null || eventRunId === foregroundRunId ? hostRunSignal : undefined;
       const runSignal =
         foregroundHostSignal != null &&
         eventRunSignal != null &&


### PR DESCRIPTION
## Summary

I fixed foreground Stop propagation for attached BYOM commands by binding cancellation ownership to the response-scoped runtime message identity rather than the user message ID carried by the incoming HTTP request.

- Pass the exact runtime request message ID through both fresh execution and approval resume initialization so it matches the SDK event's response `run_id`.
- Preserve detached child-run isolation by applying the host abort signal only to untagged events or events matching the foreground response identity.
- Fail closed for tagged child events when a canonical foreground identity is unavailable.
- Cover distinct user/response IDs, approval reconstruction, detached execution ownership, and package-level type safety.
- Pair with [Code Interpreter PR #172](https://github.com/LibreChat-AI/code-interpreter/pull/172) so Code API drains the cancellation settlement and the native worker can safely reuse the workspace.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `cd packages/api && npx jest src/agents/handlers.spec.ts --runInBand -t "run cancellation"`
- `cd packages/api && npx tsc --noEmit -p tsconfig.json`
- `cd api && npx jest server/services/Endpoints/agents/initialize.spec.js --runInBand --no-cache -t "binds foreground tool execution"`
- `cd api && npx jest server/controllers/agents/__tests__/request.resumeMetadata.spec.js --runInBand`
- `cd api && npx jest server/controllers/agents/__tests__/resume.spec.js --runInBand -t "seeds the thread parent before reconstruction"`
- `npm run static-checks`
- Isolated live LibreChat handler → HTTP → Code API bridge store → native SRT worker verification with #172: Stop returned in 2 ms, terminated the process tree, prevented the delayed write, cleared quarantine, and allowed immediate workspace reuse.

### **Test Configuration**:

- macOS arm64
- Node.js v24.16.0
- Ephemeral HTTP port and Redis Unix socket
- Temporary writable native SRT workspace

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
