### PR TITLE
🔐 fix: Send One Code API Authentication Method

### DIFF
--- a/packages/api/src/files/provision/service.spec.ts
+++ b/packages/api/src/files/provision/service.spec.ts
@@ -270,13 +270,27 @@ describe('createProvisionService', () => {
       expect(alive.has('f-agent')).toBe(true);
     });
 
-    it('sends the legacy key alongside minted headers', async () => {
+    it('prefers bearer auth when a legacy key is also configured', async () => {
+      mockGetCodeApiAuthHeaders.mockResolvedValue({ Authorization: 'Bearer jwt' });
+      mockAxios.mockResolvedValue({ data: [] });
+      const { service } = buildService();
+
+      await service.checkSessionsAlive({ files: [staleFile('f2')], apiKey: 'legacy-key' });
+
+      expect(mockAxios.mock.calls[0][0].headers).toEqual(
+        expect.objectContaining({ Authorization: 'Bearer jwt' }),
+      );
+      expect(mockAxios.mock.calls[0][0].headers['X-API-Key']).toBeUndefined();
+    });
+
+    it('uses the legacy key when managed bearer auth is unavailable', async () => {
       mockAxios.mockResolvedValue({ data: [] });
       const { service } = buildService();
 
       await service.checkSessionsAlive({ files: [staleFile('f2')], apiKey: 'legacy-key' });
 
       expect(mockAxios.mock.calls[0][0].headers['X-API-Key']).toBe('legacy-key');
+      expect(mockAxios.mock.calls[0][0].headers.Authorization).toBeUndefined();
     });
 
     it('preserves references when the probe itself fails', async () => {

--- a/packages/api/src/files/provision/service.ts
+++ b/packages/api/src/files/provision/service.ts
@@ -180,7 +180,7 @@ export function createProvisionService({
     return stream;
   }
 
-  /** Composes code-API auth: legacy X-API-Key when configured, plus JWT bearer when enabled. */
+  /** Uses managed bearer auth when available, otherwise the configured legacy API key. */
   async function buildCodeApiHeaders({
     apiKey,
     req,
@@ -188,10 +188,11 @@ export function createProvisionService({
     apiKey?: string;
     req?: ServerRequest;
   }): Promise<Record<string, string>> {
+    const authHeaders = await getCodeApiAuthHeaders(req);
     return {
       'User-Agent': 'LibreChat/1.0',
-      ...(apiKey ? { 'X-API-Key': apiKey } : {}),
-      ...(await getCodeApiAuthHeaders(req)),
+      ...(authHeaders.Authorization == null && apiKey ? { 'X-API-Key': apiKey } : {}),
+      ...authHeaders,
     };
   }
 


### PR DESCRIPTION
## Summary

CodeAPI liveness probes sent both a managed bearer token and a configured legacy API key when both authentication paths were present. CodeAPI rejects that ambiguous request with HTTP 400, so every stale file reference was retained as unverified and polled again on later turns. I changed the shared probe-header builder to prefer managed bearer authentication while preserving the API key as the fallback for legacy deployments.

## How it works

```diff
-X-API-Key + Authorization
+Authorization, falling back to X-API-Key when no bearer header is available
```

The shared builder covers batch session checks and single-file liveness checks, so both paths now send exactly one CodeAPI credential.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npm test --workspace=packages/api -- --watch=false --runInBand --coverage=false --testPathPatterns='src/files/provision/service.spec.ts'` (17 passed).
- Ran `npx tsc --noEmit -p packages/api/tsconfig.json`.
- Ran `npm run lighthouse:run` on isolated local ports (1 passed; median LCP 3.0 s, CLS 0.039, TBT 34 ms).
- Verified the regression case omits `X-API-Key` when bearer authentication is available.
- Verified legacy deployments still send `X-API-Key` when bearer authentication is unavailable.

### **Test Configuration**:

- macOS arm64
- Node.js local workspace runtime

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
