### PR TITLE
🛂 fix: Back Off MCP OAuth Discovery

### DIFF
--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -13,6 +13,7 @@ const {
   waitForGenerationPersistence,
   deleteAllSharedLinksWithCleanup,
   revokeUserCodeEnvironmentWorkers,
+  publishMCPAuthorizationMutation,
 } = require('@librechat/api');
 const { Tools, Constants, FileSources, ResourceType } = require('librechat-data-provider');
 const { updateUserPluginAuth, deleteUserPluginAuth } = require('~/server/services/PluginService');
@@ -252,6 +253,7 @@ const updateUserPluginsController = async (req, res) => {
     let message;
     /** @type {IPluginAuth | Error} */
     let authService;
+    let mcpCredentialMutationCommitted = false;
 
     if (pluginKey === Tools.web_search) {
       /** @type  {TCustomConfig['webSearch']} */
@@ -274,6 +276,8 @@ const updateUserPluginsController = async (req, res) => {
           if (pluginKey === Tools.web_search) {
             break;
           }
+        } else if (isMCPTool) {
+          mcpCredentialMutationCommitted = true;
         }
       }
     } else if (action === 'uninstall') {
@@ -288,10 +292,19 @@ const updateUserPluginsController = async (req, res) => {
             authService,
           );
           ({ status, message } = normalizeHttpError(authService));
+        } else {
+          mcpCredentialMutationCommitted = true;
         }
         const serverName = pluginKey.replace(Constants.mcp_prefix, '');
         try {
-          await invalidateCachedTools({ userId: user.id, serverName });
+          await publishMCPAuthorizationMutation(
+            { userId: user.id, serverName },
+            {
+              invalidateRecoveryGeneration: invalidateCachedTools,
+              clearLocalRecovery: (changedUserId, changedServerName) =>
+                getMCPManager()?.clearCatalogRecoveryState?.(changedUserId, changedServerName),
+            },
+          );
         } catch (error) {
           logger.error(
             `[updateUserPluginsController] Error fencing MCP connection before OAuth teardown for user ${user.id}:`,
@@ -327,49 +340,59 @@ const updateUserPluginsController = async (req, res) => {
           if (authService instanceof Error) {
             logger.error('[authService] Error deleting specific auth key:', authService);
             ({ status, message } = normalizeHttpError(authService));
+          } else if (isMCPTool) {
+            mcpCredentialMutationCommitted = true;
           }
         }
       }
     }
 
-    if (status === 200) {
-      // If auth was updated successfully, disconnect MCP sessions as they might use these credentials
-      if (pluginKey.startsWith(Constants.mcp_prefix)) {
-        try {
-          const mcpManager = getMCPManager();
-          // Extract server name from pluginKey (format: "mcp_<serverName>")
-          const serverName = pluginKey.replace(Constants.mcp_prefix, '');
-          if (mcpManager) {
-            logger.info(
-              `[updateUserPluginsController] Attempting disconnect of MCP server "${serverName}" for user ${user.id} after plugin auth update.`,
-            );
-          }
-          let invalidationError;
-          try {
-            await invalidateCachedTools({ userId: user.id, serverName });
-          } catch (error) {
-            invalidationError = error;
-          }
-          try {
-            await mcpManager?.disconnectUserConnection(user.id, serverName);
-          } catch (error) {
-            logger.error(
-              `[updateUserPluginsController] Error disconnecting MCP connection for user ${user.id} after plugin auth update:`,
-              error,
-            );
-          }
-          if (invalidationError) {
-            throw invalidationError;
-          }
-        } catch (disconnectError) {
-          logger.error(
-            `[updateUserPluginsController] Error fencing MCP connection for user ${user.id} after plugin auth update:`,
-            disconnectError,
+    // Every committed MCP credential write advances the fence, including a partial batch whose
+    // later field failed. Otherwise another worker can retain a stale authorization decision.
+    if (mcpCredentialMutationCommitted && pluginKey.startsWith(Constants.mcp_prefix)) {
+      try {
+        const mcpManager = getMCPManager();
+        // Extract server name from pluginKey (format: "mcp_<serverName>")
+        const serverName = pluginKey.replace(Constants.mcp_prefix, '');
+        if (mcpManager) {
+          logger.info(
+            `[updateUserPluginsController] Attempting disconnect of MCP server "${serverName}" for user ${user.id} after plugin auth update.`,
           );
-          // A credential mutation is not safely published until the shared generation fence moves.
-          throw disconnectError;
         }
+        let invalidationError;
+        try {
+          await publishMCPAuthorizationMutation(
+            { userId: user.id, serverName },
+            {
+              invalidateRecoveryGeneration: invalidateCachedTools,
+              clearLocalRecovery: (changedUserId, changedServerName) =>
+                mcpManager?.clearCatalogRecoveryState?.(changedUserId, changedServerName),
+            },
+          );
+        } catch (error) {
+          invalidationError = error;
+        }
+        try {
+          await mcpManager?.disconnectUserConnection(user.id, serverName);
+        } catch (error) {
+          logger.error(
+            `[updateUserPluginsController] Error disconnecting MCP connection for user ${user.id} after plugin auth update:`,
+            error,
+          );
+        }
+        if (invalidationError) {
+          throw invalidationError;
+        }
+      } catch (disconnectError) {
+        logger.error(
+          `[updateUserPluginsController] Error fencing MCP connection for user ${user.id} after plugin auth update:`,
+          disconnectError,
+        );
+        // A credential mutation is not safely published until the shared generation fence moves.
+        throw disconnectError;
       }
+    }
+    if (status === 200) {
       return res.status(status).send();
     }
 

--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -259,6 +259,16 @@ const updateUserPluginsController = async (req, res) => {
     let authService;
     const mcpCredentialMutationResults = [];
     let mcpTeardown = false;
+    const mcpScope = pluginKey.startsWith(Constants.mcp_prefix)
+      ? {
+          userId: user.id,
+          serverName: pluginKey.replace(Constants.mcp_prefix, ''),
+        }
+      : null;
+    /** Write durable fence intent before the first credential write. A crash or retry-marker
+     * outage therefore cannot commit credentials that other replicas continue to authorize. */
+    const publicationRetryVersion =
+      mcpScope == null ? undefined : await persistMCPAuthorizationFenceRetry(mcpScope);
 
     if (pluginKey === Tools.web_search) {
       /** @type  {TCustomConfig['webSearch']} */
@@ -321,15 +331,14 @@ const updateUserPluginsController = async (req, res) => {
 
     // Every committed MCP credential write advances the fence, including a partial batch whose
     // later field failed. Otherwise another worker can retain a stale authorization decision.
-    if (pluginKey.startsWith(Constants.mcp_prefix)) {
+    if (mcpScope != null) {
       try {
         const mcpManager = getMCPManager();
-        // Extract server name from pluginKey (format: "mcp_<serverName>")
-        const serverName = pluginKey.replace(Constants.mcp_prefix, '');
         await finalizeMCPAuthorizationMutation(
           {
-            scope: { userId: user.id, serverName },
+            scope: mcpScope,
             mutationResults: mcpCredentialMutationResults,
+            publicationRetryVersion,
             teardown: mcpTeardown,
           },
           {

--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -22,6 +22,10 @@ const { verifyEmail, resendVerificationEmail } = require('~/server/services/Auth
 const { getMCPManager } = require('~/config');
 const { maybeUninstallOAuthMCP } = require('~/server/services/MCP/oauthCleanup');
 const { invalidateCachedTools } = require('~/server/services/Config/getCachedTools');
+const {
+  clearMCPAuthorizationFenceRetry,
+  persistMCPAuthorizationFenceRetry,
+} = require('~/server/services/MCPAuthorizationFenceRetry');
 const { processDeleteRequest } = require('~/server/services/Files/process');
 const subagentThreadTaskStore = require('~/server/services/Endpoints/agents/subagentThreadStore');
 const {
@@ -330,6 +334,8 @@ const updateUserPluginsController = async (req, res) => {
           },
           {
             invalidateRecoveryGeneration: invalidateCachedTools,
+            persistPublicationRetry: persistMCPAuthorizationFenceRetry,
+            clearPublicationRetry: clearMCPAuthorizationFenceRetry,
             clearLocalRecovery: (changedUserId, changedServerName) =>
               mcpManager?.clearCatalogRecoveryState?.(changedUserId, changedServerName),
             disconnectUserConnection: (changedUserId, changedServerName) =>

--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -13,7 +13,7 @@ const {
   waitForGenerationPersistence,
   deleteAllSharedLinksWithCleanup,
   revokeUserCodeEnvironmentWorkers,
-  publishMCPAuthorizationMutation,
+  finalizeMCPAuthorizationMutation,
 } = require('@librechat/api');
 const { Tools, Constants, FileSources, ResourceType } = require('librechat-data-provider');
 const { updateUserPluginAuth, deleteUserPluginAuth } = require('~/server/services/PluginService');
@@ -253,7 +253,8 @@ const updateUserPluginsController = async (req, res) => {
     let message;
     /** @type {IPluginAuth | Error} */
     let authService;
-    let mcpCredentialMutationCommitted = false;
+    const mcpCredentialMutationResults = [];
+    let mcpTeardown = false;
 
     if (pluginKey === Tools.web_search) {
       /** @type  {TCustomConfig['webSearch']} */
@@ -276,8 +277,9 @@ const updateUserPluginsController = async (req, res) => {
           if (pluginKey === Tools.web_search) {
             break;
           }
-        } else if (isMCPTool) {
-          mcpCredentialMutationCommitted = true;
+        }
+        if (isMCPTool) {
+          mcpCredentialMutationResults.push(authService);
         }
       }
     } else if (action === 'uninstall') {
@@ -292,44 +294,9 @@ const updateUserPluginsController = async (req, res) => {
             authService,
           );
           ({ status, message } = normalizeHttpError(authService));
-        } else {
-          mcpCredentialMutationCommitted = true;
         }
-        const serverName = pluginKey.replace(Constants.mcp_prefix, '');
-        try {
-          await publishMCPAuthorizationMutation(
-            { userId: user.id, serverName },
-            {
-              invalidateRecoveryGeneration: invalidateCachedTools,
-              clearLocalRecovery: (changedUserId, changedServerName) =>
-                getMCPManager()?.clearCatalogRecoveryState?.(changedUserId, changedServerName),
-            },
-          );
-        } catch (error) {
-          logger.error(
-            `[updateUserPluginsController] Error fencing MCP connection before OAuth teardown for user ${user.id}:`,
-            error,
-          );
-        }
-        try {
-          await getMCPManager()?.disconnectUserConnection(user.id, serverName);
-        } catch (error) {
-          logger.error(
-            `[updateUserPluginsController] Error disconnecting MCP connection before OAuth teardown for user ${user.id}:`,
-            error,
-          );
-        }
-        try {
-          // if the MCP server uses OAuth, perform a full cleanup and token revocation
-          await maybeUninstallOAuthMCP(user.id, pluginKey, appConfig);
-        } catch (error) {
-          logger.error(
-            `[updateUserPluginsController] Error uninstalling OAuth MCP for ${pluginKey}:`,
-            error,
-          );
-          status = 503;
-          message = 'OAuth credential cleanup is temporarily unavailable';
-        }
+        mcpCredentialMutationResults.push(authService);
+        mcpTeardown = true;
       } else {
         // This handles:
         // 1. Web_search uninstall (entries include every configured field).
@@ -340,8 +307,9 @@ const updateUserPluginsController = async (req, res) => {
           if (authService instanceof Error) {
             logger.error('[authService] Error deleting specific auth key:', authService);
             ({ status, message } = normalizeHttpError(authService));
-          } else if (isMCPTool) {
-            mcpCredentialMutationCommitted = true;
+          }
+          if (isMCPTool) {
+            mcpCredentialMutationResults.push(authService);
           }
         }
       }
@@ -349,40 +317,45 @@ const updateUserPluginsController = async (req, res) => {
 
     // Every committed MCP credential write advances the fence, including a partial batch whose
     // later field failed. Otherwise another worker can retain a stale authorization decision.
-    if (mcpCredentialMutationCommitted && pluginKey.startsWith(Constants.mcp_prefix)) {
+    if (pluginKey.startsWith(Constants.mcp_prefix)) {
       try {
         const mcpManager = getMCPManager();
         // Extract server name from pluginKey (format: "mcp_<serverName>")
         const serverName = pluginKey.replace(Constants.mcp_prefix, '');
-        if (mcpManager) {
-          logger.info(
-            `[updateUserPluginsController] Attempting disconnect of MCP server "${serverName}" for user ${user.id} after plugin auth update.`,
-          );
-        }
-        let invalidationError;
-        try {
-          await publishMCPAuthorizationMutation(
-            { userId: user.id, serverName },
-            {
-              invalidateRecoveryGeneration: invalidateCachedTools,
-              clearLocalRecovery: (changedUserId, changedServerName) =>
-                mcpManager?.clearCatalogRecoveryState?.(changedUserId, changedServerName),
-            },
-          );
-        } catch (error) {
-          invalidationError = error;
-        }
-        try {
-          await mcpManager?.disconnectUserConnection(user.id, serverName);
-        } catch (error) {
-          logger.error(
-            `[updateUserPluginsController] Error disconnecting MCP connection for user ${user.id} after plugin auth update:`,
-            error,
-          );
-        }
-        if (invalidationError) {
-          throw invalidationError;
-        }
+        await finalizeMCPAuthorizationMutation(
+          {
+            scope: { userId: user.id, serverName },
+            mutationResults: mcpCredentialMutationResults,
+            teardown: mcpTeardown,
+          },
+          {
+            invalidateRecoveryGeneration: invalidateCachedTools,
+            clearLocalRecovery: (changedUserId, changedServerName) =>
+              mcpManager?.clearCatalogRecoveryState?.(changedUserId, changedServerName),
+            disconnectUserConnection: (changedUserId, changedServerName) =>
+              mcpManager?.disconnectUserConnection(changedUserId, changedServerName),
+            retryDelaysMs: appConfig?.mcpSettings?.catalogRecovery?.authorizationFenceRetryMs,
+            onDisconnectError: (error) =>
+              logger.error(
+                `[updateUserPluginsController] Error disconnecting MCP connection for user ${user.id} after plugin auth update:`,
+                error,
+              ),
+            ...(mcpTeardown && {
+              afterDisconnect: async () => {
+                try {
+                  await maybeUninstallOAuthMCP(user.id, pluginKey, appConfig);
+                } catch (error) {
+                  logger.error(
+                    `[updateUserPluginsController] Error uninstalling OAuth MCP for ${pluginKey}:`,
+                    error,
+                  );
+                  status = 503;
+                  message = 'OAuth credential cleanup is temporarily unavailable';
+                }
+              },
+            }),
+          },
+        );
       } catch (disconnectError) {
         logger.error(
           `[updateUserPluginsController] Error fencing MCP connection for user ${user.id} after plugin auth update:`,

--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -335,6 +335,7 @@ const updateUserPluginsController = async (req, res) => {
             disconnectUserConnection: (changedUserId, changedServerName) =>
               mcpManager?.disconnectUserConnection(changedUserId, changedServerName),
             retryDelaysMs: appConfig?.mcpSettings?.catalogRecovery?.authorizationFenceRetryMs,
+            attemptTimeoutMs: appConfig?.mcpSettings?.catalogRecovery?.authorizationFenceTimeoutMs,
             onDisconnectError: (error) =>
               logger.error(
                 `[updateUserPluginsController] Error disconnecting MCP connection for user ${user.id} after plugin auth update:`,

--- a/api/server/controllers/__tests__/UserController.mcpOAuth.spec.js
+++ b/api/server/controllers/__tests__/UserController.mcpOAuth.spec.js
@@ -195,6 +195,28 @@ beforeEach(() => {
 });
 
 describe('updateUserPluginsController MCP OAuth cleanup', () => {
+  it('advances the fence after a partial MCP credential batch commits', async () => {
+    setupMCPMocks();
+    const { updateUserPluginAuth } = require('~/server/services/PluginService');
+    const laterFailure = Object.assign(new Error('second field failed'), { status: 400 });
+    updateUserPluginAuth.mockResolvedValueOnce({}).mockResolvedValueOnce(laterFailure);
+    const req = createRequest();
+    req.body = {
+      pluginKey: 'mcp_test-server',
+      action: 'install',
+      auth: { API_KEY: 'new-key', ACCOUNT: 'new-account' },
+    };
+
+    const res = createResponse();
+    await updateUserPluginsController(req, res);
+
+    expect(mockInvalidateCachedTools).toHaveBeenCalledWith({
+      userId: 'user-1',
+      serverName: 'test-server',
+    });
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
   it('invalidates the shared tool generation even when local disconnect fails', async () => {
     const { mcpManager } = setupMCPMocks();
     mcpManager.disconnectUserConnection.mockRejectedValue(new Error('local dispose failed'));

--- a/api/server/controllers/__tests__/UserController.mcpOAuth.spec.js
+++ b/api/server/controllers/__tests__/UserController.mcpOAuth.spec.js
@@ -88,6 +88,11 @@ jest.mock('~/server/services/Config/getCachedTools', () => ({
   invalidateCachedTools: (...args) => mockInvalidateCachedTools(...args),
 }));
 
+jest.mock('~/server/services/MCPAuthorizationFenceRetry', () => ({
+  persistMCPAuthorizationFenceRetry: jest.fn().mockResolvedValue(undefined),
+  clearMCPAuthorizationFenceRetry: jest.fn().mockResolvedValue(undefined),
+}));
+
 jest.mock('~/server/services/Files/process', () => ({
   processDeleteRequest: jest.fn().mockResolvedValue({ deletedFileIds: [], failedFileIds: [] }),
 }));

--- a/api/server/controllers/__tests__/UserController.mcpOAuth.spec.js
+++ b/api/server/controllers/__tests__/UserController.mcpOAuth.spec.js
@@ -7,6 +7,8 @@ const mockGetLogStores = jest.fn();
 const mockGetMCPManager = jest.fn();
 const mockGetFlowStateManager = jest.fn();
 const mockGetMCPServersRegistry = jest.fn();
+const mockPersistMCPAuthorizationFenceRetry = jest.fn();
+const mockClearMCPAuthorizationFenceRetry = jest.fn();
 
 jest.mock('@librechat/data-schemas', () => ({
   ...jest.requireActual('@librechat/data-schemas'),
@@ -89,8 +91,8 @@ jest.mock('~/server/services/Config/getCachedTools', () => ({
 }));
 
 jest.mock('~/server/services/MCPAuthorizationFenceRetry', () => ({
-  persistMCPAuthorizationFenceRetry: jest.fn().mockResolvedValue(undefined),
-  clearMCPAuthorizationFenceRetry: jest.fn().mockResolvedValue(undefined),
+  persistMCPAuthorizationFenceRetry: (...args) => mockPersistMCPAuthorizationFenceRetry(...args),
+  clearMCPAuthorizationFenceRetry: (...args) => mockClearMCPAuthorizationFenceRetry(...args),
 }));
 
 jest.mock('~/server/services/Files/process', () => ({
@@ -192,6 +194,8 @@ const storedOAuthBinding = {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockPersistMCPAuthorizationFenceRetry.mockResolvedValue('retry-v1');
+  mockClearMCPAuthorizationFenceRetry.mockResolvedValue(undefined);
   getTenantId.mockReturnValue(undefined);
   mockFindToken.mockImplementation(async ({ type }) => ({
     token: `encrypted-${type}`,
@@ -200,6 +204,26 @@ beforeEach(() => {
 });
 
 describe('updateUserPluginsController MCP OAuth cleanup', () => {
+  it('does not mutate credentials when durable fence preparation fails', async () => {
+    setupMCPMocks();
+    const { updateUserPluginAuth } = require('~/server/services/PluginService');
+    const error = new Error('retry storage unavailable');
+    mockPersistMCPAuthorizationFenceRetry.mockRejectedValueOnce(error);
+    const req = createRequest();
+    req.body = {
+      pluginKey: 'mcp_test-server',
+      action: 'install',
+      auth: { API_KEY: 'new-key' },
+    };
+
+    const res = createResponse();
+    await updateUserPluginsController(req, res);
+
+    expect(updateUserPluginAuth).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(logger.error).toHaveBeenCalledWith('[updateUserPluginsController]', error);
+  });
+
   it('advances the fence after a partial MCP credential batch commits', async () => {
     setupMCPMocks();
     const { updateUserPluginAuth } = require('~/server/services/PluginService');
@@ -215,10 +239,17 @@ describe('updateUserPluginsController MCP OAuth cleanup', () => {
     const res = createResponse();
     await updateUserPluginsController(req, res);
 
+    expect(mockPersistMCPAuthorizationFenceRetry.mock.invocationCallOrder[0]).toBeLessThan(
+      updateUserPluginAuth.mock.invocationCallOrder[0],
+    );
     expect(mockInvalidateCachedTools).toHaveBeenCalledWith({
       userId: 'user-1',
       serverName: 'test-server',
     });
+    expect(mockClearMCPAuthorizationFenceRetry).toHaveBeenCalledWith(
+      { userId: 'user-1', serverName: 'test-server' },
+      'retry-v1',
+    );
     expect(res.status).toHaveBeenCalledWith(400);
   });
 

--- a/api/server/controllers/__tests__/deleteUser.spec.js
+++ b/api/server/controllers/__tests__/deleteUser.spec.js
@@ -138,6 +138,11 @@ jest.mock('~/server/services/Config/getCachedTools', () => ({
   invalidateCachedTools: jest.fn(),
 }));
 
+jest.mock('~/server/services/MCPAuthorizationFenceRetry', () => ({
+  clearMCPAuthorizationFenceRetry: jest.fn(),
+  persistMCPAuthorizationFenceRetry: jest.fn(),
+}));
+
 jest.mock('~/server/services/Files/process', () => ({
   processDeleteRequest: (...args) => mockProcessDeleteRequest(...args),
 }));

--- a/api/server/controllers/mcp.js
+++ b/api/server/controllers/mcp.js
@@ -230,6 +230,9 @@ const getMCPTools = async (req, res) => {
         }),
         oboIdentityContext,
         signal: catalogAbortController.signal,
+        ...(req.config?.mcpSettings?.catalogRecovery && {
+          recoveryPolicy: req.config.mcpSettings.catalogRecovery,
+        }),
       });
     } finally {
       res.off('close', abortCatalogLoad);

--- a/api/server/controllers/mcp.js
+++ b/api/server/controllers/mcp.js
@@ -230,15 +230,14 @@ const getMCPTools = async (req, res) => {
         }),
         oboIdentityContext,
         signal: catalogAbortController.signal,
-        ...(req.config?.mcpSettings?.catalogRecovery && {
-          recoveryPolicy: req.config.mcpSettings.catalogRecovery,
-        }),
+        recoveryPolicy: req.config?.mcpSettings?.catalogRecovery,
       });
     } finally {
       res.off('close', abortCatalogLoad);
     }
     const { serverTools: serverToolsMap, serversWithoutTools } = catalogResult;
     const reauthRequiredServers = catalogResult.reauthRequiredServers ?? new Set();
+    const reauthRequiredGenerations = catalogResult.reauthRequiredGenerations ?? new Map();
     if (serversWithoutTools.length > 0) {
       logger.debug(
         `[getMCPTools] No tools (${serversWithoutTools.length}): ${serversWithoutTools.join(', ')}`,
@@ -258,6 +257,7 @@ const getMCPTools = async (req, res) => {
           authenticated: !reauthRequiredServers.has(serverName),
           ...(reauthRequiredServers.has(serverName) && {
             authorizationState: 'reauth_required',
+            authorizationGeneration: reauthRequiredGenerations.get(serverName),
           }),
           authConfig: [],
           tools: [],

--- a/api/server/controllers/mcp.js
+++ b/api/server/controllers/mcp.js
@@ -235,6 +235,7 @@ const getMCPTools = async (req, res) => {
       res.off('close', abortCatalogLoad);
     }
     const { serverTools: serverToolsMap, serversWithoutTools } = catalogResult;
+    const reauthRequiredServers = catalogResult.reauthRequiredServers ?? new Set();
     if (serversWithoutTools.length > 0) {
       logger.debug(
         `[getMCPTools] No tools (${serversWithoutTools.length}): ${serversWithoutTools.join(', ')}`,
@@ -251,7 +252,10 @@ const getMCPTools = async (req, res) => {
         const server = {
           name: serverName,
           icon: serverConfig?.iconPath || '',
-          authenticated: true,
+          authenticated: !reauthRequiredServers.has(serverName),
+          ...(reauthRequiredServers.has(serverName) && {
+            authorizationState: 'reauth_required',
+          }),
           authConfig: [],
           tools: [],
         };

--- a/api/server/routes/__tests__/mcp.spec.js
+++ b/api/server/routes/__tests__/mcp.spec.js
@@ -193,8 +193,15 @@ const mockOAuthCompletion = (tokens) => {
   const { MCPOAuthHandler } = require('@librechat/api');
   MCPOAuthHandler.completeOAuthFlow.mockImplementation(
     async (flowId, _code, flowManager, _headers, persistBeforeComplete) => {
-      const storedTokens = await persistBeforeComplete(tokens);
-      await flowManager.completeFlow(flowId, 'mcp_oauth', storedTokens);
+      let completed = false;
+      const completePersistedFlow = async (storedTokens) => {
+        await flowManager.completeFlow(flowId, 'mcp_oauth', storedTokens);
+        completed = true;
+      };
+      const storedTokens = await persistBeforeComplete(tokens, completePersistedFlow);
+      if (!completed) {
+        await completePersistedFlow(storedTokens);
+      }
       return storedTokens;
     },
   );
@@ -957,7 +964,11 @@ describe('MCP Routes', () => {
         mockOAuthCompletion({
           access_token: 'test-token',
         });
-        MCPTokenStorage.storeTokens.mockResolvedValue();
+        MCPTokenStorage.storeTokens.mockImplementation(async (params) => {
+          const storedTokens = { ...params.tokens, credential_set_id: 'callback-generation' };
+          await params.onStoreCommitted(storedTokens);
+          return storedTokens;
+        });
         mockRegistryInstance.getServerConfig.mockResolvedValue({
           url: 'https://override.example.com/{{LIBRECHAT_BODY_CONVERSATIONID}}/mcp',
         });
@@ -1913,7 +1924,7 @@ describe('MCP Routes', () => {
       expect(mockMcpManager.withUserConnectionLease).not.toHaveBeenCalled();
     });
 
-    it('rolls back stored callback tokens when their shared generation cannot advance', async () => {
+    it('keeps generation publication inside the token-store rollback boundary', async () => {
       const flowId = 'test-user-id:test-server';
       const mockFlowManager = {
         getFlowState: jest.fn().mockResolvedValue({ status: 'PENDING', createdAt: Date.now() }),
@@ -1934,8 +1945,10 @@ describe('MCP Routes', () => {
         codeVerifier: 'test-verifier',
       });
       mockOAuthCompletion(storedTokens);
-      MCPTokenStorage.storeTokens.mockResolvedValue(storedTokens);
-      MCPTokenStorage.deleteUserTokens.mockResolvedValue(undefined);
+      MCPTokenStorage.storeTokens.mockImplementation(async (params) => {
+        await params.onStoreCommitted(storedTokens);
+        return storedTokens;
+      });
       mockRegistryInstance.getServerConfig.mockResolvedValue({
         url: 'https://mcp.example.com/mcp',
       });
@@ -1951,8 +1964,8 @@ describe('MCP Routes', () => {
 
       expect(response.status).toBe(302);
       expect(response.headers.location).toContain('/oauth/error?error=callback_failed');
-      expect(MCPTokenStorage.deleteUserTokens).toHaveBeenCalledWith(
-        expect.objectContaining({ userId: 'test-user-id', serverName: 'test-server' }),
+      expect(MCPTokenStorage.storeTokens).toHaveBeenCalledWith(
+        expect.objectContaining({ onStoreCommitted: expect.any(Function) }),
       );
       expect(mockFlowManager.completeFlow).not.toHaveBeenCalled();
     });
@@ -3037,7 +3050,7 @@ describe('MCP Routes', () => {
         requiresOAuth: true,
         authorizationState: 'needs_authorization',
       });
-      require('~/server/services/Config').getMCPToolsCacheGeneration.mockResolvedValueOnce(
+      require('~/server/services/Config').getMCPToolsCacheGeneration.mockResolvedValue(
         'generation-2',
       );
 

--- a/api/server/routes/__tests__/mcp.spec.js
+++ b/api/server/routes/__tests__/mcp.spec.js
@@ -603,6 +603,13 @@ describe('MCP Routes', () => {
   describe('GET /:serverName/oauth/callback', () => {
     const { MCPOAuthHandler, MCPTokenStorage } = require('@librechat/api');
     const { getLogStores } = require('~/cache');
+    const mockTokenStorageCommit = (storedTokens) => {
+      MCPTokenStorage.storeTokens.mockImplementation(async (params) => {
+        const committedTokens = storedTokens ?? params.tokens;
+        await params.onStoreCommitted?.(committedTokens);
+        return committedTokens;
+      });
+    };
 
     beforeEach(() => {
       mockRegistryInstance.getServerConfig.mockResolvedValue({});
@@ -903,7 +910,7 @@ describe('MCP Routes', () => {
         codeVerifier: 'current-verifier',
       });
       mockOAuthCompletion({ access_token: 'test-token' });
-      MCPTokenStorage.storeTokens.mockResolvedValue();
+      mockTokenStorageCommit();
       mockRegistryInstance.getServerConfig.mockResolvedValue({});
 
       const mockMcpManager = createLeasedMcpManager({
@@ -997,6 +1004,9 @@ describe('MCP Routes', () => {
           userId: 'test-user-id',
           serverName: 'test-server',
         });
+        expect(mockFlowManager.deleteFlow.mock.invocationCallOrder[0]).toBeLessThan(
+          mockFlowManager.completeFlow.mock.invocationCallOrder[0],
+        );
       });
 
       it('should use the merged server config to defer request-scoped post-OAuth reconnect', async () => {
@@ -1029,7 +1039,7 @@ describe('MCP Routes', () => {
         mockOAuthCompletion({
           access_token: 'test-token',
         });
-        MCPTokenStorage.storeTokens.mockResolvedValue();
+        mockTokenStorageCommit();
         mockRegistryInstance.getServerConfig.mockResolvedValue({});
         mockResolveAllMcpConfigs.mockResolvedValue({ 'test-server': mergedServerConfig });
 
@@ -1097,7 +1107,7 @@ describe('MCP Routes', () => {
         mockOAuthCompletion({
           access_token: 'test-token',
         });
-        MCPTokenStorage.storeTokens.mockResolvedValue();
+        mockTokenStorageCommit();
         mockRegistryInstance.getServerConfig.mockResolvedValue({});
         mockResolveAllMcpConfigs.mockResolvedValue({ 'test-server': mergedServerConfig });
         require('@librechat/api').getUserMCPAuthMap.mockResolvedValueOnce({
@@ -1162,7 +1172,7 @@ describe('MCP Routes', () => {
         mockOAuthCompletion({
           access_token: 'test-token',
         });
-        MCPTokenStorage.storeTokens.mockResolvedValue();
+        mockTokenStorageCommit();
         mockRegistryInstance.getServerConfig.mockResolvedValue({});
         mockResolveAllMcpConfigs.mockResolvedValue({ 'test-server': mergedServerConfig });
         require('@librechat/api').getUserMCPAuthMap.mockClear();
@@ -1341,7 +1351,7 @@ describe('MCP Routes', () => {
 
       MCPOAuthHandler.getFlowState.mockResolvedValue(mockFlowState);
       mockOAuthCompletion(mockTokens);
-      MCPTokenStorage.storeTokens.mockResolvedValue();
+      mockTokenStorageCommit();
       mockRegistryInstance.getServerConfig.mockResolvedValue({
         url: 'https://mcp.example.com/mcp',
       });
@@ -1449,7 +1459,7 @@ describe('MCP Routes', () => {
 
       MCPOAuthHandler.getFlowState.mockResolvedValue(mockFlowState);
       mockOAuthCompletion(mockTokens);
-      MCPTokenStorage.storeTokens.mockResolvedValue();
+      mockTokenStorageCommit();
       getLogStores.mockReturnValue({});
       require('~/config').getFlowStateManager.mockReturnValue(mockFlowManager);
       require('~/config').getOAuthReconnectionManager.mockReturnValue({
@@ -1524,7 +1534,7 @@ describe('MCP Routes', () => {
 
       MCPOAuthHandler.getFlowState.mockResolvedValue(mockFlowState);
       mockOAuthCompletion(mockTokens);
-      MCPTokenStorage.storeTokens.mockResolvedValue(storedTokens);
+      mockTokenStorageCommit(storedTokens);
       getLogStores.mockReturnValue({});
       require('~/config').getFlowStateManager.mockReturnValue(mockFlowManager);
       require('~/config').getOAuthReconnectionManager.mockReturnValue({
@@ -1583,7 +1593,7 @@ describe('MCP Routes', () => {
 
       MCPOAuthHandler.getFlowState.mockResolvedValue(mockFlowState);
       mockOAuthCompletion(mockTokens);
-      MCPTokenStorage.storeTokens.mockResolvedValue();
+      mockTokenStorageCommit();
       mockResolveAllMcpConfigs.mockResolvedValue({
         'test-server': { url: 'https://mcp.example.com/mcp' },
       });
@@ -1640,7 +1650,7 @@ describe('MCP Routes', () => {
 
       MCPOAuthHandler.getFlowState.mockResolvedValue(mockFlowState);
       mockOAuthCompletion(mockTokens);
-      MCPTokenStorage.storeTokens.mockResolvedValue();
+      mockTokenStorageCommit();
       mockRegistryInstance.getServerConfig.mockResolvedValue({
         url: 'https://mcp.example.com/mcp',
         oauth_headers: { 'X-Registry-Header': 'from-registry' },
@@ -1723,7 +1733,7 @@ describe('MCP Routes', () => {
 
       MCPOAuthHandler.getFlowState.mockResolvedValue(mockFlowState);
       mockOAuthCompletion(mockTokens);
-      MCPTokenStorage.storeTokens.mockResolvedValue();
+      mockTokenStorageCommit();
       mockRegistryInstance.getServerConfig.mockResolvedValue({});
       getLogStores.mockReturnValue({});
       require('~/config').getFlowStateManager.mockReturnValue(mockFlowManager);
@@ -1767,7 +1777,7 @@ describe('MCP Routes', () => {
 
       MCPOAuthHandler.getFlowState.mockResolvedValue(mockFlowState);
       mockOAuthCompletion(mockTokens);
-      MCPTokenStorage.storeTokens.mockResolvedValue();
+      mockTokenStorageCommit();
       mockRegistryInstance.getServerConfig.mockResolvedValue({});
       getLogStores.mockReturnValue({});
       require('~/config').getFlowStateManager.mockReturnValue(mockFlowManager);
@@ -1829,7 +1839,7 @@ describe('MCP Routes', () => {
 
       MCPOAuthHandler.getFlowState.mockResolvedValue(mockFlowState);
       mockOAuthCompletion(mockTokens);
-      MCPTokenStorage.storeTokens.mockResolvedValue(mockTokens);
+      mockTokenStorageCommit(mockTokens);
       mockResolveAllMcpConfigs.mockResolvedValue({
         'test-server': {
           type: 'streamable-http',
@@ -2006,7 +2016,7 @@ describe('MCP Routes', () => {
 
       MCPOAuthHandler.getFlowState.mockResolvedValue(flowState);
       mockOAuthCompletion(mockTokens);
-      MCPTokenStorage.storeTokens.mockResolvedValue();
+      mockTokenStorageCommit();
       mockRegistryInstance.getServerConfig.mockResolvedValue({});
       getLogStores.mockReturnValue({});
       require('~/config').getFlowStateManager.mockReturnValue(mockFlowManager);

--- a/api/server/routes/__tests__/mcp.spec.js
+++ b/api/server/routes/__tests__/mcp.spec.js
@@ -71,6 +71,7 @@ jest.mock('@librechat/api', () => {
     getMCPServerGeneration: jest.fn((config) =>
       config.dbId ? `db:${config.dbId}` : `config:${JSON.stringify(config)}`,
     ),
+    getMCPAuthorizationGeneration: jest.fn().mockResolvedValue(undefined),
     MCPConnection: {
       clearCooldown: jest.fn(),
     },
@@ -982,6 +983,10 @@ describe('MCP Routes', () => {
           'test-user-id',
           'test-server',
         );
+        expect(require('~/server/services/Config').invalidateCachedTools).toHaveBeenCalledWith({
+          userId: 'test-user-id',
+          serverName: 'test-server',
+        });
       });
 
       it('should use the merged server config to defer request-scoped post-OAuth reconnect', async () => {
@@ -2987,6 +2992,7 @@ describe('MCP Routes', () => {
         requiresOAuth: true,
         authorizationState: 'needs_authorization',
       });
+      require('@librechat/api').getMCPAuthorizationGeneration.mockResolvedValueOnce('generation-2');
 
       const response = await request(app).get('/api/mcp/connection/status/oauth-server');
 
@@ -2997,6 +3003,7 @@ describe('MCP Routes', () => {
         connectionStatus: 'requires_auth',
         requiresOAuth: true,
         authorizationState: 'needs_authorization',
+        authorizationGeneration: 'generation-2',
       });
     });
 

--- a/api/server/routes/__tests__/mcp.spec.js
+++ b/api/server/routes/__tests__/mcp.spec.js
@@ -3508,6 +3508,24 @@ describe('MCP Routes', () => {
       });
     });
 
+    it('reports a stable reauthorization state from passive discovery', async () => {
+      const serverConfig = { type: 'sse', url: 'https://oauth.example.com/sse' };
+      mockResolveAllMcpConfigs.mockResolvedValueOnce({ oauth: serverConfig });
+      mockLoadMCPServerCatalogs.mockResolvedValueOnce({
+        serverTools: new Map([['oauth', {}]]),
+        serversWithoutTools: [],
+        reauthRequiredServers: new Set(['oauth']),
+      });
+
+      const response = await request(app).get('/api/mcp/tools');
+
+      expect(response.status).toBe(200);
+      expect(response.body.servers.oauth).toMatchObject({
+        authenticated: false,
+        authorizationState: 'reauth_required',
+      });
+    });
+
     it('continues rendering available tools when another server has no catalog', async () => {
       const { Constants } = require('librechat-data-provider');
       const configs = {

--- a/api/server/routes/__tests__/mcp.spec.js
+++ b/api/server/routes/__tests__/mcp.spec.js
@@ -169,6 +169,11 @@ jest.mock('~/server/services/MCP/oauthCleanup', () => ({
   maybeUninstallOAuthMCP: jest.fn().mockResolvedValue(undefined),
 }));
 
+jest.mock('~/server/services/MCPAuthorizationFenceRetry', () => ({
+  persistMCPAuthorizationFenceRetry: jest.fn().mockResolvedValue(undefined),
+  clearMCPAuthorizationFenceRetry: jest.fn().mockResolvedValue(undefined),
+}));
+
 jest.mock('~/config', () => ({
   getMCPManager: jest.fn(),
   getFlowStateManager: jest.fn(),
@@ -953,13 +958,15 @@ describe('MCP Routes', () => {
     describe('CSRF fallback via active PENDING flow', () => {
       it('should proceed when a fresh PENDING flow exists and no cookies are present', async () => {
         const flowId = 'test-user-id:test-server';
+        const pendingCreatedAt = Date.now();
         const mockFlowManager = {
           getFlowState: jest.fn().mockResolvedValue({
             type: 'mcp_get_tokens',
             status: 'PENDING',
-            createdAt: Date.now(),
+            createdAt: pendingCreatedAt,
           }),
           completeFlow: jest.fn().mockResolvedValue(true),
+          settleFlowIfCurrent: jest.fn().mockResolvedValue('updated'),
           deleteFlow: jest.fn().mockResolvedValue(true),
         };
         const mockFlowState = {
@@ -1014,14 +1021,10 @@ describe('MCP Routes', () => {
         const oauthCompletionIndex = mockFlowManager.completeFlow.mock.calls.findIndex(
           ([, type]) => type === 'mcp_oauth',
         );
-        const tokenCompletionIndex = mockFlowManager.completeFlow.mock.calls.findIndex(
-          ([, type]) => type === 'mcp_get_tokens',
-        );
         expect(oauthCompletionIndex).toBeGreaterThanOrEqual(0);
-        expect(tokenCompletionIndex).toBeGreaterThanOrEqual(0);
         expect(
           mockFlowManager.completeFlow.mock.invocationCallOrder[oauthCompletionIndex],
-        ).toBeLessThan(mockFlowManager.completeFlow.mock.invocationCallOrder[tokenCompletionIndex]);
+        ).toBeLessThan(mockFlowManager.settleFlowIfCurrent.mock.invocationCallOrder[0]);
       });
 
       it('should use the merged server config to defer request-scoped post-OAuth reconnect', async () => {
@@ -1522,11 +1525,13 @@ describe('MCP Routes', () => {
             return Promise.resolve({
               type: 'mcp_get_tokens',
               status: 'PENDING',
+              createdAt: 123,
             });
           }
           return Promise.resolve({ status: 'PENDING', createdAt: Date.now() });
         }),
         completeFlow: jest.fn().mockResolvedValue(true),
+        settleFlowIfCurrent: jest.fn().mockResolvedValue('updated'),
         deleteFlow: jest.fn().mockResolvedValue(true),
       };
       const mockFlowState = {
@@ -1576,9 +1581,11 @@ describe('MCP Routes', () => {
         });
 
       expect(response.status).toBe(302);
-      expect(mockFlowManager.completeFlow).toHaveBeenCalledWith(
+      expect(mockFlowManager.settleFlowIfCurrent).toHaveBeenCalledWith(
         'tenant:tenant-a:test-user-id:test-server',
         'mcp_get_tokens',
+        123,
+        '',
         storedTokens,
       );
       expect(mockFlowManager.deleteFlow).not.toHaveBeenCalledWith(

--- a/api/server/routes/__tests__/mcp.spec.js
+++ b/api/server/routes/__tests__/mcp.spec.js
@@ -33,6 +33,7 @@ const mockRegistryInstance = {
   }),
 };
 let mockMCPUseAllowed = true;
+let mockRequestConfig = {};
 const mockLoadMCPServerCatalogs = jest.fn().mockResolvedValue({
   serverTools: new Map(),
   serversWithoutTools: [],
@@ -181,6 +182,10 @@ jest.mock('~/cache', () => ({
 
 jest.mock('~/server/middleware', () => ({
   requireJwtAuth: (req, res, next) => next(),
+  configMiddleware: (req, res, next) => {
+    req.config = mockRequestConfig;
+    next();
+  },
   canAccessMCPServerResource: () => (req, res, next) => next(),
 }));
 
@@ -253,6 +258,7 @@ describe('MCP Routes', () => {
     currentUser = undefined;
     mockResolveAllMcpConfigs.mockResolvedValue({});
     mockResolveMcpConfigNames.mockResolvedValue([]);
+    mockRequestConfig = {};
     // `clearAllMocks` preserves queued `mockReturnValueOnce` entries. A callback
     // test can legitimately leave one unconsumed, which then masks a later test's
     // default implementation when this file shares a CI shard with other suites.
@@ -3553,6 +3559,8 @@ describe('MCP Routes', () => {
         },
       };
       const serverConfig = { type: 'sse', url: 'https://user.example.com/sse' };
+      const recoveryPolicy = { discoveryBackoffMs: [125, 250] };
+      mockRequestConfig = { mcpSettings: { catalogRecovery: recoveryPolicy } };
       mockResolveAllMcpConfigs.mockResolvedValueOnce({ 'user-server': serverConfig });
       mockLoadMCPServerCatalogs.mockResolvedValueOnce({
         serverTools: new Map([['user-server', serverTools]]),
@@ -3571,6 +3579,7 @@ describe('MCP Routes', () => {
         upstreamTokenProvider: expect.any(Function),
         oboIdentityContext: expect.any(Object),
         signal: expect.any(AbortSignal),
+        recoveryPolicy,
       });
     });
 

--- a/api/server/routes/__tests__/mcp.spec.js
+++ b/api/server/routes/__tests__/mcp.spec.js
@@ -201,6 +201,7 @@ const mockOAuthCompletion = (tokens) => {
 };
 
 const createLeasedMcpManager = (connection, overrides = {}) => ({
+  clearCatalogRecoveryState: jest.fn(),
   ...overrides,
   withUserConnectionLease: jest.fn((_options, useConnection) => useConnection(connection)),
 });
@@ -977,6 +978,10 @@ describe('MCP Routes', () => {
         const basePath = getBasePath();
         expect(response.status).toBe(302);
         expect(response.headers.location).toContain(`${basePath}/oauth/success`);
+        expect(mockMcpManager.clearCatalogRecoveryState).toHaveBeenCalledWith(
+          'test-user-id',
+          'test-server',
+        );
       });
 
       it('should use the merged server config to defer request-scoped post-OAuth reconnect', async () => {

--- a/api/server/routes/__tests__/mcp.spec.js
+++ b/api/server/routes/__tests__/mcp.spec.js
@@ -71,7 +71,6 @@ jest.mock('@librechat/api', () => {
     getMCPServerGeneration: jest.fn((config) =>
       config.dbId ? `db:${config.dbId}` : `config:${JSON.stringify(config)}`,
     ),
-    getMCPAuthorizationGeneration: jest.fn().mockResolvedValue(undefined),
     MCPConnection: {
       clearCooldown: jest.fn(),
     },
@@ -1914,6 +1913,50 @@ describe('MCP Routes', () => {
       expect(mockMcpManager.withUserConnectionLease).not.toHaveBeenCalled();
     });
 
+    it('rolls back stored callback tokens when their shared generation cannot advance', async () => {
+      const flowId = 'test-user-id:test-server';
+      const mockFlowManager = {
+        getFlowState: jest.fn().mockResolvedValue({ status: 'PENDING', createdAt: Date.now() }),
+        completeFlow: jest.fn().mockResolvedValue(),
+        deleteFlow: jest.fn().mockResolvedValue(true),
+      };
+      const storedTokens = {
+        access_token: 'stored-access-token',
+        credential_set_id: 'credential-set-new',
+      };
+      MCPOAuthHandler.getFlowState.mockResolvedValue({
+        state: flowId,
+        serverName: 'test-server',
+        userId: 'test-user-id',
+        serverUrl: 'https://mcp.example.com/mcp',
+        metadata: {},
+        clientInfo: {},
+        codeVerifier: 'test-verifier',
+      });
+      mockOAuthCompletion(storedTokens);
+      MCPTokenStorage.storeTokens.mockResolvedValue(storedTokens);
+      MCPTokenStorage.deleteUserTokens.mockResolvedValue(undefined);
+      mockRegistryInstance.getServerConfig.mockResolvedValue({
+        url: 'https://mcp.example.com/mcp',
+      });
+      require('~/config').getFlowStateManager.mockReturnValue(mockFlowManager);
+      require('~/server/services/Config').invalidateCachedTools.mockRejectedValue(
+        new Error('generation unavailable'),
+      );
+
+      const response = await request(app)
+        .get('/api/mcp/test-server/oauth/callback')
+        .set('Cookie', [`oauth_csrf=${generateTestCsrfToken(flowId)}`])
+        .query({ code: 'test-auth-code', state: flowId });
+
+      expect(response.status).toBe(302);
+      expect(response.headers.location).toContain('/oauth/error?error=callback_failed');
+      expect(MCPTokenStorage.deleteUserTokens).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'test-user-id', serverName: 'test-server' }),
+      );
+      expect(mockFlowManager.completeFlow).not.toHaveBeenCalled();
+    });
+
     it('should use original flow state credentials when storing tokens', async () => {
       // mockRegistryInstance is defined at the top of the file
       const mockFlowManager = {
@@ -2800,11 +2843,13 @@ describe('MCP Routes', () => {
             connectionState: 'connected',
             requiresOAuth: false,
             authorizationState: 'not_required',
+            authorizationGeneration: 'test-generation',
           },
           server2: {
             connectionState: 'disconnected',
             requiresOAuth: true,
             authorizationState: 'needs_authorization',
+            authorizationGeneration: 'test-generation',
           },
         },
       });
@@ -2992,7 +3037,9 @@ describe('MCP Routes', () => {
         requiresOAuth: true,
         authorizationState: 'needs_authorization',
       });
-      require('@librechat/api').getMCPAuthorizationGeneration.mockResolvedValueOnce('generation-2');
+      require('~/server/services/Config').getMCPToolsCacheGeneration.mockResolvedValueOnce(
+        'generation-2',
+      );
 
       const response = await request(app).get('/api/mcp/connection/status/oauth-server');
 
@@ -3004,6 +3051,34 @@ describe('MCP Routes', () => {
         requiresOAuth: true,
         authorizationState: 'needs_authorization',
         authorizationGeneration: 'generation-2',
+      });
+    });
+
+    it('keeps connection status available when the shared generation cache is unavailable', async () => {
+      getMCPSetupData.mockResolvedValue({
+        mcpConfig: { 'oauth-server': { endpoint: 'http://oauth-server.com' } },
+        appConnections: {},
+        userConnections: {},
+        oauthServers: new Set(['oauth-server']),
+      });
+      getServerConnectionStatus.mockResolvedValue({
+        connectionState: 'requires_auth',
+        requiresOAuth: true,
+        authorizationState: 'needs_authorization',
+      });
+      require('~/server/services/Config').getMCPToolsCacheGeneration.mockRejectedValueOnce(
+        new Error('cache unavailable'),
+      );
+
+      const response = await request(app).get('/api/mcp/connection/status/oauth-server');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        success: true,
+        serverName: 'oauth-server',
+        connectionStatus: 'requires_auth',
+        requiresOAuth: true,
+        authorizationState: 'needs_authorization',
       });
     });
 

--- a/api/server/routes/__tests__/mcp.spec.js
+++ b/api/server/routes/__tests__/mcp.spec.js
@@ -949,6 +949,7 @@ describe('MCP Routes', () => {
         const flowId = 'test-user-id:test-server';
         const mockFlowManager = {
           getFlowState: jest.fn().mockResolvedValue({
+            type: 'mcp_get_tokens',
             status: 'PENDING',
             createdAt: Date.now(),
           }),
@@ -1004,9 +1005,17 @@ describe('MCP Routes', () => {
           userId: 'test-user-id',
           serverName: 'test-server',
         });
-        expect(mockFlowManager.deleteFlow.mock.invocationCallOrder[0]).toBeLessThan(
-          mockFlowManager.completeFlow.mock.invocationCallOrder[0],
+        const oauthCompletionIndex = mockFlowManager.completeFlow.mock.calls.findIndex(
+          ([, type]) => type === 'mcp_oauth',
         );
+        const tokenCompletionIndex = mockFlowManager.completeFlow.mock.calls.findIndex(
+          ([, type]) => type === 'mcp_get_tokens',
+        );
+        expect(oauthCompletionIndex).toBeGreaterThanOrEqual(0);
+        expect(tokenCompletionIndex).toBeGreaterThanOrEqual(0);
+        expect(
+          mockFlowManager.completeFlow.mock.invocationCallOrder[oauthCompletionIndex],
+        ).toBeLessThan(mockFlowManager.completeFlow.mock.invocationCallOrder[tokenCompletionIndex]);
       });
 
       it('should use the merged server config to defer request-scoped post-OAuth reconnect', async () => {

--- a/api/server/routes/__tests__/mcp.spec.js
+++ b/api/server/routes/__tests__/mcp.spec.js
@@ -2899,7 +2899,10 @@ describe('MCP Routes', () => {
         },
       });
 
-      expect(getMCPSetupData).toHaveBeenCalledWith('test-user-id', expect.any(Object));
+      expect(getMCPSetupData).toHaveBeenCalledWith(
+        'test-user-id',
+        expect.objectContaining({ appConfig: mockRequestConfig }),
+      );
       expect(getServerConnectionStatus).toHaveBeenCalledTimes(2);
     });
 

--- a/api/server/routes/mcp.js
+++ b/api/server/routes/mcp.js
@@ -32,6 +32,7 @@ const {
   OpenIDReauthRequiredError,
   readMCPRecoveryGenerationAround,
   publishMCPAuthorizationMutation,
+  completeMCPAuthorizationWithTokenWaiters,
 } = require('@librechat/api');
 const {
   createMCPServerController,
@@ -53,7 +54,11 @@ const {
   resolveConfigServers,
   getMCPSetupData,
 } = require('~/server/services/MCP');
-const { requireJwtAuth, canAccessMCPServerResource } = require('~/server/middleware');
+const {
+  requireJwtAuth,
+  configMiddleware,
+  canAccessMCPServerResource,
+} = require('~/server/middleware');
 const { getUserPluginAuthValue } = require('~/server/services/PluginService');
 const { maybeUninstallOAuthMCP } = require('~/server/services/MCP/oauthCleanup');
 const {
@@ -85,15 +90,6 @@ const canAccessOAuthFlow = (flowId, userId) => {
   return parsed.userId === userId || parsed.userId === 'system';
 };
 
-const prepareGetTokensFlow = async ({ flowManager, flowId }) => {
-  const state = await flowManager.getFlowState(flowId, 'mcp_get_tokens');
-  if (state?.type === 'mcp_get_tokens' && state.status === 'PENDING') {
-    return true;
-  }
-  await flowManager.deleteFlow(flowId, 'mcp_get_tokens');
-  return false;
-};
-
 const checkMCPUsePermissions = generateCheckAccess({
   permissionType: PermissionTypes.MCP_SERVERS,
   permissions: [Permissions.USE],
@@ -110,7 +106,7 @@ const checkMCPCreate = generateCheckAccess({
  * Get all MCP tools available to the user
  * Returns only MCP tools, completely decoupled from regular LibreChat tools
  */
-router.get('/tools', requireJwtAuth, checkMCPUsePermissions, async (req, res) => {
+router.get('/tools', requireJwtAuth, configMiddleware, checkMCPUsePermissions, async (req, res) => {
   return getMCPTools(req, res);
 });
 
@@ -436,11 +432,13 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
     await runWithTenant(async () => {
       const oauthHeaders =
         flowState.oauthHeaders ?? (await getOAuthHeaders(serverName, flowState.userId));
+      let recoveryPolicy;
       const resolveActiveServer = async () => {
         const [configs, appConfig] = await Promise.all([
           resolveAllMcpConfigs(flowState.userId),
           getAppConfig({ userId: flowState.userId, tenantId: getTenantId() }),
         ]);
+        recoveryPolicy = appConfig?.mcpSettings?.catalogRecovery;
         const activeConfig =
           configs?.[serverName] ??
           appConfig?.mcpConfig?.[serverName] ??
@@ -516,28 +514,6 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
             return exchangedTokens;
           }
 
-          const prepareCachedTokenFlows = async () => {
-            if (typeof flowManager?.deleteFlow !== 'function') {
-              return [];
-            }
-            const pendingFlowIds = [];
-            try {
-              const tokenFlowId = MCPOAuthHandler.generateTokenFlowId(
-                flowState.userId,
-                serverName,
-                flowState.tenantId,
-              );
-              for (const candidateFlowId of new Set([tokenFlowId, flowId])) {
-                if (await prepareGetTokensFlow({ flowManager, flowId: candidateFlowId })) {
-                  pendingFlowIds.push(candidateFlowId);
-                }
-              }
-            } catch (error) {
-              logger.warn('[MCP OAuth] Failed to clear cached token flow state', error);
-            }
-            return pendingFlowIds;
-          };
-
           let storedTokens;
           try {
             storedTokens =
@@ -568,25 +544,32 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
                       invalidateRecoveryGeneration: invalidateCachedTools,
                       clearLocalRecovery: (userId, changedServerName) =>
                         getMCPManager()?.clearCatalogRecoveryState?.(userId, changedServerName),
-                      retryDelaysMs:
-                        req.config?.mcpSettings?.catalogRecovery?.authorizationFenceRetryMs,
-                      attemptTimeoutMs:
-                        req.config?.mcpSettings?.catalogRecovery?.authorizationFenceTimeoutMs,
+                      retryDelaysMs: recoveryPolicy?.authorizationFenceRetryMs,
+                      attemptTimeoutMs: recoveryPolicy?.authorizationFenceTimeoutMs,
                     },
                   );
-                  const pendingTokenFlowIds = await prepareCachedTokenFlows();
-                  await completePersistedFlow(committedTokens);
-                  for (const pendingFlowId of pendingTokenFlowIds) {
-                    try {
-                      await flowManager.completeFlow(
-                        pendingFlowId,
-                        'mcp_get_tokens',
-                        committedTokens,
-                      );
-                    } catch (error) {
-                      logger.warn('[MCP OAuth] Failed to wake a pending token flow', error);
-                    }
-                  }
+                  const tokenFlowId = MCPOAuthHandler.generateTokenFlowId(
+                    flowState.userId,
+                    serverName,
+                    flowState.tenantId,
+                  );
+                  await completeMCPAuthorizationWithTokenWaiters(
+                    {
+                      flowIds: [tokenFlowId, flowId],
+                      tokens: committedTokens,
+                      completeAuthorization: completePersistedFlow,
+                    },
+                    {
+                      flowManager,
+                      onTokenFlowError: (phase, error) =>
+                        logger.warn(
+                          phase === 'prepare'
+                            ? '[MCP OAuth] Failed to clear cached token flow state'
+                            : '[MCP OAuth] Failed to wake a pending token flow',
+                          error,
+                        ),
+                    },
+                  );
                 },
               })) ?? exchangedTokens;
             logger.debug('[MCP OAuth] Stored OAuth tokens before completing callback flow', {
@@ -679,10 +662,8 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
                     invalidateRecoveryGeneration: invalidateCachedTools,
                     clearLocalRecovery: (userId, changedServerName) =>
                       getMCPManager()?.clearCatalogRecoveryState?.(userId, changedServerName),
-                    retryDelaysMs:
-                      req.config?.mcpSettings?.catalogRecovery?.authorizationFenceRetryMs,
-                    attemptTimeoutMs:
-                      req.config?.mcpSettings?.catalogRecovery?.authorizationFenceTimeoutMs,
+                    retryDelaysMs: recoveryPolicy?.authorizationFenceRetryMs,
+                    attemptTimeoutMs: recoveryPolicy?.authorizationFenceTimeoutMs,
                   }),
               },
               async (userConnection) => {
@@ -938,6 +919,7 @@ function getMCPReinitializeOAuthTimeout(oauthExpiresAt) {
 router.post(
   '/:serverName/reinitialize',
   requireJwtAuth,
+  configMiddleware,
   checkMCPUsePermissions,
   setOAuthSession,
   async (req, res, next) => {
@@ -1055,7 +1037,7 @@ router.post(
  * Get connection status for all MCP servers
  * This endpoint returns all app level and user-scoped connection statuses from MCPManager without disconnecting idle connections
  */
-router.get('/connection/status', requireJwtAuth, async (req, res) => {
+router.get('/connection/status', requireJwtAuth, configMiddleware, async (req, res) => {
   try {
     const user = req.user;
 
@@ -1126,7 +1108,7 @@ router.get('/connection/status', requireJwtAuth, async (req, res) => {
  * Get connection status for a single MCP server
  * This endpoint returns the connection status for a specific server for a given user
  */
-router.get('/connection/status/:serverName', requireJwtAuth, async (req, res) => {
+router.get('/connection/status/:serverName', requireJwtAuth, configMiddleware, async (req, res) => {
   try {
     const user = req.user;
     const { serverName } = req.params;

--- a/api/server/routes/mcp.js
+++ b/api/server/routes/mcp.js
@@ -85,13 +85,13 @@ const canAccessOAuthFlow = (flowId, userId) => {
   return parsed.userId === userId || parsed.userId === 'system';
 };
 
-const clearGetTokensFlow = async ({ flowManager, flowId, tokens }) => {
+const prepareGetTokensFlow = async ({ flowManager, flowId }) => {
   const state = await flowManager.getFlowState(flowId, 'mcp_get_tokens');
   if (state?.type === 'mcp_get_tokens' && state.status === 'PENDING') {
-    await flowManager.completeFlow(flowId, 'mcp_get_tokens', tokens);
-    return;
+    return true;
   }
   await flowManager.deleteFlow(flowId, 'mcp_get_tokens');
+  return false;
 };
 
 const checkMCPUsePermissions = generateCheckAccess({
@@ -516,31 +516,26 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
             return exchangedTokens;
           }
 
-          const clearCachedTokenFlows = async (committedTokens) => {
+          const prepareCachedTokenFlows = async () => {
             if (typeof flowManager?.deleteFlow !== 'function') {
-              return;
+              return [];
             }
+            const pendingFlowIds = [];
             try {
               const tokenFlowId = MCPOAuthHandler.generateTokenFlowId(
                 flowState.userId,
                 serverName,
                 flowState.tenantId,
               );
-              await clearGetTokensFlow({
-                flowManager,
-                flowId: tokenFlowId,
-                tokens: committedTokens,
-              });
-              if (tokenFlowId !== flowId) {
-                await clearGetTokensFlow({
-                  flowManager,
-                  flowId,
-                  tokens: committedTokens,
-                });
+              for (const candidateFlowId of new Set([tokenFlowId, flowId])) {
+                if (await prepareGetTokensFlow({ flowManager, flowId: candidateFlowId })) {
+                  pendingFlowIds.push(candidateFlowId);
+                }
               }
             } catch (error) {
               logger.warn('[MCP OAuth] Failed to clear cached token flow state', error);
             }
+            return pendingFlowIds;
           };
 
           let storedTokens;
@@ -575,10 +570,23 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
                         getMCPManager()?.clearCatalogRecoveryState?.(userId, changedServerName),
                       retryDelaysMs:
                         req.config?.mcpSettings?.catalogRecovery?.authorizationFenceRetryMs,
+                      attemptTimeoutMs:
+                        req.config?.mcpSettings?.catalogRecovery?.authorizationFenceTimeoutMs,
                     },
                   );
-                  await clearCachedTokenFlows(committedTokens);
+                  const pendingTokenFlowIds = await prepareCachedTokenFlows();
                   await completePersistedFlow(committedTokens);
+                  for (const pendingFlowId of pendingTokenFlowIds) {
+                    try {
+                      await flowManager.completeFlow(
+                        pendingFlowId,
+                        'mcp_get_tokens',
+                        committedTokens,
+                      );
+                    } catch (error) {
+                      logger.warn('[MCP OAuth] Failed to wake a pending token flow', error);
+                    }
+                  }
                 },
               })) ?? exchangedTokens;
             logger.debug('[MCP OAuth] Stored OAuth tokens before completing callback flow', {
@@ -673,6 +681,8 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
                       getMCPManager()?.clearCatalogRecoveryState?.(userId, changedServerName),
                     retryDelaysMs:
                       req.config?.mcpSettings?.catalogRecovery?.authorizationFenceRetryMs,
+                    attemptTimeoutMs:
+                      req.config?.mcpSettings?.catalogRecovery?.authorizationFenceTimeoutMs,
                   }),
               },
               async (userConnection) => {

--- a/api/server/routes/mcp.js
+++ b/api/server/routes/mcp.js
@@ -31,7 +31,7 @@ const {
   MCPAuthenticationRefreshError,
   OpenIDReauthRequiredError,
   readMCPRecoveryGenerationAround,
-  publishMCPAuthorizationMutation,
+  prepareMCPAuthorizationMutation,
   persistMCPAuthorizationTransaction,
 } = require('@librechat/api');
 const {
@@ -656,8 +656,8 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
                   createToken: db.createToken,
                   deleteTokens: db.deleteTokens,
                 },
-                onOAuthCredentialsChanged: (scope) =>
-                  publishMCPAuthorizationMutation(scope, {
+                onOAuthCredentialsChanging: (scope) =>
+                  prepareMCPAuthorizationMutation(scope, {
                     invalidateRecoveryGeneration: invalidateCachedTools,
                     persistPublicationRetry: persistMCPAuthorizationFenceRetry,
                     clearPublicationRetry: clearMCPAuthorizationFenceRetry,

--- a/api/server/routes/mcp.js
+++ b/api/server/routes/mcp.js
@@ -533,6 +533,7 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
               await rollbackStoredTokens(storedTokens);
               throw new Error(`MCP server ${serverName} was deleted during OAuth authorization`);
             }
+            getMCPManager()?.clearCatalogRecoveryState?.(flowState.userId, serverName);
             logger.debug('[MCP OAuth] Stored OAuth tokens before completing callback flow', {
               serverName,
               userId: flowState.userId,

--- a/api/server/routes/mcp.js
+++ b/api/server/routes/mcp.js
@@ -30,7 +30,7 @@ const {
   MCPAuthenticationRejectedError,
   MCPAuthenticationRefreshError,
   OpenIDReauthRequiredError,
-  readMCPRecoveryGeneration,
+  readMCPRecoveryGenerationAround,
   publishMCPAuthorizationMutation,
 } = require('@librechat/api');
 const {
@@ -511,13 +511,12 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
         code,
         flowManager,
         oauthHeaders,
-        async (exchangedTokens) => {
+        async (exchangedTokens, completePersistedFlow) => {
           if (!flowState?.userId) {
             return exchangedTokens;
           }
 
           let storedTokens;
-          let rolledBack = false;
           try {
             storedTokens =
               (await MCPTokenStorage.storeTokens({
@@ -535,35 +534,28 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
                   flowState.serverUrl,
                   flowState.clientSource,
                 ),
+                onStoreCommitted: async (committedTokens) => {
+                  if (!(await resolveActiveServer())) {
+                    throw new Error(
+                      `MCP server ${serverName} was deleted during OAuth authorization`,
+                    );
+                  }
+                  await publishMCPAuthorizationMutation(
+                    { userId: flowState.userId, serverName },
+                    {
+                      invalidateRecoveryGeneration: invalidateCachedTools,
+                      clearLocalRecovery: (userId, changedServerName) =>
+                        getMCPManager()?.clearCatalogRecoveryState?.(userId, changedServerName),
+                    },
+                  );
+                  await completePersistedFlow(committedTokens);
+                },
               })) ?? exchangedTokens;
-            if (!(await resolveActiveServer())) {
-              await rollbackStoredTokens(storedTokens);
-              rolledBack = true;
-              throw new Error(`MCP server ${serverName} was deleted during OAuth authorization`);
-            }
-            await publishMCPAuthorizationMutation(
-              { userId: flowState.userId, serverName },
-              {
-                invalidateRecoveryGeneration: invalidateCachedTools,
-                clearLocalRecovery: (userId, changedServerName) =>
-                  getMCPManager()?.clearCatalogRecoveryState?.(userId, changedServerName),
-              },
-            );
             logger.debug('[MCP OAuth] Stored OAuth tokens before completing callback flow', {
               serverName,
               userId: flowState.userId,
             });
           } catch (error) {
-            if (storedTokens != null && !rolledBack) {
-              try {
-                await rollbackStoredTokens(storedTokens);
-              } catch (rollbackError) {
-                logger.error(
-                  '[MCP OAuth] Failed to roll back unfenced OAuth tokens',
-                  rollbackError,
-                );
-              }
-            }
             logger.error('[MCP OAuth] Failed to store OAuth tokens before flow completion', error);
             throw error;
           }
@@ -1065,24 +1057,24 @@ router.get('/connection/status', requireJwtAuth, async (req, res) => {
       await Promise.all(
         Object.entries(mcpConfig).map(async ([serverName, config]) => {
           try {
-            const [status, authorizationGeneration] = await Promise.all([
-              getServerConnectionStatus(
-                user.id,
-                serverName,
-                config,
-                appConnections,
-                userConnections,
-                oauthServers,
-                runtimeContext,
-              ),
-              readMCPRecoveryGeneration(
+            const { value: status, generation: authorizationGeneration } =
+              await readMCPRecoveryGenerationAround(
                 { userId: user.id, serverName },
                 getMCPToolsCacheGeneration,
+                () =>
+                  getServerConnectionStatus(
+                    user.id,
+                    serverName,
+                    config,
+                    appConnections,
+                    userConnections,
+                    oauthServers,
+                    runtimeContext,
+                  ),
                 {
                   timeoutMs: req.config?.mcpSettings?.catalogRecovery?.generationReadTimeoutMs,
                 },
-              ),
-            ]);
+              );
             return [serverName, { ...status, authorizationGeneration }];
           } catch (error) {
             const message = `Failed to get status for server "${serverName}"`;
@@ -1141,20 +1133,24 @@ router.get('/connection/status/:serverName', requireJwtAuth, async (req, res) =>
 
     const runtimeContext = createMCPStatusRuntimeContext(user, mcpConfig, [serverName]);
 
-    const [serverStatus, authorizationGeneration] = await Promise.all([
-      getServerConnectionStatus(
-        user.id,
-        serverName,
-        mcpConfig[serverName],
-        appConnections,
-        userConnections,
-        oauthServers,
-        runtimeContext,
-      ),
-      readMCPRecoveryGeneration({ userId: user.id, serverName }, getMCPToolsCacheGeneration, {
-        timeoutMs: req.config?.mcpSettings?.catalogRecovery?.generationReadTimeoutMs,
-      }),
-    ]);
+    const { value: serverStatus, generation: authorizationGeneration } =
+      await readMCPRecoveryGenerationAround(
+        { userId: user.id, serverName },
+        getMCPToolsCacheGeneration,
+        () =>
+          getServerConnectionStatus(
+            user.id,
+            serverName,
+            mcpConfig[serverName],
+            appConnections,
+            userConnections,
+            oauthServers,
+            runtimeContext,
+          ),
+        {
+          timeoutMs: req.config?.mcpSettings?.catalogRecovery?.generationReadTimeoutMs,
+        },
+      );
 
     res.json({
       success: true,

--- a/api/server/routes/mcp.js
+++ b/api/server/routes/mcp.js
@@ -30,7 +30,8 @@ const {
   MCPAuthenticationRejectedError,
   MCPAuthenticationRefreshError,
   OpenIDReauthRequiredError,
-  getMCPAuthorizationGeneration,
+  readMCPRecoveryGeneration,
+  publishMCPAuthorizationMutation,
 } = require('@librechat/api');
 const {
   createMCPServerController,
@@ -55,7 +56,11 @@ const {
 const { requireJwtAuth, canAccessMCPServerResource } = require('~/server/middleware');
 const { getUserPluginAuthValue } = require('~/server/services/PluginService');
 const { maybeUninstallOAuthMCP } = require('~/server/services/MCP/oauthCleanup');
-const { invalidateCachedTools, getAppConfig } = require('~/server/services/Config');
+const {
+  invalidateCachedTools,
+  getAppConfig,
+  getMCPToolsCacheGeneration,
+} = require('~/server/services/Config');
 const { updateMCPServerTools } = require('~/server/services/Config/mcp');
 const { reinitMCPServer } = require('~/server/services/Tools/mcp');
 const { createOpenIDSessionTokenProvider } = require('~/server/services/OpenIDSessionRefresh');
@@ -512,6 +517,7 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
           }
 
           let storedTokens;
+          let rolledBack = false;
           try {
             storedTokens =
               (await MCPTokenStorage.storeTokens({
@@ -532,15 +538,32 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
               })) ?? exchangedTokens;
             if (!(await resolveActiveServer())) {
               await rollbackStoredTokens(storedTokens);
+              rolledBack = true;
               throw new Error(`MCP server ${serverName} was deleted during OAuth authorization`);
             }
-            await invalidateCachedTools({ userId: flowState.userId, serverName });
-            getMCPManager()?.clearCatalogRecoveryState?.(flowState.userId, serverName);
+            await publishMCPAuthorizationMutation(
+              { userId: flowState.userId, serverName },
+              {
+                invalidateRecoveryGeneration: invalidateCachedTools,
+                clearLocalRecovery: (userId, changedServerName) =>
+                  getMCPManager()?.clearCatalogRecoveryState?.(userId, changedServerName),
+              },
+            );
             logger.debug('[MCP OAuth] Stored OAuth tokens before completing callback flow', {
               serverName,
               userId: flowState.userId,
             });
           } catch (error) {
+            if (storedTokens != null && !rolledBack) {
+              try {
+                await rollbackStoredTokens(storedTokens);
+              } catch (rollbackError) {
+                logger.error(
+                  '[MCP OAuth] Failed to roll back unfenced OAuth tokens',
+                  rollbackError,
+                );
+              }
+            }
             logger.error('[MCP OAuth] Failed to store OAuth tokens before flow completion', error);
             throw error;
           }
@@ -649,6 +672,12 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
                   createToken: db.createToken,
                   deleteTokens: db.deleteTokens,
                 },
+                onOAuthCredentialsChanged: (scope) =>
+                  publishMCPAuthorizationMutation(scope, {
+                    invalidateRecoveryGeneration: invalidateCachedTools,
+                    clearLocalRecovery: (userId, changedServerName) =>
+                      getMCPManager()?.clearCatalogRecoveryState?.(userId, changedServerName),
+                  }),
               },
               async (userConnection) => {
                 logger.info(
@@ -1046,7 +1075,13 @@ router.get('/connection/status', requireJwtAuth, async (req, res) => {
                 oauthServers,
                 runtimeContext,
               ),
-              getMCPAuthorizationGeneration(user.id, serverName),
+              readMCPRecoveryGeneration(
+                { userId: user.id, serverName },
+                getMCPToolsCacheGeneration,
+                {
+                  timeoutMs: req.config?.mcpSettings?.catalogRecovery?.generationReadTimeoutMs,
+                },
+              ),
             ]);
             return [serverName, { ...status, authorizationGeneration }];
           } catch (error) {
@@ -1116,7 +1151,9 @@ router.get('/connection/status/:serverName', requireJwtAuth, async (req, res) =>
         oauthServers,
         runtimeContext,
       ),
-      getMCPAuthorizationGeneration(user.id, serverName),
+      readMCPRecoveryGeneration({ userId: user.id, serverName }, getMCPToolsCacheGeneration, {
+        timeoutMs: req.config?.mcpSettings?.catalogRecovery?.generationReadTimeoutMs,
+      }),
     ]);
 
     res.json({

--- a/api/server/routes/mcp.js
+++ b/api/server/routes/mcp.js
@@ -30,6 +30,7 @@ const {
   MCPAuthenticationRejectedError,
   MCPAuthenticationRefreshError,
   OpenIDReauthRequiredError,
+  getMCPAuthorizationGeneration,
 } = require('@librechat/api');
 const {
   createMCPServerController,
@@ -533,6 +534,7 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
               await rollbackStoredTokens(storedTokens);
               throw new Error(`MCP server ${serverName} was deleted during OAuth authorization`);
             }
+            await invalidateCachedTools({ userId: flowState.userId, serverName });
             getMCPManager()?.clearCatalogRecoveryState?.(flowState.userId, serverName);
             logger.debug('[MCP OAuth] Stored OAuth tokens before completing callback flow', {
               serverName,
@@ -1034,16 +1036,19 @@ router.get('/connection/status', requireJwtAuth, async (req, res) => {
       await Promise.all(
         Object.entries(mcpConfig).map(async ([serverName, config]) => {
           try {
-            const status = await getServerConnectionStatus(
-              user.id,
-              serverName,
-              config,
-              appConnections,
-              userConnections,
-              oauthServers,
-              runtimeContext,
-            );
-            return [serverName, status];
+            const [status, authorizationGeneration] = await Promise.all([
+              getServerConnectionStatus(
+                user.id,
+                serverName,
+                config,
+                appConnections,
+                userConnections,
+                oauthServers,
+                runtimeContext,
+              ),
+              getMCPAuthorizationGeneration(user.id, serverName),
+            ]);
+            return [serverName, { ...status, authorizationGeneration }];
           } catch (error) {
             const message = `Failed to get status for server "${serverName}"`;
             logger.error(`[MCP Connection Status] ${message},`, error);
@@ -1101,15 +1106,18 @@ router.get('/connection/status/:serverName', requireJwtAuth, async (req, res) =>
 
     const runtimeContext = createMCPStatusRuntimeContext(user, mcpConfig, [serverName]);
 
-    const serverStatus = await getServerConnectionStatus(
-      user.id,
-      serverName,
-      mcpConfig[serverName],
-      appConnections,
-      userConnections,
-      oauthServers,
-      runtimeContext,
-    );
+    const [serverStatus, authorizationGeneration] = await Promise.all([
+      getServerConnectionStatus(
+        user.id,
+        serverName,
+        mcpConfig[serverName],
+        appConnections,
+        userConnections,
+        oauthServers,
+        runtimeContext,
+      ),
+      getMCPAuthorizationGeneration(user.id, serverName),
+    ]);
 
     res.json({
       success: true,
@@ -1119,6 +1127,7 @@ router.get('/connection/status/:serverName', requireJwtAuth, async (req, res) =>
       requestScoped: serverStatus.requestScoped,
       configurationState: serverStatus.configurationState,
       authorizationState: serverStatus.authorizationState,
+      authorizationGeneration,
     });
   } catch (error) {
     logger.error(

--- a/api/server/routes/mcp.js
+++ b/api/server/routes/mcp.js
@@ -1048,7 +1048,7 @@ router.get('/connection/status', requireJwtAuth, configMiddleware, async (req, r
 
     const { mcpConfig, appConnections, userConnections, oauthServers } = await getMCPSetupData(
       user.id,
-      { role: user.role, tenantId: getTenantId() },
+      { role: user.role, tenantId: getTenantId(), appConfig: req.config },
     );
     const runtimeContext = createMCPStatusRuntimeContext(user, mcpConfig, Object.keys(mcpConfig));
     const connectionStatus = Object.fromEntries(
@@ -1120,7 +1120,7 @@ router.get('/connection/status/:serverName', requireJwtAuth, configMiddleware, a
 
     const { mcpConfig, appConnections, userConnections, oauthServers } = await getMCPSetupData(
       user.id,
-      { role: user.role, tenantId: getTenantId() },
+      { role: user.role, tenantId: getTenantId(), appConfig: req.config },
     );
 
     if (!mcpConfig[serverName]) {

--- a/api/server/routes/mcp.js
+++ b/api/server/routes/mcp.js
@@ -32,7 +32,7 @@ const {
   OpenIDReauthRequiredError,
   readMCPRecoveryGenerationAround,
   publishMCPAuthorizationMutation,
-  completeMCPAuthorizationWithTokenWaiters,
+  persistMCPAuthorizationTransaction,
 } = require('@librechat/api');
 const {
   createMCPServerController,
@@ -68,6 +68,10 @@ const {
 } = require('~/server/services/Config');
 const { updateMCPServerTools } = require('~/server/services/Config/mcp');
 const { reinitMCPServer } = require('~/server/services/Tools/mcp');
+const {
+  clearMCPAuthorizationFenceRetry,
+  persistMCPAuthorizationFenceRetry,
+} = require('~/server/services/MCPAuthorizationFenceRetry');
 const { createOpenIDSessionTokenProvider } = require('~/server/services/OpenIDSessionRefresh');
 const { getLogStores } = require('~/cache');
 const db = require('~/models');
@@ -516,62 +520,57 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
 
           let storedTokens;
           try {
-            storedTokens =
-              (await MCPTokenStorage.storeTokens({
-                userId: flowState.userId,
-                serverName,
+            const tokenFlowId = MCPOAuthHandler.generateTokenFlowId(
+              flowState.userId,
+              serverName,
+              flowState.tenantId,
+            );
+            storedTokens = await persistMCPAuthorizationTransaction(
+              {
+                scope: { userId: flowState.userId, serverName },
+                flowIds: [tokenFlowId, flowId],
                 tokens: exchangedTokens,
-                createToken: db.createToken,
-                updateToken: db.updateToken,
-                deleteTokens: db.deleteTokens,
-                findToken: db.findToken,
-                clientInfo: flowState.clientInfo,
-                metadata: MCPOAuthHandler.buildStoredClientMetadata(
-                  flowState.metadata,
-                  flowState.resourceMetadata,
-                  flowState.serverUrl,
-                  flowState.clientSource,
-                ),
-                onStoreCommitted: async (committedTokens) => {
-                  if (!(await resolveActiveServer())) {
-                    throw new Error(
-                      `MCP server ${serverName} was deleted during OAuth authorization`,
-                    );
-                  }
-                  await publishMCPAuthorizationMutation(
-                    { userId: flowState.userId, serverName },
-                    {
-                      invalidateRecoveryGeneration: invalidateCachedTools,
-                      clearLocalRecovery: (userId, changedServerName) =>
-                        getMCPManager()?.clearCatalogRecoveryState?.(userId, changedServerName),
-                      retryDelaysMs: recoveryPolicy?.authorizationFenceRetryMs,
-                      attemptTimeoutMs: recoveryPolicy?.authorizationFenceTimeoutMs,
-                    },
-                  );
-                  const tokenFlowId = MCPOAuthHandler.generateTokenFlowId(
-                    flowState.userId,
+                completeAuthorization: completePersistedFlow,
+                persistTokens: async (candidateTokens, onStoreCommitted) =>
+                  (await MCPTokenStorage.storeTokens({
+                    userId: flowState.userId,
                     serverName,
-                    flowState.tenantId,
-                  );
-                  await completeMCPAuthorizationWithTokenWaiters(
-                    {
-                      flowIds: [tokenFlowId, flowId],
-                      tokens: committedTokens,
-                      completeAuthorization: completePersistedFlow,
-                    },
-                    {
-                      flowManager,
-                      onTokenFlowError: (phase, error) =>
-                        logger.warn(
-                          phase === 'prepare'
-                            ? '[MCP OAuth] Failed to clear cached token flow state'
-                            : '[MCP OAuth] Failed to wake a pending token flow',
-                          error,
-                        ),
-                    },
-                  );
-                },
-              })) ?? exchangedTokens;
+                    tokens: candidateTokens,
+                    createToken: db.createToken,
+                    updateToken: db.updateToken,
+                    deleteTokens: db.deleteTokens,
+                    findToken: db.findToken,
+                    clientInfo: flowState.clientInfo,
+                    metadata: MCPOAuthHandler.buildStoredClientMetadata(
+                      flowState.metadata,
+                      flowState.resourceMetadata,
+                      flowState.serverUrl,
+                      flowState.clientSource,
+                    ),
+                    onStoreCommitted,
+                  })) ?? candidateTokens,
+              },
+              {
+                ensureServerActive: resolveActiveServer,
+                inactiveServerError: () =>
+                  new Error(`MCP server ${serverName} was deleted during OAuth authorization`),
+                invalidateRecoveryGeneration: invalidateCachedTools,
+                clearLocalRecovery: (userId, changedServerName) =>
+                  getMCPManager()?.clearCatalogRecoveryState?.(userId, changedServerName),
+                persistPublicationRetry: persistMCPAuthorizationFenceRetry,
+                clearPublicationRetry: clearMCPAuthorizationFenceRetry,
+                retryDelaysMs: recoveryPolicy?.authorizationFenceRetryMs,
+                attemptTimeoutMs: recoveryPolicy?.authorizationFenceTimeoutMs,
+                flowManager,
+                onTokenFlowError: (phase, error) =>
+                  logger.warn(
+                    phase === 'prepare'
+                      ? '[MCP OAuth] Failed to clear cached token flow state'
+                      : '[MCP OAuth] Failed to wake a pending token flow',
+                    error,
+                  ),
+              },
+            );
             logger.debug('[MCP OAuth] Stored OAuth tokens before completing callback flow', {
               serverName,
               userId: flowState.userId,
@@ -660,6 +659,8 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
                 onOAuthCredentialsChanged: (scope) =>
                   publishMCPAuthorizationMutation(scope, {
                     invalidateRecoveryGeneration: invalidateCachedTools,
+                    persistPublicationRetry: persistMCPAuthorizationFenceRetry,
+                    clearPublicationRetry: clearMCPAuthorizationFenceRetry,
                     clearLocalRecovery: (userId, changedServerName) =>
                       getMCPManager()?.clearCatalogRecoveryState?.(userId, changedServerName),
                     retryDelaysMs: recoveryPolicy?.authorizationFenceRetryMs,

--- a/api/server/routes/mcp.js
+++ b/api/server/routes/mcp.js
@@ -516,6 +516,33 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
             return exchangedTokens;
           }
 
+          const clearCachedTokenFlows = async (committedTokens) => {
+            if (typeof flowManager?.deleteFlow !== 'function') {
+              return;
+            }
+            try {
+              const tokenFlowId = MCPOAuthHandler.generateTokenFlowId(
+                flowState.userId,
+                serverName,
+                flowState.tenantId,
+              );
+              await clearGetTokensFlow({
+                flowManager,
+                flowId: tokenFlowId,
+                tokens: committedTokens,
+              });
+              if (tokenFlowId !== flowId) {
+                await clearGetTokensFlow({
+                  flowManager,
+                  flowId,
+                  tokens: committedTokens,
+                });
+              }
+            } catch (error) {
+              logger.warn('[MCP OAuth] Failed to clear cached token flow state', error);
+            }
+          };
+
           let storedTokens;
           try {
             storedTokens =
@@ -546,8 +573,11 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
                       invalidateRecoveryGeneration: invalidateCachedTools,
                       clearLocalRecovery: (userId, changedServerName) =>
                         getMCPManager()?.clearCatalogRecoveryState?.(userId, changedServerName),
+                      retryDelaysMs:
+                        req.config?.mcpSettings?.catalogRecovery?.authorizationFenceRetryMs,
                     },
                   );
+                  await clearCachedTokenFlows(committedTokens);
                   await completePersistedFlow(committedTokens);
                 },
               })) ?? exchangedTokens;
@@ -558,34 +588,6 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
           } catch (error) {
             logger.error('[MCP OAuth] Failed to store OAuth tokens before flow completion', error);
             throw error;
-          }
-
-          /**
-           * Clear any cached `mcp_get_tokens` flow result before the OAuth flow wakes its
-           * waiters, so they cannot observe stale credentials after completion.
-           */
-          if (typeof flowManager?.deleteFlow === 'function') {
-            try {
-              const tokenFlowId = MCPOAuthHandler.generateTokenFlowId(
-                flowState.userId,
-                serverName,
-                flowState.tenantId,
-              );
-              await clearGetTokensFlow({
-                flowManager,
-                flowId: tokenFlowId,
-                tokens: storedTokens,
-              });
-              if (tokenFlowId !== flowId) {
-                await clearGetTokensFlow({
-                  flowManager,
-                  flowId,
-                  tokens: storedTokens,
-                });
-              }
-            } catch (error) {
-              logger.warn('[MCP OAuth] Failed to clear cached token flow state', error);
-            }
           }
 
           return storedTokens;
@@ -669,6 +671,8 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
                     invalidateRecoveryGeneration: invalidateCachedTools,
                     clearLocalRecovery: (userId, changedServerName) =>
                       getMCPManager()?.clearCatalogRecoveryState?.(userId, changedServerName),
+                    retryDelaysMs:
+                      req.config?.mcpSettings?.catalogRecovery?.authorizationFenceRetryMs,
                   }),
               },
               async (userConnection) => {
@@ -987,6 +991,7 @@ router.post(
           tokenPreference: 'access_token',
         }),
         oboIdentityContext,
+        recoveryPolicy: req.config?.mcpSettings?.catalogRecovery,
       });
 
       if (!result) {

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -45,6 +45,7 @@ const {
   OpenIDReauthRequiredError,
   MCPAuthenticationRefreshError,
   MCPAuthenticationRejectedError,
+  publishMCPAuthorizationMutation,
 } = require('@librechat/api');
 const {
   Time,
@@ -72,6 +73,7 @@ const {
   getCachedTools,
   getMCPServerTools,
   cacheMCPServerTools,
+  invalidateCachedTools,
 } = require('./Config');
 const { getLogStores } = require('~/cache');
 
@@ -1303,6 +1305,12 @@ function createToolInstance({
           updateToken,
           deleteTokens,
         },
+        onOAuthCredentialsChanged: (scope) =>
+          publishMCPAuthorizationMutation(scope, {
+            invalidateRecoveryGeneration: invalidateCachedTools,
+            clearLocalRecovery: (userId, changedServerName) =>
+              mcpManager.clearCatalogRecoveryState?.(userId, changedServerName),
+          }),
         oauthStart,
         oauthEnd,
         graphTokenResolver: getGraphApiToken,

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -45,7 +45,7 @@ const {
   OpenIDReauthRequiredError,
   MCPAuthenticationRefreshError,
   MCPAuthenticationRejectedError,
-  publishMCPAuthorizationMutation,
+  prepareMCPAuthorizationMutation,
 } = require('@librechat/api');
 const {
   Time,
@@ -1321,8 +1321,8 @@ function createToolInstance({
           updateToken,
           deleteTokens,
         },
-        onOAuthCredentialsChanged: (scope) =>
-          publishMCPAuthorizationMutation(scope, {
+        onOAuthCredentialsChanging: (scope) =>
+          prepareMCPAuthorizationMutation(scope, {
             invalidateRecoveryGeneration: invalidateCachedTools,
             persistPublicationRetry: persistMCPAuthorizationFenceRetry,
             clearPublicationRetry: clearMCPAuthorizationFenceRetry,

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -427,6 +427,7 @@ async function getAssistantToolDefinitions({ req, res, tools }) {
           userMCPAuthMap,
           upstreamTokenProvider,
           oboIdentityContext,
+          recoveryPolicy: appConfig?.mcpSettings?.catalogRecovery,
         });
         return result?.availableTools ?? null;
       },
@@ -759,6 +760,7 @@ async function reconnectServer({
   oboIdentityContext,
   streamId = null,
   jobCreatedAt,
+  recoveryPolicy,
 }) {
   logger.debug('[MCP][reconnectServer] Starting reconnect', {
     userId: user?.id,
@@ -823,6 +825,7 @@ async function reconnectServer({
     requestBody,
     requestScopedConnections,
     upstreamTokenProvider,
+    recoveryPolicy,
     oboIdentityContext,
     forceNew: true,
     returnOnOAuth: false,
@@ -873,6 +876,7 @@ async function createMCPTools({
   streamId = null,
   jobCreatedAt,
 }) {
+  let recoveryPolicy;
   const serverConfig =
     config ?? (await getMCPServersRegistry().getServerConfig(serverName, user?.id, configServers));
 
@@ -882,6 +886,7 @@ async function createMCPTools({
       tenantId: user?.tenantId,
       userId: user?.id,
     });
+    recoveryPolicy = appConfig?.mcpSettings?.catalogRecovery;
     const allowedDomains = appConfig?.mcpSettings?.allowedDomains;
     const allowedAddresses = appConfig?.mcpSettings?.allowedAddresses;
     const isDomainAllowed = await isEarlyDomainAllowed({
@@ -914,6 +919,7 @@ async function createMCPTools({
     oboIdentityContext,
     streamId,
     jobCreatedAt,
+    recoveryPolicy,
   });
   if (result === null) {
     logger.debug('[MCP] Reconnect throttled; skipping tool creation');
@@ -940,6 +946,7 @@ async function createMCPTools({
       configServers,
       streamId,
       jobCreatedAt,
+      authorizationFenceRetryMs: recoveryPolicy?.authorizationFenceRetryMs,
       availableTools: result.availableTools,
       serverName,
       /** Model-facing key: matches the normalized `availableTools` keys and
@@ -1003,6 +1010,7 @@ async function createMCPTool({
   onAvailableTools,
   streamId = null,
   jobCreatedAt,
+  authorizationFenceRetryMs,
 }) {
   /** `loadTools` already resolved the server for this key; parsing is the fallback. */
   const [parsedToolName, parsedServerName] = splitMCPToolKey(
@@ -1047,6 +1055,8 @@ async function createMCPTool({
       tenantId: user?.tenantId,
       userId: user?.id,
     });
+    authorizationFenceRetryMs ??=
+      appConfig?.mcpSettings?.catalogRecovery?.authorizationFenceRetryMs;
     const allowedDomains = appConfig?.mcpSettings?.allowedDomains;
     const allowedAddresses = appConfig?.mcpSettings?.allowedAddresses;
     const isDomainAllowed = await isEarlyDomainAllowed({
@@ -1175,6 +1185,7 @@ async function createMCPTool({
     oboIdentityContext,
     streamId,
     jobCreatedAt,
+    authorizationFenceRetryMs,
   });
 }
 
@@ -1195,6 +1206,7 @@ function createToolInstance({
   oboIdentityContext: capturedOboIdentityContext = null,
   streamId = null,
   jobCreatedAt,
+  authorizationFenceRetryMs,
 }) {
   /** @type {LCTool} */
   const { description, parameters } = toolDefinition;
@@ -1310,6 +1322,7 @@ function createToolInstance({
             invalidateRecoveryGeneration: invalidateCachedTools,
             clearLocalRecovery: (userId, changedServerName) =>
               mcpManager.clearCatalogRecoveryState?.(userId, changedServerName),
+            retryDelaysMs: authorizationFenceRetryMs,
           }),
         oauthStart,
         oauthEnd,

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -1438,14 +1438,14 @@ function createToolInstance({
  * Get MCP setup data including config, connections, and OAuth servers.
  * Resolves config-source servers from admin Config overrides when tenant context is available.
  * @param {string} userId - The user ID
- * @param {{ role?: string, tenantId?: string }} [options] - Optional role/tenant context
+ * @param {{ role?: string, tenantId?: string, appConfig?: object }} [options] - Optional request context
  * @returns {Object} Object containing mcpConfig, appConnections, userConnections, and oauthServers
  */
 async function getMCPSetupData(userId, options = {}) {
   const registry = getMCPServersRegistry();
   const { role, tenantId } = options;
 
-  const appConfig = await getAppConfig({ role, tenantId, userId });
+  const appConfig = options.appConfig ?? (await getAppConfig({ role, tenantId, userId }));
   const configServers = await registry.ensureConfigServers(appConfig?.mcpConfig || {});
   const mcpConfig = role
     ? await registry.getAllServerConfigs(userId, configServers, role)

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -76,6 +76,10 @@ const {
   invalidateCachedTools,
 } = require('./Config');
 const { getLogStores } = require('~/cache');
+const {
+  clearMCPAuthorizationFenceRetry,
+  persistMCPAuthorizationFenceRetry,
+} = require('./MCPAuthorizationFenceRetry');
 
 const MAX_CACHE_SIZE = 1000;
 const lastReconnectAttempts = new Map();
@@ -1320,6 +1324,8 @@ function createToolInstance({
         onOAuthCredentialsChanged: (scope) =>
           publishMCPAuthorizationMutation(scope, {
             invalidateRecoveryGeneration: invalidateCachedTools,
+            persistPublicationRetry: persistMCPAuthorizationFenceRetry,
+            clearPublicationRetry: clearMCPAuthorizationFenceRetry,
             clearLocalRecovery: (userId, changedServerName) =>
               mcpManager.clearCatalogRecoveryState?.(userId, changedServerName),
             retryDelaysMs: recoveryPolicy?.authorizationFenceRetryMs,

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -946,7 +946,7 @@ async function createMCPTools({
       configServers,
       streamId,
       jobCreatedAt,
-      authorizationFenceRetryMs: recoveryPolicy?.authorizationFenceRetryMs,
+      recoveryPolicy,
       availableTools: result.availableTools,
       serverName,
       /** Model-facing key: matches the normalized `availableTools` keys and
@@ -1010,7 +1010,7 @@ async function createMCPTool({
   onAvailableTools,
   streamId = null,
   jobCreatedAt,
-  authorizationFenceRetryMs,
+  recoveryPolicy,
 }) {
   /** `loadTools` already resolved the server for this key; parsing is the fallback. */
   const [parsedToolName, parsedServerName] = splitMCPToolKey(
@@ -1055,8 +1055,7 @@ async function createMCPTool({
       tenantId: user?.tenantId,
       userId: user?.id,
     });
-    authorizationFenceRetryMs ??=
-      appConfig?.mcpSettings?.catalogRecovery?.authorizationFenceRetryMs;
+    recoveryPolicy ??= appConfig?.mcpSettings?.catalogRecovery;
     const allowedDomains = appConfig?.mcpSettings?.allowedDomains;
     const allowedAddresses = appConfig?.mcpSettings?.allowedAddresses;
     const isDomainAllowed = await isEarlyDomainAllowed({
@@ -1141,6 +1140,7 @@ async function createMCPTool({
       oboIdentityContext,
       streamId,
       jobCreatedAt,
+      ...(recoveryPolicy && { recoveryPolicy }),
     });
     if (result?.availableTools) {
       onAvailableTools?.(result.availableTools);
@@ -1185,7 +1185,7 @@ async function createMCPTool({
     oboIdentityContext,
     streamId,
     jobCreatedAt,
-    authorizationFenceRetryMs,
+    recoveryPolicy,
   });
 }
 
@@ -1206,7 +1206,7 @@ function createToolInstance({
   oboIdentityContext: capturedOboIdentityContext = null,
   streamId = null,
   jobCreatedAt,
-  authorizationFenceRetryMs,
+  recoveryPolicy,
 }) {
   /** @type {LCTool} */
   const { description, parameters } = toolDefinition;
@@ -1322,7 +1322,8 @@ function createToolInstance({
             invalidateRecoveryGeneration: invalidateCachedTools,
             clearLocalRecovery: (userId, changedServerName) =>
               mcpManager.clearCatalogRecoveryState?.(userId, changedServerName),
-            retryDelaysMs: authorizationFenceRetryMs,
+            retryDelaysMs: recoveryPolicy?.authorizationFenceRetryMs,
+            attemptTimeoutMs: recoveryPolicy?.authorizationFenceTimeoutMs,
           }),
         oauthStart,
         oauthEnd,

--- a/api/server/services/MCP.spec.js
+++ b/api/server/services/MCP.spec.js
@@ -258,6 +258,16 @@ describe('tests for the new helper functions used by the MCP connection status e
       expect(result.oauthServers).toEqual(new Set());
     });
 
+    it('reuses request-loaded app configuration', async () => {
+      const appConfig = { mcpConfig: { server1: { type: 'stdio' } } };
+      mockGetAppConfig.mockClear();
+
+      await getMCPSetupData(mockUserId, { role: 'user', appConfig });
+
+      expect(mockGetAppConfig).not.toHaveBeenCalled();
+      expect(mockRegistryInstance.ensureConfigServers).toHaveBeenCalledWith(appConfig.mcpConfig);
+    });
+
     it('should handle null values from MCP manager gracefully', async () => {
       mockRegistryInstance.getAllServerConfigs.mockResolvedValue(mockConfig);
 

--- a/api/server/services/MCPAuthorizationFenceRetry.js
+++ b/api/server/services/MCPAuthorizationFenceRetry.js
@@ -1,78 +1,34 @@
 const mongoose = require('mongoose');
-const { getTenantId, runAsSystem, tenantStorage } = require('@librechat/data-schemas');
+const {
+  createMCPAuthorizationFenceRetryStorage,
+  getTenantId,
+  tenantStorage,
+} = require('@librechat/data-schemas');
 const { createMCPAuthorizationFenceRetryService } = require('@librechat/api');
 
-const COLLECTION_NAME = 'mcp_authorization_fence_retries';
-let retryIndexPromise;
+let retryService;
 
-function collection() {
-  return mongoose.connection.collection(COLLECTION_NAME);
-}
-
-function retryId({ userId, serverName }, tenantId) {
-  return JSON.stringify([tenantId ?? '', String(userId), serverName]);
-}
-
-function ensureRetryIndex() {
-  retryIndexPromise ??= collection()
-    .createIndex({ updatedAt: 1 })
-    .catch((error) => {
-      retryIndexPromise = undefined;
-      throw error;
-    });
-  return retryIndexPromise;
-}
-
-const retryService = createMCPAuthorizationFenceRetryService({
-  getTenantId,
-  storage: {
-    async upsert({ scope, tenantId, version, now }) {
-      await collection().updateOne(
-        { _id: retryId(scope, tenantId) },
+function getRetryService() {
+  retryService ??= createMCPAuthorizationFenceRetryService({
+    getTenantId,
+    storage: createMCPAuthorizationFenceRetryStorage(mongoose),
+    runInRetryScope: (retry, operation) =>
+      tenantStorage.run(
         {
-          $set: {
-            userId: String(scope.userId),
-            serverName: scope.serverName,
-            tenantId: tenantId ?? null,
-            version,
-            updatedAt: now,
-          },
-          $setOnInsert: { createdAt: now },
+          ...(typeof retry.tenantId === 'string' && retry.tenantId
+            ? { tenantId: retry.tenantId }
+            : {}),
+          userId: String(retry.userId),
         },
-        { upsert: true },
-      );
-    },
-    async deleteVersion({ scope, tenantId, version }) {
-      await collection().deleteOne({ _id: retryId(scope, tenantId), version });
-    },
-    async deferVersion({ scope, tenantId, version, updatedAt }) {
-      await collection().updateOne(
-        { _id: retryId(scope, tenantId), version },
-        { $set: { updatedAt } },
-      );
-    },
-    async list(limit) {
-      await ensureRetryIndex();
-      return runAsSystem(async () =>
-        collection().find({}).sort({ updatedAt: 1 }).limit(limit).toArray(),
-      );
-    },
-  },
-  runInRetryScope: (retry, operation) =>
-    tenantStorage.run(
-      {
-        ...(typeof retry.tenantId === 'string' && retry.tenantId
-          ? { tenantId: retry.tenantId }
-          : {}),
-        userId: String(retry.userId),
-      },
-      operation,
-    ),
-});
+        operation,
+      ),
+  });
+  return retryService;
+}
 
 module.exports = {
-  clearMCPAuthorizationFenceRetry: retryService.clear,
-  drainMCPAuthorizationFenceRetries: retryService.drain,
-  persistMCPAuthorizationFenceRetry: retryService.persist,
-  startMCPAuthorizationFenceRetryWorker: retryService.start,
+  clearMCPAuthorizationFenceRetry: (...args) => getRetryService().clear(...args),
+  drainMCPAuthorizationFenceRetries: (...args) => getRetryService().drain(...args),
+  persistMCPAuthorizationFenceRetry: (...args) => getRetryService().persist(...args),
+  startMCPAuthorizationFenceRetryWorker: (...args) => getRetryService().start(...args),
 };

--- a/api/server/services/MCPAuthorizationFenceRetry.js
+++ b/api/server/services/MCPAuthorizationFenceRetry.js
@@ -1,120 +1,60 @@
-const { randomUUID } = require('crypto');
 const mongoose = require('mongoose');
-const { logger, getTenantId, runAsSystem, tenantStorage } = require('@librechat/data-schemas');
-const { registerShutdownTask } = require('@librechat/api');
+const { getTenantId, runAsSystem, tenantStorage } = require('@librechat/data-schemas');
+const { createMCPAuthorizationFenceRetryService } = require('@librechat/api');
 
 const COLLECTION_NAME = 'mcp_authorization_fence_retries';
-const RETRY_INTERVAL_MS = 30_000;
-const RETRY_BATCH_SIZE = 100;
-
-let retryTimer;
-let drainPromise;
-let invalidateRecoveryGeneration;
 
 function collection() {
   return mongoose.connection.collection(COLLECTION_NAME);
 }
 
-function retryId({ userId, serverName }, tenantId = getTenantId()) {
+function retryId({ userId, serverName }, tenantId) {
   return JSON.stringify([tenantId ?? '', String(userId), serverName]);
 }
 
-/** Stores one latest-wins retry marker in MongoDB before a shared-cache fence is attempted. */
-async function persistMCPAuthorizationFenceRetry(scope) {
-  const tenantId = getTenantId();
-  const now = new Date();
-  await collection().updateOne(
-    { _id: retryId(scope, tenantId) },
-    {
-      $set: {
-        userId: String(scope.userId),
-        serverName: scope.serverName,
-        tenantId: tenantId ?? null,
-        version: randomUUID(),
-        updatedAt: now,
-      },
-      $setOnInsert: { createdAt: now },
-    },
-    { upsert: true },
-  );
-}
-
-async function clearMCPAuthorizationFenceRetry(scope) {
-  await collection().deleteOne({ _id: retryId(scope) });
-}
-
-async function listRetryBatch() {
-  return runAsSystem(async () =>
-    collection().find({}).sort({ updatedAt: 1 }).limit(RETRY_BATCH_SIZE).toArray(),
-  );
-}
-
-async function deleteProcessedRetry(retry) {
-  await runAsSystem(async () => collection().deleteOne({ _id: retry._id, version: retry.version }));
-}
-
-async function drainMCPAuthorizationFenceRetries() {
-  if (drainPromise != null || invalidateRecoveryGeneration == null) {
-    return drainPromise;
-  }
-  drainPromise = (async () => {
-    const retries = await listRetryBatch();
-    for (const retry of retries) {
-      try {
-        await tenantStorage.run(
-          {
-            ...(typeof retry.tenantId === 'string' && retry.tenantId
-              ? { tenantId: retry.tenantId }
-              : {}),
-            userId: String(retry.userId),
+const retryService = createMCPAuthorizationFenceRetryService({
+  getTenantId,
+  storage: {
+    async upsert({ scope, tenantId, version, now }) {
+      await collection().updateOne(
+        { _id: retryId(scope, tenantId) },
+        {
+          $set: {
+            userId: String(scope.userId),
+            serverName: scope.serverName,
+            tenantId: tenantId ?? null,
+            version,
+            updatedAt: now,
           },
-          async () =>
-            invalidateRecoveryGeneration({
-              userId: String(retry.userId),
-              serverName: retry.serverName,
-            }),
-        );
-        /** The version predicate preserves a newer mutation queued while this one published. */
-        await deleteProcessedRetry(retry);
-      } catch (error) {
-        logger.warn(
-          `[MCP authorization] Durable generation retry failed for ${retry.serverName}`,
-          error,
-        );
-      }
-    }
-  })().finally(() => {
-    drainPromise = undefined;
-  });
-  return drainPromise;
-}
-
-function scheduleMCPAuthorizationFenceRetryDrain() {
-  void drainMCPAuthorizationFenceRetries().catch((error) =>
-    logger.warn('[MCP authorization] Could not read durable generation retries', error),
-  );
-}
-
-function startMCPAuthorizationFenceRetryWorker(invalidator) {
-  invalidateRecoveryGeneration = invalidator;
-  if (retryTimer != null) {
-    return;
-  }
-  retryTimer = setInterval(() => {
-    scheduleMCPAuthorizationFenceRetryDrain();
-  }, RETRY_INTERVAL_MS);
-  retryTimer.unref?.();
-  registerShutdownTask('MCP authorization fence retry worker', async () => {
-    clearInterval(retryTimer);
-    retryTimer = undefined;
-    await drainPromise?.catch(() => undefined);
-  });
-  scheduleMCPAuthorizationFenceRetryDrain();
-}
+          $setOnInsert: { createdAt: now },
+        },
+        { upsert: true },
+      );
+    },
+    async deleteVersion({ scope, tenantId, version }) {
+      await collection().deleteOne({ _id: retryId(scope, tenantId), version });
+    },
+    async list(limit) {
+      return runAsSystem(async () =>
+        collection().find({}).sort({ updatedAt: 1 }).limit(limit).toArray(),
+      );
+    },
+  },
+  runInRetryScope: (retry, operation) =>
+    tenantStorage.run(
+      {
+        ...(typeof retry.tenantId === 'string' && retry.tenantId
+          ? { tenantId: retry.tenantId }
+          : {}),
+        userId: String(retry.userId),
+      },
+      operation,
+    ),
+});
 
 module.exports = {
-  clearMCPAuthorizationFenceRetry,
-  drainMCPAuthorizationFenceRetries,
-  persistMCPAuthorizationFenceRetry,
-  startMCPAuthorizationFenceRetryWorker,
+  clearMCPAuthorizationFenceRetry: retryService.clear,
+  drainMCPAuthorizationFenceRetries: retryService.drain,
+  persistMCPAuthorizationFenceRetry: retryService.persist,
+  startMCPAuthorizationFenceRetryWorker: retryService.start,
 };

--- a/api/server/services/MCPAuthorizationFenceRetry.js
+++ b/api/server/services/MCPAuthorizationFenceRetry.js
@@ -3,6 +3,7 @@ const { getTenantId, runAsSystem, tenantStorage } = require('@librechat/data-sch
 const { createMCPAuthorizationFenceRetryService } = require('@librechat/api');
 
 const COLLECTION_NAME = 'mcp_authorization_fence_retries';
+let retryIndexPromise;
 
 function collection() {
   return mongoose.connection.collection(COLLECTION_NAME);
@@ -10,6 +11,16 @@ function collection() {
 
 function retryId({ userId, serverName }, tenantId) {
   return JSON.stringify([tenantId ?? '', String(userId), serverName]);
+}
+
+function ensureRetryIndex() {
+  retryIndexPromise ??= collection()
+    .createIndex({ updatedAt: 1 })
+    .catch((error) => {
+      retryIndexPromise = undefined;
+      throw error;
+    });
+  return retryIndexPromise;
 }
 
 const retryService = createMCPAuthorizationFenceRetryService({
@@ -34,7 +45,14 @@ const retryService = createMCPAuthorizationFenceRetryService({
     async deleteVersion({ scope, tenantId, version }) {
       await collection().deleteOne({ _id: retryId(scope, tenantId), version });
     },
+    async deferVersion({ scope, tenantId, version, updatedAt }) {
+      await collection().updateOne(
+        { _id: retryId(scope, tenantId), version },
+        { $set: { updatedAt } },
+      );
+    },
     async list(limit) {
+      await ensureRetryIndex();
       return runAsSystem(async () =>
         collection().find({}).sort({ updatedAt: 1 }).limit(limit).toArray(),
       );

--- a/api/server/services/MCPAuthorizationFenceRetry.js
+++ b/api/server/services/MCPAuthorizationFenceRetry.js
@@ -1,0 +1,120 @@
+const { randomUUID } = require('crypto');
+const mongoose = require('mongoose');
+const { logger, getTenantId, runAsSystem, tenantStorage } = require('@librechat/data-schemas');
+const { registerShutdownTask } = require('@librechat/api');
+
+const COLLECTION_NAME = 'mcp_authorization_fence_retries';
+const RETRY_INTERVAL_MS = 30_000;
+const RETRY_BATCH_SIZE = 100;
+
+let retryTimer;
+let drainPromise;
+let invalidateRecoveryGeneration;
+
+function collection() {
+  return mongoose.connection.collection(COLLECTION_NAME);
+}
+
+function retryId({ userId, serverName }, tenantId = getTenantId()) {
+  return JSON.stringify([tenantId ?? '', String(userId), serverName]);
+}
+
+/** Stores one latest-wins retry marker in MongoDB before a shared-cache fence is attempted. */
+async function persistMCPAuthorizationFenceRetry(scope) {
+  const tenantId = getTenantId();
+  const now = new Date();
+  await collection().updateOne(
+    { _id: retryId(scope, tenantId) },
+    {
+      $set: {
+        userId: String(scope.userId),
+        serverName: scope.serverName,
+        tenantId: tenantId ?? null,
+        version: randomUUID(),
+        updatedAt: now,
+      },
+      $setOnInsert: { createdAt: now },
+    },
+    { upsert: true },
+  );
+}
+
+async function clearMCPAuthorizationFenceRetry(scope) {
+  await collection().deleteOne({ _id: retryId(scope) });
+}
+
+async function listRetryBatch() {
+  return runAsSystem(async () =>
+    collection().find({}).sort({ updatedAt: 1 }).limit(RETRY_BATCH_SIZE).toArray(),
+  );
+}
+
+async function deleteProcessedRetry(retry) {
+  await runAsSystem(async () => collection().deleteOne({ _id: retry._id, version: retry.version }));
+}
+
+async function drainMCPAuthorizationFenceRetries() {
+  if (drainPromise != null || invalidateRecoveryGeneration == null) {
+    return drainPromise;
+  }
+  drainPromise = (async () => {
+    const retries = await listRetryBatch();
+    for (const retry of retries) {
+      try {
+        await tenantStorage.run(
+          {
+            ...(typeof retry.tenantId === 'string' && retry.tenantId
+              ? { tenantId: retry.tenantId }
+              : {}),
+            userId: String(retry.userId),
+          },
+          async () =>
+            invalidateRecoveryGeneration({
+              userId: String(retry.userId),
+              serverName: retry.serverName,
+            }),
+        );
+        /** The version predicate preserves a newer mutation queued while this one published. */
+        await deleteProcessedRetry(retry);
+      } catch (error) {
+        logger.warn(
+          `[MCP authorization] Durable generation retry failed for ${retry.serverName}`,
+          error,
+        );
+      }
+    }
+  })().finally(() => {
+    drainPromise = undefined;
+  });
+  return drainPromise;
+}
+
+function scheduleMCPAuthorizationFenceRetryDrain() {
+  void drainMCPAuthorizationFenceRetries().catch((error) =>
+    logger.warn('[MCP authorization] Could not read durable generation retries', error),
+  );
+}
+
+function startMCPAuthorizationFenceRetryWorker(invalidator) {
+  invalidateRecoveryGeneration = invalidator;
+  if (retryTimer != null) {
+    return;
+  }
+  retryTimer = setInterval(() => {
+    scheduleMCPAuthorizationFenceRetryDrain();
+  }, RETRY_INTERVAL_MS);
+  retryTimer.unref?.();
+  registerShutdownTask('MCP authorization fence retry worker', async () => {
+    clearInterval(retryTimer);
+    retryTimer = undefined;
+    await drainPromise?.catch(() => undefined);
+  });
+  scheduleMCPAuthorizationFenceRetryDrain();
+}
+
+module.exports = {
+  clearMCPAuthorizationFenceRetry,
+  drainMCPAuthorizationFenceRetries,
+  persistMCPAuthorizationFenceRetry,
+  startMCPAuthorizationFenceRetryWorker,
+};

--- a/api/server/services/MCPAuthorizationFenceRetry.spec.js
+++ b/api/server/services/MCPAuthorizationFenceRetry.spec.js
@@ -4,10 +4,12 @@ const mockToArray = jest.fn();
 const mockLimit = jest.fn(() => ({ toArray: mockToArray }));
 const mockSort = jest.fn(() => ({ limit: mockLimit }));
 const mockFind = jest.fn(() => ({ sort: mockSort }));
+const mockCreateIndex = jest.fn();
 const mockCollection = {
   updateOne: mockUpdateOne,
   deleteOne: mockDeleteOne,
   find: mockFind,
+  createIndex: mockCreateIndex,
 };
 const mockGetTenantId = jest.fn();
 const mockTenantRun = jest.fn((_context, fn) => fn());
@@ -43,6 +45,7 @@ describe('MCPAuthorizationFenceRetry adapter', () => {
     mockUpdateOne.mockResolvedValue({ acknowledged: true });
     mockDeleteOne.mockResolvedValue({ deletedCount: 1 });
     mockToArray.mockResolvedValue([]);
+    mockCreateIndex.mockResolvedValue('updatedAt_1');
   });
 
   it('exports the package-owned retry lifecycle', () => {
@@ -64,6 +67,13 @@ describe('MCPAuthorizationFenceRetry adapter', () => {
       tenantId: 'tenant-a',
       version: 'v1',
     });
+    const deferredAt = new Date(now.getTime() + 1);
+    await capturedDeps.storage.deferVersion({
+      scope,
+      tenantId: 'tenant-a',
+      version: 'v2',
+      updatedAt: deferredAt,
+    });
 
     expect(mockUpdateOne).toHaveBeenCalledWith(
       { _id: JSON.stringify(['tenant-a', 'user-1', 'github']) },
@@ -83,6 +93,10 @@ describe('MCPAuthorizationFenceRetry adapter', () => {
       _id: JSON.stringify(['tenant-a', 'user-1', 'github']),
       version: 'v1',
     });
+    expect(mockUpdateOne).toHaveBeenLastCalledWith(
+      { _id: JSON.stringify(['tenant-a', 'user-1', 'github']), version: 'v2' },
+      { $set: { updatedAt: deferredAt } },
+    );
   });
 
   it('reads retry batches globally and restores tenant context for replay', async () => {
@@ -99,6 +113,7 @@ describe('MCPAuthorizationFenceRetry adapter', () => {
     await capturedDeps.runInRetryScope(retry, operation);
 
     expect(mockRunAsSystem).toHaveBeenCalledWith(expect.any(Function));
+    expect(mockCreateIndex).toHaveBeenCalledWith({ updatedAt: 1 });
     expect(mockLimit).toHaveBeenCalledWith(7);
     expect(mockTenantRun).toHaveBeenCalledWith(
       { tenantId: 'tenant-a', userId: 'user-1' },

--- a/api/server/services/MCPAuthorizationFenceRetry.spec.js
+++ b/api/server/services/MCPAuthorizationFenceRetry.spec.js
@@ -1,19 +1,11 @@
-const mockUpdateOne = jest.fn();
-const mockDeleteOne = jest.fn();
-const mockToArray = jest.fn();
-const mockLimit = jest.fn(() => ({ toArray: mockToArray }));
-const mockSort = jest.fn(() => ({ limit: mockLimit }));
-const mockFind = jest.fn(() => ({ sort: mockSort }));
-const mockCreateIndex = jest.fn();
-const mockCollection = {
-  updateOne: mockUpdateOne,
-  deleteOne: mockDeleteOne,
-  find: mockFind,
-  createIndex: mockCreateIndex,
+const mockStorage = {
+  upsert: jest.fn(),
+  deleteVersion: jest.fn(),
+  deferVersion: jest.fn(),
+  list: jest.fn(),
 };
 const mockGetTenantId = jest.fn();
 const mockTenantRun = jest.fn((_context, fn) => fn());
-const mockRunAsSystem = jest.fn((fn) => fn());
 const mockRetryService = {
   clear: jest.fn(),
   drain: jest.fn(),
@@ -22,12 +14,10 @@ const mockRetryService = {
 };
 let capturedDeps;
 
-jest.mock('mongoose', () => ({
-  connection: { collection: jest.fn(() => mockCollection) },
-}));
+jest.mock('mongoose', () => ({}));
 jest.mock('@librechat/data-schemas', () => ({
+  createMCPAuthorizationFenceRetryStorage: jest.fn(() => mockStorage),
   getTenantId: (...args) => mockGetTenantId(...args),
-  runAsSystem: (...args) => mockRunAsSystem(...args),
   tenantStorage: { run: (...args) => mockTenantRun(...args) },
 }));
 jest.mock('@librechat/api', () => ({
@@ -42,79 +32,29 @@ const retryAdapter = require('./MCPAuthorizationFenceRetry');
 describe('MCPAuthorizationFenceRetry adapter', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUpdateOne.mockResolvedValue({ acknowledged: true });
-    mockDeleteOne.mockResolvedValue({ deletedCount: 1 });
-    mockToArray.mockResolvedValue([]);
-    mockCreateIndex.mockResolvedValue('updatedAt_1');
   });
 
   it('exports the package-owned retry lifecycle', () => {
-    expect(retryAdapter).toEqual({
-      clearMCPAuthorizationFenceRetry: mockRetryService.clear,
-      drainMCPAuthorizationFenceRetries: mockRetryService.drain,
-      persistMCPAuthorizationFenceRetry: mockRetryService.persist,
-      startMCPAuthorizationFenceRetryWorker: mockRetryService.start,
-    });
+    expect(Object.keys(retryAdapter).sort()).toEqual([
+      'clearMCPAuthorizationFenceRetry',
+      'drainMCPAuthorizationFenceRetries',
+      'persistMCPAuthorizationFenceRetry',
+      'startMCPAuthorizationFenceRetryWorker',
+    ]);
   });
 
-  it('maps versioned retry storage to MongoDB', async () => {
-    const now = new Date();
-    const scope = { userId: 'user-1', serverName: 'github' };
-
-    await capturedDeps.storage.upsert({ scope, tenantId: 'tenant-a', version: 'v2', now });
-    await capturedDeps.storage.deleteVersion({
-      scope,
-      tenantId: 'tenant-a',
-      version: 'v1',
-    });
-    const deferredAt = new Date(now.getTime() + 1);
-    await capturedDeps.storage.deferVersion({
-      scope,
-      tenantId: 'tenant-a',
-      version: 'v2',
-      updatedAt: deferredAt,
-    });
-
-    expect(mockUpdateOne).toHaveBeenCalledWith(
-      { _id: JSON.stringify(['tenant-a', 'user-1', 'github']) },
-      {
-        $set: {
-          userId: 'user-1',
-          serverName: 'github',
-          tenantId: 'tenant-a',
-          version: 'v2',
-          updatedAt: now,
-        },
-        $setOnInsert: { createdAt: now },
-      },
-      { upsert: true },
-    );
-    expect(mockDeleteOne).toHaveBeenCalledWith({
-      _id: JSON.stringify(['tenant-a', 'user-1', 'github']),
-      version: 'v1',
-    });
-    expect(mockUpdateOne).toHaveBeenLastCalledWith(
-      { _id: JSON.stringify(['tenant-a', 'user-1', 'github']), version: 'v2' },
-      { $set: { updatedAt: deferredAt } },
-    );
-  });
-
-  it('reads retry batches globally and restores tenant context for replay', async () => {
+  it('restores tenant context for replay', async () => {
     const retry = {
       tenantId: 'tenant-a',
       userId: 'user-1',
       serverName: 'github',
       version: 'v1',
     };
-    mockToArray.mockResolvedValue([retry]);
-
-    await expect(capturedDeps.storage.list(7)).resolves.toEqual([retry]);
+    retryAdapter.startMCPAuthorizationFenceRetryWorker();
+    expect(capturedDeps.storage).toBe(mockStorage);
     const operation = jest.fn().mockResolvedValue(undefined);
     await capturedDeps.runInRetryScope(retry, operation);
 
-    expect(mockRunAsSystem).toHaveBeenCalledWith(expect.any(Function));
-    expect(mockCreateIndex).toHaveBeenCalledWith({ updatedAt: 1 });
-    expect(mockLimit).toHaveBeenCalledWith(7);
     expect(mockTenantRun).toHaveBeenCalledWith(
       { tenantId: 'tenant-a', userId: 'user-1' },
       operation,

--- a/api/server/services/MCPAuthorizationFenceRetry.spec.js
+++ b/api/server/services/MCPAuthorizationFenceRetry.spec.js
@@ -11,79 +11,98 @@ const mockCollection = {
 };
 const mockGetTenantId = jest.fn();
 const mockTenantRun = jest.fn((_context, fn) => fn());
-const mockRegisterShutdownTask = jest.fn();
+const mockRunAsSystem = jest.fn((fn) => fn());
+const mockRetryService = {
+  clear: jest.fn(),
+  drain: jest.fn(),
+  persist: jest.fn(),
+  start: jest.fn(),
+};
+let capturedDeps;
 
 jest.mock('mongoose', () => ({
   connection: { collection: jest.fn(() => mockCollection) },
 }));
 jest.mock('@librechat/data-schemas', () => ({
-  logger: { warn: jest.fn() },
   getTenantId: (...args) => mockGetTenantId(...args),
-  runAsSystem: (fn) => fn(),
+  runAsSystem: (...args) => mockRunAsSystem(...args),
   tenantStorage: { run: (...args) => mockTenantRun(...args) },
 }));
 jest.mock('@librechat/api', () => ({
-  registerShutdownTask: (...args) => mockRegisterShutdownTask(...args),
+  createMCPAuthorizationFenceRetryService: (deps) => {
+    capturedDeps = deps;
+    return mockRetryService;
+  },
 }));
 
-const {
-  drainMCPAuthorizationFenceRetries,
-  persistMCPAuthorizationFenceRetry,
-  startMCPAuthorizationFenceRetryWorker,
-} = require('./MCPAuthorizationFenceRetry');
+const retryAdapter = require('./MCPAuthorizationFenceRetry');
 
-describe('MCPAuthorizationFenceRetry', () => {
-  beforeAll(() => jest.useFakeTimers());
-  afterAll(() => jest.useRealTimers());
-
+describe('MCPAuthorizationFenceRetry adapter', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUpdateOne.mockResolvedValue({ acknowledged: true });
     mockDeleteOne.mockResolvedValue({ deletedCount: 1 });
     mockToArray.mockResolvedValue([]);
-    mockGetTenantId.mockReturnValue('tenant-a');
   });
 
-  it('persists latest-wins retry intent in MongoDB', async () => {
-    await persistMCPAuthorizationFenceRetry({ userId: 'user-1', serverName: 'github' });
+  it('exports the package-owned retry lifecycle', () => {
+    expect(retryAdapter).toEqual({
+      clearMCPAuthorizationFenceRetry: mockRetryService.clear,
+      drainMCPAuthorizationFenceRetries: mockRetryService.drain,
+      persistMCPAuthorizationFenceRetry: mockRetryService.persist,
+      startMCPAuthorizationFenceRetryWorker: mockRetryService.start,
+    });
+  });
+
+  it('maps versioned retry storage to MongoDB', async () => {
+    const now = new Date();
+    const scope = { userId: 'user-1', serverName: 'github' };
+
+    await capturedDeps.storage.upsert({ scope, tenantId: 'tenant-a', version: 'v2', now });
+    await capturedDeps.storage.deleteVersion({
+      scope,
+      tenantId: 'tenant-a',
+      version: 'v1',
+    });
 
     expect(mockUpdateOne).toHaveBeenCalledWith(
       { _id: JSON.stringify(['tenant-a', 'user-1', 'github']) },
-      expect.objectContaining({
-        $set: expect.objectContaining({
+      {
+        $set: {
           userId: 'user-1',
           serverName: 'github',
           tenantId: 'tenant-a',
-          version: expect.any(String),
-        }),
-      }),
+          version: 'v2',
+          updatedAt: now,
+        },
+        $setOnInsert: { createdAt: now },
+      },
       { upsert: true },
     );
+    expect(mockDeleteOne).toHaveBeenCalledWith({
+      _id: JSON.stringify(['tenant-a', 'user-1', 'github']),
+      version: 'v1',
+    });
   });
 
-  it('replays persisted fences in their tenant and deletes only the published version', async () => {
+  it('reads retry batches globally and restores tenant context for replay', async () => {
     const retry = {
-      _id: 'retry-1',
-      version: 'version-1',
       tenantId: 'tenant-a',
       userId: 'user-1',
       serverName: 'github',
+      version: 'v1',
     };
     mockToArray.mockResolvedValue([retry]);
-    const invalidate = jest.fn().mockResolvedValue(undefined);
 
-    startMCPAuthorizationFenceRetryWorker(invalidate);
-    await drainMCPAuthorizationFenceRetries();
+    await expect(capturedDeps.storage.list(7)).resolves.toEqual([retry]);
+    const operation = jest.fn().mockResolvedValue(undefined);
+    await capturedDeps.runInRetryScope(retry, operation);
 
+    expect(mockRunAsSystem).toHaveBeenCalledWith(expect.any(Function));
+    expect(mockLimit).toHaveBeenCalledWith(7);
     expect(mockTenantRun).toHaveBeenCalledWith(
       { tenantId: 'tenant-a', userId: 'user-1' },
-      expect.any(Function),
-    );
-    expect(invalidate).toHaveBeenCalledWith({ userId: 'user-1', serverName: 'github' });
-    expect(mockDeleteOne).toHaveBeenCalledWith({ _id: 'retry-1', version: 'version-1' });
-    expect(mockRegisterShutdownTask).toHaveBeenCalledWith(
-      'MCP authorization fence retry worker',
-      expect.any(Function),
+      operation,
     );
   });
 });

--- a/api/server/services/MCPAuthorizationFenceRetry.spec.js
+++ b/api/server/services/MCPAuthorizationFenceRetry.spec.js
@@ -1,0 +1,89 @@
+const mockUpdateOne = jest.fn();
+const mockDeleteOne = jest.fn();
+const mockToArray = jest.fn();
+const mockLimit = jest.fn(() => ({ toArray: mockToArray }));
+const mockSort = jest.fn(() => ({ limit: mockLimit }));
+const mockFind = jest.fn(() => ({ sort: mockSort }));
+const mockCollection = {
+  updateOne: mockUpdateOne,
+  deleteOne: mockDeleteOne,
+  find: mockFind,
+};
+const mockGetTenantId = jest.fn();
+const mockTenantRun = jest.fn((_context, fn) => fn());
+const mockRegisterShutdownTask = jest.fn();
+
+jest.mock('mongoose', () => ({
+  connection: { collection: jest.fn(() => mockCollection) },
+}));
+jest.mock('@librechat/data-schemas', () => ({
+  logger: { warn: jest.fn() },
+  getTenantId: (...args) => mockGetTenantId(...args),
+  runAsSystem: (fn) => fn(),
+  tenantStorage: { run: (...args) => mockTenantRun(...args) },
+}));
+jest.mock('@librechat/api', () => ({
+  registerShutdownTask: (...args) => mockRegisterShutdownTask(...args),
+}));
+
+const {
+  drainMCPAuthorizationFenceRetries,
+  persistMCPAuthorizationFenceRetry,
+  startMCPAuthorizationFenceRetryWorker,
+} = require('./MCPAuthorizationFenceRetry');
+
+describe('MCPAuthorizationFenceRetry', () => {
+  beforeAll(() => jest.useFakeTimers());
+  afterAll(() => jest.useRealTimers());
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUpdateOne.mockResolvedValue({ acknowledged: true });
+    mockDeleteOne.mockResolvedValue({ deletedCount: 1 });
+    mockToArray.mockResolvedValue([]);
+    mockGetTenantId.mockReturnValue('tenant-a');
+  });
+
+  it('persists latest-wins retry intent in MongoDB', async () => {
+    await persistMCPAuthorizationFenceRetry({ userId: 'user-1', serverName: 'github' });
+
+    expect(mockUpdateOne).toHaveBeenCalledWith(
+      { _id: JSON.stringify(['tenant-a', 'user-1', 'github']) },
+      expect.objectContaining({
+        $set: expect.objectContaining({
+          userId: 'user-1',
+          serverName: 'github',
+          tenantId: 'tenant-a',
+          version: expect.any(String),
+        }),
+      }),
+      { upsert: true },
+    );
+  });
+
+  it('replays persisted fences in their tenant and deletes only the published version', async () => {
+    const retry = {
+      _id: 'retry-1',
+      version: 'version-1',
+      tenantId: 'tenant-a',
+      userId: 'user-1',
+      serverName: 'github',
+    };
+    mockToArray.mockResolvedValue([retry]);
+    const invalidate = jest.fn().mockResolvedValue(undefined);
+
+    startMCPAuthorizationFenceRetryWorker(invalidate);
+    await drainMCPAuthorizationFenceRetries();
+
+    expect(mockTenantRun).toHaveBeenCalledWith(
+      { tenantId: 'tenant-a', userId: 'user-1' },
+      expect.any(Function),
+    );
+    expect(invalidate).toHaveBeenCalledWith({ userId: 'user-1', serverName: 'github' });
+    expect(mockDeleteOne).toHaveBeenCalledWith({ _id: 'retry-1', version: 'version-1' });
+    expect(mockRegisterShutdownTask).toHaveBeenCalledWith(
+      'MCP authorization fence retry worker',
+      expect.any(Function),
+    );
+  });
+});

--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -1183,6 +1183,7 @@ async function loadToolDefinitionsWrapper({
       requestScopedConnections,
       upstreamTokenProvider,
       oboIdentityContext,
+      recoveryPolicy: appConfig?.mcpSettings?.catalogRecovery,
     });
 
     rememberMCPAvailableTools(serverName, result?.availableTools);
@@ -1212,6 +1213,7 @@ async function loadToolDefinitionsWrapper({
       requestScopedConnections,
       upstreamTokenProvider,
       oboIdentityContext,
+      recoveryPolicy: appConfig?.mcpSettings?.catalogRecovery,
     });
 
     rememberMCPAvailableTools(serverName, result?.availableTools);
@@ -1362,6 +1364,7 @@ async function loadToolDefinitionsWrapper({
           connectionTimeout: Time.TWO_MINUTES,
           upstreamTokenProvider,
           oboIdentityContext,
+          recoveryPolicy: appConfig?.mcpSettings?.catalogRecovery,
         });
 
         if (result?.availableTools && Object.keys(result.availableTools).length > 0) {

--- a/api/server/services/Tools/mcp.js
+++ b/api/server/services/Tools/mcp.js
@@ -4,7 +4,6 @@ const {
   getUserMCPAuthMap,
   getMissingCustomUserVars,
   loadMCPServerCatalogs: loadCatalogs,
-  clearMCPServerCatalogRecoveryState,
   requiresEphemeralUserConnection,
   getMissingRuntimeBodyPlaceholderFields,
   MCPAuthenticationRejectedError,
@@ -50,6 +49,7 @@ const isMCPReauthenticationError = (error) =>
  * @param {import('@librechat/api').UpstreamTokenProvider} [params.upstreamTokenProvider] - Live upstream-token closure for OBO discovery, built at the request boundary so this layer never receives the raw Express request.
  * @param {import('@librechat/api').AuthIdentityContext} [params.oboIdentityContext] - Non-template-visible OBO identity context built from the real request user.
  * @param {AbortSignal} [params.signal] - Cancels queued and in-flight catalog reads when the request ends.
+ * @param {import('@librechat/api').MCPServerCatalogRecoveryPolicy} [params.recoveryPolicy]
  */
 async function loadMCPServerCatalogs({
   user,
@@ -57,12 +57,13 @@ async function loadMCPServerCatalogs({
   upstreamTokenProvider,
   oboIdentityContext,
   signal,
+  recoveryPolicy,
 }) {
   const flowManager = getFlowStateManager(getLogStores(CacheKeys.FLOWS));
   const tokenMethods = { findToken, updateToken, createToken, deleteTokens };
   const mcpManager = getMCPManager();
   return loadCatalogs(
-    { user, servers, signal },
+    { user, servers, signal, ...(recoveryPolicy && { recoveryPolicy }) },
     {
       loadUserMCPAuthMap: (userId, serverNames) =>
         getUserMCPAuthMap({
@@ -82,6 +83,7 @@ async function loadMCPServerCatalogs({
           oboIdentityContext,
         }),
       formatServerTools: formatMCPServerTools,
+      recoveryTracker: mcpManager.getCatalogRecoveryTracker?.(),
       getCachedServerTools: getMCPServerTools,
       getServerToolFunctionsSnapshot: (userId, serverName, serverConfig, options) =>
         mcpManager.getServerToolFunctionsSnapshot(userId, serverName, serverConfig, options),
@@ -128,7 +130,6 @@ async function reinitMCPServer({
   oboIdentityContext,
   oauthEnd,
 }) {
-  clearMCPServerCatalogRecoveryState(user.id, serverName);
   /** @type {MCPConnection | null} */
   let connection = null;
   let serverConfig = providedConfig;

--- a/api/server/services/Tools/mcp.js
+++ b/api/server/services/Tools/mcp.js
@@ -63,7 +63,7 @@ async function loadMCPServerCatalogs({
   const tokenMethods = { findToken, updateToken, createToken, deleteTokens };
   const mcpManager = getMCPManager();
   return loadCatalogs(
-    { user, servers, signal, ...(recoveryPolicy && { recoveryPolicy }) },
+    { user, servers, signal, recoveryPolicy },
     {
       loadUserMCPAuthMap: (userId, serverNames) =>
         getUserMCPAuthMap({

--- a/api/server/services/Tools/mcp.js
+++ b/api/server/services/Tools/mcp.js
@@ -70,6 +70,7 @@ async function loadMCPServerCatalogs({
       clearLocalRecovery: (userId, serverName) =>
         mcpManager.clearCatalogRecoveryState?.(userId, serverName),
       retryDelaysMs: recoveryPolicy?.authorizationFenceRetryMs,
+      attemptTimeoutMs: recoveryPolicy?.authorizationFenceTimeoutMs,
     });
   return loadCatalogs(
     { user, servers, signal, recoveryPolicy },
@@ -254,6 +255,7 @@ async function reinitMCPServer({
         clearLocalRecovery: (userId, changedServerName) =>
           mcpManager.clearCatalogRecoveryState?.(userId, changedServerName),
         retryDelaysMs: recoveryPolicy?.authorizationFenceRetryMs,
+        attemptTimeoutMs: recoveryPolicy?.authorizationFenceTimeoutMs,
       });
     const tokenMethods = { findToken, updateToken, createToken, deleteTokens };
 

--- a/api/server/services/Tools/mcp.js
+++ b/api/server/services/Tools/mcp.js
@@ -69,6 +69,7 @@ async function loadMCPServerCatalogs({
       invalidateRecoveryGeneration: invalidateCachedTools,
       clearLocalRecovery: (userId, serverName) =>
         mcpManager.clearCatalogRecoveryState?.(userId, serverName),
+      retryDelaysMs: recoveryPolicy?.authorizationFenceRetryMs,
     });
   return loadCatalogs(
     { user, servers, signal, recoveryPolicy },
@@ -121,6 +122,7 @@ async function loadMCPServerCatalogs({
  * @param {import('@librechat/api').RequestBody} [params.requestBody]
  * @param {import('@librechat/api').RequestScopedMCPConnectionStore} [params.requestScopedConnections]
  * @param {Record<string, Record<string, string>>} [params.userMCPAuthMap]
+ * @param {import('@librechat/api').MCPServerCatalogRecoveryPolicy} [params.recoveryPolicy]
  */
 async function reinitMCPServer({
   user,
@@ -139,6 +141,7 @@ async function reinitMCPServer({
   upstreamTokenProvider,
   oboIdentityContext,
   oauthEnd,
+  recoveryPolicy,
 }) {
   /** @type {MCPConnection | null} */
   let connection = null;
@@ -250,6 +253,7 @@ async function reinitMCPServer({
         invalidateRecoveryGeneration: invalidateCachedTools,
         clearLocalRecovery: (userId, changedServerName) =>
           mcpManager.clearCatalogRecoveryState?.(userId, changedServerName),
+        retryDelaysMs: recoveryPolicy?.authorizationFenceRetryMs,
       });
     const tokenMethods = { findToken, updateToken, createToken, deleteTokens };
 

--- a/api/server/services/Tools/mcp.js
+++ b/api/server/services/Tools/mcp.js
@@ -4,6 +4,7 @@ const {
   getUserMCPAuthMap,
   getMissingCustomUserVars,
   loadMCPServerCatalogs: loadCatalogs,
+  clearMCPServerCatalogRecoveryState,
   requiresEphemeralUserConnection,
   getMissingRuntimeBodyPlaceholderFields,
   MCPAuthenticationRejectedError,
@@ -127,6 +128,7 @@ async function reinitMCPServer({
   oboIdentityContext,
   oauthEnd,
 }) {
+  clearMCPServerCatalogRecoveryState(user.id, serverName);
   /** @type {MCPConnection | null} */
   let connection = null;
   let serverConfig = providedConfig;

--- a/api/server/services/Tools/mcp.js
+++ b/api/server/services/Tools/mcp.js
@@ -9,7 +9,7 @@ const {
   MCPAuthenticationRejectedError,
   MCPAuthenticationRefreshError,
   OpenIDReauthRequiredError,
-  publishMCPAuthorizationMutation,
+  prepareMCPAuthorizationMutation,
 } = require('@librechat/api');
 const { CacheKeys, Constants } = require('librechat-data-provider');
 const { getMCPManager, getMCPServersRegistry, getFlowStateManager } = require('~/config');
@@ -68,8 +68,8 @@ async function loadMCPServerCatalogs({
   const flowManager = getFlowStateManager(getLogStores(CacheKeys.FLOWS));
   const tokenMethods = { findToken, updateToken, createToken, deleteTokens };
   const mcpManager = getMCPManager();
-  const onOAuthCredentialsChanged = (scope) =>
-    publishMCPAuthorizationMutation(scope, {
+  const onOAuthCredentialsChanging = (scope) =>
+    prepareMCPAuthorizationMutation(scope, {
       invalidateRecoveryGeneration: invalidateCachedTools,
       persistPublicationRetry: persistMCPAuthorizationFenceRetry,
       clearPublicationRetry: clearMCPAuthorizationFenceRetry,
@@ -97,7 +97,7 @@ async function loadMCPServerCatalogs({
           oboTrustChecker: createOboTrustChecker(),
           upstreamTokenProvider,
           oboIdentityContext,
-          onOAuthCredentialsChanged,
+          onOAuthCredentialsChanging,
         }),
       formatServerTools: formatMCPServerTools,
       recoveryTracker: mcpManager.getCatalogRecoveryTracker?.(),
@@ -255,8 +255,8 @@ async function reinitMCPServer({
 
     const flowManager = _flowManager ?? getFlowStateManager(getLogStores(CacheKeys.FLOWS));
     const mcpManager = getMCPManager();
-    const onOAuthCredentialsChanged = (scope) =>
-      publishMCPAuthorizationMutation(scope, {
+    const onOAuthCredentialsChanging = (scope) =>
+      prepareMCPAuthorizationMutation(scope, {
         invalidateRecoveryGeneration: invalidateCachedTools,
         persistPublicationRetry: persistMCPAuthorizationFenceRetry,
         clearPublicationRetry: clearMCPAuthorizationFenceRetry,
@@ -297,7 +297,7 @@ async function reinitMCPServer({
         serverName,
         flowManager,
         tokenMethods,
-        onOAuthCredentialsChanged,
+        onOAuthCredentialsChanging,
         returnOnOAuth,
         oauthEnd,
         customUserVars,
@@ -340,7 +340,7 @@ async function reinitMCPServer({
             serverName,
             flowManager,
             tokenMethods,
-            onOAuthCredentialsChanged,
+            onOAuthCredentialsChanging,
             oauthStart,
             customUserVars,
             requestBody,

--- a/api/server/services/Tools/mcp.js
+++ b/api/server/services/Tools/mcp.js
@@ -9,6 +9,7 @@ const {
   MCPAuthenticationRejectedError,
   MCPAuthenticationRefreshError,
   OpenIDReauthRequiredError,
+  publishMCPAuthorizationMutation,
 } = require('@librechat/api');
 const { CacheKeys, Constants } = require('librechat-data-provider');
 const { getMCPManager, getMCPServersRegistry, getFlowStateManager } = require('~/config');
@@ -27,6 +28,7 @@ const {
   cacheMCPServerTools,
   getMCPToolsCacheGeneration,
   updateMCPServerTools,
+  invalidateCachedTools,
 } = require('~/server/services/Config');
 const { getLogStores } = require('~/cache');
 
@@ -62,6 +64,12 @@ async function loadMCPServerCatalogs({
   const flowManager = getFlowStateManager(getLogStores(CacheKeys.FLOWS));
   const tokenMethods = { findToken, updateToken, createToken, deleteTokens };
   const mcpManager = getMCPManager();
+  const onOAuthCredentialsChanged = (scope) =>
+    publishMCPAuthorizationMutation(scope, {
+      invalidateRecoveryGeneration: invalidateCachedTools,
+      clearLocalRecovery: (userId, serverName) =>
+        mcpManager.clearCatalogRecoveryState?.(userId, serverName),
+    });
   return loadCatalogs(
     { user, servers, signal, recoveryPolicy },
     {
@@ -81,9 +89,11 @@ async function loadMCPServerCatalogs({
           oboTrustChecker: createOboTrustChecker(),
           upstreamTokenProvider,
           oboIdentityContext,
+          onOAuthCredentialsChanged,
         }),
       formatServerTools: formatMCPServerTools,
       recoveryTracker: mcpManager.getCatalogRecoveryTracker?.(),
+      getRecoveryGeneration: getMCPToolsCacheGeneration,
       getCachedServerTools: getMCPServerTools,
       getServerToolFunctionsSnapshot: (userId, serverName, serverConfig, options) =>
         mcpManager.getServerToolFunctionsSnapshot(userId, serverName, serverConfig, options),
@@ -235,6 +245,12 @@ async function reinitMCPServer({
 
     const flowManager = _flowManager ?? getFlowStateManager(getLogStores(CacheKeys.FLOWS));
     const mcpManager = getMCPManager();
+    const onOAuthCredentialsChanged = (scope) =>
+      publishMCPAuthorizationMutation(scope, {
+        invalidateRecoveryGeneration: invalidateCachedTools,
+        clearLocalRecovery: (userId, changedServerName) =>
+          mcpManager.clearCatalogRecoveryState?.(userId, changedServerName),
+      });
     const tokenMethods = { findToken, updateToken, createToken, deleteTokens };
 
     if (!ephemeralServer) {
@@ -267,6 +283,7 @@ async function reinitMCPServer({
         serverName,
         flowManager,
         tokenMethods,
+        onOAuthCredentialsChanged,
         returnOnOAuth,
         oauthEnd,
         customUserVars,
@@ -309,6 +326,7 @@ async function reinitMCPServer({
             serverName,
             flowManager,
             tokenMethods,
+            onOAuthCredentialsChanged,
             oauthStart,
             customUserVars,
             requestBody,

--- a/api/server/services/Tools/mcp.js
+++ b/api/server/services/Tools/mcp.js
@@ -31,6 +31,10 @@ const {
   invalidateCachedTools,
 } = require('~/server/services/Config');
 const { getLogStores } = require('~/cache');
+const {
+  clearMCPAuthorizationFenceRetry,
+  persistMCPAuthorizationFenceRetry,
+} = require('~/server/services/MCPAuthorizationFenceRetry');
 
 const MCP_REINITIALIZE_FAILURE_REASONS = {
   UNREACHABLE: 'unreachable',
@@ -67,6 +71,8 @@ async function loadMCPServerCatalogs({
   const onOAuthCredentialsChanged = (scope) =>
     publishMCPAuthorizationMutation(scope, {
       invalidateRecoveryGeneration: invalidateCachedTools,
+      persistPublicationRetry: persistMCPAuthorizationFenceRetry,
+      clearPublicationRetry: clearMCPAuthorizationFenceRetry,
       clearLocalRecovery: (userId, serverName) =>
         mcpManager.clearCatalogRecoveryState?.(userId, serverName),
       retryDelaysMs: recoveryPolicy?.authorizationFenceRetryMs,
@@ -252,6 +258,8 @@ async function reinitMCPServer({
     const onOAuthCredentialsChanged = (scope) =>
       publishMCPAuthorizationMutation(scope, {
         invalidateRecoveryGeneration: invalidateCachedTools,
+        persistPublicationRetry: persistMCPAuthorizationFenceRetry,
+        clearPublicationRetry: clearMCPAuthorizationFenceRetry,
         clearLocalRecovery: (userId, changedServerName) =>
           mcpManager.clearCatalogRecoveryState?.(userId, changedServerName),
         retryDelaysMs: recoveryPolicy?.authorizationFenceRetryMs,

--- a/api/server/services/Tools/mcp.spec.js
+++ b/api/server/services/Tools/mcp.spec.js
@@ -88,6 +88,7 @@ describe('loadMCPServerCatalogs', () => {
       await deps.getServerToolFunctionsSnapshot(user.id, 'config-only', servers[0].serverConfig, {
         deadlineMs: 123,
       });
+      await deps.getRecoveryGeneration({ userId: user.id, serverName: 'config-only' });
       await deps.cacheServerTools({ serverName: 'config-only' });
       return { serverTools: new Map([['config-only', {}]]), serversWithoutTools: [] };
     });
@@ -102,6 +103,10 @@ describe('loadMCPServerCatalogs', () => {
     });
 
     expect(mockGetUserMCPAuthMap).toHaveBeenCalledTimes(1);
+    expect(mockGetMCPToolsCacheGeneration).toHaveBeenCalledWith({
+      userId: user.id,
+      serverName: 'config-only',
+    });
     expect(mockGetUserMCPAuthMap).toHaveBeenCalledWith({
       userId: user.id,
       servers: ['config-only', 'user-server'],

--- a/api/server/services/__tests__/MCP.spec.js
+++ b/api/server/services/__tests__/MCP.spec.js
@@ -751,4 +751,32 @@ describe('createMCPTool', () => {
     expect(toolInstance.name).toBe(canonicalToolKey);
     expect(reinitMCPServer).not.toHaveBeenCalled();
   });
+
+  it('forwards the configured recovery policy when a missing tool reconnects', async () => {
+    const recoveryPolicy = {
+      authorizationFenceRetryMs: [0, 25, 100],
+      authorizationFenceTimeoutMs: 750,
+    };
+    getAppConfig.mockResolvedValue({ mcpSettings: { catalogRecovery: recoveryPolicy } });
+    require('@librechat/api').isMCPDomainAllowed.mockResolvedValue(true);
+    require('~/config').getFlowStateManager.mockReturnValue({});
+    require('~/cache').getLogStores.mockReturnValue({});
+    reinitMCPServer.mockResolvedValue({
+      availableTools: { [canonicalToolKey]: { type: 'function', function: toolFunction } },
+    });
+
+    const toolInstance = await createMCPTool({
+      user: { id: 'user-1' },
+      toolKey: canonicalToolKey,
+      serverName: rawServerName,
+      availableTools: {},
+      config: { type: 'streamable-http', url: 'https://mcp.example.com' },
+      provider: 'openAI',
+    });
+
+    expect(toolInstance).toBeDefined();
+    expect(reinitMCPServer).toHaveBeenCalledWith(
+      expect.objectContaining({ serverName: rawServerName, recoveryPolicy }),
+    );
+  });
 });

--- a/api/server/services/initializeMCPs.js
+++ b/api/server/services/initializeMCPs.js
@@ -120,6 +120,7 @@ async function initializeMCPs() {
     startMCPAuthorizationFenceRetryWorker(invalidateCachedTools, {
       intervalMs: appConfig?.mcpSettings?.catalogRecovery?.authorizationFenceRetryIntervalMs,
       batchSize: appConfig?.mcpSettings?.catalogRecovery?.authorizationFenceRetryBatchSize,
+      attemptTimeoutMs: appConfig?.mcpSettings?.catalogRecovery?.authorizationFenceTimeoutMs,
     });
     setMCPToolsChangedHandler(refreshChangedServerTools);
     setMCPToolsChangedGenerationHandler(getMCPToolsCacheGeneration);

--- a/api/server/services/initializeMCPs.js
+++ b/api/server/services/initializeMCPs.js
@@ -113,7 +113,9 @@ async function initializeMCPs() {
   }
 
   try {
-    const mcpManager = await createMCPManager(mcpServers || {});
+    const mcpManager = await createMCPManager(mcpServers || {}, {
+      catalogRecoveryMaxStateEntries: appConfig?.mcpSettings?.catalogRecovery?.maxStateEntries,
+    });
     setMCPToolsChangedHandler(refreshChangedServerTools);
     setMCPToolsChangedGenerationHandler(getMCPToolsCacheGeneration);
     setMCPToolsChangedGenerationRenewalHandler(renewMCPToolsCacheGeneration);

--- a/api/server/services/initializeMCPs.js
+++ b/api/server/services/initializeMCPs.js
@@ -117,7 +117,10 @@ async function initializeMCPs() {
     const mcpManager = await createMCPManager(mcpServers || {}, {
       catalogRecoveryMaxStateEntries: appConfig?.mcpSettings?.catalogRecovery?.maxStateEntries,
     });
-    startMCPAuthorizationFenceRetryWorker(invalidateCachedTools);
+    startMCPAuthorizationFenceRetryWorker(invalidateCachedTools, {
+      intervalMs: appConfig?.mcpSettings?.catalogRecovery?.authorizationFenceRetryIntervalMs,
+      batchSize: appConfig?.mcpSettings?.catalogRecovery?.authorizationFenceRetryBatchSize,
+    });
     setMCPToolsChangedHandler(refreshChangedServerTools);
     setMCPToolsChangedGenerationHandler(getMCPToolsCacheGeneration);
     setMCPToolsChangedGenerationRenewalHandler(renewMCPToolsCacheGeneration);

--- a/api/server/services/initializeMCPs.js
+++ b/api/server/services/initializeMCPs.js
@@ -8,7 +8,8 @@ const {
   setMCPToolsChangedGenerationRenewalHandler,
   setMCPToolsChangedRevisionHandler,
 } = require('@librechat/api');
-const { syncStaticTools, mergeAppTools, getAppConfig } = require('./Config');
+const { syncStaticTools, mergeAppTools, getAppConfig, invalidateCachedTools } = require('./Config');
+const { startMCPAuthorizationFenceRetryWorker } = require('./MCPAuthorizationFenceRetry');
 const {
   getMCPToolsCacheGeneration,
   renewMCPToolsCacheGeneration,
@@ -116,6 +117,7 @@ async function initializeMCPs() {
     const mcpManager = await createMCPManager(mcpServers || {}, {
       catalogRecoveryMaxStateEntries: appConfig?.mcpSettings?.catalogRecovery?.maxStateEntries,
     });
+    startMCPAuthorizationFenceRetryWorker(invalidateCachedTools);
     setMCPToolsChangedHandler(refreshChangedServerTools);
     setMCPToolsChangedGenerationHandler(getMCPToolsCacheGeneration);
     setMCPToolsChangedGenerationRenewalHandler(renewMCPToolsCacheGeneration);

--- a/api/server/services/initializeMCPs.plugins.spec.js
+++ b/api/server/services/initializeMCPs.plugins.spec.js
@@ -51,6 +51,10 @@ jest.mock('./Config/mcp', () => ({
   updateMCPServerTools: jest.fn(),
 }));
 
+jest.mock('./MCPAuthorizationFenceRetry', () => ({
+  startMCPAuthorizationFenceRetryWorker: jest.fn(),
+}));
+
 const mockGetAppConfig = jest.fn();
 const mockMergeAppTools = jest.fn();
 const mockSyncStaticTools = jest.fn();

--- a/api/server/services/initializeMCPs.spec.js
+++ b/api/server/services/initializeMCPs.spec.js
@@ -29,6 +29,14 @@ jest.mock('@librechat/data-schemas', () => ({
 const mockGetAppConfig = jest.fn();
 const mockSyncStaticTools = jest.fn();
 const mockMergeAppTools = jest.fn();
+const mockInvalidateCachedTools = jest.fn();
+const mockStartMCPAuthorizationFenceRetryWorker = jest.fn();
+
+jest.mock('./MCPAuthorizationFenceRetry', () => ({
+  get startMCPAuthorizationFenceRetryWorker() {
+    return mockStartMCPAuthorizationFenceRetryWorker;
+  },
+}));
 
 jest.mock('./Config', () => ({
   get getAppConfig() {
@@ -39,6 +47,9 @@ jest.mock('./Config', () => ({
   },
   get syncStaticTools() {
     return mockSyncStaticTools;
+  },
+  get invalidateCachedTools() {
+    return mockInvalidateCachedTools;
   },
 }));
 

--- a/api/server/services/initializeMCPs.spec.js
+++ b/api/server/services/initializeMCPs.spec.js
@@ -260,7 +260,13 @@ describe('initializeMCPs', () => {
     it('sets process-wide recovery capacity from the base config', async () => {
       mockGetAppConfig.mockResolvedValue({
         mcpConfig: {},
-        mcpSettings: { catalogRecovery: { maxStateEntries: 2500 } },
+        mcpSettings: {
+          catalogRecovery: {
+            maxStateEntries: 2500,
+            authorizationFenceRetryIntervalMs: 15_000,
+            authorizationFenceRetryBatchSize: 250,
+          },
+        },
       });
 
       await initializeMCPs();
@@ -270,6 +276,10 @@ describe('initializeMCPs', () => {
         {
           catalogRecoveryMaxStateEntries: 2500,
         },
+      );
+      expect(mockStartMCPAuthorizationFenceRetryWorker).toHaveBeenCalledWith(
+        mockInvalidateCachedTools,
+        { intervalMs: 15_000, batchSize: 250 },
       );
     });
 

--- a/api/server/services/initializeMCPs.spec.js
+++ b/api/server/services/initializeMCPs.spec.js
@@ -265,6 +265,7 @@ describe('initializeMCPs', () => {
             maxStateEntries: 2500,
             authorizationFenceRetryIntervalMs: 15_000,
             authorizationFenceRetryBatchSize: 250,
+            authorizationFenceTimeoutMs: 750,
           },
         },
       });
@@ -279,7 +280,7 @@ describe('initializeMCPs', () => {
       );
       expect(mockStartMCPAuthorizationFenceRetryWorker).toHaveBeenCalledWith(
         mockInvalidateCachedTools,
-        { intervalMs: 15_000, batchSize: 250 },
+        { intervalMs: 15_000, batchSize: 250, attemptTimeoutMs: 750 },
       );
     });
 

--- a/api/server/services/initializeMCPs.spec.js
+++ b/api/server/services/initializeMCPs.spec.js
@@ -224,7 +224,12 @@ describe('initializeMCPs', () => {
 
       // MCPManager should be created with empty object when no configured servers
       expect(mockCreateMCPManager).toHaveBeenCalledTimes(1);
-      expect(mockCreateMCPManager).toHaveBeenCalledWith({});
+      expect(mockCreateMCPManager).toHaveBeenCalledWith(
+        {},
+        {
+          catalogRecoveryMaxStateEntries: undefined,
+        },
+      );
     });
 
     it('should initialize MCPManager with configured servers when provided', async () => {
@@ -236,7 +241,25 @@ describe('initializeMCPs', () => {
 
       await initializeMCPs();
 
-      expect(mockCreateMCPManager).toHaveBeenCalledWith(mcpServers);
+      expect(mockCreateMCPManager).toHaveBeenCalledWith(mcpServers, {
+        catalogRecoveryMaxStateEntries: undefined,
+      });
+    });
+
+    it('sets process-wide recovery capacity from the base config', async () => {
+      mockGetAppConfig.mockResolvedValue({
+        mcpConfig: {},
+        mcpSettings: { catalogRecovery: { maxStateEntries: 2500 } },
+      });
+
+      await initializeMCPs();
+
+      expect(mockCreateMCPManager).toHaveBeenCalledWith(
+        {},
+        {
+          catalogRecoveryMaxStateEntries: 2500,
+        },
+      );
     });
 
     it('should register app connections for graceful shutdown', async () => {
@@ -416,7 +439,12 @@ describe('initializeMCPs', () => {
       expect(mockCreateMCPManager).toHaveBeenCalledTimes(1);
 
       // Verify manager was created with empty config (not null/undefined)
-      expect(mockCreateMCPManager).toHaveBeenCalledWith({});
+      expect(mockCreateMCPManager).toHaveBeenCalledWith(
+        {},
+        {
+          catalogRecoveryMaxStateEntries: undefined,
+        },
+      );
     });
   });
 });

--- a/api/server/services/initializeOAuthReconnectManager.js
+++ b/api/server/services/initializeOAuthReconnectManager.js
@@ -5,6 +5,10 @@ const { createOAuthReconnectionManager, getFlowStateManager, getMCPManager } = r
 const { findToken, updateToken, createToken, deleteTokens } = require('~/models');
 const { getLogStores } = require('~/cache');
 const { getAppConfig, invalidateCachedTools } = require('~/server/services/Config');
+const {
+  clearMCPAuthorizationFenceRetry,
+  persistMCPAuthorizationFenceRetry,
+} = require('~/server/services/MCPAuthorizationFenceRetry');
 
 /**
  * Initialize OAuth reconnect manager
@@ -22,6 +26,8 @@ async function initializeOAuthReconnectManager() {
     await createOAuthReconnectionManager(flowManager, tokenMethods, undefined, (scope) =>
       publishMCPAuthorizationMutation(scope, {
         invalidateRecoveryGeneration: invalidateCachedTools,
+        persistPublicationRetry: persistMCPAuthorizationFenceRetry,
+        clearPublicationRetry: clearMCPAuthorizationFenceRetry,
         clearLocalRecovery: (userId, serverName) =>
           getMCPManager()?.clearCatalogRecoveryState?.(userId, serverName),
         retryDelaysMs: appConfig?.mcpSettings?.catalogRecovery?.authorizationFenceRetryMs,

--- a/api/server/services/initializeOAuthReconnectManager.js
+++ b/api/server/services/initializeOAuthReconnectManager.js
@@ -4,7 +4,7 @@ const { CacheKeys } = require('librechat-data-provider');
 const { createOAuthReconnectionManager, getFlowStateManager, getMCPManager } = require('~/config');
 const { findToken, updateToken, createToken, deleteTokens } = require('~/models');
 const { getLogStores } = require('~/cache');
-const { invalidateCachedTools } = require('~/server/services/Config');
+const { getAppConfig, invalidateCachedTools } = require('~/server/services/Config');
 
 /**
  * Initialize OAuth reconnect manager
@@ -12,6 +12,7 @@ const { invalidateCachedTools } = require('~/server/services/Config');
 async function initializeOAuthReconnectManager() {
   try {
     const flowManager = getFlowStateManager(getLogStores(CacheKeys.FLOWS));
+    const appConfig = await getAppConfig({ baseOnly: true });
     const tokenMethods = {
       findToken,
       updateToken,
@@ -23,6 +24,7 @@ async function initializeOAuthReconnectManager() {
         invalidateRecoveryGeneration: invalidateCachedTools,
         clearLocalRecovery: (userId, serverName) =>
           getMCPManager()?.clearCatalogRecoveryState?.(userId, serverName),
+        retryDelaysMs: appConfig?.mcpSettings?.catalogRecovery?.authorizationFenceRetryMs,
       }),
     );
     logger.info(`OAuth reconnect manager initialized successfully.`);

--- a/api/server/services/initializeOAuthReconnectManager.js
+++ b/api/server/services/initializeOAuthReconnectManager.js
@@ -1,8 +1,10 @@
 const { logger } = require('@librechat/data-schemas');
+const { publishMCPAuthorizationMutation } = require('@librechat/api');
 const { CacheKeys } = require('librechat-data-provider');
-const { createOAuthReconnectionManager, getFlowStateManager } = require('~/config');
+const { createOAuthReconnectionManager, getFlowStateManager, getMCPManager } = require('~/config');
 const { findToken, updateToken, createToken, deleteTokens } = require('~/models');
 const { getLogStores } = require('~/cache');
+const { invalidateCachedTools } = require('~/server/services/Config');
 
 /**
  * Initialize OAuth reconnect manager
@@ -16,7 +18,13 @@ async function initializeOAuthReconnectManager() {
       createToken,
       deleteTokens,
     };
-    await createOAuthReconnectionManager(flowManager, tokenMethods);
+    await createOAuthReconnectionManager(flowManager, tokenMethods, undefined, (scope) =>
+      publishMCPAuthorizationMutation(scope, {
+        invalidateRecoveryGeneration: invalidateCachedTools,
+        clearLocalRecovery: (userId, serverName) =>
+          getMCPManager()?.clearCatalogRecoveryState?.(userId, serverName),
+      }),
+    );
     logger.info(`OAuth reconnect manager initialized successfully.`);
   } catch (error) {
     logger.error('Failed to initialize OAuth reconnect manager:', error);

--- a/api/server/services/initializeOAuthReconnectManager.js
+++ b/api/server/services/initializeOAuthReconnectManager.js
@@ -1,5 +1,5 @@
-const { logger } = require('@librechat/data-schemas');
-const { publishMCPAuthorizationMutation } = require('@librechat/api');
+const { logger, getTenantId } = require('@librechat/data-schemas');
+const { prepareMCPAuthorizationMutation } = require('@librechat/api');
 const { CacheKeys } = require('librechat-data-provider');
 const { createOAuthReconnectionManager, getFlowStateManager, getMCPManager } = require('~/config');
 const { findToken, updateToken, createToken, deleteTokens } = require('~/models');
@@ -16,23 +16,29 @@ const {
 async function initializeOAuthReconnectManager() {
   try {
     const flowManager = getFlowStateManager(getLogStores(CacheKeys.FLOWS));
-    const appConfig = await getAppConfig({ baseOnly: true });
     const tokenMethods = {
       findToken,
       updateToken,
       createToken,
       deleteTokens,
     };
-    await createOAuthReconnectionManager(flowManager, tokenMethods, undefined, (scope) =>
-      publishMCPAuthorizationMutation(scope, {
-        invalidateRecoveryGeneration: invalidateCachedTools,
-        persistPublicationRetry: persistMCPAuthorizationFenceRetry,
-        clearPublicationRetry: clearMCPAuthorizationFenceRetry,
-        clearLocalRecovery: (userId, serverName) =>
-          getMCPManager()?.clearCatalogRecoveryState?.(userId, serverName),
-        retryDelaysMs: appConfig?.mcpSettings?.catalogRecovery?.authorizationFenceRetryMs,
-        attemptTimeoutMs: appConfig?.mcpSettings?.catalogRecovery?.authorizationFenceTimeoutMs,
-      }),
+    await createOAuthReconnectionManager(
+      flowManager,
+      tokenMethods,
+      undefined,
+      undefined,
+      async (scope) => {
+        const appConfig = await getAppConfig({ tenantId: getTenantId(), userId: scope.userId });
+        return prepareMCPAuthorizationMutation(scope, {
+          invalidateRecoveryGeneration: invalidateCachedTools,
+          persistPublicationRetry: persistMCPAuthorizationFenceRetry,
+          clearPublicationRetry: clearMCPAuthorizationFenceRetry,
+          clearLocalRecovery: (userId, serverName) =>
+            getMCPManager()?.clearCatalogRecoveryState?.(userId, serverName),
+          retryDelaysMs: appConfig?.mcpSettings?.catalogRecovery?.authorizationFenceRetryMs,
+          attemptTimeoutMs: appConfig?.mcpSettings?.catalogRecovery?.authorizationFenceTimeoutMs,
+        });
+      },
     );
     logger.info(`OAuth reconnect manager initialized successfully.`);
   } catch (error) {

--- a/api/server/services/initializeOAuthReconnectManager.js
+++ b/api/server/services/initializeOAuthReconnectManager.js
@@ -25,6 +25,7 @@ async function initializeOAuthReconnectManager() {
         clearLocalRecovery: (userId, serverName) =>
           getMCPManager()?.clearCatalogRecoveryState?.(userId, serverName),
         retryDelaysMs: appConfig?.mcpSettings?.catalogRecovery?.authorizationFenceRetryMs,
+        attemptTimeoutMs: appConfig?.mcpSettings?.catalogRecovery?.authorizationFenceTimeoutMs,
       }),
     );
     logger.info(`OAuth reconnect manager initialized successfully.`);

--- a/api/server/services/initializeOAuthReconnectManager.spec.js
+++ b/api/server/services/initializeOAuthReconnectManager.spec.js
@@ -1,0 +1,74 @@
+const mockCreateOAuthReconnectionManager = jest.fn();
+const mockGetAppConfig = jest.fn();
+const mockPrepareMCPAuthorizationMutation = jest.fn();
+
+jest.mock('@librechat/data-schemas', () => ({
+  logger: { info: jest.fn(), error: jest.fn() },
+  getTenantId: jest.fn(() => 'tenant-a'),
+}));
+
+jest.mock('@librechat/api', () => ({
+  prepareMCPAuthorizationMutation: (...args) => mockPrepareMCPAuthorizationMutation(...args),
+}));
+
+jest.mock('librechat-data-provider', () => ({
+  CacheKeys: { FLOWS: 'flows' },
+}));
+
+jest.mock('~/config', () => ({
+  createOAuthReconnectionManager: (...args) => mockCreateOAuthReconnectionManager(...args),
+  getFlowStateManager: jest.fn(() => ({ type: 'flow-manager' })),
+  getMCPManager: jest.fn(() => ({ clearCatalogRecoveryState: jest.fn() })),
+}));
+
+jest.mock('~/models', () => ({
+  findToken: jest.fn(),
+  updateToken: jest.fn(),
+  createToken: jest.fn(),
+  deleteTokens: jest.fn(),
+}));
+
+jest.mock('~/cache', () => ({ getLogStores: jest.fn(() => ({})) }));
+
+jest.mock('~/server/services/Config', () => ({
+  getAppConfig: (...args) => mockGetAppConfig(...args),
+  invalidateCachedTools: jest.fn(),
+}));
+
+jest.mock('~/server/services/MCPAuthorizationFenceRetry', () => ({
+  clearMCPAuthorizationFenceRetry: jest.fn(),
+  persistMCPAuthorizationFenceRetry: jest.fn(),
+}));
+
+const initializeOAuthReconnectManager = require('./initializeOAuthReconnectManager');
+
+describe('initializeOAuthReconnectManager', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateOAuthReconnectionManager.mockResolvedValue(undefined);
+    mockGetAppConfig.mockResolvedValue({
+      mcpSettings: {
+        catalogRecovery: {
+          authorizationFenceRetryMs: [0, 25],
+          authorizationFenceTimeoutMs: 750,
+        },
+      },
+    });
+    mockPrepareMCPAuthorizationMutation.mockResolvedValue(jest.fn());
+  });
+
+  it('resolves the effective user policy when a reconnect refresh prepares its write', async () => {
+    await initializeOAuthReconnectManager();
+
+    expect(mockGetAppConfig).not.toHaveBeenCalled();
+    const prepareRefresh = mockCreateOAuthReconnectionManager.mock.calls[0][4];
+    const scope = { userId: 'user-1', serverName: 'github' };
+    await prepareRefresh(scope);
+
+    expect(mockGetAppConfig).toHaveBeenCalledWith({ tenantId: 'tenant-a', userId: 'user-1' });
+    expect(mockPrepareMCPAuthorizationMutation).toHaveBeenCalledWith(
+      scope,
+      expect.objectContaining({ retryDelaysMs: [0, 25], attemptTimeoutMs: 750 }),
+    );
+  });
+});

--- a/client/src/Providers/AgentPanelContext.tsx
+++ b/client/src/Providers/AgentPanelContext.tsx
@@ -19,7 +19,7 @@ import {
 } from '~/hooks';
 import { isMCPServerReadyForAgent } from '~/components/MCP/mcpServerUtils';
 import { useMCPRefresh } from '~/hooks/MCP/useMCPRefresh';
-import { Panel, isEphemeralAgent } from '~/common';
+import { Panel } from '~/common';
 import store from '~/store';
 
 const AgentPanelContext = createContext<AgentPanelContextType | undefined>(undefined);
@@ -33,7 +33,13 @@ export function useAgentPanelContext() {
 }
 
 /** Houses relevant state for the Agent Form Panels (formerly 'commonProps') */
-export function AgentPanelProvider({ children }: { children: React.ReactNode }) {
+export function AgentPanelProvider({
+  children,
+  observeToolAuthorization = true,
+}: {
+  children: React.ReactNode;
+  observeToolAuthorization?: boolean;
+}) {
   const localize = useLocalize();
   const location = useLocation();
   /** The panel stays mounted while the sidebar is hidden (collapsed, mobile
@@ -53,10 +59,10 @@ export function AgentPanelProvider({ children }: { children: React.ReactNode }) 
   const [activePanel, setActivePanel] = useState<Panel>(Panel.builder);
   const [agent_id, setCurrentAgentId] = useState<string | undefined>(undefined);
   const { availableMCPServers, isLoading, availableMCPServersMap, connectionStatus } =
-    useMCPServerManager({ observeToolAuthorization: !isEphemeralAgent(agent_id) });
+    useMCPServerManager({ observeToolAuthorization });
   const { data: startupConfig } = useGetStartupConfig();
   const { data: actions } = useGetActionsQuery(EModelEndpoint.agents, {
-    enabled: !isEphemeralAgent(agent_id),
+    enabled: observeToolAuthorization,
   });
 
   const { data: regularTools } = useAvailableToolsQuery(EModelEndpoint.agents);
@@ -68,7 +74,7 @@ export function AgentPanelProvider({ children }: { children: React.ReactNode }) 
     enabled:
       panelVisible &&
       mcpToolsReady &&
-      !isEphemeralAgent(agent_id) &&
+      observeToolAuthorization &&
       !isLoading &&
       availableMCPServers.length > 0,
     tools: true,
@@ -76,7 +82,7 @@ export function AgentPanelProvider({ children }: { children: React.ReactNode }) 
   const { data: mcpData, isFetching: mcpToolsFetching } = useMCPToolsQuery({
     enabled:
       mcpToolsReady &&
-      !isEphemeralAgent(agent_id) &&
+      observeToolAuthorization &&
       !isLoading &&
       availableMCPServers != null &&
       availableMCPServers.length > 0,

--- a/client/src/Providers/AgentPanelContext.tsx
+++ b/client/src/Providers/AgentPanelContext.tsx
@@ -5,19 +5,18 @@ import { EModelEndpoint } from 'librechat-data-provider';
 import type { MCP, Action, TPlugin } from 'librechat-data-provider';
 import type { AgentPanelContextType, MCPServerInfo } from '~/common';
 import {
-  useMCPConnectionStatus,
+  useAvailableToolsQuery,
+  useGetActionsQuery,
+  useGetStartupConfig,
+  useMCPToolsQuery,
+} from '~/data-provider';
+import {
   useMCPServerManager,
   useGetAgentsConfig,
   activateCatalog,
   useCatalogReady,
   useLocalize,
 } from '~/hooks';
-import {
-  useAvailableToolsQuery,
-  useGetActionsQuery,
-  useGetStartupConfig,
-  useMCPToolsQuery,
-} from '~/data-provider';
 import { isMCPServerReadyForAgent } from '~/components/MCP/mcpServerUtils';
 import { useMCPRefresh } from '~/hooks/MCP/useMCPRefresh';
 import { Panel, isEphemeralAgent } from '~/common';
@@ -53,7 +52,8 @@ export function AgentPanelProvider({ children }: { children: React.ReactNode }) 
   const [action, setAction] = useState<Action | undefined>(undefined);
   const [activePanel, setActivePanel] = useState<Panel>(Panel.builder);
   const [agent_id, setCurrentAgentId] = useState<string | undefined>(undefined);
-  const { availableMCPServers, isLoading, availableMCPServersMap } = useMCPServerManager();
+  const { availableMCPServers, isLoading, availableMCPServersMap, connectionStatus } =
+    useMCPServerManager();
   const { data: startupConfig } = useGetStartupConfig();
   const { data: actions } = useGetActionsQuery(EModelEndpoint.agents, {
     enabled: !isEphemeralAgent(agent_id),
@@ -91,9 +91,6 @@ export function AgentPanelProvider({ children }: { children: React.ReactNode }) 
     [availableMCPServers],
   );
 
-  const { connectionStatus } = useMCPConnectionStatus({
-    enabled: !isEphemeralAgent(agent_id) && mcpServerNames.length > 0,
-  });
   //TODO to refactor when tools come from tool box
   const mcpServersMap = useMemo(() => {
     const configuredServers = new Set(mcpServerNames);

--- a/client/src/Providers/AgentPanelContext.tsx
+++ b/client/src/Providers/AgentPanelContext.tsx
@@ -53,7 +53,7 @@ export function AgentPanelProvider({ children }: { children: React.ReactNode }) 
   const [activePanel, setActivePanel] = useState<Panel>(Panel.builder);
   const [agent_id, setCurrentAgentId] = useState<string | undefined>(undefined);
   const { availableMCPServers, isLoading, availableMCPServersMap, connectionStatus } =
-    useMCPServerManager();
+    useMCPServerManager({ observeToolAuthorization: !isEphemeralAgent(agent_id) });
   const { data: startupConfig } = useGetStartupConfig();
   const { data: actions } = useGetActionsQuery(EModelEndpoint.agents, {
     enabled: !isEphemeralAgent(agent_id),

--- a/client/src/Providers/BadgeRowContext.tsx
+++ b/client/src/Providers/BadgeRowContext.tsx
@@ -37,6 +37,7 @@ interface BadgeRowProviderProps {
   isSubmitting?: boolean;
   conversationId?: string | null;
   specName?: string | null;
+  observeToolAuthorization?: boolean;
 }
 
 export default function BadgeRowProvider({
@@ -44,6 +45,7 @@ export default function BadgeRowProvider({
   isSubmitting,
   conversationId,
   specName,
+  observeToolAuthorization = false,
 }: BadgeRowProviderProps) {
   const lastContextKeyRef = useRef<string>('');
   const hasInitializedRef = useRef(false);
@@ -275,6 +277,7 @@ export default function BadgeRowProvider({
     storageContextKey,
     specName,
     ownsChatSelection: true,
+    observeToolAuthorization,
   });
 
   const value: BadgeRowContextType = {

--- a/client/src/components/Chat/Input/BadgeRow.tsx
+++ b/client/src/components/Chat/Input/BadgeRow.tsx
@@ -328,6 +328,7 @@ function BadgeRow({
       conversationId={conversationId}
       specName={specName}
       isSubmitting={isSubmitting}
+      observeToolAuthorization={showEphemeralBadges === true}
     >
       <div ref={containerRef} className="relative flex flex-wrap items-center gap-2">
         {showEphemeralBadges === true && <ToolsDropdown />}

--- a/client/src/components/MCP/ServerInitializationSection.spec.tsx
+++ b/client/src/components/MCP/ServerInitializationSection.spec.tsx
@@ -15,9 +15,6 @@ jest.mock('~/hooks/MCP/useMCPRefresh', () => ({
 
 jest.mock('~/hooks', () => ({
   useLocalize: () => (key: string) => key,
-  useMCPConnectionStatus: () => ({
-    connectionStatus: { server: mockConnectionStatus() },
-  }),
   useMCPServerManager: () => ({
     getOAuthUrl: () => undefined,
     isCancellable: () => false,
@@ -26,6 +23,7 @@ jest.mock('~/hooks', () => ({
     initializeServer: mockInitializeServer,
     availableMCPServers: [{ serverName: 'server' }],
     availableMCPServersMap: { server: { requestScoped: true } },
+    connectionStatus: { server: mockConnectionStatus() },
     revokeOAuthForServer: jest.fn(),
   }),
 }));

--- a/client/src/components/MCP/ServerInitializationSection.tsx
+++ b/client/src/components/MCP/ServerInitializationSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { RefreshCw, Trash2 } from 'lucide-react';
 import { Button, Spinner } from '@librechat/client';
-import { useLocalize, useMCPServerManager, useMCPConnectionStatus } from '~/hooks';
+import { useLocalize, useMCPServerManager } from '~/hooks';
 import { useMCPRefresh } from '~/hooks/MCP/useMCPRefresh';
 
 interface ServerInitializationSectionProps {
@@ -31,12 +31,9 @@ export default function ServerInitializationSection({
     initializeServer,
     availableMCPServers,
     availableMCPServersMap,
+    connectionStatus,
     revokeOAuthForServer,
   } = useMCPServerManager({ conversationId, storageContextKey });
-
-  const { connectionStatus } = useMCPConnectionStatus({
-    enabled: !!availableMCPServers && availableMCPServers.length > 0,
-  });
 
   useMCPRefresh({ enabled: availableMCPServers.length > 0 });
 

--- a/client/src/components/MCP/ServerInitializationSection.tsx
+++ b/client/src/components/MCP/ServerInitializationSection.tsx
@@ -33,7 +33,11 @@ export default function ServerInitializationSection({
     availableMCPServersMap,
     connectionStatus,
     revokeOAuthForServer,
-  } = useMCPServerManager({ conversationId, storageContextKey });
+  } = useMCPServerManager({
+    conversationId,
+    storageContextKey,
+    observeToolAuthorization: true,
+  });
 
   useMCPRefresh({ enabled: availableMCPServers.length > 0 });
 

--- a/client/src/components/SidePanel/Agents/AgentPanelSwitch.spec.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanelSwitch.spec.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { RecoilRoot } from 'recoil';
+import { render } from '@testing-library/react';
+import { EModelEndpoint } from 'librechat-data-provider';
+import type { TConversation } from 'librechat-data-provider';
+import store from '~/store';
+
+const mockObserveToolAuthorization = jest.fn();
+const mockSetCurrentAgentId = jest.fn();
+
+jest.mock('~/Providers/AgentPanelContext', () => ({
+  AgentPanelProvider: ({
+    children,
+    observeToolAuthorization,
+  }: {
+    children: React.ReactNode;
+    observeToolAuthorization: boolean;
+  }) => {
+    mockObserveToolAuthorization(observeToolAuthorization);
+    return children;
+  },
+  useAgentPanelContext: () => ({
+    activePanel: 'builder',
+    setCurrentAgentId: mockSetCurrentAgentId,
+  }),
+}));
+jest.mock('./AgentPanel', () => () => null);
+jest.mock('./Version/VersionPanel', () => () => null);
+
+import AgentPanelSwitch from './AgentPanelSwitch';
+
+function renderWithConversation(conversation?: TConversation) {
+  return render(
+    <RecoilRoot
+      initializeState={({ set }) => {
+        if (conversation != null) {
+          set(store.conversationByIndex(0), conversation);
+        }
+      }}
+    >
+      <AgentPanelSwitch />
+    </RecoilRoot>,
+  );
+}
+
+describe('AgentPanelSwitch authorization observers', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('holds observers until the conversation is hydrated', () => {
+    renderWithConversation();
+    expect(mockObserveToolAuthorization).toHaveBeenLastCalledWith(false);
+  });
+
+  it('enables observers for a hydrated persistent agent', () => {
+    renderWithConversation({
+      conversationId: 'new',
+      endpoint: EModelEndpoint.agents,
+      agent_id: 'agent_1',
+    } as TConversation);
+    expect(mockObserveToolAuthorization).toHaveBeenLastCalledWith(true);
+  });
+
+  it('keeps observers disabled for a hydrated ephemeral agent', () => {
+    renderWithConversation({
+      conversationId: 'new',
+      endpoint: EModelEndpoint.agents,
+      agent_id: 'ephemeral',
+    } as TConversation);
+    expect(mockObserveToolAuthorization).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/client/src/components/SidePanel/Agents/AgentPanelSwitch.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanelSwitch.tsx
@@ -7,9 +7,12 @@ import AgentPanel from './AgentPanel';
 import store from '~/store';
 
 export default function AgentPanelSwitch() {
-  const agentId = useRecoilValue(store.conversationAgentIdByIndex(0));
+  const conversation = useRecoilValue(store.conversationByIndex(0));
+  const agentId = conversation?.agent_id ?? null;
   return (
-    <AgentPanelProvider observeToolAuthorization={!isEphemeralAgent(agentId)}>
+    <AgentPanelProvider
+      observeToolAuthorization={conversation != null && !isEphemeralAgent(agentId)}
+    >
       <AgentPanelSwitchWithContext agentId={agentId} />
     </AgentPanelProvider>
   );

--- a/client/src/components/SidePanel/Agents/AgentPanelSwitch.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanelSwitch.tsx
@@ -7,16 +7,16 @@ import AgentPanel from './AgentPanel';
 import store from '~/store';
 
 export default function AgentPanelSwitch() {
+  const agentId = useRecoilValue(store.conversationAgentIdByIndex(0));
   return (
-    <AgentPanelProvider>
-      <AgentPanelSwitchWithContext />
+    <AgentPanelProvider observeToolAuthorization={!isEphemeralAgent(agentId)}>
+      <AgentPanelSwitchWithContext agentId={agentId} />
     </AgentPanelProvider>
   );
 }
 
-function AgentPanelSwitchWithContext() {
+function AgentPanelSwitchWithContext({ agentId }: { agentId?: string | null }) {
   const { activePanel, setCurrentAgentId } = useAgentPanelContext();
-  const agentId = useRecoilValue(store.conversationAgentIdByIndex(0));
 
   useEffect(() => {
     const agent_id = agentId ?? '';

--- a/client/src/components/SidePanel/Agents/Tools/ItemDialog/sections/McpSection.tsx
+++ b/client/src/components/SidePanel/Agents/Tools/ItemDialog/sections/McpSection.tsx
@@ -26,7 +26,6 @@ import { getStatusColor, getStatusTextKey } from '~/components/MCP/mcpServerUtil
 import MCPServerStatusIcon from '~/components/MCP/MCPServerStatusIcon';
 import MCPConfigDialog from '~/components/MCP/MCPConfigDialog';
 import McpOAuthDialog from '~/components/MCP/McpOAuthDialog';
-import { useMCPRefresh } from '~/hooks/MCP/useMCPRefresh';
 import { useAgentPanelContext } from '~/Providers';
 import { getIconForItem } from '../../items/icons';
 import OptionToggle from '../../../OptionToggle';
@@ -80,7 +79,6 @@ export default function McpSection({ item }: Props) {
   const [prevReadyForAgent, setPrevReadyForAgent] = useState(false);
   const [autoSelectPending, setAutoSelectPending] = useState(false);
   const { mcpServersMap, mcpToolsLoading } = useAgentPanelContext();
-  useMCPRefresh({ enabled: true, tools: true });
   const { agentsConfig } = useGetAgentsConfig();
   const {
     codeEnabled,

--- a/client/src/components/SidePanel/MCPBuilder/MCPBuilderPanel.tsx
+++ b/client/src/components/SidePanel/MCPBuilder/MCPBuilderPanel.tsx
@@ -35,7 +35,7 @@ export default function MCPBuilderPanel() {
   }, [panelVisible]);
   const { user } = useAuthContext();
   const { availableMCPServers, isLoading, getServerStatusIconProps, getConfigDialogProps } =
-    useMCPServerManager();
+    useMCPServerManager({ observeToolAuthorization: panelVisible });
   useMCPRefresh({ enabled: panelVisible && !isLoading && availableMCPServers.length > 0 });
 
   const hasCreateAccess = useHasAccess({

--- a/client/src/hooks/Config/__tests__/useAppStartup.spec.tsx
+++ b/client/src/hooks/Config/__tests__/useAppStartup.spec.tsx
@@ -73,6 +73,18 @@ const mockUser = {
 const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <RecoilRoot>{children}</RecoilRoot>
 );
+const hydratedWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <RecoilRoot
+    initializeState={({ set }) =>
+      set(store.conversationByIndex(0), {
+        conversationId: 'new',
+        endpoint: EModelEndpoint.openAI,
+      } as TConversation)
+    }
+  >
+    {children}
+  </RecoilRoot>
+);
 
 describe('useAppStartup: MCP permission gating', () => {
   beforeEach(() => {
@@ -85,7 +97,9 @@ describe('useAppStartup: MCP permission gating', () => {
   it('checks the MCP_SERVERS.USE permission via useHasAccess', () => {
     mockUseHasAccess.mockReturnValue(false);
 
-    renderHook(() => useAppStartup({ startupConfig: undefined, user: mockUser }), { wrapper });
+    renderHook(() => useAppStartup({ startupConfig: undefined, user: mockUser }), {
+      wrapper: hydratedWrapper,
+    });
 
     expect(mockUseHasAccess).toHaveBeenCalledWith({
       permissionType: PermissionTypes.MCP_SERVERS,
@@ -121,10 +135,24 @@ describe('useAppStartup: MCP permission gating', () => {
       isLoading: false,
     });
 
-    renderHook(() => useAppStartup({ startupConfig: undefined, user: mockUser }), { wrapper });
+    renderHook(() => useAppStartup({ startupConfig: undefined, user: mockUser }), {
+      wrapper: hydratedWrapper,
+    });
 
     expect(mockUseMCPServersQuery).toHaveBeenCalledWith({ enabled: true });
     expect(mockUseMCPToolsQuery).toHaveBeenCalledWith({ enabled: true });
+  });
+
+  it('waits for conversation hydration before warming the tools catalog', () => {
+    mockUseHasAccess.mockReturnValue(true);
+    mockUseMCPServersQuery.mockReturnValue({
+      data: { 'test-server': { url: 'http://test' } },
+      isLoading: false,
+    });
+
+    renderHook(() => useAppStartup({ startupConfig: undefined, user: mockUser }), { wrapper });
+
+    expect(mockUseMCPToolsQuery).toHaveBeenCalledWith({ enabled: false });
   });
 
   it('suppresses background tool discovery for an ephemeral agent conversation', () => {

--- a/client/src/hooks/Config/__tests__/useAppStartup.spec.tsx
+++ b/client/src/hooks/Config/__tests__/useAppStartup.spec.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { RecoilRoot } from 'recoil';
 import { renderHook } from '@testing-library/react';
-import { PermissionTypes, Permissions } from 'librechat-data-provider';
-import type { TUser } from 'librechat-data-provider';
+import { EModelEndpoint, PermissionTypes, Permissions } from 'librechat-data-provider';
+import type { TConversation, TUser } from 'librechat-data-provider';
+import store from '~/store';
 
 type CloudFrontRetryOptions = { getAuthorizationHeader: () => string | undefined };
 
@@ -124,6 +125,34 @@ describe('useAppStartup: MCP permission gating', () => {
 
     expect(mockUseMCPServersQuery).toHaveBeenCalledWith({ enabled: true });
     expect(mockUseMCPToolsQuery).toHaveBeenCalledWith({ enabled: true });
+  });
+
+  it('suppresses background tool discovery for an ephemeral agent conversation', () => {
+    mockUseHasAccess.mockReturnValue(true);
+    mockUseMCPServersQuery.mockReturnValue({
+      data: { 'test-server': { url: 'http://test' } },
+      isLoading: false,
+    });
+    const ephemeralWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+      <RecoilRoot
+        initializeState={({ set }) =>
+          set(store.conversationByIndex(0), {
+            conversationId: 'new',
+            endpoint: EModelEndpoint.agents,
+            agent_id: 'ephemeral',
+          } as TConversation)
+        }
+      >
+        {children}
+      </RecoilRoot>
+    );
+
+    renderHook(() => useAppStartup({ startupConfig: undefined, user: mockUser }), {
+      wrapper: ephemeralWrapper,
+    });
+
+    expect(mockUseMCPServersQuery).toHaveBeenCalledWith({ enabled: true });
+    expect(mockUseMCPToolsQuery).toHaveBeenCalledWith({ enabled: false });
   });
 
   it('suppresses tools query when permission granted but user prop is undefined', () => {

--- a/client/src/hooks/Config/__tests__/useAppStartup.spec.tsx
+++ b/client/src/hooks/Config/__tests__/useAppStartup.spec.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { RecoilRoot } from 'recoil';
 import { renderHook } from '@testing-library/react';
-import { EModelEndpoint, PermissionTypes, Permissions } from 'librechat-data-provider';
-import type { TConversation, TUser } from 'librechat-data-provider';
-import store from '~/store';
+import { PermissionTypes, Permissions } from 'librechat-data-provider';
+import type { TUser } from 'librechat-data-provider';
 
 type CloudFrontRetryOptions = { getAuthorizationHeader: () => string | undefined };
 
@@ -73,19 +72,6 @@ const mockUser = {
 const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <RecoilRoot>{children}</RecoilRoot>
 );
-const hydratedWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <RecoilRoot
-    initializeState={({ set }) =>
-      set(store.conversationByIndex(0), {
-        conversationId: 'new',
-        endpoint: EModelEndpoint.openAI,
-      } as TConversation)
-    }
-  >
-    {children}
-  </RecoilRoot>
-);
-
 describe('useAppStartup: MCP permission gating', () => {
   beforeEach(() => {
     mockInstallCloudFrontImageRetry.mockClear();
@@ -97,9 +83,12 @@ describe('useAppStartup: MCP permission gating', () => {
   it('checks the MCP_SERVERS.USE permission via useHasAccess', () => {
     mockUseHasAccess.mockReturnValue(false);
 
-    renderHook(() => useAppStartup({ startupConfig: undefined, user: mockUser }), {
-      wrapper: hydratedWrapper,
-    });
+    renderHook(
+      () => useAppStartup({ startupConfig: undefined, user: mockUser, mcpWarmupAllowed: true }),
+      {
+        wrapper,
+      },
+    );
 
     expect(mockUseHasAccess).toHaveBeenCalledWith({
       permissionType: PermissionTypes.MCP_SERVERS,
@@ -110,7 +99,10 @@ describe('useAppStartup: MCP permission gating', () => {
   it('suppresses all MCP queries when user lacks MCP_SERVERS.USE', () => {
     mockUseHasAccess.mockReturnValue(false);
 
-    renderHook(() => useAppStartup({ startupConfig: undefined, user: mockUser }), { wrapper });
+    renderHook(
+      () => useAppStartup({ startupConfig: undefined, user: mockUser, mcpWarmupAllowed: true }),
+      { wrapper },
+    );
 
     expect(mockUseMCPServersQuery).toHaveBeenCalledWith({ enabled: false });
     expect(mockUseMCPToolsQuery).toHaveBeenCalledWith({ enabled: false });
@@ -120,7 +112,10 @@ describe('useAppStartup: MCP permission gating', () => {
     mockUseHasAccess.mockReturnValue(true);
     mockUseCatalogReady.mockReturnValue(false);
 
-    renderHook(() => useAppStartup({ startupConfig: undefined, user: mockUser }), { wrapper });
+    renderHook(
+      () => useAppStartup({ startupConfig: undefined, user: mockUser, mcpWarmupAllowed: true }),
+      { wrapper },
+    );
 
     expect(mockUseCatalogReady).toHaveBeenCalledWith('mcpServers');
     expect(mockUseCatalogReady).toHaveBeenCalledWith('mcpTools');
@@ -135,22 +130,28 @@ describe('useAppStartup: MCP permission gating', () => {
       isLoading: false,
     });
 
-    renderHook(() => useAppStartup({ startupConfig: undefined, user: mockUser }), {
-      wrapper: hydratedWrapper,
-    });
+    renderHook(
+      () => useAppStartup({ startupConfig: undefined, user: mockUser, mcpWarmupAllowed: true }),
+      {
+        wrapper,
+      },
+    );
 
     expect(mockUseMCPServersQuery).toHaveBeenCalledWith({ enabled: true });
     expect(mockUseMCPToolsQuery).toHaveBeenCalledWith({ enabled: true });
   });
 
-  it('waits for conversation hydration before warming the tools catalog', () => {
+  it('waits for the host to allow MCP warmup', () => {
     mockUseHasAccess.mockReturnValue(true);
     mockUseMCPServersQuery.mockReturnValue({
       data: { 'test-server': { url: 'http://test' } },
       isLoading: false,
     });
 
-    renderHook(() => useAppStartup({ startupConfig: undefined, user: mockUser }), { wrapper });
+    renderHook(
+      () => useAppStartup({ startupConfig: undefined, user: mockUser, mcpWarmupAllowed: false }),
+      { wrapper },
+    );
 
     expect(mockUseMCPToolsQuery).toHaveBeenCalledWith({ enabled: false });
   });
@@ -161,23 +162,12 @@ describe('useAppStartup: MCP permission gating', () => {
       data: { 'test-server': { url: 'http://test' } },
       isLoading: false,
     });
-    const ephemeralWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-      <RecoilRoot
-        initializeState={({ set }) =>
-          set(store.conversationByIndex(0), {
-            conversationId: 'new',
-            endpoint: EModelEndpoint.agents,
-            agent_id: 'ephemeral',
-          } as TConversation)
-        }
-      >
-        {children}
-      </RecoilRoot>
+    renderHook(
+      () => useAppStartup({ startupConfig: undefined, user: mockUser, mcpWarmupAllowed: false }),
+      {
+        wrapper,
+      },
     );
-
-    renderHook(() => useAppStartup({ startupConfig: undefined, user: mockUser }), {
-      wrapper: ephemeralWrapper,
-    });
 
     expect(mockUseMCPServersQuery).toHaveBeenCalledWith({ enabled: true });
     expect(mockUseMCPToolsQuery).toHaveBeenCalledWith({ enabled: false });
@@ -190,7 +180,10 @@ describe('useAppStartup: MCP permission gating', () => {
       isLoading: false,
     });
 
-    renderHook(() => useAppStartup({ startupConfig: undefined, user: undefined }), { wrapper });
+    renderHook(
+      () => useAppStartup({ startupConfig: undefined, user: undefined, mcpWarmupAllowed: true }),
+      { wrapper },
+    );
 
     expect(mockUseMCPServersQuery).toHaveBeenCalledWith({ enabled: true });
     expect(mockUseMCPToolsQuery).toHaveBeenCalledWith({ enabled: false });
@@ -200,7 +193,10 @@ describe('useAppStartup: MCP permission gating', () => {
     mockUseHasAccess.mockReturnValue(true);
     mockUseMCPServersQuery.mockReturnValue({ data: {}, isLoading: false });
 
-    renderHook(() => useAppStartup({ startupConfig: undefined, user: mockUser }), { wrapper });
+    renderHook(
+      () => useAppStartup({ startupConfig: undefined, user: mockUser, mcpWarmupAllowed: true }),
+      { wrapper },
+    );
 
     expect(mockUseMCPServersQuery).toHaveBeenCalledWith({ enabled: true });
     expect(mockUseMCPToolsQuery).toHaveBeenCalledWith({ enabled: false });
@@ -210,7 +206,10 @@ describe('useAppStartup: MCP permission gating', () => {
     mockUseHasAccess.mockReturnValue(true);
     mockUseMCPServersQuery.mockReturnValue({ data: undefined, isLoading: true });
 
-    renderHook(() => useAppStartup({ startupConfig: undefined, user: mockUser }), { wrapper });
+    renderHook(
+      () => useAppStartup({ startupConfig: undefined, user: mockUser, mcpWarmupAllowed: true }),
+      { wrapper },
+    );
 
     expect(mockUseMCPToolsQuery).toHaveBeenCalledWith({ enabled: false });
   });
@@ -226,7 +225,9 @@ describe('useAppStartup: MCP permission gating', () => {
       },
     } as never;
 
-    renderHook(() => useAppStartup({ startupConfig, user: mockUser }), { wrapper });
+    renderHook(() => useAppStartup({ startupConfig, user: mockUser, mcpWarmupAllowed: true }), {
+      wrapper,
+    });
 
     expect(mockInstallCloudFrontImageRetry).toHaveBeenCalledWith(startupConfig, {
       getAuthorizationHeader: expect.any(Function),

--- a/client/src/hooks/Config/useAppStartup.ts
+++ b/client/src/hooks/Config/useAppStartup.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import TagManager from 'react-gtm-module';
 import { installCloudFrontImageRetry } from '@librechat/client';
 import {
@@ -7,6 +7,8 @@ import {
   LocalStorageKeys,
   PermissionTypes,
   Permissions,
+  isAgentsEndpoint,
+  isEphemeralAgentId,
   resolveModelSpecEndpoint,
 } from 'librechat-data-provider';
 import type { TStartupConfig, TUser } from 'librechat-data-provider';
@@ -24,6 +26,10 @@ export default function useAppStartup({
   user?: TUser;
 }) {
   const [defaultPreset, setDefaultPreset] = useRecoilState(store.defaultPreset);
+  const activeConversation = useRecoilValue(store.conversationByIndex(0));
+  const isEphemeralAgentActive =
+    isAgentsEndpoint(activeConversation?.endpoint) &&
+    isEphemeralAgentId(activeConversation?.agent_id);
   const canUseMcp = useHasAccess({
     permissionType: PermissionTypes.MCP_SERVERS,
     permission: Permissions.USE,
@@ -45,6 +51,7 @@ export default function useAppStartup({
       !serversLoading &&
       !!loadedServers &&
       Object.keys(loadedServers).length > 0 &&
+      !isEphemeralAgentActive &&
       !!user,
   });
 

--- a/client/src/hooks/Config/useAppStartup.ts
+++ b/client/src/hooks/Config/useAppStartup.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
-import TagManager from 'react-gtm-module';
 import { useRecoilState } from 'recoil';
+import TagManager from 'react-gtm-module';
 import { installCloudFrontImageRetry } from '@librechat/client';
 import {
   getTokenHeader,

--- a/client/src/hooks/Config/useAppStartup.ts
+++ b/client/src/hooks/Config/useAppStartup.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
 import TagManager from 'react-gtm-module';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { installCloudFrontImageRetry } from '@librechat/client';
 import {
   getTokenHeader,
@@ -27,6 +27,7 @@ export default function useAppStartup({
 }) {
   const [defaultPreset, setDefaultPreset] = useRecoilState(store.defaultPreset);
   const activeConversation = useRecoilValue(store.conversationByIndex(0));
+  const conversationHydrated = activeConversation != null;
   const isEphemeralAgentActive =
     isAgentsEndpoint(activeConversation?.endpoint) &&
     isEphemeralAgentId(activeConversation?.agent_id);
@@ -51,6 +52,7 @@ export default function useAppStartup({
       !serversLoading &&
       !!loadedServers &&
       Object.keys(loadedServers).length > 0 &&
+      conversationHydrated &&
       !isEphemeralAgentActive &&
       !!user,
   });

--- a/client/src/hooks/Config/useAppStartup.ts
+++ b/client/src/hooks/Config/useAppStartup.ts
@@ -1,14 +1,12 @@
 import { useEffect } from 'react';
 import TagManager from 'react-gtm-module';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { installCloudFrontImageRetry } from '@librechat/client';
 import {
   getTokenHeader,
   LocalStorageKeys,
   PermissionTypes,
   Permissions,
-  isAgentsEndpoint,
-  isEphemeralAgentId,
   resolveModelSpecEndpoint,
 } from 'librechat-data-provider';
 import type { TStartupConfig, TUser } from 'librechat-data-provider';
@@ -21,16 +19,13 @@ import store from '~/store';
 export default function useAppStartup({
   startupConfig,
   user,
+  mcpWarmupAllowed,
 }: {
   startupConfig?: TStartupConfig;
   user?: TUser;
+  mcpWarmupAllowed: boolean;
 }) {
   const [defaultPreset, setDefaultPreset] = useRecoilState(store.defaultPreset);
-  const activeConversation = useRecoilValue(store.conversationByIndex(0));
-  const conversationHydrated = activeConversation != null;
-  const isEphemeralAgentActive =
-    isAgentsEndpoint(activeConversation?.endpoint) &&
-    isEphemeralAgentId(activeConversation?.agent_id);
   const canUseMcp = useHasAccess({
     permissionType: PermissionTypes.MCP_SERVERS,
     permission: Permissions.USE,
@@ -52,8 +47,7 @@ export default function useAppStartup({
       !serversLoading &&
       !!loadedServers &&
       Object.keys(loadedServers).length > 0 &&
-      conversationHydrated &&
-      !isEphemeralAgentActive &&
+      mcpWarmupAllowed &&
       !!user,
   });
 

--- a/client/src/hooks/MCP/__tests__/polling.spec.ts
+++ b/client/src/hooks/MCP/__tests__/polling.spec.ts
@@ -96,6 +96,32 @@ describe('applyMCPDiscoveryAuthorizationState', () => {
 
     expect(result).toBe(currentStatus);
   });
+
+  it('preserves an active OAuth flow over cached reauthorization state', () => {
+    const currentStatus = {
+      oauth: {
+        requiresOAuth: true,
+        connectionState: 'connecting' as const,
+        authorizationState: 'authorizing' as const,
+        authorizationGeneration: 'generation-1',
+      },
+    };
+    const result = applyMCPDiscoveryAuthorizationState(currentStatus, {
+      servers: {
+        oauth: {
+          name: 'oauth',
+          icon: '',
+          authenticated: false,
+          authorizationState: 'reauth_required',
+          authorizationGeneration: 'generation-1',
+          authConfig: [],
+          tools: [],
+        },
+      },
+    });
+
+    expect(result).toBe(currentStatus);
+  });
 });
 
 describe('getMCPOAuthTimeout', () => {

--- a/client/src/hooks/MCP/__tests__/polling.spec.ts
+++ b/client/src/hooks/MCP/__tests__/polling.spec.ts
@@ -16,6 +16,7 @@ describe('applyMCPDiscoveryAuthorizationState', () => {
           requiresOAuth: true,
           connectionState: 'connected',
           authorizationState: 'authorized',
+          authorizationGeneration: 'generation-1',
         },
       },
       {
@@ -25,6 +26,7 @@ describe('applyMCPDiscoveryAuthorizationState', () => {
             icon: '',
             authenticated: false,
             authorizationState: 'reauth_required',
+            authorizationGeneration: 'generation-1',
             authConfig: [],
             tools: [],
           },
@@ -36,7 +38,34 @@ describe('applyMCPDiscoveryAuthorizationState', () => {
       requiresOAuth: true,
       connectionState: 'disconnected',
       authorizationState: 'needs_authorization',
+      authorizationGeneration: 'generation-1',
     });
+  });
+
+  it('keeps status from a newer shared authorization generation', () => {
+    const currentStatus = {
+      oauth: {
+        requiresOAuth: true,
+        connectionState: 'connected' as const,
+        authorizationState: 'authorized' as const,
+        authorizationGeneration: 'generation-2',
+      },
+    };
+    const result = applyMCPDiscoveryAuthorizationState(currentStatus, {
+      servers: {
+        oauth: {
+          name: 'oauth',
+          icon: '',
+          authenticated: false,
+          authorizationState: 'reauth_required',
+          authorizationGeneration: 'generation-1',
+          authConfig: [],
+          tools: [],
+        },
+      },
+    });
+
+    expect(result).toBe(currentStatus);
   });
 });
 

--- a/client/src/hooks/MCP/__tests__/polling.spec.ts
+++ b/client/src/hooks/MCP/__tests__/polling.spec.ts
@@ -1,4 +1,5 @@
 import {
+  applyMCPDiscoveryAuthorizationState,
   getMCPOAuthTimeout,
   getMCPOAuthPollingOutcome,
   isMCPReadyAfterOAuth,
@@ -6,6 +7,38 @@ import {
   isTerminalMCPOAuthPollingError,
   shouldUseMCPConnectionStatus,
 } from '../polling';
+
+describe('applyMCPDiscoveryAuthorizationState', () => {
+  it('overrides stale connected status when catalog discovery requires reauthorization', () => {
+    const result = applyMCPDiscoveryAuthorizationState(
+      {
+        oauth: {
+          requiresOAuth: true,
+          connectionState: 'connected',
+          authorizationState: 'authorized',
+        },
+      },
+      {
+        servers: {
+          oauth: {
+            name: 'oauth',
+            icon: '',
+            authenticated: false,
+            authorizationState: 'reauth_required',
+            authConfig: [],
+            tools: [],
+          },
+        },
+      },
+    );
+
+    expect(result?.oauth).toEqual({
+      requiresOAuth: true,
+      connectionState: 'disconnected',
+      authorizationState: 'needs_authorization',
+    });
+  });
+});
 
 describe('getMCPOAuthTimeout', () => {
   it('preserves the remaining timeout of a reused flow over the global server window', () => {

--- a/client/src/hooks/MCP/__tests__/polling.spec.ts
+++ b/client/src/hooks/MCP/__tests__/polling.spec.ts
@@ -67,6 +67,35 @@ describe('applyMCPDiscoveryAuthorizationState', () => {
 
     expect(result).toBe(currentStatus);
   });
+
+  it.each([
+    ['missing discovery generation', undefined, 'generation-2'],
+    ['missing status generation', 'generation-1', undefined],
+  ])('keeps authorized status with %s', (_label, discoveryGeneration, statusGeneration) => {
+    const currentStatus = {
+      oauth: {
+        requiresOAuth: true,
+        connectionState: 'connected' as const,
+        authorizationState: 'authorized' as const,
+        authorizationGeneration: statusGeneration,
+      },
+    };
+    const result = applyMCPDiscoveryAuthorizationState(currentStatus, {
+      servers: {
+        oauth: {
+          name: 'oauth',
+          icon: '',
+          authenticated: false,
+          authorizationState: 'reauth_required',
+          authorizationGeneration: discoveryGeneration,
+          authConfig: [],
+          tools: [],
+        },
+      },
+    });
+
+    expect(result).toBe(currentStatus);
+  });
 });
 
 describe('getMCPOAuthTimeout', () => {

--- a/client/src/hooks/MCP/__tests__/useMCPServerManager.spec.tsx
+++ b/client/src/hooks/MCP/__tests__/useMCPServerManager.spec.tsx
@@ -9,6 +9,7 @@ import { useMCPServerManager } from '../useMCPServerManager';
 const mockShowToast = jest.fn();
 const mockSetMCPValues = jest.fn();
 const mockReinitialize = jest.fn();
+const mockUseMCPToolsQuery = jest.fn((_options?: unknown) => ({ data: undefined }));
 
 jest.mock('@librechat/client', () => ({
   useToastContext: () => ({ showToast: mockShowToast }),
@@ -25,7 +26,7 @@ jest.mock('~/hooks', () => ({
 jest.mock('~/data-provider', () => ({
   useGetStartupConfig: () => ({ data: {} }),
   useMCPServersQuery: () => ({ data: {}, isLoading: false }),
-  useMCPToolsQuery: () => ({ data: undefined }),
+  useMCPToolsQuery: (options: unknown) => mockUseMCPToolsQuery(options),
 }));
 
 jest.mock('librechat-data-provider/react-query', () => ({
@@ -46,6 +47,23 @@ function deferred<T>() {
 }
 
 describe('useMCPServerManager initialization', () => {
+  it('lets a host suppress the passive tools observer', () => {
+    const queryClient = new QueryClient();
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <Provider>
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </Provider>
+    );
+
+    const { unmount } = renderHook(() => useMCPServerManager({ observeToolAuthorization: false }), {
+      wrapper,
+    });
+
+    expect(mockUseMCPToolsQuery).toHaveBeenLastCalledWith({ enabled: false });
+    unmount();
+    queryClient.clear();
+  });
+
   it.each(['success', 'error'])(
     'finishes before a slow catalog refetch ends in %s',
     async (outcome) => {

--- a/client/src/hooks/MCP/__tests__/useMCPServerManager.spec.tsx
+++ b/client/src/hooks/MCP/__tests__/useMCPServerManager.spec.tsx
@@ -48,7 +48,7 @@ function deferred<T>() {
 }
 
 describe('useMCPServerManager initialization', () => {
-  it('lets a host suppress the passive tools observer', () => {
+  it('keeps passive authorization observers opt-in for shared hook callers', () => {
     const queryClient = new QueryClient();
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <Provider>
@@ -56,9 +56,7 @@ describe('useMCPServerManager initialization', () => {
       </Provider>
     );
 
-    const { unmount } = renderHook(() => useMCPServerManager({ observeToolAuthorization: false }), {
-      wrapper,
-    });
+    const { unmount } = renderHook(() => useMCPServerManager(), { wrapper });
 
     expect(mockUseMCPToolsQuery).toHaveBeenLastCalledWith({ enabled: false });
     expect(mockUseMCPConnectionStatus).toHaveBeenLastCalledWith({ enabled: false });

--- a/client/src/hooks/MCP/__tests__/useMCPServerManager.spec.tsx
+++ b/client/src/hooks/MCP/__tests__/useMCPServerManager.spec.tsx
@@ -10,6 +10,7 @@ const mockShowToast = jest.fn();
 const mockSetMCPValues = jest.fn();
 const mockReinitialize = jest.fn();
 const mockUseMCPToolsQuery = jest.fn((_options?: unknown) => ({ data: undefined }));
+const mockUseMCPConnectionStatus = jest.fn((_options?: unknown) => ({ connectionStatus: {} }));
 
 jest.mock('@librechat/client', () => ({
   useToastContext: () => ({ showToast: mockShowToast }),
@@ -20,7 +21,7 @@ jest.mock('~/hooks', () => ({
   useHasAccess: () => true,
   useCatalogReady: () => true,
   useMCPSelect: () => ({ mcpValues: [], setMCPValues: mockSetMCPValues }),
-  useMCPConnectionStatus: () => ({ connectionStatus: {} }),
+  useMCPConnectionStatus: (options: unknown) => mockUseMCPConnectionStatus(options),
 }));
 
 jest.mock('~/data-provider', () => ({
@@ -60,6 +61,7 @@ describe('useMCPServerManager initialization', () => {
     });
 
     expect(mockUseMCPToolsQuery).toHaveBeenLastCalledWith({ enabled: false });
+    expect(mockUseMCPConnectionStatus).toHaveBeenLastCalledWith({ enabled: false });
     unmount();
     queryClient.clear();
   });

--- a/client/src/hooks/MCP/__tests__/useMCPServerManager.spec.tsx
+++ b/client/src/hooks/MCP/__tests__/useMCPServerManager.spec.tsx
@@ -25,6 +25,7 @@ jest.mock('~/hooks', () => ({
 jest.mock('~/data-provider', () => ({
   useGetStartupConfig: () => ({ data: {} }),
   useMCPServersQuery: () => ({ data: {}, isLoading: false }),
+  useMCPToolsQuery: () => ({ data: undefined }),
 }));
 
 jest.mock('librechat-data-provider/react-query', () => ({

--- a/client/src/hooks/MCP/polling.ts
+++ b/client/src/hooks/MCP/polling.ts
@@ -22,6 +22,11 @@ export function applyMCPDiscoveryAuthorizationState(
     const discoveryGeneration = discoveredTools?.servers[serverName]?.authorizationGeneration;
     const current = nextStatus?.[serverName];
     const statusGeneration = current?.authorizationGeneration;
+    const statusIsActive =
+      current?.connectionState === 'connecting' || current?.authorizationState === 'authorizing';
+    if (statusIsActive) {
+      continue;
+    }
     const statusAuthorizes =
       current?.connectionState === 'connected' || current?.authorizationState === 'authorized';
     if (statusAuthorizes && (discoveryGeneration == null || statusGeneration == null)) {

--- a/client/src/hooks/MCP/polling.ts
+++ b/client/src/hooks/MCP/polling.ts
@@ -17,7 +17,18 @@ export function applyMCPDiscoveryAuthorizationState(
   }
 
   const nextStatus = { ...(connectionStatus ?? {}) };
+  let changed = false;
   for (const serverName of reauthRequired) {
+    const discoveryGeneration = discoveredTools?.servers[serverName]?.authorizationGeneration;
+    const statusGeneration = nextStatus?.[serverName]?.authorizationGeneration;
+    if (
+      discoveryGeneration != null &&
+      statusGeneration != null &&
+      discoveryGeneration !== statusGeneration
+    ) {
+      continue;
+    }
+    changed = true;
     nextStatus[serverName] = {
       ...nextStatus[serverName],
       requiresOAuth: true,
@@ -25,7 +36,7 @@ export function applyMCPDiscoveryAuthorizationState(
       authorizationState: 'needs_authorization',
     };
   }
-  return nextStatus;
+  return changed ? nextStatus : connectionStatus;
 }
 
 export type MCPOAuthPollingOutcome = 'pending' | 'completed' | 'failed';

--- a/client/src/hooks/MCP/polling.ts
+++ b/client/src/hooks/MCP/polling.ts
@@ -1,8 +1,32 @@
 import type {
   MCPServerStatus,
+  MCPServersResponse,
   MCPOAuthStatusResponse,
   MCPReinitializeResponse,
 } from 'librechat-data-provider';
+
+export function applyMCPDiscoveryAuthorizationState(
+  connectionStatus: Record<string, MCPServerStatus> | undefined,
+  discoveredTools: MCPServersResponse | undefined,
+): Record<string, MCPServerStatus> | undefined {
+  const reauthRequired = Object.entries(discoveredTools?.servers ?? {})
+    .filter(([, server]) => server.authorizationState === 'reauth_required')
+    .map(([serverName]) => serverName);
+  if (reauthRequired.length === 0) {
+    return connectionStatus;
+  }
+
+  const nextStatus = { ...(connectionStatus ?? {}) };
+  for (const serverName of reauthRequired) {
+    nextStatus[serverName] = {
+      ...nextStatus[serverName],
+      requiresOAuth: true,
+      connectionState: 'disconnected',
+      authorizationState: 'needs_authorization',
+    };
+  }
+  return nextStatus;
+}
 
 export type MCPOAuthPollingOutcome = 'pending' | 'completed' | 'failed';
 

--- a/client/src/hooks/MCP/polling.ts
+++ b/client/src/hooks/MCP/polling.ts
@@ -20,7 +20,13 @@ export function applyMCPDiscoveryAuthorizationState(
   let changed = false;
   for (const serverName of reauthRequired) {
     const discoveryGeneration = discoveredTools?.servers[serverName]?.authorizationGeneration;
-    const statusGeneration = nextStatus?.[serverName]?.authorizationGeneration;
+    const current = nextStatus?.[serverName];
+    const statusGeneration = current?.authorizationGeneration;
+    const statusAuthorizes =
+      current?.connectionState === 'connected' || current?.authorizationState === 'authorized';
+    if (statusAuthorizes && (discoveryGeneration == null || statusGeneration == null)) {
+      continue;
+    }
     if (
       discoveryGeneration != null &&
       statusGeneration != null &&
@@ -30,7 +36,7 @@ export function applyMCPDiscoveryAuthorizationState(
     }
     changed = true;
     nextStatus[serverName] = {
-      ...nextStatus[serverName],
+      ...current,
       requiresOAuth: true,
       connectionState: 'disconnected',
       authorizationState: 'needs_authorization',

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -65,6 +65,7 @@ export function useMCPServerManager({
   storageContextKey,
   specName,
   ownsChatSelection = false,
+  observeToolAuthorization = true,
 }: {
   conversationId?: string | null;
   storageContextKey?: string;
@@ -77,6 +78,8 @@ export function useMCPServerManager({
    * needed to prune it correctly.
    */
   ownsChatSelection?: boolean;
+  /** Allows hosts that suppress MCP catalog work (such as ephemeral agents) to reuse the manager. */
+  observeToolAuthorization?: boolean;
 } = {}) {
   const localize = useLocalize();
   const queryClient = useQueryClient();
@@ -95,7 +98,11 @@ export function useMCPServerManager({
   const { data: loadedServers, isLoading } = useMCPServersQuery({ enabled: mcpEnabled });
   const mcpToolsReady = useCatalogReady('mcpTools');
   const { data: discoveredMCPTools } = useMCPToolsQuery({
-    enabled: mcpEnabled && mcpToolsReady && Object.keys(loadedServers ?? {}).length > 0,
+    enabled:
+      observeToolAuthorization &&
+      mcpEnabled &&
+      mcpToolsReady &&
+      Object.keys(loadedServers ?? {}).length > 0,
   });
 
   // Fetch effective permissions for all MCP servers

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -33,6 +33,7 @@ import {
   shouldFailMCPOAuthFallback,
   isTerminalMCPOAuthPollingError,
   shouldUseMCPConnectionStatus,
+  applyMCPDiscoveryAuthorizationState,
 } from './polling';
 import {
   useLocalize,
@@ -41,7 +42,7 @@ import {
   useCatalogReady,
   useMCPConnectionStatus,
 } from '~/hooks';
-import { useGetStartupConfig, useMCPServersQuery } from '~/data-provider';
+import { useGetStartupConfig, useMCPServersQuery, useMCPToolsQuery } from '~/data-provider';
 import { mcpServerInitStatesAtom, getServerInitState } from '~/store/mcp';
 import { getMCPReinitializeErrorMessage } from './errors';
 
@@ -92,6 +93,10 @@ export function useMCPServerManager({
   const mcpEnabled = canUseMcp && mcpServersReady;
 
   const { data: loadedServers, isLoading } = useMCPServersQuery({ enabled: mcpEnabled });
+  const mcpToolsReady = useCatalogReady('mcpTools');
+  const { data: discoveredMCPTools } = useMCPToolsQuery({
+    enabled: mcpEnabled && mcpToolsReady && Object.keys(loadedServers ?? {}).length > 0,
+  });
 
   // Fetch effective permissions for all MCP servers
   const { data: permissionsMap } = useGetAllEffectivePermissionsQuery(ResourceType.MCPSERVER, {
@@ -201,7 +206,7 @@ export function useMCPServerManager({
   });
   const connectionStatus = useMemo(() => {
     if (!polledConnectionStatus) {
-      return polledConnectionStatus;
+      return applyMCPDiscoveryAuthorizationState(polledConnectionStatus, discoveredMCPTools);
     }
 
     let changed = false;
@@ -214,8 +219,9 @@ export function useMCPServerManager({
       changed = true;
       nextStatus[serverName] = { ...status, requestScoped: true };
     }
-    return changed ? nextStatus : polledConnectionStatus;
-  }, [polledConnectionStatus, loadedServers]);
+    const normalizedStatus = changed ? nextStatus : polledConnectionStatus;
+    return applyMCPDiscoveryAuthorizationState(normalizedStatus, discoveredMCPTools);
+  }, [polledConnectionStatus, loadedServers, discoveredMCPTools]);
 
   const updateServerInitState = useCallback(
     (serverName: string, updates: Partial<MCPServerInitState>) => {

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -209,7 +209,7 @@ export function useMCPServerManager({
   const pollIntervalsRef = useRef<PollIntervals>({});
 
   const { connectionStatus: polledConnectionStatus } = useMCPConnectionStatus({
-    enabled: !isLoading && availableMCPServers.length > 0,
+    enabled: observeToolAuthorization && !isLoading && availableMCPServers.length > 0,
   });
   const connectionStatus = useMemo(() => {
     if (!polledConnectionStatus) {

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -65,7 +65,7 @@ export function useMCPServerManager({
   storageContextKey,
   specName,
   ownsChatSelection = false,
-  observeToolAuthorization = true,
+  observeToolAuthorization = false,
 }: {
   conversationId?: string | null;
   storageContextKey?: string;

--- a/client/src/routes/ChatRoute.tsx
+++ b/client/src/routes/ChatRoute.tsx
@@ -4,7 +4,13 @@ import { useRecoilCallback, useRecoilValue } from 'recoil';
 import { Spinner, useToastContext } from '@librechat/client';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { useGetModelsQuery } from 'librechat-data-provider/react-query';
-import { Constants, EModelEndpoint, PermissionBits } from 'librechat-data-provider';
+import {
+  Constants,
+  EModelEndpoint,
+  PermissionBits,
+  isAgentsEndpoint,
+  isEphemeralAgentId,
+} from 'librechat-data-provider';
 import type { TPreset, TAgentsMap } from 'librechat-data-provider';
 import {
   defaultSpecAwaitsAgents,
@@ -55,8 +61,6 @@ export default function ChatRoute() {
       },
     [],
   );
-  useAppStartup({ startupConfig, user });
-
   const index = 0;
   const [searchParams, setSearchParams] = useSearchParams();
   const { conversationId = '' } = useParams();
@@ -64,6 +68,10 @@ export default function ChatRoute() {
   const chatProjectId = isValidChatProjectId(projectIdParam) ? projectIdParam : null;
   useIdChangeEffect(conversationId);
   const { hasSetConversation, conversation } = store.useCreateConversationAtom(index);
+  const mcpWarmupAllowed =
+    conversation != null &&
+    !(isAgentsEndpoint(conversation.endpoint) && isEphemeralAgentId(conversation.agent_id ?? ''));
+  useAppStartup({ startupConfig, user, mcpWarmupAllowed });
   const { newConversation } = useNewConvo();
   const { showToast } = useToastContext();
   const localize = useLocalize();

--- a/packages/api/src/flow/manager.test.ts
+++ b/packages/api/src/flow/manager.test.ts
@@ -276,6 +276,23 @@ describe('FlowStateManager', () => {
       expect(result).toBe('fresh-result');
     });
 
+    it('should re-read completion that wins after its guarded failure write', async () => {
+      const flowId = 'post-failure-race-flow';
+      const type = 'test-type';
+      const originalFail = flowManager.failFlowIfCurrent.bind(flowManager);
+      jest.spyOn(flowManager, 'failFlowIfCurrent').mockImplementation(async (...args) => {
+        const failureResult = await originalFail(...args);
+        await flowManager.settleFlowIfCurrent(flowId, type, args[2], args[3], 'fresh-result');
+        return failureResult;
+      });
+
+      const result = await flowManager.createFlowWithHandler(flowId, type, async () => {
+        throw new Error('stale failure');
+      });
+
+      expect(result).toBe('fresh-result');
+    });
+
     it('should handle flow timeout correctly', async () => {
       const flowId = 'timeout-flow';
       const type = 'test-type';

--- a/packages/api/src/flow/manager.test.ts
+++ b/packages/api/src/flow/manager.test.ts
@@ -149,6 +149,39 @@ describe('FlowStateManager', () => {
       });
     });
 
+    it('settles a fresher result over a completion from the same observed attempt', async () => {
+      await flowManager.initFlow('token-flow', 'mcp_get_tokens');
+      const flow = await flowManager.getFlowState('token-flow', 'mcp_get_tokens');
+      await flowManager.completeFlow('token-flow', 'mcp_get_tokens', 'old-token');
+
+      await expect(
+        flowManager.settleFlowIfCurrent(
+          'token-flow',
+          'mcp_get_tokens',
+          flow!.createdAt,
+          '',
+          'fresh-token',
+        ),
+      ).resolves.toBe('updated');
+
+      expect(await flowManager.getFlowState('token-flow', 'mcp_get_tokens')).toMatchObject({
+        status: 'COMPLETED',
+        result: 'fresh-token',
+      });
+    });
+
+    it('does not settle a replacement token-flow attempt', async () => {
+      await flowManager.initFlow('token-flow', 'mcp_get_tokens');
+
+      await expect(
+        flowManager.settleFlowIfCurrent('token-flow', 'mcp_get_tokens', 1, '', 'old-token'),
+      ).resolves.toBe('stale');
+
+      expect(await flowManager.getFlowState('token-flow', 'mcp_get_tokens')).toMatchObject({
+        status: 'PENDING',
+      });
+    });
+
     it('fails only the observed OAuth attempt', async () => {
       await flowManager.initFlow('oauth-flow', 'mcp_oauth', { state: 'expected-state' });
       const flow = await flowManager.getFlowState('oauth-flow', 'mcp_oauth');

--- a/packages/api/src/flow/manager.test.ts
+++ b/packages/api/src/flow/manager.test.ts
@@ -170,6 +170,27 @@ describe('FlowStateManager', () => {
       });
     });
 
+    it('settles a fresher result over a failure from the same observed attempt', async () => {
+      await flowManager.initFlow('token-flow', 'mcp_get_tokens');
+      const flow = await flowManager.getFlowState('token-flow', 'mcp_get_tokens');
+      await flowManager.failFlow('token-flow', 'mcp_get_tokens', new Error('stale failure'));
+
+      await expect(
+        flowManager.settleFlowIfCurrent(
+          'token-flow',
+          'mcp_get_tokens',
+          flow!.createdAt,
+          '',
+          'fresh-token',
+        ),
+      ).resolves.toBe('updated');
+
+      expect(await flowManager.getFlowState('token-flow', 'mcp_get_tokens')).toMatchObject({
+        status: 'COMPLETED',
+        result: 'fresh-token',
+      });
+    });
+
     it('does not settle a replacement token-flow attempt', async () => {
       await flowManager.initFlow('token-flow', 'mcp_get_tokens');
 
@@ -241,6 +262,18 @@ describe('FlowStateManager', () => {
           result: 'fresh-result',
         }),
       );
+    });
+
+    it('should return the externally completed result when handler loses failure race', async () => {
+      const flowId = 'failure-race-flow';
+      const type = 'test-type';
+
+      const result = await flowManager.createFlowWithHandler(flowId, type, async () => {
+        await flowManager.completeFlow(flowId, type, 'fresh-result');
+        throw new Error('stale failure');
+      });
+
+      expect(result).toBe('fresh-result');
     });
 
     it('should handle flow timeout correctly', async () => {

--- a/packages/api/src/flow/manager.ts
+++ b/packages/api/src/flow/manager.ts
@@ -86,7 +86,6 @@ local flow = data.value
 if flow.createdAt ~= tonumber(ARGV[1]) then return -1 end
 local state = flow.metadata and flow.metadata.state or ''
 if state ~= ARGV[2] then return -1 end
-if flow.status == 'FAILED' then return -1 end
 flow.status = 'COMPLETED'
 flow.result = cjson.decode(ARGV[3])
 flow.completedAt = tonumber(ARGV[4])
@@ -540,8 +539,8 @@ export class FlowStateManager<T = unknown> {
     return 'updated';
   }
 
-  /** Publishes a result for the exact observed attempt even if that attempt completed while the
-   * caller was committing a fresher durable value. A failed or replaced attempt is never revived. */
+  /** Publishes an authoritative result for the exact observed attempt even if its handler settled
+   * while the caller was committing a fresher durable value. A replacement attempt is untouched. */
   async settleFlowIfCurrent(
     flowId: string,
     type: string,
@@ -565,9 +564,6 @@ export class FlowStateManager<T = unknown> {
 
     const settle = (current: FlowState<T>): FlowState<T> | null => {
       if (!FlowStateManager.isCurrentAttempt(current, expectedCreatedAt, expectedState)) {
-        return null;
-      }
-      if (current.status === 'FAILED') {
         return null;
       }
       return { ...current, status: 'COMPLETED', result, completedAt };
@@ -975,13 +971,23 @@ export class FlowStateManager<T = unknown> {
       }
       return result;
     } catch (error) {
-      await this.failFlowIfCurrent(
+      const failureResult = await this.failFlowIfCurrent(
         flowId,
         type,
         initialState.createdAt,
         '',
         error instanceof Error ? error : new Error(String(error)),
       );
+      if (failureResult === 'stale') {
+        const settledState = (await this.keyv.get(flowKey)) as FlowState<T> | undefined;
+        if (
+          settledState?.status === 'COMPLETED' &&
+          settledState.result !== undefined &&
+          FlowStateManager.isCurrentAttempt(settledState, initialState.createdAt, '')
+        ) {
+          return settledState.result;
+        }
+      }
       throw error;
     }
   }

--- a/packages/api/src/flow/manager.ts
+++ b/packages/api/src/flow/manager.ts
@@ -76,6 +76,25 @@ redis.call('SET', KEYS[1], cjson.encode(data), 'PX', ARGV[5])
 return 1
 `;
 
+/** Replaces either a pending or completed result for the exact observed attempt. This is used
+ * when a fresher durable credential must win a race with the handler that loaded the old one. */
+const GUARDED_SETTLE_FLOW = `
+local raw = redis.call('GET', KEYS[1])
+if not raw then return 0 end
+local data = cjson.decode(raw)
+local flow = data.value
+if flow.createdAt ~= tonumber(ARGV[1]) then return -1 end
+local state = flow.metadata and flow.metadata.state or ''
+if state ~= ARGV[2] then return -1 end
+if flow.status == 'FAILED' then return -1 end
+flow.status = 'COMPLETED'
+flow.result = cjson.decode(ARGV[3])
+flow.completedAt = tonumber(ARGV[4])
+data.expires = tonumber(ARGV[4]) + tonumber(ARGV[5])
+redis.call('SET', KEYS[1], cjson.encode(data), 'PX', ARGV[5])
+return 1
+`;
+
 const READ_LEASE_GENERATION = `
 local raw = redis.call('GET', KEYS[1])
 if not raw then return 0 end
@@ -521,6 +540,62 @@ export class FlowStateManager<T = unknown> {
     return 'updated';
   }
 
+  /** Publishes a result for the exact observed attempt even if that attempt completed while the
+   * caller was committing a fresher durable value. A failed or replaced attempt is never revived. */
+  async settleFlowIfCurrent(
+    flowId: string,
+    type: string,
+    expectedCreatedAt: number,
+    expectedState: string,
+    result: T,
+  ): Promise<GuardedMutationResult> {
+    const flowKey = this.getFlowKey(flowId, type);
+    const completedAt = Date.now();
+    const redisKey = this.getRedisKey(flowKey);
+    if (redisKey) {
+      const guardedResult = await this.evalRedisScript(GUARDED_SETTLE_FLOW, redisKey, [
+        String(expectedCreatedAt),
+        expectedState,
+        JSON.stringify(result) ?? 'null',
+        String(completedAt),
+        String(this.ttl),
+      ]);
+      return FlowStateManager.guardedResult(guardedResult);
+    }
+
+    const settle = (current: FlowState<T>): FlowState<T> | null => {
+      if (!FlowStateManager.isCurrentAttempt(current, expectedCreatedAt, expectedState)) {
+        return null;
+      }
+      if (current.status === 'FAILED') {
+        return null;
+      }
+      return { ...current, status: 'COMPLETED', result, completedAt };
+    };
+    const memoryEntry = this.getInMemoryEntry(flowKey);
+    if (memoryEntry) {
+      const updated = settle(memoryEntry.envelope.value);
+      if (updated == null) {
+        return 'stale';
+      }
+      memoryEntry.envelope.value = updated;
+      memoryEntry.envelope.expires = completedAt + this.ttl;
+      memoryEntry.store.set(memoryEntry.key, JSON.stringify(memoryEntry.envelope));
+      return 'updated';
+    }
+
+    const current = (await this.keyv.get(flowKey)) as FlowState<T> | undefined;
+    if (!current) {
+      return 'missing';
+    }
+    const updated = settle(current);
+    if (updated == null) {
+      return 'stale';
+    }
+    await this.keyv.set(flowKey, updated, this.ttl);
+    return 'updated';
+  }
+
   private isTokenExpired(flowState: FlowState<T> | undefined): boolean {
     if (!flowState?.result || typeof flowState.result !== 'object') {
       return false;
@@ -893,14 +968,20 @@ export class FlowStateManager<T = unknown> {
 
     try {
       const result = await handler();
-      await this.completeFlow(flowId, type, result);
+      await this.completeFlowIfCurrent(flowId, type, initialState.createdAt, '', result);
       const completedState = (await this.keyv.get(flowKey)) as FlowState<T> | undefined;
       if (completedState?.status === 'COMPLETED' && completedState.result !== undefined) {
         return completedState.result;
       }
       return result;
     } catch (error) {
-      await this.failFlow(flowId, type, error instanceof Error ? error : new Error(String(error)));
+      await this.failFlowIfCurrent(
+        flowId,
+        type,
+        initialState.createdAt,
+        '',
+        error instanceof Error ? error : new Error(String(error)),
+      );
       throw error;
     }
   }

--- a/packages/api/src/flow/manager.ts
+++ b/packages/api/src/flow/manager.ts
@@ -971,22 +971,20 @@ export class FlowStateManager<T = unknown> {
       }
       return result;
     } catch (error) {
-      const failureResult = await this.failFlowIfCurrent(
+      await this.failFlowIfCurrent(
         flowId,
         type,
         initialState.createdAt,
         '',
         error instanceof Error ? error : new Error(String(error)),
       );
-      if (failureResult === 'stale') {
-        const settledState = (await this.keyv.get(flowKey)) as FlowState<T> | undefined;
-        if (
-          settledState?.status === 'COMPLETED' &&
-          settledState.result !== undefined &&
-          FlowStateManager.isCurrentAttempt(settledState, initialState.createdAt, '')
-        ) {
-          return settledState.result;
-        }
+      const settledState = (await this.keyv.get(flowKey)) as FlowState<T> | undefined;
+      if (
+        settledState?.status === 'COMPLETED' &&
+        settledState.result !== undefined &&
+        FlowStateManager.isCurrentAttempt(settledState, initialState.createdAt, '')
+      ) {
+        return settledState.result;
       }
       throw error;
     }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -30,6 +30,7 @@ export * from './mcp/tools';
 export * from './mcp/catalog/store';
 export * from './mcp/catalog/recovery';
 export * from './mcp/authorization';
+export * from './mcp/authorizationRetry';
 export * from './mcp/assistants';
 export * from './mcp/request';
 export * from './mcp/icons';

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -29,6 +29,7 @@ export * from './mcp/cache';
 export * from './mcp/tools';
 export * from './mcp/catalog/store';
 export * from './mcp/catalog/recovery';
+export * from './mcp/authorization';
 export * from './mcp/assistants';
 export * from './mcp/request';
 export * from './mcp/icons';

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -17,6 +17,7 @@ import type { FlowStateManager } from '~/flow/manager';
 import type * as t from './types';
 import {
   MCPTokenStorage,
+  MCPTokenStorageUnavailableError,
   MCPOAuthHandler,
   getMCPServerGeneration,
   getMCPOAuthLeaseId,
@@ -939,6 +940,13 @@ export class MCPConnectionFactory {
       if (error instanceof ReauthenticationRequiredError) {
         logger.info(`${this.logPrefix} Reauthentication required; triggering OAuth flow`);
         return null;
+      }
+      if (
+        error instanceof MCPTokenStorageUnavailableError ||
+        (error instanceof Error && error.name === 'MCPTokenStorageUnavailableError')
+      ) {
+        logger.warn(`${this.logPrefix} OAuth token loading failed; deferring connection recovery`);
+        throw error;
       }
       logger.debug(`${this.logPrefix} No existing tokens found or token loading failed`);
       return null;

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -91,6 +91,7 @@ export class MCPConnectionFactory {
   protected readonly connectionTimeout?: number;
   protected readonly deadlineMs?: number;
   protected readonly onOAuthCredentialsChanged?: t.UserConnectionContext['onOAuthCredentialsChanged'];
+  protected readonly onOAuthCredentialsChanging?: t.UserConnectionContext['onOAuthCredentialsChanging'];
   protected readonly oboTokenResolver?: OboTokenResolver;
   protected readonly oboTrustChecker?: OboTrustChecker;
   protected upstreamTokenProvider?: UpstreamTokenProvider;
@@ -579,6 +580,7 @@ export class MCPConnectionFactory {
     this.connectionTimeout = options?.connectionTimeout;
     this.deadlineMs = options?.deadlineMs;
     this.onOAuthCredentialsChanged = options?.onOAuthCredentialsChanged;
+    this.onOAuthCredentialsChanging = options?.onOAuthCredentialsChanging;
     this.signal = options?.signal;
     this.tenantContext = tenantStorage?.getStore?.();
     this.tenantId = this.tenantContext?.tenantId ?? getTenantId();
@@ -896,6 +898,7 @@ export class MCPConnectionFactory {
               singleFlightScope: this.getOAuthBindingDigest(),
               flowManager: this.flowManager,
               onRefreshSuccess: (refreshed) => this.handleOAuthRefreshSuccess(refreshed),
+              onRefreshPreparing: () => this.prepareOAuthRefreshSuccess(),
             }),
           );
         },
@@ -1096,6 +1099,7 @@ export class MCPConnectionFactory {
            * timeout still invalidates the cache.
            */
           onRefreshSuccess: (refreshed) => this.handleOAuthRefreshSuccess(refreshed),
+          onRefreshPreparing: () => this.prepareOAuthRefreshSuccess(),
           flowManager: this.flowManager,
         }),
       );
@@ -1133,6 +1137,36 @@ export class MCPConnectionFactory {
       });
     }
     await this.invalidateGetTokensFlow(freshTokens);
+  }
+
+  private async prepareOAuthRefreshSuccess(): Promise<
+    (freshTokens?: MCPOAuthTokens) => Promise<void>
+  > {
+    const publishPreparedMutation =
+      this.userId == null
+        ? undefined
+        : await this.onOAuthCredentialsChanging?.({
+            userId: this.userId,
+            serverName: this.serverName,
+          });
+    return async (freshTokens) => {
+      if (publishPreparedMutation != null) {
+        await publishPreparedMutation();
+        await this.invalidateGetTokensFlow(freshTokens);
+        return;
+      }
+      if (freshTokens != null) {
+        await this.handleOAuthRefreshSuccess(freshTokens);
+      } else {
+        if (this.userId != null) {
+          await this.onOAuthCredentialsChanged?.({
+            userId: this.userId,
+            serverName: this.serverName,
+          });
+        }
+        await this.invalidateGetTokensFlow();
+      }
+    };
   }
 
   protected async invalidateGetTokensFlow(freshTokens?: MCPOAuthTokens): Promise<void> {

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -17,6 +17,7 @@ import type { FlowStateManager } from '~/flow/manager';
 import type * as t from './types';
 import {
   MCPTokenStorage,
+  MCPTokenRefreshUnavailableError,
   MCPTokenStorageUnavailableError,
   MCPOAuthHandler,
   getMCPServerGeneration,
@@ -943,7 +944,10 @@ export class MCPConnectionFactory {
       }
       if (
         error instanceof MCPTokenStorageUnavailableError ||
-        (error instanceof Error && error.name === 'MCPTokenStorageUnavailableError')
+        error instanceof MCPTokenRefreshUnavailableError ||
+        (error instanceof Error &&
+          (error.name === 'MCPTokenStorageUnavailableError' ||
+            error.name === 'MCPTokenRefreshUnavailableError'))
       ) {
         logger.warn(`${this.logPrefix} OAuth token loading failed; deferring connection recovery`);
         throw error;

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -88,6 +88,7 @@ export class MCPConnectionFactory {
   protected returnOnOAuth?: boolean;
   protected readonly connectionTimeout?: number;
   protected readonly deadlineMs?: number;
+  protected readonly onOAuthCredentialsChanged?: t.UserConnectionContext['onOAuthCredentialsChanged'];
   protected readonly oboTokenResolver?: OboTokenResolver;
   protected readonly oboTrustChecker?: OboTrustChecker;
   protected upstreamTokenProvider?: UpstreamTokenProvider;
@@ -575,6 +576,7 @@ export class MCPConnectionFactory {
     );
     this.connectionTimeout = options?.connectionTimeout;
     this.deadlineMs = options?.deadlineMs;
+    this.onOAuthCredentialsChanged = options?.onOAuthCredentialsChanged;
     this.signal = options?.signal;
     this.tenantContext = tenantStorage?.getStore?.();
     this.tenantId = this.tenantContext?.tenantId ?? getTenantId();
@@ -891,6 +893,7 @@ export class MCPConnectionFactory {
               refreshTokens: this.createRefreshTokensFunction(),
               singleFlightScope: this.getOAuthBindingDigest(),
               flowManager: this.flowManager,
+              onRefreshSuccess: (refreshed) => this.handleOAuthRefreshSuccess(refreshed),
             }),
           );
         },
@@ -1080,9 +1083,7 @@ export class MCPConnectionFactory {
            * (not this waiter) so a refresh that completes after this caller's
            * timeout still invalidates the cache.
            */
-          onRefreshSuccess: async (refreshed) => {
-            await this.invalidateGetTokensFlow(refreshed);
-          },
+          onRefreshSuccess: (refreshed) => this.handleOAuthRefreshSuccess(refreshed),
           flowManager: this.flowManager,
         }),
       );
@@ -1112,6 +1113,16 @@ export class MCPConnectionFactory {
    * entries are deleted; PENDING entries are completed with fresh tokens so
    * concurrent waiters do not fail or later publish server-rejected tokens.
    */
+  private async handleOAuthRefreshSuccess(freshTokens: MCPOAuthTokens): Promise<void> {
+    if (this.userId != null) {
+      await this.onOAuthCredentialsChanged?.({
+        userId: this.userId,
+        serverName: this.serverName,
+      });
+    }
+    await this.invalidateGetTokensFlow(freshTokens);
+  }
+
   protected async invalidateGetTokensFlow(freshTokens?: MCPOAuthTokens): Promise<void> {
     if (!this.flowManager || !this.userId) {
       return;

--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -88,7 +88,7 @@ function getDiscoveryAuthenticationKind(
  */
 export class MCPManager extends UserConnectionManager {
   private static instance: MCPManager | null;
-  private readonly catalogRecoveryTracker = new MCPServerCatalogRecoveryTracker();
+  private readonly catalogRecoveryTracker: MCPServerCatalogRecoveryTracker;
   private readonly recoveryCancellation = new WeakMap<
     Promise<void>,
     { controller: AbortController; waiters: number; connection: MCPConnection }
@@ -106,10 +106,20 @@ export class MCPManager extends UserConnectionManager {
     }
   >();
 
+  constructor(catalogRecoveryMaxStateEntries?: number) {
+    super();
+    this.catalogRecoveryTracker = new MCPServerCatalogRecoveryTracker(
+      catalogRecoveryMaxStateEntries,
+    );
+  }
+
   /** Creates and initializes the singleton MCPManager instance */
-  public static async createInstance(configs: t.MCPServers): Promise<MCPManager> {
+  public static async createInstance(
+    configs: t.MCPServers,
+    options?: { catalogRecoveryMaxStateEntries?: number },
+  ): Promise<MCPManager> {
     if (MCPManager.instance) throw new Error('MCPManager has already been initialized.');
-    MCPManager.instance = new MCPManager();
+    MCPManager.instance = new MCPManager(options?.catalogRecoveryMaxStateEntries);
     await MCPManager.instance.initialize(configs);
     return MCPManager.instance;
   }

--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -504,6 +504,7 @@ export class MCPManager extends UserConnectionManager {
       graphTokenResolver: args.graphTokenResolver,
       connectionTimeout: args.connectionTimeout,
       deadlineMs: args.deadlineMs,
+      onOAuthCredentialsChanged: args.onOAuthCredentialsChanged,
       oboTokenResolver: args.oboTokenResolver,
       oboTrustChecker: args.oboTrustChecker,
       upstreamTokenProvider: args.upstreamTokenProvider,
@@ -814,6 +815,7 @@ Please follow these instructions when using tools from the respective MCP server
     graphTokenResolver,
     upstreamTokenProvider,
     oboIdentityContext,
+    onOAuthCredentialsChanged,
     signal,
     directBearerRecoveryState = { attempted: true },
   }: {
@@ -831,6 +833,7 @@ Please follow these instructions when using tools from the respective MCP server
     graphTokenResolver?: GraphTokenResolver;
     upstreamTokenProvider?: UpstreamTokenProvider;
     oboIdentityContext?: AuthIdentityContext;
+    onOAuthCredentialsChanged?: t.UserConnectionContext['onOAuthCredentialsChanged'];
     signal?: AbortSignal;
     directBearerRecoveryState?: t.DirectBearerRecoveryState;
   }): Promise<void> {
@@ -888,6 +891,7 @@ Please follow these instructions when using tools from the respective MCP server
           graphTokenResolver,
           upstreamTokenProvider,
           oboIdentityContext,
+          onOAuthCredentialsChanged,
           directBearerRecoveryState,
           directBearerResolvedConfig: refreshedConfig,
           signal: recoverySignal,
@@ -1060,6 +1064,7 @@ Please follow these instructions when using tools from the respective MCP server
     oboTrustChecker,
     upstreamTokenProvider,
     oboIdentityContext,
+    onOAuthCredentialsChanged,
   }: {
     user?: IUser;
     serverName: string;
@@ -1081,6 +1086,7 @@ Please follow these instructions when using tools from the respective MCP server
     oboTrustChecker?: OboTrustChecker;
     upstreamTokenProvider?: UpstreamTokenProvider;
     oboIdentityContext?: AuthIdentityContext;
+    onOAuthCredentialsChanged?: t.UserConnectionContext['onOAuthCredentialsChanged'];
   }): Promise<t.FormattedToolResponse> {
     const userId = user?.id;
     const logPrefix = userId ? `[MCP][User: ${userId}][${serverName}]` : `[MCP][${serverName}]`;
@@ -1143,6 +1149,7 @@ Please follow these instructions when using tools from the respective MCP server
             oboTrustChecker,
             upstreamTokenProvider,
             oboIdentityContext,
+            onOAuthCredentialsChanged,
             graphTokenResolver,
             signal: options?.signal,
             customUserVars,
@@ -1335,6 +1342,7 @@ Please follow these instructions when using tools from the respective MCP server
                 oauthEnd: relay.end,
                 customUserVars,
                 requestBody,
+                onOAuthCredentialsChanged,
               },
               connection!,
             );
@@ -1384,6 +1392,7 @@ Please follow these instructions when using tools from the respective MCP server
             graphTokenResolver,
             upstreamTokenProvider,
             oboIdentityContext,
+            onOAuthCredentialsChanged,
             signal: options?.signal,
             directBearerRecoveryState,
           });
@@ -1472,6 +1481,7 @@ Please follow these instructions when using tools from the respective MCP server
               graphTokenResolver,
               upstreamTokenProvider,
               oboIdentityContext,
+              onOAuthCredentialsChanged,
               signal: options?.signal,
               directBearerRecoveryState,
             });

--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -75,11 +75,15 @@ const OAUTH_RECOVERY_RECONNECT_DELAY_MS = 2000;
 
 function getDiscoveryAuthenticationKind(
   serverConfig: t.ParsedServerConfig,
+  observedOAuthRequired = false,
 ): 'oauth' | 'obo' | 'server' {
   if (serverConfig.obo != null) {
     return 'obo';
   }
-  return isOAuthServer(serverConfig) ? 'oauth' : 'server';
+  return isOAuthServer(serverConfig) ||
+    (observedOAuthRequired && serverConfig.requiresOAuth !== false)
+    ? 'oauth'
+    : 'server';
 }
 
 /**
@@ -473,7 +477,7 @@ export class MCPManager extends UserConnectionManager {
         oauthRequired: result.oauthRequired,
         oauthUrl: result.oauthUrl,
         ...(result.oauthRequired && {
-          authenticationKind: getDiscoveryAuthenticationKind(serverConfig),
+          authenticationKind: getDiscoveryAuthenticationKind(serverConfig, true),
         }),
       };
     };

--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -27,6 +27,7 @@ import { MCPAuthenticationRejectedError, isMCPTransportAuthenticationError } fro
 import { resolveDirectOpenIDBearerConfig, usesDirectOpenIDBearerRecovery } from './openid';
 import { MCPServersInitializer } from './registry/MCPServersInitializer';
 import { OboTokenResolutionError, resolveOboToken } from '~/mcp/oauth';
+import { MCPServerCatalogRecoveryTracker } from './catalog/recovery';
 import { MCPServerInspector } from './registry/MCPServerInspector';
 import { MCPServersRegistry } from './registry/MCPServersRegistry';
 import { UserConnectionManager } from './UserConnectionManager';
@@ -72,12 +73,22 @@ type OAuthReconnectResult =
 const OAUTH_RECOVERY_RECONNECT_ATTEMPTS = 3;
 const OAUTH_RECOVERY_RECONNECT_DELAY_MS = 2000;
 
+function getDiscoveryAuthenticationKind(
+  serverConfig: t.ParsedServerConfig,
+): 'oauth' | 'obo' | 'server' {
+  if (serverConfig.obo != null) {
+    return 'obo';
+  }
+  return isOAuthServer(serverConfig) ? 'oauth' : 'server';
+}
+
 /**
  * Centralized manager for MCP server connections and tool execution.
  * Extends UserConnectionManager to handle both app-level and user-specific connections.
  */
 export class MCPManager extends UserConnectionManager {
   private static instance: MCPManager | null;
+  private readonly catalogRecoveryTracker = new MCPServerCatalogRecoveryTracker();
   private readonly recoveryCancellation = new WeakMap<
     Promise<void>,
     { controller: AbortController; waiters: number; connection: MCPConnection }
@@ -113,6 +124,25 @@ export class MCPManager extends UserConnectionManager {
   public async initialize(configs: t.MCPServers): Promise<void> {
     await MCPServersInitializer.initialize(configs);
     this.appConnections = new ConnectionsRepository(undefined);
+  }
+
+  public getCatalogRecoveryTracker(): MCPServerCatalogRecoveryTracker {
+    return this.catalogRecoveryTracker;
+  }
+
+  public clearCatalogRecoveryState(userId: string, serverName?: string): void {
+    this.catalogRecoveryTracker.clear(userId, serverName);
+  }
+
+  public override async disconnectUserConnection(
+    userId: string,
+    serverName: string,
+    options?: Parameters<UserConnectionManager['disconnectUserConnection']>[2],
+  ): Promise<void> {
+    if ((options?.reason ?? 'mutation') === 'mutation') {
+      this.clearCatalogRecoveryState(userId, serverName);
+    }
+    await super.disconnectUserConnection(userId, serverName, options);
   }
 
   public override async getUserConnection(
@@ -432,6 +462,9 @@ export class MCPManager extends UserConnectionManager {
         tools: result.tools,
         oauthRequired: result.oauthRequired,
         oauthUrl: result.oauthUrl,
+        ...(result.oauthRequired && {
+          authenticationKind: getDiscoveryAuthenticationKind(serverConfig),
+        }),
       };
     };
 
@@ -451,7 +484,12 @@ export class MCPManager extends UserConnectionManager {
 
     if (!user || !args.flowManager) {
       logger.warn('[MCP][Discovery] OAuth server requires a user and flow manager');
-      return { tools: null, oauthRequired: true, oauthUrl: null };
+      return {
+        tools: null,
+        oauthRequired: true,
+        oauthUrl: null,
+        authenticationKind: getDiscoveryAuthenticationKind(serverConfig),
+      };
     }
 
     const result = await MCPConnectionFactory.discoverTools(basic, {

--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -519,6 +519,7 @@ export class MCPManager extends UserConnectionManager {
       connectionTimeout: args.connectionTimeout,
       deadlineMs: args.deadlineMs,
       onOAuthCredentialsChanged: args.onOAuthCredentialsChanged,
+      onOAuthCredentialsChanging: args.onOAuthCredentialsChanging,
       oboTokenResolver: args.oboTokenResolver,
       oboTrustChecker: args.oboTrustChecker,
       upstreamTokenProvider: args.upstreamTokenProvider,
@@ -830,6 +831,7 @@ Please follow these instructions when using tools from the respective MCP server
     upstreamTokenProvider,
     oboIdentityContext,
     onOAuthCredentialsChanged,
+    onOAuthCredentialsChanging,
     signal,
     directBearerRecoveryState = { attempted: true },
   }: {
@@ -848,6 +850,7 @@ Please follow these instructions when using tools from the respective MCP server
     upstreamTokenProvider?: UpstreamTokenProvider;
     oboIdentityContext?: AuthIdentityContext;
     onOAuthCredentialsChanged?: t.UserConnectionContext['onOAuthCredentialsChanged'];
+    onOAuthCredentialsChanging?: t.UserConnectionContext['onOAuthCredentialsChanging'];
     signal?: AbortSignal;
     directBearerRecoveryState?: t.DirectBearerRecoveryState;
   }): Promise<void> {
@@ -906,6 +909,7 @@ Please follow these instructions when using tools from the respective MCP server
           upstreamTokenProvider,
           oboIdentityContext,
           onOAuthCredentialsChanged,
+          onOAuthCredentialsChanging,
           directBearerRecoveryState,
           directBearerResolvedConfig: refreshedConfig,
           signal: recoverySignal,
@@ -1079,6 +1083,7 @@ Please follow these instructions when using tools from the respective MCP server
     upstreamTokenProvider,
     oboIdentityContext,
     onOAuthCredentialsChanged,
+    onOAuthCredentialsChanging,
   }: {
     user?: IUser;
     serverName: string;
@@ -1101,6 +1106,7 @@ Please follow these instructions when using tools from the respective MCP server
     upstreamTokenProvider?: UpstreamTokenProvider;
     oboIdentityContext?: AuthIdentityContext;
     onOAuthCredentialsChanged?: t.UserConnectionContext['onOAuthCredentialsChanged'];
+    onOAuthCredentialsChanging?: t.UserConnectionContext['onOAuthCredentialsChanging'];
   }): Promise<t.FormattedToolResponse> {
     const userId = user?.id;
     const logPrefix = userId ? `[MCP][User: ${userId}][${serverName}]` : `[MCP][${serverName}]`;
@@ -1164,6 +1170,7 @@ Please follow these instructions when using tools from the respective MCP server
             upstreamTokenProvider,
             oboIdentityContext,
             onOAuthCredentialsChanged,
+            onOAuthCredentialsChanging,
             graphTokenResolver,
             signal: options?.signal,
             customUserVars,
@@ -1357,6 +1364,7 @@ Please follow these instructions when using tools from the respective MCP server
                 customUserVars,
                 requestBody,
                 onOAuthCredentialsChanged,
+                onOAuthCredentialsChanging,
               },
               connection!,
             );
@@ -1407,6 +1415,7 @@ Please follow these instructions when using tools from the respective MCP server
             upstreamTokenProvider,
             oboIdentityContext,
             onOAuthCredentialsChanged,
+            onOAuthCredentialsChanging,
             signal: options?.signal,
             directBearerRecoveryState,
           });
@@ -1496,6 +1505,7 @@ Please follow these instructions when using tools from the respective MCP server
               upstreamTokenProvider,
               oboIdentityContext,
               onOAuthCredentialsChanged,
+              onOAuthCredentialsChanging,
               signal: options?.signal,
               directBearerRecoveryState,
             });

--- a/packages/api/src/mcp/UserConnectionManager.ts
+++ b/packages/api/src/mcp/UserConnectionManager.ts
@@ -583,6 +583,7 @@ export abstract class UserConnectionManager {
       upstreamTokenProvider,
       oboIdentityContext,
       onOAuthCredentialsChanged,
+      onOAuthCredentialsChanging,
       signal,
       returnOnOAuth = false,
       connectionTimeout,
@@ -823,6 +824,7 @@ export abstract class UserConnectionManager {
           requestBody: requestBody,
           connectionTimeout: connectionTimeout,
           onOAuthCredentialsChanged,
+          onOAuthCredentialsChanging,
         };
       } else {
         connectionOptions = {

--- a/packages/api/src/mcp/UserConnectionManager.ts
+++ b/packages/api/src/mcp/UserConnectionManager.ts
@@ -582,6 +582,7 @@ export abstract class UserConnectionManager {
       oboTrustChecker,
       upstreamTokenProvider,
       oboIdentityContext,
+      onOAuthCredentialsChanged,
       signal,
       returnOnOAuth = false,
       connectionTimeout,
@@ -821,6 +822,7 @@ export abstract class UserConnectionManager {
           returnOnOAuth: returnOnOAuth,
           requestBody: requestBody,
           connectionTimeout: connectionTimeout,
+          onOAuthCredentialsChanged,
         };
       } else {
         connectionOptions = {

--- a/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
@@ -886,6 +886,34 @@ describe('MCPConnectionFactory', () => {
         '[MCP][User: user123] OAuth token loading failed; deferring connection recovery',
       );
     });
+
+    it('does not misclassify transient refresh failures as missing authorization', async () => {
+      const basicOptions = {
+        serverName: 'test-server',
+        serverConfig: mockServerConfig,
+      };
+      const oauthOptions = {
+        useOAuth: true as const,
+        user: mockUser,
+        flowManager: mockFlowManager,
+        tokenMethods: {
+          findToken: jest.fn(),
+          createToken: jest.fn(),
+          updateToken: jest.fn(),
+          deleteTokens: jest.fn(),
+        },
+      };
+      const refreshError = new Error(
+        'OAuth token refresh is temporarily unavailable for "test-server"',
+      );
+      refreshError.name = 'MCPTokenRefreshUnavailableError';
+      mockFlowManager.createFlowWithHandler.mockRejectedValue(refreshError);
+
+      await expect(MCPConnectionFactory.create(basicOptions, oauthOptions)).rejects.toThrow(
+        'OAuth token refresh is temporarily unavailable',
+      );
+      expect(mockMCPConnection).not.toHaveBeenCalled();
+    });
   });
 
   describe('OAuth event handling', () => {

--- a/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
@@ -3,7 +3,12 @@ import type { TokenMethods, IUser } from '@librechat/data-schemas';
 import type { FlowStateManager } from '~/flow/manager';
 import type { MCPOAuthTokens } from '~/mcp/oauth';
 import type * as t from '~/mcp/types';
-import { MCPOAuthHandler, MCPTokenStorage, OboTokenResolutionError } from '~/mcp/oauth';
+import {
+  MCPOAuthHandler,
+  MCPTokenStorage,
+  OboTokenResolutionError,
+  ReauthenticationRequiredError,
+} from '~/mcp/oauth';
 import { MCPConnectionFactory } from '~/mcp/MCPConnectionFactory';
 import { MCPAuthenticationRejectedError } from '~/mcp/errors';
 import { preProcessGraphTokens } from '~/utils/graph';
@@ -659,7 +664,7 @@ describe('MCPConnectionFactory', () => {
       mockMCPTokenStorage.assertCredentialSetBinding.mockImplementationOnce(
         (_serverName, tokenCredentialSetId, clientMetadata) => {
           if (tokenCredentialSetId !== clientMetadata?.credential_set_id) {
-            throw new Error('mixed OAuth credential generations');
+            throw new ReauthenticationRequiredError('test-server', 'binding');
           }
         },
       );
@@ -852,7 +857,7 @@ describe('MCPConnectionFactory', () => {
       },
     );
 
-    it('should handle token retrieval errors gracefully', async () => {
+    it('does not misclassify token storage failures as missing authorization', async () => {
       const basicOptions = {
         serverName: 'test-server',
         serverConfig: mockServerConfig,
@@ -870,25 +875,16 @@ describe('MCPConnectionFactory', () => {
         },
       };
 
-      mockFlowManager.createFlowWithHandler.mockRejectedValue(new Error('Token fetch failed'));
-      mockConnectionInstance.isConnected.mockResolvedValue(true);
-
-      const connection = await MCPConnectionFactory.create(basicOptions, oauthOptions);
-
-      expect(connection).toBe(mockConnectionInstance);
-      expect(mockMCPConnection).toHaveBeenCalledWith({
-        serverName: 'test-server',
-        serverConfig: mockServerConfig,
-        userId: 'user123',
-        oauthTokens: null,
-        useSSRFProtection: false,
-        allowedAddresses: undefined,
-        ephemeralConnection: false,
-      });
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        '[MCP][User: user123] No existing tokens found or token loading failed',
+      const storageError = new Error('OAuth token storage is unavailable for "test-server"');
+      storageError.name = 'MCPTokenStorageUnavailableError';
+      mockFlowManager.createFlowWithHandler.mockRejectedValue(storageError);
+      await expect(MCPConnectionFactory.create(basicOptions, oauthOptions)).rejects.toThrow(
+        'OAuth token storage is unavailable',
       );
-      expect(JSON.stringify(mockLogger.debug.mock.calls)).not.toContain('Token fetch failed');
+      expect(mockMCPConnection).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        '[MCP][User: user123] OAuth token loading failed; deferring connection recovery',
+      );
     });
   });
 

--- a/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
@@ -1818,11 +1818,13 @@ describe('MCPConnectionFactory', () => {
         serverConfig: sseConfig,
       };
 
+      const onOAuthCredentialsChanged = jest.fn().mockResolvedValue(undefined);
       const oauthOptions = {
         useOAuth: true as const,
         user: mockUser,
         flowManager: mockFlowManager,
         oauthStart: jest.fn(),
+        onOAuthCredentialsChanged,
         tokenMethods: {
           findToken: jest.fn(),
           createToken: jest.fn(),
@@ -1903,6 +1905,10 @@ describe('MCPConnectionFactory', () => {
       // The connection receives the FRESHLY refreshed tokens, NOT the stale
       // cached ones — that's the whole point of the fix.
       expect(mockConnectionInstance.setOAuthTokens).toHaveBeenCalledWith(freshlyRefreshedTokens);
+      expect(onOAuthCredentialsChanged).toHaveBeenCalledWith({
+        userId: mockUser!.id,
+        serverName: 'test-server',
+      });
       expect(mockConnectionInstance.setOAuthTokens).not.toHaveBeenCalledWith(staleCachedTokens);
       expect(mockConnectionInstance.emit).toHaveBeenCalledWith('oauthHandled', 'silent-refresh');
       // The cached `mcp_get_tokens` flow state is dropped so the next

--- a/packages/api/src/mcp/__tests__/MCPFlowRedis.cache_integration.spec.ts
+++ b/packages/api/src/mcp/__tests__/MCPFlowRedis.cache_integration.spec.ts
@@ -124,4 +124,24 @@ describe('MCP OAuth flow state across Redis-backed instances', () => {
       expect.objectContaining({ status: 'COMPLETED', result: 'fresh-result' }),
     );
   });
+
+  it('settles a fresher result over a failure from the same attempt across pods', async () => {
+    const flowId = createFlowId();
+    await podA.initFlow(flowId, FLOW_TYPE, { state: 'observed-state' });
+    const flow = await podB.getFlowState(flowId, FLOW_TYPE);
+
+    await podA.failFlow(flowId, FLOW_TYPE, new Error('stale failure'));
+    await expect(
+      podB.settleFlowIfCurrent(
+        flowId,
+        FLOW_TYPE,
+        flow!.createdAt,
+        'observed-state',
+        'fresh-result',
+      ),
+    ).resolves.toBe('updated');
+    await expect(podA.getFlowState(flowId, FLOW_TYPE)).resolves.toEqual(
+      expect.objectContaining({ status: 'COMPLETED', result: 'fresh-result' }),
+    );
+  });
 });

--- a/packages/api/src/mcp/__tests__/MCPFlowRedis.cache_integration.spec.ts
+++ b/packages/api/src/mcp/__tests__/MCPFlowRedis.cache_integration.spec.ts
@@ -104,4 +104,24 @@ describe('MCP OAuth flow state across Redis-backed instances', () => {
       expect.objectContaining({ status: 'FAILED', error: 'cancelled' }),
     );
   });
+
+  it('settles a fresher result over a completion from the same attempt across pods', async () => {
+    const flowId = createFlowId();
+    await podA.initFlow(flowId, FLOW_TYPE, { state: 'observed-state' });
+    const flow = await podB.getFlowState(flowId, FLOW_TYPE);
+
+    await podA.completeFlow(flowId, FLOW_TYPE, 'stale-result');
+    await expect(
+      podB.settleFlowIfCurrent(
+        flowId,
+        FLOW_TYPE,
+        flow!.createdAt,
+        'observed-state',
+        'fresh-result',
+      ),
+    ).resolves.toBe('updated');
+    await expect(podA.getFlowState(flowId, FLOW_TYPE)).resolves.toEqual(
+      expect.objectContaining({ status: 'COMPLETED', result: 'fresh-result' }),
+    );
+  });
 });

--- a/packages/api/src/mcp/__tests__/MCPManager.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPManager.test.ts
@@ -2312,6 +2312,37 @@ describe('MCPManager', () => {
       requiresOAuth: false,
     };
 
+    it('forwards the OAuth credential mutation callback to the connection factory', async () => {
+      mockAppConnections({
+        has: jest.fn().mockResolvedValue(false),
+      });
+      const connection = {
+        isConnected: jest.fn().mockResolvedValue(true),
+        refreshToolList: jest.fn().mockResolvedValue({ tools: [] }),
+        on: jest.fn(),
+      } as unknown as MCPConnection;
+      (MCPConnectionFactory.create as jest.Mock).mockResolvedValue(connection);
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      const onOAuthCredentialsChanged = jest.fn().mockResolvedValue(undefined);
+      const oauthConfig = { ...serverConfig, requiresOAuth: true };
+
+      await manager.getUserConnection({
+        serverName,
+        user: mockUser,
+        serverConfig: oauthConfig,
+        flowManager: {} as Parameters<typeof manager.getUserConnection>[0]['flowManager'],
+        onOAuthCredentialsChanged,
+      });
+
+      expect(MCPConnectionFactory.create).toHaveBeenCalledWith(
+        expect.objectContaining({ serverName }),
+        expect.objectContaining({
+          useOAuth: true,
+          onOAuthCredentialsChanged,
+        }),
+      );
+    });
+
     it('waits for an active recovery before reusing a cached connection', async () => {
       mockAppConnections({
         has: jest.fn().mockResolvedValue(false),

--- a/packages/api/src/mcp/__tests__/MCPManager.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPManager.test.ts
@@ -4068,6 +4068,28 @@ describe('MCPManager', () => {
       expect(discoveryConnection.dispose).toHaveBeenCalledTimes(1);
     });
 
+    it('classifies an authentication challenge from a plain server separately from OAuth', async () => {
+      mockAppConnections({
+        get: jest.fn().mockResolvedValue(null),
+      });
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({
+        type: 'streamable-http',
+        url: 'https://api.example.com/mcp',
+      });
+      (MCPConnectionFactory.discoverTools as jest.Mock).mockResolvedValue({
+        tools: null,
+        connection: null,
+        oauthRequired: true,
+        oauthUrl: null,
+      });
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      const result = await manager.discoverServerTools({ serverName });
+
+      expect(result.oauthRequired).toBe(true);
+      expect(result.authenticationKind).toBe('server');
+    });
+
     it('should forward runtime context to discoverTools in the non-OAuth path', async () => {
       const mockUser = { id: 'user123', email: 'test@example.com' } as unknown as IUser;
       const customUserVars = { MY_CUSTOM_KEY: 'c527bd0abc123' };
@@ -4176,6 +4198,7 @@ describe('MCPManager', () => {
 
       expect(result.tools).toBeNull();
       expect(result.oauthRequired).toBe(true);
+      expect(result.authenticationKind).toBe('oauth');
       expect(MCPConnectionFactory.discoverTools).not.toHaveBeenCalled();
     });
 
@@ -4195,6 +4218,7 @@ describe('MCPManager', () => {
 
       expect(result.tools).toBeNull();
       expect(result.oauthRequired).toBe(true);
+      expect(result.authenticationKind).toBe('oauth');
       expect(mockLogger.warn).toHaveBeenCalledWith(
         '[MCP][Discovery] OAuth server requires a user and flow manager',
       );
@@ -4236,6 +4260,7 @@ describe('MCPManager', () => {
       expect(result.tools).toEqual(mockTools);
       expect(result.oauthRequired).toBe(true);
       expect(result.oauthUrl).toBe('https://auth.example.com/authorize');
+      expect(result.authenticationKind).toBe('oauth');
       expect(MCPConnectionFactory.discoverTools).toHaveBeenCalledWith(
         expect.objectContaining({ serverName }),
         expect.objectContaining({
@@ -4960,6 +4985,17 @@ describe('MCPManager', () => {
       } finally {
         cancelSpy.mockRestore();
       }
+    });
+
+    it('clears catalog recovery suppression for mutations but preserves it for lifecycle cleanup', async () => {
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      const clearRecoveryState = jest.spyOn(manager.getCatalogRecoveryTracker(), 'clear');
+
+      await manager.disconnectUserConnection(userId, serverName, { reason: 'lifecycle' });
+      expect(clearRecoveryState).not.toHaveBeenCalled();
+
+      await manager.disconnectUserConnection(userId, serverName);
+      expect(clearRecoveryState).toHaveBeenCalledWith(userId, serverName);
     });
 
     it('fails a creation that a lifecycle teardown keeps cancelling on every attempt', async () => {

--- a/packages/api/src/mcp/__tests__/MCPManager.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPManager.test.ts
@@ -4099,13 +4099,36 @@ describe('MCPManager', () => {
       expect(discoveryConnection.dispose).toHaveBeenCalledTimes(1);
     });
 
-    it('classifies an authentication challenge from a plain server separately from OAuth', async () => {
+    it('classifies a dynamically detected authentication challenge as OAuth', async () => {
       mockAppConnections({
         get: jest.fn().mockResolvedValue(null),
       });
       (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({
         type: 'streamable-http',
         url: 'https://api.example.com/mcp',
+      });
+      (MCPConnectionFactory.discoverTools as jest.Mock).mockResolvedValue({
+        tools: null,
+        connection: null,
+        oauthRequired: true,
+        oauthUrl: null,
+      });
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      const result = await manager.discoverServerTools({ serverName });
+
+      expect(result.oauthRequired).toBe(true);
+      expect(result.authenticationKind).toBe('oauth');
+    });
+
+    it('keeps an authentication challenge server-managed when OAuth is explicitly disabled', async () => {
+      mockAppConnections({
+        get: jest.fn().mockResolvedValue(null),
+      });
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({
+        type: 'streamable-http',
+        url: 'https://api.example.com/mcp',
+        requiresOAuth: false,
       });
       (MCPConnectionFactory.discoverTools as jest.Mock).mockResolvedValue({
         tools: null,

--- a/packages/api/src/mcp/__tests__/MCPOAuthTokenStorage.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPOAuthTokenStorage.test.ts
@@ -7,7 +7,11 @@
 
 import type { TokenMethods } from '@librechat/data-schemas';
 import type { MCPOAuthTokens } from '~/mcp/oauth';
-import { MCPTokenStorage, ReauthenticationRequiredError } from '~/mcp/oauth';
+import {
+  MCPTokenStorage,
+  MCPTokenStorageUnavailableError,
+  ReauthenticationRequiredError,
+} from '~/mcp/oauth';
 import { InMemoryTokenStore } from './helpers/oauthTestServer';
 
 const credentialSetId = 'credential-set-a';
@@ -973,6 +977,21 @@ describe('MCPTokenStorage', () => {
       expect(result).not.toBeNull();
       expect(result!.access_token).toBe('valid-token');
       expect(result!.token_type).toBe('Bearer');
+    });
+
+    it('reports token-store outages separately from reauthentication', async () => {
+      const storageError = new Error('database unavailable');
+
+      await expect(
+        MCPTokenStorage.getTokens({
+          userId: 'u1',
+          serverName: 'srv1',
+          findToken: jest.fn().mockRejectedValue(storageError),
+        }),
+      ).rejects.toMatchObject({
+        name: 'MCPTokenStorageUnavailableError',
+        cause: storageError,
+      } satisfies Partial<MCPTokenStorageUnavailableError>);
     });
 
     it('rejects an access token read before a concurrent client generation replacement', async () => {

--- a/packages/api/src/mcp/__tests__/MCPOAuthTokenStorage.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPOAuthTokenStorage.test.ts
@@ -9,6 +9,7 @@ import type { TokenMethods } from '@librechat/data-schemas';
 import type { MCPOAuthTokens } from '~/mcp/oauth';
 import {
   MCPTokenStorage,
+  MCPTokenRefreshUnavailableError,
   MCPTokenStorageUnavailableError,
   ReauthenticationRequiredError,
 } from '~/mcp/oauth';
@@ -1152,7 +1153,7 @@ describe('MCPTokenStorage', () => {
       );
     });
 
-    it('should return null when refresh fails', async () => {
+    it('reports transient refresh failures separately from reauthentication', async () => {
       await createBoundToken(store, {
         userId: 'u1',
         type: 'mcp_oauth',
@@ -1170,16 +1171,18 @@ describe('MCPTokenStorage', () => {
 
       const refreshTokens = jest.fn().mockRejectedValue(new Error('refresh failed'));
 
-      const result = await MCPTokenStorage.getTokens({
-        userId: 'u1',
-        serverName: 'srv1',
-        findToken: store.findToken,
-        createToken: store.createToken,
-        updateToken: store.updateToken,
-        refreshTokens,
-      });
-
-      expect(result).toBeNull();
+      await expect(
+        MCPTokenStorage.getTokens({
+          userId: 'u1',
+          serverName: 'srv1',
+          findToken: store.findToken,
+          createToken: store.createToken,
+          updateToken: store.updateToken,
+          refreshTokens,
+        }),
+      ).rejects.toMatchObject({
+        name: 'MCPTokenRefreshUnavailableError',
+      } satisfies Partial<MCPTokenRefreshUnavailableError>);
     });
 
     it('should return null when no refreshTokens callback provided', async () => {
@@ -1912,7 +1915,7 @@ describe('MCPTokenStorage', () => {
       expect(refreshTokens).not.toHaveBeenCalled();
     });
 
-    it('should return null when refresh callback throws non-client-rejection error', async () => {
+    it('should throw a retryable error when refresh callback fails transiently', async () => {
       await createBoundToken(store, {
         userId: 'u1',
         type: 'mcp_oauth_refresh',
@@ -1923,15 +1926,17 @@ describe('MCPTokenStorage', () => {
 
       const refreshTokens = jest.fn().mockRejectedValue(new Error('network blew up'));
 
-      const result = await MCPTokenStorage.forceRefreshTokens({
-        userId: 'u1',
-        serverName: 'srv1',
-        findToken: store.findToken,
-        createToken: store.createToken,
-        refreshTokens,
-      });
-
-      expect(result).toBeNull();
+      await expect(
+        MCPTokenStorage.forceRefreshTokens({
+          userId: 'u1',
+          serverName: 'srv1',
+          findToken: store.findToken,
+          createToken: store.createToken,
+          refreshTokens,
+        }),
+      ).rejects.toMatchObject({
+        name: 'MCPTokenRefreshUnavailableError',
+      } satisfies Partial<MCPTokenRefreshUnavailableError>);
     });
 
     it('should throw ReauthenticationRequiredError when refresh fails with invalid_client', async () => {
@@ -2459,8 +2464,8 @@ describe('MCPTokenStorage', () => {
       await waitFor(() => refreshTokens.mock.calls.length === 1);
       rejectRefresh(new Error('network blew up'));
 
-      await expect(first).resolves.toBeNull();
-      await expect(second).resolves.toBeNull();
+      await expect(first).rejects.toThrow(MCPTokenRefreshUnavailableError);
+      await expect(second).rejects.toThrow(MCPTokenRefreshUnavailableError);
 
       refreshTokens.mockResolvedValueOnce(rotatedTokens(2));
       const third = await MCPTokenStorage.forceRefreshTokens(params);
@@ -2589,7 +2594,7 @@ describe('MCPTokenStorage', () => {
           ...refreshParams(jest.fn().mockResolvedValue(rotatedTokens(2)), 'unfenced-srv'),
           onRefreshSuccess,
         }),
-      ).resolves.toBeNull();
+      ).rejects.toThrow(MCPTokenRefreshUnavailableError);
 
       expect(onRefreshSuccess).toHaveBeenCalledTimes(1);
       const rejectedCredentialSetId = onRefreshSuccess.mock.calls[0][0].credential_set_id;

--- a/packages/api/src/mcp/__tests__/MCPOAuthTokenStorage.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPOAuthTokenStorage.test.ts
@@ -2561,6 +2561,30 @@ describe('MCPTokenStorage', () => {
       expect(callbackTokens.credential_set_id).not.toBe(credentialSetId);
     });
 
+    it('removes refreshed credentials when their authorization fence cannot be published', async () => {
+      await seedRefreshableTokens('unfenced-srv');
+      const onRefreshSuccess = jest.fn().mockRejectedValue(new Error('generation unavailable'));
+
+      await expect(
+        MCPTokenStorage.forceRefreshTokens({
+          ...refreshParams(jest.fn().mockResolvedValue(rotatedTokens(2)), 'unfenced-srv'),
+          onRefreshSuccess,
+        }),
+      ).resolves.toBeNull();
+
+      expect(onRefreshSuccess).toHaveBeenCalledTimes(1);
+      const rejectedCredentialSetId = onRefreshSuccess.mock.calls[0][0].credential_set_id;
+      expect(
+        store.getAll().some((token) => {
+          const storedId =
+            token.metadata instanceof Map
+              ? token.metadata.get('credential_set_id')
+              : token.metadata?.credential_set_id;
+          return storedId === rejectedCredentialSetId;
+        }),
+      ).toBe(false);
+    });
+
     it("an initiator's abort resolves only its own wait, not the shared redemption", async () => {
       await seedRefreshableTokens('abort-srv');
 

--- a/packages/api/src/mcp/__tests__/MCPOAuthTokenStorage.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPOAuthTokenStorage.test.ts
@@ -2496,7 +2496,7 @@ describe('MCPTokenStorage', () => {
 
         jest.advanceTimersByTime(MCPTokenStorage.INFLIGHT_REFRESH_STALE_MS + 1);
         /** The stale abort settles the stalled execution, which frees the slot. */
-        await expect(stalled).resolves.toBeNull();
+        await expect(stalled).rejects.toThrow(MCPTokenRefreshUnavailableError);
 
         const fresh = await MCPTokenStorage.forceRefreshTokens(params);
         expect(fresh!.access_token).toBe('at-2');
@@ -2534,7 +2534,7 @@ describe('MCPTokenStorage', () => {
         jest.advanceTimersByTime(MCPTokenStorage.INFLIGHT_REFRESH_STALE_MS + 1);
         releaseRead();
 
-        await expect(stalled).resolves.toBeNull();
+        await expect(stalled).rejects.toThrow(MCPTokenRefreshUnavailableError);
         expect(refreshTokens).not.toHaveBeenCalled();
       } finally {
         jest.useRealTimers();

--- a/packages/api/src/mcp/__tests__/MCPOAuthTokenStorage.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPOAuthTokenStorage.test.ts
@@ -280,6 +280,23 @@ describe('MCPTokenStorage', () => {
   });
 
   describe('storeTokens', () => {
+    it('persists fence intent before writing the first token row', async () => {
+      const onStorePreparing = jest.fn().mockResolvedValue(undefined);
+      const createToken = jest.fn(store.createToken);
+
+      await MCPTokenStorage.storeTokens({
+        userId: 'u1',
+        serverName: 'srv1',
+        tokens: { access_token: 'at1', token_type: 'Bearer' },
+        createToken,
+        onStorePreparing,
+      });
+
+      expect(onStorePreparing.mock.invocationCallOrder[0]).toBeLessThan(
+        createToken.mock.invocationCallOrder[0],
+      );
+    });
+
     it('keeps the trusted flow generation when provider metadata supplies a conflicting ID', async () => {
       const result = await MCPTokenStorage.storeTokens({
         userId: 'u1',
@@ -2583,6 +2600,32 @@ describe('MCPTokenStorage', () => {
           : storedAccess!.metadata?.credential_set_id;
       expect(callbackTokens.credential_set_id).toBe(storedCredentialSetId);
       expect(callbackTokens.credential_set_id).not.toBe(credentialSetId);
+    });
+
+    it('prepares a durable fence before persisting refreshed token rows', async () => {
+      await seedRefreshableTokens('prepared-srv');
+      const events: string[] = [];
+      const updateToken: TokenMethods['updateToken'] = async (...args) => {
+        events.push('write');
+        return store.updateToken(...args);
+      };
+      const onRefreshPreparing = jest.fn(async () => {
+        events.push('prepare');
+        return async () => {
+          events.push('publish');
+        };
+      });
+
+      await MCPTokenStorage.forceRefreshTokens({
+        ...refreshParams(jest.fn().mockResolvedValue(rotatedTokens(2)), 'prepared-srv'),
+        updateToken,
+        onRefreshPreparing,
+      });
+
+      expect(events[0]).toBe('prepare');
+      expect(events[events.length - 1]).toBe('publish');
+      expect(events).toContain('write');
+      expect(onRefreshPreparing).toHaveBeenCalledTimes(1);
     });
 
     it('removes refreshed credentials when their authorization fence cannot be published', async () => {

--- a/packages/api/src/mcp/__tests__/MCPOAuthTokenStorage.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPOAuthTokenStorage.test.ts
@@ -2583,6 +2583,15 @@ describe('MCPTokenStorage', () => {
           return storedId === rejectedCredentialSetId;
         }),
       ).toBe(false);
+      expect(
+        store.getAll().some((token) => {
+          const storedId =
+            token.metadata instanceof Map
+              ? token.metadata.get('credential_set_id')
+              : token.metadata?.credential_set_id;
+          return token.type === 'mcp_oauth' && storedId === credentialSetId;
+        }),
+      ).toBe(true);
     });
 
     it("an initiator's abort resolves only its own wait, not the shared redemption", async () => {

--- a/packages/api/src/mcp/__tests__/handler.test.ts
+++ b/packages/api/src/mcp/__tests__/handler.test.ts
@@ -1851,6 +1851,51 @@ describe('MCPOAuthHandler - Configurable OAuth Metadata', () => {
       );
     });
 
+    it('lets persistence settle the flow inside its rollback boundary', async () => {
+      const mockFlowManager = {
+        getFlowState: jest.fn().mockResolvedValue({
+          status: 'PENDING',
+          createdAt: 123,
+          metadata: {
+            serverName: 'test-server',
+            codeVerifier: 'test-verifier',
+            clientInfo: {},
+            metadata: {},
+          } as MCPOAuthFlowMetadata,
+        }),
+        completeFlowIfCurrent: jest.fn().mockResolvedValue('updated'),
+      } as unknown as FlowStateManager<MCPOAuthTokens>;
+      mockExchangeAuthorization.mockResolvedValue({
+        access_token: 'test-token',
+        token_type: 'Bearer',
+        expires_in: 3600,
+      });
+      const persistBeforeComplete = jest.fn(
+        async (
+          tokens: MCPOAuthTokens,
+          completePersistedFlow: (tokens: MCPOAuthTokens) => Promise<void>,
+        ) => {
+          const storedTokens = { ...tokens, expires_at: 123456 };
+          await completePersistedFlow(storedTokens);
+          return storedTokens;
+        },
+      );
+      const rollbackPersistedTokens = jest.fn(async () => undefined);
+
+      const result = await MCPOAuthHandler.completeOAuthFlow(
+        'test-flow-id',
+        'test-auth-code',
+        mockFlowManager,
+        {},
+        persistBeforeComplete,
+        rollbackPersistedTokens,
+      );
+
+      expect(result.expires_at).toBe(123456);
+      expect(mockFlowManager.completeFlowIfCurrent).toHaveBeenCalledTimes(1);
+      expect(rollbackPersistedTokens).not.toHaveBeenCalled();
+    });
+
     it('rejects a replaced callback attempt before exchanging its authorization code', async () => {
       const mockFlowManager = {
         getFlowState: jest.fn().mockResolvedValue({

--- a/packages/api/src/mcp/authorization.spec.ts
+++ b/packages/api/src/mcp/authorization.spec.ts
@@ -1,0 +1,65 @@
+import { finalizeMCPAuthorizationMutation } from './authorization';
+
+const scope = { userId: 'user-1', serverName: 'server-1' };
+
+describe('finalizeMCPAuthorizationMutation', () => {
+  it('publishes and disconnects after any write in a partial batch commits', async () => {
+    const invalidateRecoveryGeneration = jest.fn().mockResolvedValue(undefined);
+    const clearLocalRecovery = jest.fn();
+    const disconnectUserConnection = jest.fn().mockResolvedValue(undefined);
+
+    await expect(
+      finalizeMCPAuthorizationMutation(
+        { scope, mutationResults: [{ id: 'saved' }, new Error('later field failed')] },
+        {
+          invalidateRecoveryGeneration,
+          clearLocalRecovery,
+          disconnectUserConnection,
+          retryDelaysMs: [0],
+        },
+      ),
+    ).resolves.toBe(true);
+
+    expect(invalidateRecoveryGeneration).toHaveBeenCalledWith(scope);
+    expect(clearLocalRecovery).toHaveBeenCalledWith(scope.userId, scope.serverName);
+    expect(disconnectUserConnection).toHaveBeenCalledWith(scope.userId, scope.serverName);
+  });
+
+  it('disconnects and completes teardown before surfacing a publication failure', async () => {
+    const error = new Error('cache unavailable');
+    const disconnectUserConnection = jest.fn().mockRejectedValue(new Error('disconnect failed'));
+    const onDisconnectError = jest.fn();
+    const afterDisconnect = jest.fn().mockResolvedValue(undefined);
+
+    await expect(
+      finalizeMCPAuthorizationMutation(
+        { scope, mutationResults: [error], teardown: true },
+        {
+          invalidateRecoveryGeneration: jest.fn().mockRejectedValue(error),
+          disconnectUserConnection,
+          retryDelaysMs: [0],
+          onDisconnectError,
+          afterDisconnect,
+        },
+      ),
+    ).rejects.toBe(error);
+
+    expect(onDisconnectError).toHaveBeenCalledWith(expect.any(Error));
+    expect(afterDisconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when every ordinary credential mutation failed', async () => {
+    const invalidateRecoveryGeneration = jest.fn();
+    const disconnectUserConnection = jest.fn();
+
+    await expect(
+      finalizeMCPAuthorizationMutation(
+        { scope, mutationResults: [new Error('failed')] },
+        { invalidateRecoveryGeneration, disconnectUserConnection },
+      ),
+    ).resolves.toBe(false);
+
+    expect(invalidateRecoveryGeneration).not.toHaveBeenCalled();
+    expect(disconnectUserConnection).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/mcp/authorization.spec.ts
+++ b/packages/api/src/mcp/authorization.spec.ts
@@ -1,6 +1,58 @@
-import { finalizeMCPAuthorizationMutation } from './authorization';
+import {
+  completeMCPAuthorizationWithTokenWaiters,
+  finalizeMCPAuthorizationMutation,
+} from './authorization';
 
 const scope = { userId: 'user-1', serverName: 'server-1' };
+
+describe('completeMCPAuthorizationWithTokenWaiters', () => {
+  it('removes stale results and wakes pending waiters only after guarded completion', async () => {
+    const tokens = { access_token: 'fresh' };
+    const completeAuthorization = jest.fn().mockResolvedValue(undefined);
+    const flowManager = {
+      getFlowState: jest.fn(async (flowId: string) =>
+        flowId === 'pending'
+          ? { type: 'mcp_get_tokens', status: 'PENDING' }
+          : { type: 'mcp_get_tokens', status: 'COMPLETED' },
+      ),
+      deleteFlow: jest.fn().mockResolvedValue(undefined),
+      completeFlow: jest.fn().mockResolvedValue(undefined),
+    };
+
+    await completeMCPAuthorizationWithTokenWaiters(
+      { flowIds: ['pending', 'stale', 'pending'], tokens, completeAuthorization },
+      { flowManager },
+    );
+
+    expect(flowManager.deleteFlow).toHaveBeenCalledWith('stale', 'mcp_get_tokens');
+    expect(flowManager.completeFlow).toHaveBeenCalledWith('pending', 'mcp_get_tokens', tokens);
+    expect(completeAuthorization.mock.invocationCallOrder[0]).toBeLessThan(
+      flowManager.completeFlow.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('does not expose tokens when guarded authorization completion fails', async () => {
+    const error = new Error('cancelled');
+    const flowManager = {
+      getFlowState: jest.fn().mockResolvedValue({ type: 'mcp_get_tokens', status: 'PENDING' }),
+      deleteFlow: jest.fn(),
+      completeFlow: jest.fn(),
+    };
+
+    await expect(
+      completeMCPAuthorizationWithTokenWaiters(
+        {
+          flowIds: ['pending'],
+          tokens: { access_token: 'rolled-back' },
+          completeAuthorization: jest.fn().mockRejectedValue(error),
+        },
+        { flowManager },
+      ),
+    ).rejects.toBe(error);
+
+    expect(flowManager.completeFlow).not.toHaveBeenCalled();
+  });
+});
 
 describe('finalizeMCPAuthorizationMutation', () => {
   it('publishes and disconnects after any write in a partial batch commits', async () => {

--- a/packages/api/src/mcp/authorization.spec.ts
+++ b/packages/api/src/mcp/authorization.spec.ts
@@ -94,6 +94,8 @@ describe('persistMCPAuthorizationTransaction', () => {
     const completeAuthorization = jest.fn().mockResolvedValue(undefined);
     const invalidateRecoveryGeneration = jest.fn().mockResolvedValue(undefined);
     const ensureServerActive = jest.fn().mockResolvedValue(true);
+    const persistPublicationRetry = jest.fn().mockResolvedValue('prepared-v1');
+    const clearPublicationRetry = jest.fn().mockResolvedValue(undefined);
     const flowManager = {
       getFlowState: jest.fn().mockResolvedValue(null),
       deleteFlow: jest.fn().mockResolvedValue(true),
@@ -113,12 +115,17 @@ describe('persistMCPAuthorizationTransaction', () => {
           ensureServerActive,
           inactiveServerError: () => new Error('deleted'),
           invalidateRecoveryGeneration,
+          persistPublicationRetry,
+          clearPublicationRetry,
           flowManager,
           retryDelaysMs: [0],
         },
       ),
     ).resolves.toBe(tokens);
 
+    expect(persistPublicationRetry.mock.invocationCallOrder[0]).toBeLessThan(
+      persistTokens.mock.invocationCallOrder[0],
+    );
     expect(ensureServerActive.mock.invocationCallOrder[0]).toBeLessThan(
       invalidateRecoveryGeneration.mock.invocationCallOrder[0],
     );
@@ -182,6 +189,44 @@ describe('finalizeMCPAuthorizationMutation', () => {
 
     expect(onDisconnectError).toHaveBeenCalledWith(expect.any(Error));
     expect(afterDisconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('writes a second durable intent before teardown token cleanup and fences it afterward', async () => {
+    const invalidateRecoveryGeneration = jest.fn().mockResolvedValue(undefined);
+    const persistPublicationRetry = jest.fn().mockResolvedValue('cleanup-v2');
+    const clearPublicationRetry = jest.fn().mockResolvedValue(undefined);
+    const disconnectUserConnection = jest.fn().mockResolvedValue(undefined);
+    const afterDisconnect = jest.fn().mockResolvedValue(undefined);
+
+    await finalizeMCPAuthorizationMutation(
+      {
+        scope,
+        mutationResults: [{}],
+        publicationRetryVersion: 'credentials-v1',
+        teardown: true,
+      },
+      {
+        invalidateRecoveryGeneration,
+        persistPublicationRetry,
+        clearPublicationRetry,
+        disconnectUserConnection,
+        afterDisconnect,
+        retryDelaysMs: [0],
+      },
+    );
+
+    expect(invalidateRecoveryGeneration).toHaveBeenCalledTimes(2);
+    expect(disconnectUserConnection.mock.invocationCallOrder[0]).toBeLessThan(
+      persistPublicationRetry.mock.invocationCallOrder[0],
+    );
+    expect(persistPublicationRetry.mock.invocationCallOrder[0]).toBeLessThan(
+      afterDisconnect.mock.invocationCallOrder[0],
+    );
+    expect(afterDisconnect.mock.invocationCallOrder[0]).toBeLessThan(
+      invalidateRecoveryGeneration.mock.invocationCallOrder[1],
+    );
+    expect(clearPublicationRetry).toHaveBeenNthCalledWith(1, scope, 'credentials-v1');
+    expect(clearPublicationRetry).toHaveBeenNthCalledWith(2, scope, 'cleanup-v2');
   });
 
   it('does nothing when every ordinary credential mutation failed', async () => {

--- a/packages/api/src/mcp/authorization.spec.ts
+++ b/packages/api/src/mcp/authorization.spec.ts
@@ -61,6 +61,27 @@ describe('completeMCPAuthorizationWithTokenWaiters', () => {
 
     expect(flowManager.settleFlowIfCurrent).not.toHaveBeenCalled();
   });
+
+  it('does not commit authorization when stale token-flow cleanup is unavailable', async () => {
+    const error = new Error('flow store unavailable');
+    const completeAuthorization = jest.fn();
+    const onTokenFlowError = jest.fn();
+    const flowManager = {
+      getFlowState: jest.fn().mockRejectedValue(error),
+      deleteFlow: jest.fn(),
+      settleFlowIfCurrent: jest.fn(),
+    };
+
+    await expect(
+      completeMCPAuthorizationWithTokenWaiters(
+        { flowIds: ['token-flow'], tokens: { access_token: 'fresh' }, completeAuthorization },
+        { flowManager, onTokenFlowError },
+      ),
+    ).rejects.toBe(error);
+
+    expect(onTokenFlowError).toHaveBeenCalledWith('prepare', error);
+    expect(completeAuthorization).not.toHaveBeenCalled();
+  });
 });
 
 describe('persistMCPAuthorizationTransaction', () => {
@@ -110,14 +131,22 @@ describe('persistMCPAuthorizationTransaction', () => {
 describe('finalizeMCPAuthorizationMutation', () => {
   it('publishes and disconnects after any write in a partial batch commits', async () => {
     const invalidateRecoveryGeneration = jest.fn().mockResolvedValue(undefined);
+    const persistPublicationRetry = jest.fn();
+    const clearPublicationRetry = jest.fn().mockResolvedValue(undefined);
     const clearLocalRecovery = jest.fn();
     const disconnectUserConnection = jest.fn().mockResolvedValue(undefined);
 
     await expect(
       finalizeMCPAuthorizationMutation(
-        { scope, mutationResults: [{ id: 'saved' }, new Error('later field failed')] },
+        {
+          scope,
+          mutationResults: [{ id: 'saved' }, new Error('later field failed')],
+          publicationRetryVersion: 'prepared-v1',
+        },
         {
           invalidateRecoveryGeneration,
+          persistPublicationRetry,
+          clearPublicationRetry,
           clearLocalRecovery,
           disconnectUserConnection,
           retryDelaysMs: [0],
@@ -126,6 +155,8 @@ describe('finalizeMCPAuthorizationMutation', () => {
     ).resolves.toBe(true);
 
     expect(invalidateRecoveryGeneration).toHaveBeenCalledWith(scope);
+    expect(persistPublicationRetry).not.toHaveBeenCalled();
+    expect(clearPublicationRetry).toHaveBeenCalledWith(scope, 'prepared-v1');
     expect(clearLocalRecovery).toHaveBeenCalledWith(scope.userId, scope.serverName);
     expect(disconnectUserConnection).toHaveBeenCalledWith(scope.userId, scope.serverName);
   });
@@ -156,15 +187,21 @@ describe('finalizeMCPAuthorizationMutation', () => {
   it('does nothing when every ordinary credential mutation failed', async () => {
     const invalidateRecoveryGeneration = jest.fn();
     const disconnectUserConnection = jest.fn();
+    const clearPublicationRetry = jest.fn().mockResolvedValue(undefined);
 
     await expect(
       finalizeMCPAuthorizationMutation(
-        { scope, mutationResults: [new Error('failed')] },
-        { invalidateRecoveryGeneration, disconnectUserConnection },
+        {
+          scope,
+          mutationResults: [new Error('failed')],
+          publicationRetryVersion: 'prepared-v1',
+        },
+        { invalidateRecoveryGeneration, disconnectUserConnection, clearPublicationRetry },
       ),
     ).resolves.toBe(false);
 
     expect(invalidateRecoveryGeneration).not.toHaveBeenCalled();
     expect(disconnectUserConnection).not.toHaveBeenCalled();
+    expect(clearPublicationRetry).toHaveBeenCalledWith(scope, 'prepared-v1');
   });
 });

--- a/packages/api/src/mcp/authorization.spec.ts
+++ b/packages/api/src/mcp/authorization.spec.ts
@@ -1,6 +1,7 @@
 import {
   completeMCPAuthorizationWithTokenWaiters,
   finalizeMCPAuthorizationMutation,
+  persistMCPAuthorizationTransaction,
 } from './authorization';
 
 const scope = { userId: 'user-1', serverName: 'server-1' };
@@ -12,11 +13,11 @@ describe('completeMCPAuthorizationWithTokenWaiters', () => {
     const flowManager = {
       getFlowState: jest.fn(async (flowId: string) =>
         flowId === 'pending'
-          ? { type: 'mcp_get_tokens', status: 'PENDING' }
+          ? { type: 'mcp_get_tokens', status: 'PENDING', createdAt: 123, metadata: {} }
           : { type: 'mcp_get_tokens', status: 'COMPLETED' },
       ),
       deleteFlow: jest.fn().mockResolvedValue(undefined),
-      completeFlow: jest.fn().mockResolvedValue(undefined),
+      settleFlowIfCurrent: jest.fn().mockResolvedValue('updated'),
     };
 
     await completeMCPAuthorizationWithTokenWaiters(
@@ -25,18 +26,26 @@ describe('completeMCPAuthorizationWithTokenWaiters', () => {
     );
 
     expect(flowManager.deleteFlow).toHaveBeenCalledWith('stale', 'mcp_get_tokens');
-    expect(flowManager.completeFlow).toHaveBeenCalledWith('pending', 'mcp_get_tokens', tokens);
+    expect(flowManager.settleFlowIfCurrent).toHaveBeenCalledWith(
+      'pending',
+      'mcp_get_tokens',
+      123,
+      '',
+      tokens,
+    );
     expect(completeAuthorization.mock.invocationCallOrder[0]).toBeLessThan(
-      flowManager.completeFlow.mock.invocationCallOrder[0],
+      flowManager.settleFlowIfCurrent.mock.invocationCallOrder[0],
     );
   });
 
   it('does not expose tokens when guarded authorization completion fails', async () => {
     const error = new Error('cancelled');
     const flowManager = {
-      getFlowState: jest.fn().mockResolvedValue({ type: 'mcp_get_tokens', status: 'PENDING' }),
+      getFlowState: jest
+        .fn()
+        .mockResolvedValue({ type: 'mcp_get_tokens', status: 'PENDING', createdAt: 123 }),
       deleteFlow: jest.fn(),
-      completeFlow: jest.fn(),
+      settleFlowIfCurrent: jest.fn(),
     };
 
     await expect(
@@ -50,7 +59,51 @@ describe('completeMCPAuthorizationWithTokenWaiters', () => {
       ),
     ).rejects.toBe(error);
 
-    expect(flowManager.completeFlow).not.toHaveBeenCalled();
+    expect(flowManager.settleFlowIfCurrent).not.toHaveBeenCalled();
+  });
+});
+
+describe('persistMCPAuthorizationTransaction', () => {
+  it('keeps validation, publication, OAuth settlement, and token-waiter settlement in one boundary', async () => {
+    const tokens = { access_token: 'fresh' };
+    const persistTokens = jest.fn(async (_tokens, onStoreCommitted) => {
+      await onStoreCommitted(tokens);
+      return tokens;
+    });
+    const completeAuthorization = jest.fn().mockResolvedValue(undefined);
+    const invalidateRecoveryGeneration = jest.fn().mockResolvedValue(undefined);
+    const ensureServerActive = jest.fn().mockResolvedValue(true);
+    const flowManager = {
+      getFlowState: jest.fn().mockResolvedValue(null),
+      deleteFlow: jest.fn().mockResolvedValue(true),
+      settleFlowIfCurrent: jest.fn(),
+    };
+
+    await expect(
+      persistMCPAuthorizationTransaction(
+        {
+          scope,
+          flowIds: ['token-flow'],
+          tokens,
+          completeAuthorization,
+          persistTokens,
+        },
+        {
+          ensureServerActive,
+          inactiveServerError: () => new Error('deleted'),
+          invalidateRecoveryGeneration,
+          flowManager,
+          retryDelaysMs: [0],
+        },
+      ),
+    ).resolves.toBe(tokens);
+
+    expect(ensureServerActive.mock.invocationCallOrder[0]).toBeLessThan(
+      invalidateRecoveryGeneration.mock.invocationCallOrder[0],
+    );
+    expect(invalidateRecoveryGeneration.mock.invocationCallOrder[0]).toBeLessThan(
+      completeAuthorization.mock.invocationCallOrder[0],
+    );
   });
 });
 

--- a/packages/api/src/mcp/authorization.ts
+++ b/packages/api/src/mcp/authorization.ts
@@ -1,0 +1,59 @@
+import { publishMCPAuthorizationMutation } from './catalog/recovery';
+import type { MCPRecoveryGenerationScope } from './catalog/recovery';
+
+export interface FinalizeMCPAuthorizationMutationParams {
+  scope: MCPRecoveryGenerationScope;
+  mutationResults: readonly unknown[];
+  /** Teardown also fences when the credential delete itself was a no-op or failed. */
+  teardown?: boolean;
+}
+
+export interface FinalizeMCPAuthorizationMutationDeps {
+  invalidateRecoveryGeneration: (scope: MCPRecoveryGenerationScope) => Promise<unknown>;
+  clearLocalRecovery?: (userId: string, serverName: string) => void;
+  disconnectUserConnection: (userId: string, serverName: string) => Promise<void>;
+  retryDelaysMs?: readonly number[];
+  afterDisconnect?: () => Promise<void>;
+  onDisconnectError?: (error: unknown) => void;
+}
+
+/**
+ * Publishes every committed credential batch before disconnecting its live connection. Partial
+ * batches still advance the generation, and teardown runs the same sequence even when its
+ * credential delete did not commit so OAuth token cleanup cannot race an old connection.
+ */
+export async function finalizeMCPAuthorizationMutation(
+  params: FinalizeMCPAuthorizationMutationParams,
+  deps: FinalizeMCPAuthorizationMutationDeps,
+): Promise<boolean> {
+  const committed = params.mutationResults.some((result) => !(result instanceof Error));
+  if (!committed && params.teardown !== true) {
+    return false;
+  }
+
+  let publicationError: unknown;
+  let publicationFailed = false;
+  try {
+    await publishMCPAuthorizationMutation(params.scope, {
+      invalidateRecoveryGeneration: deps.invalidateRecoveryGeneration,
+      clearLocalRecovery: deps.clearLocalRecovery,
+      retryDelaysMs: deps.retryDelaysMs,
+    });
+  } catch (error) {
+    publicationFailed = true;
+    publicationError = error;
+  }
+
+  try {
+    await deps.disconnectUserConnection(params.scope.userId, params.scope.serverName);
+  } catch (error) {
+    deps.onDisconnectError?.(error);
+  }
+
+  await deps.afterDisconnect?.();
+
+  if (publicationFailed) {
+    throw publicationError;
+  }
+  return committed;
+}

--- a/packages/api/src/mcp/authorization.ts
+++ b/packages/api/src/mcp/authorization.ts
@@ -1,6 +1,15 @@
 import type { MCPRecoveryGenerationScope } from './catalog/recovery';
 import { publishMCPAuthorizationMutation } from './catalog/recovery';
 
+export interface MCPAuthorizationPublicationDeps {
+  invalidateRecoveryGeneration: (scope: MCPRecoveryGenerationScope) => Promise<unknown>;
+  clearLocalRecovery?: (userId: string, serverName: string) => void;
+  persistPublicationRetry?: (scope: MCPRecoveryGenerationScope) => Promise<string>;
+  clearPublicationRetry?: (scope: MCPRecoveryGenerationScope, version: string) => Promise<void>;
+  retryDelaysMs?: readonly number[];
+  attemptTimeoutMs?: number;
+}
+
 export interface FinalizeMCPAuthorizationMutationParams {
   scope: MCPRecoveryGenerationScope;
   mutationResults: readonly unknown[];
@@ -10,11 +19,7 @@ export interface FinalizeMCPAuthorizationMutationParams {
   teardown?: boolean;
 }
 
-export interface FinalizeMCPAuthorizationMutationDeps {
-  invalidateRecoveryGeneration: (scope: MCPRecoveryGenerationScope) => Promise<unknown>;
-  clearLocalRecovery?: (userId: string, serverName: string) => void;
-  persistPublicationRetry?: (scope: MCPRecoveryGenerationScope) => Promise<string>;
-  clearPublicationRetry?: (scope: MCPRecoveryGenerationScope, version: string) => Promise<void>;
+export interface FinalizeMCPAuthorizationMutationDeps extends MCPAuthorizationPublicationDeps {
   disconnectUserConnection: (userId: string, serverName: string) => Promise<void>;
   retryDelaysMs?: readonly number[];
   attemptTimeoutMs?: number;
@@ -123,15 +128,24 @@ export interface PersistMCPAuthorizationTransactionParams<TTokens> {
 }
 
 export interface PersistMCPAuthorizationTransactionDeps<TTokens>
-  extends CompleteMCPAuthorizationWithTokenWaitersDeps<TTokens> {
+  extends CompleteMCPAuthorizationWithTokenWaitersDeps<TTokens>,
+    MCPAuthorizationPublicationDeps {
   ensureServerActive: () => Promise<boolean>;
   inactiveServerError: () => Error;
-  invalidateRecoveryGeneration: (scope: MCPRecoveryGenerationScope) => Promise<unknown>;
-  clearLocalRecovery?: (userId: string, serverName: string) => void;
-  persistPublicationRetry?: (scope: MCPRecoveryGenerationScope) => Promise<string>;
-  clearPublicationRetry?: (scope: MCPRecoveryGenerationScope, version: string) => Promise<void>;
-  retryDelaysMs?: readonly number[];
-  attemptTimeoutMs?: number;
+}
+
+/** Writes a durable intent now and returns the exact publication that clears only that intent. */
+export async function prepareMCPAuthorizationMutation(
+  scope: MCPRecoveryGenerationScope,
+  deps: MCPAuthorizationPublicationDeps,
+): Promise<() => Promise<void>> {
+  const publicationRetryVersion = await deps.persistPublicationRetry?.(scope);
+  return () =>
+    publishMCPAuthorizationMutation(scope, {
+      ...deps,
+      persistPublicationRetry:
+        publicationRetryVersion != null ? async () => publicationRetryVersion : undefined,
+    });
 }
 
 /** Owns the OAuth authorization transaction while the token store's rollback journal is live. */
@@ -139,18 +153,15 @@ export async function persistMCPAuthorizationTransaction<TTokens>(
   params: PersistMCPAuthorizationTransactionParams<TTokens>,
   deps: PersistMCPAuthorizationTransactionDeps<TTokens>,
 ): Promise<TTokens> {
+  if (!(await deps.ensureServerActive())) {
+    throw deps.inactiveServerError();
+  }
+  const publishPreparedMutation = await prepareMCPAuthorizationMutation(params.scope, deps);
   return params.persistTokens(params.tokens, async (committedTokens) => {
     if (!(await deps.ensureServerActive())) {
       throw deps.inactiveServerError();
     }
-    await publishMCPAuthorizationMutation(params.scope, {
-      invalidateRecoveryGeneration: deps.invalidateRecoveryGeneration,
-      clearLocalRecovery: deps.clearLocalRecovery,
-      persistPublicationRetry: deps.persistPublicationRetry,
-      clearPublicationRetry: deps.clearPublicationRetry,
-      retryDelaysMs: deps.retryDelaysMs,
-      attemptTimeoutMs: deps.attemptTimeoutMs,
-    });
+    await publishPreparedMutation();
     await completeMCPAuthorizationWithTokenWaiters(
       {
         flowIds: params.flowIds,
@@ -164,8 +175,8 @@ export async function persistMCPAuthorizationTransaction<TTokens>(
 
 /**
  * Publishes every committed credential batch before disconnecting its live connection. Partial
- * batches still advance the generation, and teardown runs the same sequence even when its
- * credential delete did not commit so OAuth token cleanup cannot race an old connection.
+ * batches still advance the generation. Teardown fences the credential change, disconnects, then
+ * writes a second durable intent before OAuth cleanup and fences that cleanup independently.
  */
 export async function finalizeMCPAuthorizationMutation(
   params: FinalizeMCPAuthorizationMutationParams,
@@ -205,10 +216,22 @@ export async function finalizeMCPAuthorizationMutation(
     deps.onDisconnectError?.(error);
   }
 
-  await deps.afterDisconnect?.();
+  let cleanupPublicationError: unknown;
+  if (deps.afterDisconnect != null) {
+    try {
+      const publishCleanupMutation = await prepareMCPAuthorizationMutation(params.scope, deps);
+      await deps.afterDisconnect();
+      await publishCleanupMutation();
+    } catch (error) {
+      cleanupPublicationError = error;
+    }
+  }
 
   if (publicationFailed) {
     throw publicationError;
+  }
+  if (cleanupPublicationError != null) {
+    throw cleanupPublicationError;
   }
   return committed;
 }

--- a/packages/api/src/mcp/authorization.ts
+++ b/packages/api/src/mcp/authorization.ts
@@ -11,8 +11,8 @@ export interface FinalizeMCPAuthorizationMutationParams {
 export interface FinalizeMCPAuthorizationMutationDeps {
   invalidateRecoveryGeneration: (scope: MCPRecoveryGenerationScope) => Promise<unknown>;
   clearLocalRecovery?: (userId: string, serverName: string) => void;
-  persistPublicationRetry?: (scope: MCPRecoveryGenerationScope) => Promise<void>;
-  clearPublicationRetry?: (scope: MCPRecoveryGenerationScope) => Promise<void>;
+  persistPublicationRetry?: (scope: MCPRecoveryGenerationScope) => Promise<string>;
+  clearPublicationRetry?: (scope: MCPRecoveryGenerationScope, version: string) => Promise<void>;
   disconnectUserConnection: (userId: string, serverName: string) => Promise<void>;
   retryDelaysMs?: readonly number[];
   attemptTimeoutMs?: number;
@@ -125,8 +125,8 @@ export interface PersistMCPAuthorizationTransactionDeps<TTokens>
   inactiveServerError: () => Error;
   invalidateRecoveryGeneration: (scope: MCPRecoveryGenerationScope) => Promise<unknown>;
   clearLocalRecovery?: (userId: string, serverName: string) => void;
-  persistPublicationRetry?: (scope: MCPRecoveryGenerationScope) => Promise<void>;
-  clearPublicationRetry?: (scope: MCPRecoveryGenerationScope) => Promise<void>;
+  persistPublicationRetry?: (scope: MCPRecoveryGenerationScope) => Promise<string>;
+  clearPublicationRetry?: (scope: MCPRecoveryGenerationScope, version: string) => Promise<void>;
   retryDelaysMs?: readonly number[];
   attemptTimeoutMs?: number;
 }

--- a/packages/api/src/mcp/authorization.ts
+++ b/packages/api/src/mcp/authorization.ts
@@ -18,6 +18,65 @@ export interface FinalizeMCPAuthorizationMutationDeps {
   onDisconnectError?: (error: unknown) => void;
 }
 
+export interface CompleteMCPAuthorizationWithTokenWaitersParams<TTokens> {
+  flowIds: readonly string[];
+  tokens: TTokens;
+  completeAuthorization: (tokens: TTokens) => Promise<void>;
+}
+
+export interface CompleteMCPAuthorizationWithTokenWaitersDeps<TTokens> {
+  flowManager: {
+    getFlowState?: (flowId: string, type: 'mcp_get_tokens') => Promise<unknown>;
+    deleteFlow?: (flowId: string, type: 'mcp_get_tokens') => Promise<unknown>;
+    completeFlow?: (flowId: string, type: 'mcp_get_tokens', tokens: TTokens) => Promise<unknown>;
+  };
+  onTokenFlowError?: (phase: 'prepare' | 'complete', error: unknown) => void;
+}
+
+/**
+ * Settles the guarded OAuth flow before exposing its tokens to connection-factory waiters. Stale
+ * token-flow results are removed before settlement, while live waiters are retained and woken only
+ * after the authorization completion can no longer roll the credential write back.
+ */
+export async function completeMCPAuthorizationWithTokenWaiters<TTokens>(
+  params: CompleteMCPAuthorizationWithTokenWaitersParams<TTokens>,
+  deps: CompleteMCPAuthorizationWithTokenWaitersDeps<TTokens>,
+): Promise<void> {
+  const pendingFlowIds: string[] = [];
+  const { flowManager } = deps;
+  if (
+    typeof flowManager.getFlowState === 'function' &&
+    typeof flowManager.deleteFlow === 'function' &&
+    typeof flowManager.completeFlow === 'function'
+  ) {
+    for (const flowId of new Set(params.flowIds)) {
+      try {
+        const state = (await flowManager.getFlowState(flowId, 'mcp_get_tokens')) as
+          | { type?: string; status?: string }
+          | null
+          | undefined;
+        if (state?.type === 'mcp_get_tokens' && state.status === 'PENDING') {
+          pendingFlowIds.push(flowId);
+        } else {
+          await flowManager.deleteFlow(flowId, 'mcp_get_tokens');
+        }
+      } catch (error) {
+        deps.onTokenFlowError?.('prepare', error);
+      }
+    }
+  }
+
+  await params.completeAuthorization(params.tokens);
+
+  for (const flowId of pendingFlowIds) {
+    try {
+      await flowManager.completeFlow?.(flowId, 'mcp_get_tokens', params.tokens);
+    } catch (error) {
+      deps.onTokenFlowError?.('complete', error);
+    }
+  }
+}
+
 /**
  * Publishes every committed credential batch before disconnecting its live connection. Partial
  * batches still advance the generation, and teardown runs the same sequence even when its

--- a/packages/api/src/mcp/authorization.ts
+++ b/packages/api/src/mcp/authorization.ts
@@ -4,6 +4,8 @@ import { publishMCPAuthorizationMutation } from './catalog/recovery';
 export interface FinalizeMCPAuthorizationMutationParams {
   scope: MCPRecoveryGenerationScope;
   mutationResults: readonly unknown[];
+  /** Durable intent written before the first credential mutation. */
+  publicationRetryVersion?: string;
   /** Teardown also fences when the credential delete itself was a no-op or failed. */
   teardown?: boolean;
 }
@@ -84,6 +86,7 @@ export async function completeMCPAuthorizationWithTokenWaiters<TTokens>(
         }
       } catch (error) {
         deps.onTokenFlowError?.('prepare', error);
+        throw error;
       }
     }
   }
@@ -170,16 +173,23 @@ export async function finalizeMCPAuthorizationMutation(
 ): Promise<boolean> {
   const committed = params.mutationResults.some((result) => !(result instanceof Error));
   if (!committed && params.teardown !== true) {
+    if (params.publicationRetryVersion != null) {
+      await deps.clearPublicationRetry?.(params.scope, params.publicationRetryVersion);
+    }
     return false;
   }
 
   let publicationError: unknown;
   let publicationFailed = false;
+  const preparedPublicationRetryVersion = params.publicationRetryVersion;
   try {
     await publishMCPAuthorizationMutation(params.scope, {
       invalidateRecoveryGeneration: deps.invalidateRecoveryGeneration,
       clearLocalRecovery: deps.clearLocalRecovery,
-      persistPublicationRetry: deps.persistPublicationRetry,
+      persistPublicationRetry:
+        preparedPublicationRetryVersion != null
+          ? async () => preparedPublicationRetryVersion
+          : deps.persistPublicationRetry,
       clearPublicationRetry: deps.clearPublicationRetry,
       retryDelaysMs: deps.retryDelaysMs,
       attemptTimeoutMs: deps.attemptTimeoutMs,

--- a/packages/api/src/mcp/authorization.ts
+++ b/packages/api/src/mcp/authorization.ts
@@ -1,5 +1,5 @@
-import { publishMCPAuthorizationMutation } from './catalog/recovery';
 import type { MCPRecoveryGenerationScope } from './catalog/recovery';
+import { publishMCPAuthorizationMutation } from './catalog/recovery';
 
 export interface FinalizeMCPAuthorizationMutationParams {
   scope: MCPRecoveryGenerationScope;
@@ -11,6 +11,8 @@ export interface FinalizeMCPAuthorizationMutationParams {
 export interface FinalizeMCPAuthorizationMutationDeps {
   invalidateRecoveryGeneration: (scope: MCPRecoveryGenerationScope) => Promise<unknown>;
   clearLocalRecovery?: (userId: string, serverName: string) => void;
+  persistPublicationRetry?: (scope: MCPRecoveryGenerationScope) => Promise<void>;
+  clearPublicationRetry?: (scope: MCPRecoveryGenerationScope) => Promise<void>;
   disconnectUserConnection: (userId: string, serverName: string) => Promise<void>;
   retryDelaysMs?: readonly number[];
   attemptTimeoutMs?: number;
@@ -28,9 +30,21 @@ export interface CompleteMCPAuthorizationWithTokenWaitersDeps<TTokens> {
   flowManager: {
     getFlowState?: (flowId: string, type: 'mcp_get_tokens') => Promise<unknown>;
     deleteFlow?: (flowId: string, type: 'mcp_get_tokens') => Promise<unknown>;
-    completeFlow?: (flowId: string, type: 'mcp_get_tokens', tokens: TTokens) => Promise<unknown>;
+    settleFlowIfCurrent?: (
+      flowId: string,
+      type: 'mcp_get_tokens',
+      expectedCreatedAt: number,
+      expectedState: string,
+      tokens: TTokens,
+    ) => Promise<'updated' | 'stale' | 'missing'>;
   };
   onTokenFlowError?: (phase: 'prepare' | 'complete', error: unknown) => void;
+}
+
+interface PendingTokenFlowAttempt {
+  flowId: string;
+  createdAt: number;
+  state: string;
 }
 
 /**
@@ -42,21 +56,29 @@ export async function completeMCPAuthorizationWithTokenWaiters<TTokens>(
   params: CompleteMCPAuthorizationWithTokenWaitersParams<TTokens>,
   deps: CompleteMCPAuthorizationWithTokenWaitersDeps<TTokens>,
 ): Promise<void> {
-  const pendingFlowIds: string[] = [];
+  const pendingFlows: PendingTokenFlowAttempt[] = [];
   const { flowManager } = deps;
   if (
     typeof flowManager.getFlowState === 'function' &&
-    typeof flowManager.deleteFlow === 'function' &&
-    typeof flowManager.completeFlow === 'function'
+    typeof flowManager.deleteFlow === 'function'
   ) {
     for (const flowId of new Set(params.flowIds)) {
       try {
         const state = (await flowManager.getFlowState(flowId, 'mcp_get_tokens')) as
-          | { type?: string; status?: string }
+          | { type?: string; status?: string; createdAt?: number; metadata?: { state?: unknown } }
           | null
           | undefined;
-        if (state?.type === 'mcp_get_tokens' && state.status === 'PENDING') {
-          pendingFlowIds.push(flowId);
+        if (
+          state?.type === 'mcp_get_tokens' &&
+          state.status === 'PENDING' &&
+          typeof state.createdAt === 'number' &&
+          typeof flowManager.settleFlowIfCurrent === 'function'
+        ) {
+          pendingFlows.push({
+            flowId,
+            createdAt: state.createdAt,
+            state: typeof state.metadata?.state === 'string' ? state.metadata.state : '',
+          });
         } else {
           await flowManager.deleteFlow(flowId, 'mcp_get_tokens');
         }
@@ -68,13 +90,73 @@ export async function completeMCPAuthorizationWithTokenWaiters<TTokens>(
 
   await params.completeAuthorization(params.tokens);
 
-  for (const flowId of pendingFlowIds) {
+  for (const pending of pendingFlows) {
     try {
-      await flowManager.completeFlow?.(flowId, 'mcp_get_tokens', params.tokens);
+      const result = await flowManager.settleFlowIfCurrent?.(
+        pending.flowId,
+        'mcp_get_tokens',
+        pending.createdAt,
+        pending.state,
+        params.tokens,
+      );
+      if (result !== 'updated') {
+        throw new Error(`Pending MCP token flow was ${result}`);
+      }
     } catch (error) {
       deps.onTokenFlowError?.('complete', error);
     }
   }
+}
+
+export interface PersistMCPAuthorizationTransactionParams<TTokens> {
+  scope: MCPRecoveryGenerationScope;
+  flowIds: readonly string[];
+  tokens: TTokens;
+  completeAuthorization: (tokens: TTokens) => Promise<void>;
+  persistTokens: (
+    tokens: TTokens,
+    onStoreCommitted: (tokens: TTokens) => Promise<void>,
+  ) => Promise<TTokens>;
+}
+
+export interface PersistMCPAuthorizationTransactionDeps<TTokens>
+  extends CompleteMCPAuthorizationWithTokenWaitersDeps<TTokens> {
+  ensureServerActive: () => Promise<boolean>;
+  inactiveServerError: () => Error;
+  invalidateRecoveryGeneration: (scope: MCPRecoveryGenerationScope) => Promise<unknown>;
+  clearLocalRecovery?: (userId: string, serverName: string) => void;
+  persistPublicationRetry?: (scope: MCPRecoveryGenerationScope) => Promise<void>;
+  clearPublicationRetry?: (scope: MCPRecoveryGenerationScope) => Promise<void>;
+  retryDelaysMs?: readonly number[];
+  attemptTimeoutMs?: number;
+}
+
+/** Owns the OAuth authorization transaction while the token store's rollback journal is live. */
+export async function persistMCPAuthorizationTransaction<TTokens>(
+  params: PersistMCPAuthorizationTransactionParams<TTokens>,
+  deps: PersistMCPAuthorizationTransactionDeps<TTokens>,
+): Promise<TTokens> {
+  return params.persistTokens(params.tokens, async (committedTokens) => {
+    if (!(await deps.ensureServerActive())) {
+      throw deps.inactiveServerError();
+    }
+    await publishMCPAuthorizationMutation(params.scope, {
+      invalidateRecoveryGeneration: deps.invalidateRecoveryGeneration,
+      clearLocalRecovery: deps.clearLocalRecovery,
+      persistPublicationRetry: deps.persistPublicationRetry,
+      clearPublicationRetry: deps.clearPublicationRetry,
+      retryDelaysMs: deps.retryDelaysMs,
+      attemptTimeoutMs: deps.attemptTimeoutMs,
+    });
+    await completeMCPAuthorizationWithTokenWaiters(
+      {
+        flowIds: params.flowIds,
+        tokens: committedTokens,
+        completeAuthorization: params.completeAuthorization,
+      },
+      deps,
+    );
+  });
 }
 
 /**
@@ -97,6 +179,8 @@ export async function finalizeMCPAuthorizationMutation(
     await publishMCPAuthorizationMutation(params.scope, {
       invalidateRecoveryGeneration: deps.invalidateRecoveryGeneration,
       clearLocalRecovery: deps.clearLocalRecovery,
+      persistPublicationRetry: deps.persistPublicationRetry,
+      clearPublicationRetry: deps.clearPublicationRetry,
       retryDelaysMs: deps.retryDelaysMs,
       attemptTimeoutMs: deps.attemptTimeoutMs,
     });

--- a/packages/api/src/mcp/authorization.ts
+++ b/packages/api/src/mcp/authorization.ts
@@ -13,6 +13,7 @@ export interface FinalizeMCPAuthorizationMutationDeps {
   clearLocalRecovery?: (userId: string, serverName: string) => void;
   disconnectUserConnection: (userId: string, serverName: string) => Promise<void>;
   retryDelaysMs?: readonly number[];
+  attemptTimeoutMs?: number;
   afterDisconnect?: () => Promise<void>;
   onDisconnectError?: (error: unknown) => void;
 }
@@ -38,6 +39,7 @@ export async function finalizeMCPAuthorizationMutation(
       invalidateRecoveryGeneration: deps.invalidateRecoveryGeneration,
       clearLocalRecovery: deps.clearLocalRecovery,
       retryDelaysMs: deps.retryDelaysMs,
+      attemptTimeoutMs: deps.attemptTimeoutMs,
     });
   } catch (error) {
     publicationFailed = true;

--- a/packages/api/src/mcp/authorizationRetry.spec.ts
+++ b/packages/api/src/mcp/authorizationRetry.spec.ts
@@ -1,0 +1,100 @@
+import type {
+  MCPAuthorizationFenceRetryRecord,
+  MCPAuthorizationFenceRetryStorage,
+} from './authorizationRetry';
+import { createMCPAuthorizationFenceRetryService } from './authorizationRetry';
+
+const scope = { userId: 'user-1', serverName: 'server-1' };
+
+function createHarness() {
+  const records = new Map<string, MCPAuthorizationFenceRetryRecord>();
+  const key = (tenantId: string | null | undefined, userId: string, serverName: string) =>
+    JSON.stringify([tenantId ?? '', userId, serverName]);
+  const storage: MCPAuthorizationFenceRetryStorage = {
+    upsert: jest.fn(async ({ scope: inputScope, tenantId, version, now }) => {
+      records.set(key(tenantId, inputScope.userId, inputScope.serverName), {
+        ...inputScope,
+        tenantId,
+        version,
+        updatedAt: now,
+      });
+    }),
+    deleteVersion: jest.fn(async ({ scope: inputScope, tenantId, version }) => {
+      const recordKey = key(tenantId, inputScope.userId, inputScope.serverName);
+      if (records.get(recordKey)?.version === version) {
+        records.delete(recordKey);
+      }
+    }),
+    list: jest.fn(async (limit) => [...records.values()].slice(0, limit)),
+  };
+  const runInRetryScope = jest.fn(async (_retry, operation) => operation());
+  const registerShutdown = jest.fn();
+  const service = createMCPAuthorizationFenceRetryService({
+    storage,
+    getTenantId: () => 'tenant-a',
+    runInRetryScope,
+    registerShutdown,
+  });
+  return { records, registerShutdown, runInRetryScope, service, storage };
+}
+
+describe('MCP authorization fence retry service', () => {
+  afterEach(() => jest.useRealTimers());
+
+  it('clears only the marker version created by that publisher', async () => {
+    const { records, service, storage } = createHarness();
+    const firstVersion = await service.persist(scope);
+    const secondVersion = await service.persist(scope);
+
+    await service.clear(scope, firstVersion);
+
+    expect(storage.deleteVersion).toHaveBeenCalledWith({
+      scope,
+      tenantId: 'tenant-a',
+      version: firstVersion,
+    });
+    expect([...records.values()]).toEqual([
+      expect.objectContaining({ ...scope, version: secondVersion }),
+    ]);
+  });
+
+  it('replays a bounded batch in tenant scope and deletes exact published versions', async () => {
+    const { records, runInRetryScope, service, storage } = createHarness();
+    const version = await service.persist(scope);
+    const invalidate = jest.fn().mockResolvedValue(undefined);
+
+    service.start(invalidate, { intervalMs: 5_000, batchSize: 7 });
+    await service.drain();
+
+    expect(storage.list).toHaveBeenCalledWith(7);
+    expect(runInRetryScope).toHaveBeenCalledWith(
+      expect.objectContaining({ ...scope, tenantId: 'tenant-a', version }),
+      expect.any(Function),
+    );
+    expect(invalidate).toHaveBeenCalledWith(scope);
+    expect(storage.deleteVersion).toHaveBeenCalledWith({
+      scope,
+      tenantId: 'tenant-a',
+      version,
+    });
+    expect(records.size).toBe(0);
+    await service.stop();
+  });
+
+  it('uses the configured cadence and registers clean shutdown', async () => {
+    jest.useFakeTimers();
+    const { registerShutdown, service, storage } = createHarness();
+    service.start(jest.fn().mockResolvedValue(undefined), { intervalMs: 2_500, batchSize: 3 });
+    await service.drain();
+    (storage.list as jest.Mock).mockClear();
+
+    await jest.advanceTimersByTimeAsync(2_500);
+
+    expect(storage.list).toHaveBeenCalledWith(3);
+    expect(registerShutdown).toHaveBeenCalledWith(
+      'MCP authorization fence retry worker',
+      expect.any(Function),
+    );
+    await service.stop();
+  });
+});

--- a/packages/api/src/mcp/authorizationRetry.spec.ts
+++ b/packages/api/src/mcp/authorizationRetry.spec.ts
@@ -25,7 +25,18 @@ function createHarness() {
         records.delete(recordKey);
       }
     }),
-    list: jest.fn(async (limit) => [...records.values()].slice(0, limit)),
+    deferVersion: jest.fn(async ({ scope: inputScope, tenantId, version, updatedAt }) => {
+      const recordKey = key(tenantId, inputScope.userId, inputScope.serverName);
+      const record = records.get(recordKey);
+      if (record?.version === version) {
+        record.updatedAt = updatedAt;
+      }
+    }),
+    list: jest.fn(async (limit) =>
+      [...records.values()]
+        .sort((left, right) => left.updatedAt.getTime() - right.updatedAt.getTime())
+        .slice(0, limit),
+    ),
   };
   const runInRetryScope = jest.fn(async (_retry, operation) => operation());
   const registerShutdown = jest.fn();
@@ -95,6 +106,46 @@ describe('MCP authorization fence retry service', () => {
       'MCP authorization fence retry worker',
       expect.any(Function),
     );
+    await service.stop();
+  });
+
+  it('times out and defers a failed oldest record so later retries are not starved', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    const { records, service, storage } = createHarness();
+    await service.persist({ userId: 'user-1', serverName: 'first' });
+    jest.setSystemTime(new Date('2026-01-01T00:00:00.001Z'));
+    await service.persist({ userId: 'user-1', serverName: 'second' });
+    let finishFirst: (() => void) | undefined;
+    const firstAttempt = new Promise<void>((resolve) => {
+      finishFirst = resolve;
+    });
+    const invalidate = jest.fn(({ serverName }: typeof scope) =>
+      serverName === 'first' ? firstAttempt : Promise.resolve(),
+    );
+
+    service.start(invalidate, { intervalMs: 10_000, batchSize: 1, attemptTimeoutMs: 5 });
+    const firstDrain = service.drain();
+    await jest.advanceTimersByTimeAsync(5);
+    await firstDrain;
+    await service.drain();
+    const thirdDrain = service.drain();
+    await jest.advanceTimersByTimeAsync(5);
+    await thirdDrain;
+
+    expect(invalidate).toHaveBeenNthCalledWith(1, { userId: 'user-1', serverName: 'first' });
+    expect(invalidate).toHaveBeenNthCalledWith(2, { userId: 'user-1', serverName: 'second' });
+    expect(invalidate).toHaveBeenCalledTimes(2);
+    expect(storage.deferVersion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: { userId: 'user-1', serverName: 'first' },
+        updatedAt: new Date('2026-01-01T00:00:00.006Z'),
+      }),
+    );
+    expect([...records.values()].map(({ serverName }) => serverName)).toEqual(['first']);
+    finishFirst?.();
+    await firstAttempt;
+    await service.drain();
+    expect(records.size).toBe(0);
     await service.stop();
   });
 });

--- a/packages/api/src/mcp/authorizationRetry.spec.ts
+++ b/packages/api/src/mcp/authorizationRetry.spec.ts
@@ -134,7 +134,8 @@ describe('MCP authorization fence retry service', () => {
 
     expect(invalidate).toHaveBeenNthCalledWith(1, { userId: 'user-1', serverName: 'first' });
     expect(invalidate).toHaveBeenNthCalledWith(2, { userId: 'user-1', serverName: 'second' });
-    expect(invalidate).toHaveBeenCalledTimes(2);
+    expect(invalidate).toHaveBeenNthCalledWith(3, { userId: 'user-1', serverName: 'first' });
+    expect(invalidate).toHaveBeenCalledTimes(3);
     expect(storage.deferVersion).toHaveBeenCalledWith(
       expect.objectContaining({
         scope: { userId: 'user-1', serverName: 'first' },

--- a/packages/api/src/mcp/authorizationRetry.spec.ts
+++ b/packages/api/src/mcp/authorizationRetry.spec.ts
@@ -8,11 +8,15 @@ const scope = { userId: 'user-1', serverName: 'server-1' };
 
 function createHarness() {
   const records = new Map<string, MCPAuthorizationFenceRetryRecord>();
-  const key = (tenantId: string | null | undefined, userId: string, serverName: string) =>
-    JSON.stringify([tenantId ?? '', userId, serverName]);
+  const key = (
+    tenantId: string | null | undefined,
+    userId: string,
+    serverName: string,
+    version: string,
+  ) => JSON.stringify([tenantId ?? '', userId, serverName, version]);
   const storage: MCPAuthorizationFenceRetryStorage = {
     upsert: jest.fn(async ({ scope: inputScope, tenantId, version, now }) => {
-      records.set(key(tenantId, inputScope.userId, inputScope.serverName), {
+      records.set(key(tenantId, inputScope.userId, inputScope.serverName, version), {
         ...inputScope,
         tenantId,
         version,
@@ -20,13 +24,10 @@ function createHarness() {
       });
     }),
     deleteVersion: jest.fn(async ({ scope: inputScope, tenantId, version }) => {
-      const recordKey = key(tenantId, inputScope.userId, inputScope.serverName);
-      if (records.get(recordKey)?.version === version) {
-        records.delete(recordKey);
-      }
+      records.delete(key(tenantId, inputScope.userId, inputScope.serverName, version));
     }),
     deferVersion: jest.fn(async ({ scope: inputScope, tenantId, version, updatedAt }) => {
-      const recordKey = key(tenantId, inputScope.userId, inputScope.serverName);
+      const recordKey = key(tenantId, inputScope.userId, inputScope.serverName, version);
       const record = records.get(recordKey);
       if (record?.version === version) {
         record.updatedAt = updatedAt;
@@ -66,6 +67,18 @@ describe('MCP authorization fence retry service', () => {
     });
     expect([...records.values()]).toEqual([
       expect.objectContaining({ ...scope, version: secondVersion }),
+    ]);
+  });
+
+  it('preserves every overlapping publication intent for the same scope', async () => {
+    const { records, service } = createHarness();
+    const firstVersion = await service.persist(scope);
+    const secondVersion = await service.persist(scope);
+
+    expect(records.size).toBe(2);
+    expect([...records.values()].map(({ version }) => version)).toEqual([
+      firstVersion,
+      secondVersion,
     ]);
   });
 
@@ -147,6 +160,31 @@ describe('MCP authorization fence retry service', () => {
     await firstAttempt;
     await service.drain();
     expect(records.size).toBe(0);
+    await service.stop();
+  });
+
+  it('bounds a stalled deferral so the worker can drain again', async () => {
+    jest.useFakeTimers();
+    const { service, storage } = createHarness();
+    await service.persist(scope);
+    (storage.deferVersion as jest.Mock).mockImplementationOnce(() => new Promise(() => undefined));
+    service.start(
+      jest.fn(() => new Promise(() => undefined)),
+      {
+        intervalMs: 10_000,
+        batchSize: 1,
+        attemptTimeoutMs: 5,
+      },
+    );
+
+    const firstDrain = service.drain();
+    await jest.advanceTimersByTimeAsync(10);
+    await firstDrain;
+    const secondDrain = service.drain();
+    await jest.advanceTimersByTimeAsync(10);
+    await secondDrain;
+
+    expect(storage.list).toHaveBeenCalledTimes(2);
     await service.stop();
   });
 });

--- a/packages/api/src/mcp/authorizationRetry.ts
+++ b/packages/api/src/mcp/authorizationRetry.ts
@@ -139,14 +139,17 @@ export function createMCPAuthorizationFenceRetryService(
       const retries = await deps.storage.list(retryBatchSize);
       for (const retry of retries) {
         let timeoutId: ReturnType<typeof setTimeout> | undefined;
+        let timedOut = false;
+        const key = attemptKey(retry);
+        const attempt = getOrStartAttempt(retry);
         try {
           const result = await Promise.race([
-            getOrStartAttempt(retry),
+            attempt,
             new Promise<never>((_, reject) => {
-              timeoutId = setTimeout(
-                () => reject(new Error('MCP authorization generation replay timed out')),
-                attemptTimeoutMs,
-              );
+              timeoutId = setTimeout(() => {
+                timedOut = true;
+                reject(new Error('MCP authorization generation replay timed out'));
+              }, attemptTimeoutMs);
             }),
           ]);
           if (!result.succeeded) {
@@ -157,6 +160,12 @@ export function createMCPAuthorizationFenceRetryService(
             `[MCP authorization] Durable generation retry failed for ${retry.serverName}`,
             error,
           );
+          /** The underlying cache call may ignore cancellation. Retire it from deduplication so a
+           * recovered dependency gets a fresh attempt; its exact-version delete remains safe if
+           * the old promise eventually succeeds. */
+          if (timedOut && activeAttempts.get(key) === attempt) {
+            activeAttempts.delete(key);
+          }
           try {
             await deps.storage.deferVersion({
               scope: { userId: retry.userId, serverName: retry.serverName },

--- a/packages/api/src/mcp/authorizationRetry.ts
+++ b/packages/api/src/mcp/authorizationRetry.ts
@@ -5,6 +5,7 @@ import { registerShutdownTask } from '~/app/shutdown';
 
 const DEFAULT_RETRY_INTERVAL_MS = 30_000;
 const DEFAULT_RETRY_BATCH_SIZE = 100;
+const DEFAULT_ATTEMPT_TIMEOUT_MS = 1_000;
 
 export interface MCPAuthorizationFenceRetryRecord extends MCPRecoveryGenerationScope {
   tenantId?: string | null;
@@ -24,6 +25,12 @@ export interface MCPAuthorizationFenceRetryStorage {
     tenantId?: string | null;
     version: string;
   }): Promise<void>;
+  deferVersion(input: {
+    scope: MCPRecoveryGenerationScope;
+    tenantId?: string | null;
+    version: string;
+    updatedAt: Date;
+  }): Promise<void>;
   list(limit: number): Promise<readonly MCPAuthorizationFenceRetryRecord[]>;
 }
 
@@ -40,6 +47,7 @@ export interface MCPAuthorizationFenceRetryServiceDeps {
 export interface MCPAuthorizationFenceRetryWorkerPolicy {
   intervalMs?: number;
   batchSize?: number;
+  attemptTimeoutMs?: number;
 }
 
 export interface MCPAuthorizationFenceRetryService {
@@ -57,12 +65,52 @@ export interface MCPAuthorizationFenceRetryService {
 export function createMCPAuthorizationFenceRetryService(
   deps: MCPAuthorizationFenceRetryServiceDeps,
 ): MCPAuthorizationFenceRetryService {
+  type RetryAttemptResult = { succeeded: true } | { succeeded: false; error: unknown };
   let retryTimer: ReturnType<typeof setInterval> | undefined;
   let drainPromise: Promise<void> | undefined;
+  const activeAttempts = new Map<string, Promise<RetryAttemptResult>>();
   let invalidateRecoveryGeneration:
     | ((scope: MCPRecoveryGenerationScope) => Promise<unknown>)
     | undefined;
   let retryBatchSize = DEFAULT_RETRY_BATCH_SIZE;
+  let attemptTimeoutMs = DEFAULT_ATTEMPT_TIMEOUT_MS;
+
+  const attemptKey = (retry: MCPAuthorizationFenceRetryRecord): string =>
+    JSON.stringify([retry.tenantId ?? '', retry.userId, retry.serverName, retry.version]);
+
+  const getOrStartAttempt = (
+    retry: MCPAuthorizationFenceRetryRecord,
+  ): Promise<RetryAttemptResult> => {
+    const key = attemptKey(retry);
+    const activeAttempt = activeAttempts.get(key);
+    if (activeAttempt != null) {
+      return activeAttempt;
+    }
+
+    const attempt = deps
+      .runInRetryScope(retry, async () => {
+        await invalidateRecoveryGeneration?.({
+          userId: retry.userId,
+          serverName: retry.serverName,
+        });
+      })
+      .then(async () => {
+        await deps.storage.deleteVersion({
+          scope: { userId: retry.userId, serverName: retry.serverName },
+          tenantId: retry.tenantId,
+          version: retry.version,
+        });
+        return { succeeded: true } as const;
+      })
+      .catch((error: unknown) => ({ succeeded: false, error }) as const)
+      .finally(() => {
+        if (activeAttempts.get(key) === attempt) {
+          activeAttempts.delete(key);
+        }
+      });
+    activeAttempts.set(key, attempt);
+    return attempt;
+  };
 
   const persist = async (scope: MCPRecoveryGenerationScope): Promise<string> => {
     const version = randomUUID();
@@ -90,23 +138,42 @@ export function createMCPAuthorizationFenceRetryService(
     drainPromise = (async () => {
       const retries = await deps.storage.list(retryBatchSize);
       for (const retry of retries) {
+        let timeoutId: ReturnType<typeof setTimeout> | undefined;
         try {
-          await deps.runInRetryScope(retry, async () => {
-            await invalidateRecoveryGeneration?.({
-              userId: retry.userId,
-              serverName: retry.serverName,
-            });
-          });
-          await deps.storage.deleteVersion({
-            scope: { userId: retry.userId, serverName: retry.serverName },
-            tenantId: retry.tenantId,
-            version: retry.version,
-          });
+          const result = await Promise.race([
+            getOrStartAttempt(retry),
+            new Promise<never>((_, reject) => {
+              timeoutId = setTimeout(
+                () => reject(new Error('MCP authorization generation replay timed out')),
+                attemptTimeoutMs,
+              );
+            }),
+          ]);
+          if (!result.succeeded) {
+            throw result.error;
+          }
         } catch (error) {
           logger.warn(
             `[MCP authorization] Durable generation retry failed for ${retry.serverName}`,
             error,
           );
+          try {
+            await deps.storage.deferVersion({
+              scope: { userId: retry.userId, serverName: retry.serverName },
+              tenantId: retry.tenantId,
+              version: retry.version,
+              updatedAt: new Date(Math.max(Date.now(), retry.updatedAt.getTime() + 1)),
+            });
+          } catch (deferError) {
+            logger.warn(
+              `[MCP authorization] Could not defer generation retry for ${retry.serverName}`,
+              deferError,
+            );
+          }
+        } finally {
+          if (timeoutId != null) {
+            clearTimeout(timeoutId);
+          }
         }
       }
     })().finally(() => {
@@ -135,6 +202,7 @@ export function createMCPAuthorizationFenceRetryService(
   ): void => {
     invalidateRecoveryGeneration = invalidator;
     retryBatchSize = policy.batchSize ?? DEFAULT_RETRY_BATCH_SIZE;
+    attemptTimeoutMs = policy.attemptTimeoutMs ?? DEFAULT_ATTEMPT_TIMEOUT_MS;
     if (retryTimer != null) {
       return;
     }

--- a/packages/api/src/mcp/authorizationRetry.ts
+++ b/packages/api/src/mcp/authorizationRetry.ts
@@ -1,0 +1,148 @@
+import { randomUUID } from 'crypto';
+import { logger } from '@librechat/data-schemas';
+import type { MCPRecoveryGenerationScope } from './catalog/recovery';
+import { registerShutdownTask } from '~/app/shutdown';
+
+const DEFAULT_RETRY_INTERVAL_MS = 30_000;
+const DEFAULT_RETRY_BATCH_SIZE = 100;
+
+export interface MCPAuthorizationFenceRetryRecord extends MCPRecoveryGenerationScope {
+  tenantId?: string | null;
+  version: string;
+  updatedAt: Date;
+}
+
+export interface MCPAuthorizationFenceRetryStorage {
+  upsert(input: {
+    scope: MCPRecoveryGenerationScope;
+    tenantId?: string | null;
+    version: string;
+    now: Date;
+  }): Promise<void>;
+  deleteVersion(input: {
+    scope: MCPRecoveryGenerationScope;
+    tenantId?: string | null;
+    version: string;
+  }): Promise<void>;
+  list(limit: number): Promise<readonly MCPAuthorizationFenceRetryRecord[]>;
+}
+
+export interface MCPAuthorizationFenceRetryServiceDeps {
+  storage: MCPAuthorizationFenceRetryStorage;
+  getTenantId: () => string | null | undefined;
+  runInRetryScope: (
+    retry: MCPAuthorizationFenceRetryRecord,
+    operation: () => Promise<void>,
+  ) => Promise<void>;
+  registerShutdown?: typeof registerShutdownTask;
+}
+
+export interface MCPAuthorizationFenceRetryWorkerPolicy {
+  intervalMs?: number;
+  batchSize?: number;
+}
+
+export interface MCPAuthorizationFenceRetryService {
+  clear(scope: MCPRecoveryGenerationScope, version: string): Promise<void>;
+  drain(): Promise<void>;
+  persist(scope: MCPRecoveryGenerationScope): Promise<string>;
+  start(
+    invalidator: (scope: MCPRecoveryGenerationScope) => Promise<unknown>,
+    policy?: MCPAuthorizationFenceRetryWorkerPolicy,
+  ): void;
+  stop(): Promise<void>;
+}
+
+/** Owns durable authorization-fence retry lifecycle independently of the legacy server adapter. */
+export function createMCPAuthorizationFenceRetryService(
+  deps: MCPAuthorizationFenceRetryServiceDeps,
+): MCPAuthorizationFenceRetryService {
+  let retryTimer: ReturnType<typeof setInterval> | undefined;
+  let drainPromise: Promise<void> | undefined;
+  let invalidateRecoveryGeneration:
+    | ((scope: MCPRecoveryGenerationScope) => Promise<unknown>)
+    | undefined;
+  let retryBatchSize = DEFAULT_RETRY_BATCH_SIZE;
+
+  const persist = async (scope: MCPRecoveryGenerationScope): Promise<string> => {
+    const version = randomUUID();
+    await deps.storage.upsert({
+      scope,
+      tenantId: deps.getTenantId() ?? null,
+      version,
+      now: new Date(),
+    });
+    return version;
+  };
+
+  const clear = async (scope: MCPRecoveryGenerationScope, version: string): Promise<void> => {
+    await deps.storage.deleteVersion({
+      scope,
+      tenantId: deps.getTenantId() ?? null,
+      version,
+    });
+  };
+
+  const drain = async (): Promise<void> => {
+    if (drainPromise != null || invalidateRecoveryGeneration == null) {
+      return drainPromise;
+    }
+    drainPromise = (async () => {
+      const retries = await deps.storage.list(retryBatchSize);
+      for (const retry of retries) {
+        try {
+          await deps.runInRetryScope(retry, async () => {
+            await invalidateRecoveryGeneration?.({
+              userId: retry.userId,
+              serverName: retry.serverName,
+            });
+          });
+          await deps.storage.deleteVersion({
+            scope: { userId: retry.userId, serverName: retry.serverName },
+            tenantId: retry.tenantId,
+            version: retry.version,
+          });
+        } catch (error) {
+          logger.warn(
+            `[MCP authorization] Durable generation retry failed for ${retry.serverName}`,
+            error,
+          );
+        }
+      }
+    })().finally(() => {
+      drainPromise = undefined;
+    });
+    return drainPromise;
+  };
+
+  const scheduleDrain = (): void => {
+    void drain().catch((error) =>
+      logger.warn('[MCP authorization] Could not read durable generation retries', error),
+    );
+  };
+
+  const stop = async (): Promise<void> => {
+    if (retryTimer != null) {
+      clearInterval(retryTimer);
+      retryTimer = undefined;
+    }
+    await drainPromise?.catch(() => undefined);
+  };
+
+  const start = (
+    invalidator: (scope: MCPRecoveryGenerationScope) => Promise<unknown>,
+    policy: MCPAuthorizationFenceRetryWorkerPolicy = {},
+  ): void => {
+    invalidateRecoveryGeneration = invalidator;
+    retryBatchSize = policy.batchSize ?? DEFAULT_RETRY_BATCH_SIZE;
+    if (retryTimer != null) {
+      return;
+    }
+    retryTimer = setInterval(scheduleDrain, policy.intervalMs ?? DEFAULT_RETRY_INTERVAL_MS);
+    retryTimer.unref?.();
+    (deps.registerShutdown ?? registerShutdownTask)('MCP authorization fence retry worker', stop);
+    scheduleDrain();
+  };
+
+  return { clear, drain, persist, start, stop };
+}

--- a/packages/api/src/mcp/authorizationRetry.ts
+++ b/packages/api/src/mcp/authorizationRetry.ts
@@ -167,12 +167,27 @@ export function createMCPAuthorizationFenceRetryService(
             activeAttempts.delete(key);
           }
           try {
-            await deps.storage.deferVersion({
-              scope: { userId: retry.userId, serverName: retry.serverName },
-              tenantId: retry.tenantId,
-              version: retry.version,
-              updatedAt: new Date(Math.max(Date.now(), retry.updatedAt.getTime() + 1)),
-            });
+            let deferTimeoutId: ReturnType<typeof setTimeout> | undefined;
+            try {
+              await Promise.race([
+                deps.storage.deferVersion({
+                  scope: { userId: retry.userId, serverName: retry.serverName },
+                  tenantId: retry.tenantId,
+                  version: retry.version,
+                  updatedAt: new Date(Math.max(Date.now(), retry.updatedAt.getTime() + 1)),
+                }),
+                new Promise<never>((_, reject) => {
+                  deferTimeoutId = setTimeout(
+                    () => reject(new Error('MCP authorization retry deferral timed out')),
+                    attemptTimeoutMs,
+                  );
+                }),
+              ]);
+            } finally {
+              if (deferTimeoutId != null) {
+                clearTimeout(deferTimeoutId);
+              }
+            }
           } catch (deferError) {
             logger.warn(
               `[MCP authorization] Could not defer generation retry for ${retry.serverName}`,

--- a/packages/api/src/mcp/catalog/recovery.spec.ts
+++ b/packages/api/src/mcp/catalog/recovery.spec.ts
@@ -144,6 +144,7 @@ describe('publishMCPAuthorizationMutation', () => {
 describe('MCPServerCatalogRecoveryTracker capacity', () => {
   const policy = {
     discoveryBackoffMs: [60_000],
+    discoveryTimeoutMs: 3_000,
     reauthRetryMs: 60_000,
     maxStateEntries: 2,
     generationReadTimeoutMs: 500,
@@ -854,6 +855,24 @@ describe('recoverMCPServerCatalogs — bounded, skippable discovery', () => {
     const [options] = discoverServerTools.mock.calls[0];
     expect(options.deadlineMs).toBeGreaterThanOrEqual(before + 900);
     expect(options.deadlineMs).toBeLessThanOrEqual(Date.now() + 900);
+  });
+
+  it('honors a larger configured passive discovery budget', async () => {
+    const discoverServerTools = jest.fn().mockResolvedValue({ tools: [] });
+    const before = Date.now();
+
+    await recoverMCPServerCatalogs(
+      {
+        user,
+        servers: [{ serverName: 'remote', serverConfig: serverConfig('remote') }],
+        recoveryPolicy: { discoveryTimeoutMs: 12_000 },
+      },
+      recoveryDeps(discoverServerTools),
+    );
+
+    const [options] = discoverServerTools.mock.calls[0];
+    expect(options.deadlineMs).toBeGreaterThanOrEqual(before + 12_000);
+    expect(options.deadlineMs).toBeLessThanOrEqual(Date.now() + 12_000);
   });
 
   it('leaves a server the config tier marked unreachable to that tier’s retry window', async () => {

--- a/packages/api/src/mcp/catalog/recovery.spec.ts
+++ b/packages/api/src/mcp/catalog/recovery.spec.ts
@@ -5,7 +5,7 @@ import type { IUser } from '@librechat/data-schemas';
 import type { LCAvailableTools, ParsedServerConfig, ToolDiscoveryOptions } from '../types';
 import {
   MCPCatalogCapacityError,
-  clearMCPServerCatalogRecoveryState,
+  MCPServerCatalogRecoveryTracker,
   loadMCPServerCatalogs,
   recoverMCPServerCatalogs,
 } from './recovery';
@@ -15,6 +15,7 @@ jest.mock('@librechat/data-schemas', () => ({
 }));
 
 const user = { id: 'user-1' } as IUser;
+const recoveryTracker = new MCPServerCatalogRecoveryTracker();
 const serverConfig = (name: string): ParsedServerConfig =>
   ({ type: 'streamable-http', url: `https://${name}.example.com/mcp` }) as ParsedServerConfig;
 const withUserVars = (config: ParsedServerConfig): ParsedServerConfig =>
@@ -34,7 +35,7 @@ const availableTools = (name: string): LCAvailableTools => ({
 });
 
 afterEach(() => {
-  clearMCPServerCatalogRecoveryState(user.id);
+  recoveryTracker.clear(user.id);
   jest.restoreAllMocks();
 });
 
@@ -201,6 +202,7 @@ describe('recoverMCPServerCatalogs', () => {
       loadUserMCPAuthMap: jest.fn().mockResolvedValue({}),
       discoverServerTools,
       formatServerTools: jest.fn().mockReturnValue(availableTools('shared-tool')),
+      recoveryTracker,
     };
 
     const first = recoverMCPServerCatalogs({ user, servers }, deps);
@@ -219,6 +221,7 @@ describe('recoverMCPServerCatalogs', () => {
     const discoverServerTools = jest.fn().mockResolvedValue({
       tools: [{ name: 'public-tool', inputSchema: { type: 'object' as const } }],
       oauthRequired: true,
+      authenticationKind: 'oauth' as const,
     });
     const servers = [{ serverName: 'oauth-server', serverConfig: serverConfig('oauth-server') }];
     const deps = {
@@ -228,6 +231,7 @@ describe('recoverMCPServerCatalogs', () => {
       loadUserMCPAuthMap: jest.fn().mockResolvedValue({}),
       discoverServerTools,
       formatServerTools: jest.fn().mockReturnValue(availableTools('public-tool')),
+      recoveryTracker,
     };
 
     const first = await loadMCPServerCatalogs({ user, servers }, deps);
@@ -240,6 +244,73 @@ describe('recoverMCPServerCatalogs', () => {
     expect(second.serverTools).toEqual(new Map());
   });
 
+  it('backs off non-OAuth authorization failures instead of requesting reauthorization', async () => {
+    const discoverServerTools = jest.fn().mockResolvedValue({
+      tools: null,
+      oauthRequired: true,
+      authenticationKind: 'server' as const,
+    });
+    const servers = [{ serverName: 'server-auth', serverConfig: serverConfig('server-auth') }];
+    const deps = {
+      getCachedServerTools: jest.fn().mockResolvedValue(null),
+      getServerToolFunctionsSnapshot: jest.fn().mockResolvedValue({ tools: null }),
+      cacheServerTools: jest.fn(),
+      loadUserMCPAuthMap: jest.fn().mockResolvedValue({}),
+      discoverServerTools,
+      formatServerTools: jest.fn(),
+      recoveryTracker,
+    };
+
+    const first = await loadMCPServerCatalogs({ user, servers }, deps);
+    const second = await loadMCPServerCatalogs({ user, servers }, deps);
+
+    expect(discoverServerTools).toHaveBeenCalledTimes(1);
+    expect(first.reauthRequiredServers).toEqual(new Set());
+    expect(second.reauthRequiredServers).toEqual(new Set());
+  });
+
+  it.each([
+    [
+      'OBO',
+      {
+        ...serverConfig('request-auth'),
+        obo: { scopes: 'api://mcp/.default' },
+      } as ParsedServerConfig,
+    ],
+    [
+      'direct OpenID bearer',
+      {
+        ...serverConfig('request-auth'),
+        source: 'yaml',
+        headers: { Authorization: 'Bearer {{LIBRECHAT_OPENID_ACCESS_TOKEN}}' },
+      } as ParsedServerConfig,
+    ],
+  ])('keeps %s discovery request-bound', async (_kind, requestAuthConfig) => {
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const discoverServerTools = jest.fn().mockResolvedValue({ tools: null });
+    const servers = [{ serverName: 'request-auth', serverConfig: requestAuthConfig }];
+    const deps = {
+      loadUserMCPAuthMap: jest.fn().mockResolvedValue({}),
+      discoverServerTools,
+      formatServerTools: jest.fn(),
+      recoveryTracker,
+    };
+
+    await Promise.all([
+      recoverMCPServerCatalogs({ user, servers, signal: firstController.signal }, deps),
+      recoverMCPServerCatalogs({ user, servers, signal: secondController.signal }, deps),
+    ]);
+
+    expect(discoverServerTools).toHaveBeenCalledTimes(2);
+    expect(discoverServerTools).toHaveBeenCalledWith(
+      expect.objectContaining({ signal: firstController.signal }),
+    );
+    expect(discoverServerTools).toHaveBeenCalledWith(
+      expect.objectContaining({ signal: secondController.signal }),
+    );
+  });
+
   it('backs off failed discovery progressively and resets after explicit reconnect', async () => {
     let now = 1_800_000_000_000;
     jest.spyOn(Date, 'now').mockImplementation(() => now);
@@ -249,6 +320,7 @@ describe('recoverMCPServerCatalogs', () => {
       loadUserMCPAuthMap: jest.fn().mockResolvedValue({}),
       discoverServerTools,
       formatServerTools: jest.fn(),
+      recoveryTracker,
     };
 
     await recoverMCPServerCatalogs({ user, servers }, deps);
@@ -263,7 +335,7 @@ describe('recoverMCPServerCatalogs', () => {
     await recoverMCPServerCatalogs({ user, servers }, deps);
     expect(discoverServerTools).toHaveBeenCalledTimes(2);
 
-    clearMCPServerCatalogRecoveryState(user.id, 'offline');
+    recoveryTracker.clear(user.id, 'offline');
     await recoverMCPServerCatalogs({ user, servers }, deps);
     expect(discoverServerTools).toHaveBeenCalledTimes(3);
   });
@@ -372,6 +444,36 @@ describe('loadMCPServerCatalogs', () => {
 
     expect(result.serverTools).toEqual(new Map([['recovered', {}]]));
     expect(result.serversWithoutTools).toEqual(['missing']);
+  });
+
+  it('applies the configured recovery policy through the catalog loader', async () => {
+    let now = 1_800_000_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+    const servers = [{ serverName: 'offline', serverConfig: serverConfig('offline') }];
+    const discoverServerTools = jest.fn().mockResolvedValue({ tools: null });
+    const deps = {
+      getCachedServerTools: jest.fn().mockResolvedValue(null),
+      getServerToolFunctionsSnapshot: jest.fn().mockResolvedValue({ tools: null }),
+      cacheServerTools: jest.fn(),
+      loadUserMCPAuthMap: jest.fn().mockResolvedValue({}),
+      discoverServerTools,
+      formatServerTools: jest.fn(),
+      recoveryTracker,
+    };
+    const recoveryPolicy = {
+      discoveryBackoffMs: [10],
+      reauthRetryMs: 20,
+      maxStateEntries: 10,
+    };
+
+    await loadMCPServerCatalogs({ user, servers, recoveryPolicy }, deps);
+    now += 9;
+    await loadMCPServerCatalogs({ user, servers, recoveryPolicy }, deps);
+    expect(discoverServerTools).toHaveBeenCalledTimes(1);
+
+    now += 1;
+    await loadMCPServerCatalogs({ user, servers, recoveryPolicy }, deps);
+    expect(discoverServerTools).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/packages/api/src/mcp/catalog/recovery.spec.ts
+++ b/packages/api/src/mcp/catalog/recovery.spec.ts
@@ -12,6 +12,7 @@ import {
   readMCPRecoveryGenerationAround,
   recoverMCPServerCatalogs,
 } from './recovery';
+import { MCPTokenRefreshUnavailableError } from '../oauth';
 
 jest.mock('@librechat/data-schemas', () => ({
   logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
@@ -91,7 +92,7 @@ describe('publishMCPAuthorizationMutation', () => {
       .mockRejectedValueOnce(new Error('cache unavailable'))
       .mockResolvedValue(undefined);
     const clearLocalRecovery = jest.fn();
-    const persistPublicationRetry = jest.fn().mockResolvedValue(undefined);
+    const persistPublicationRetry = jest.fn().mockResolvedValue('retry-v1');
     const clearPublicationRetry = jest.fn().mockResolvedValue(undefined);
 
     await publishMCPAuthorizationMutation(
@@ -109,13 +110,16 @@ describe('publishMCPAuthorizationMutation', () => {
     expect(persistPublicationRetry.mock.invocationCallOrder[0]).toBeLessThan(
       invalidateRecoveryGeneration.mock.invocationCallOrder[0],
     );
-    expect(clearPublicationRetry).toHaveBeenCalledWith({ userId: user.id, serverName: 'oauth' });
+    expect(clearPublicationRetry).toHaveBeenCalledWith(
+      { userId: user.id, serverName: 'oauth' },
+      'retry-v1',
+    );
     expect(clearLocalRecovery).toHaveBeenCalledWith(user.id, 'oauth');
   });
 
   it('bounds each shared fence attempt', async () => {
     const invalidateRecoveryGeneration = jest.fn(() => new Promise(() => undefined));
-    const persistPublicationRetry = jest.fn().mockResolvedValue(undefined);
+    const persistPublicationRetry = jest.fn().mockResolvedValue('retry-v1');
     const clearPublicationRetry = jest.fn();
 
     await expect(
@@ -145,6 +149,8 @@ describe('MCPServerCatalogRecoveryTracker capacity', () => {
     generationReadTimeoutMs: 500,
     authorizationFenceRetryMs: [0],
     authorizationFenceTimeoutMs: 1_000,
+    authorizationFenceRetryIntervalMs: 30_000,
+    authorizationFenceRetryBatchSize: 100,
   };
 
   const candidate = (serverName: string) => ({
@@ -557,6 +563,31 @@ describe('recoverMCPServerCatalogs', () => {
       authenticationKind: 'server' as const,
     });
     const servers = [{ serverName: 'server-auth', serverConfig: serverConfig('server-auth') }];
+    const deps = {
+      getCachedServerTools: jest.fn().mockResolvedValue(null),
+      getServerToolFunctionsSnapshot: jest.fn().mockResolvedValue({ tools: null }),
+      cacheServerTools: jest.fn(),
+      loadUserMCPAuthMap: jest.fn().mockResolvedValue({}),
+      discoverServerTools,
+      formatServerTools: jest.fn(),
+      recoveryTracker,
+    };
+
+    const first = await loadMCPServerCatalogs({ user, servers }, deps);
+    const second = await loadMCPServerCatalogs({ user, servers }, deps);
+
+    expect(discoverServerTools).toHaveBeenCalledTimes(1);
+    expect(first.reauthRequiredServers).toEqual(new Set());
+    expect(second.reauthRequiredServers).toEqual(new Set());
+  });
+
+  it('backs off transient OAuth refresh failures instead of requesting reauthorization', async () => {
+    const discoverServerTools = jest
+      .fn()
+      .mockRejectedValue(
+        new MCPTokenRefreshUnavailableError('oauth-server', new Error('provider unavailable')),
+      );
+    const servers = [{ serverName: 'oauth-server', serverConfig: serverConfig('oauth-server') }];
     const deps = {
       getCachedServerTools: jest.fn().mockResolvedValue(null),
       getServerToolFunctionsSnapshot: jest.fn().mockResolvedValue({ tools: null }),

--- a/packages/api/src/mcp/catalog/recovery.spec.ts
+++ b/packages/api/src/mcp/catalog/recovery.spec.ts
@@ -100,6 +100,19 @@ describe('publishMCPAuthorizationMutation', () => {
     expect(invalidateRecoveryGeneration).toHaveBeenCalledTimes(2);
     expect(clearLocalRecovery).toHaveBeenCalledWith(user.id, 'oauth');
   });
+
+  it('bounds each shared fence attempt', async () => {
+    const invalidateRecoveryGeneration = jest.fn(() => new Promise(() => undefined));
+
+    await expect(
+      publishMCPAuthorizationMutation(
+        { userId: user.id, serverName: 'oauth' },
+        { invalidateRecoveryGeneration, retryDelaysMs: [0], attemptTimeoutMs: 5 },
+      ),
+    ).rejects.toThrow('MCP authorization generation publication timed out');
+
+    expect(invalidateRecoveryGeneration).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('MCPServerCatalogRecoveryTracker capacity', () => {
@@ -109,6 +122,7 @@ describe('MCPServerCatalogRecoveryTracker capacity', () => {
     maxStateEntries: 2,
     generationReadTimeoutMs: 500,
     authorizationFenceRetryMs: [0],
+    authorizationFenceTimeoutMs: 1_000,
   };
 
   const candidate = (serverName: string) => ({

--- a/packages/api/src/mcp/catalog/recovery.spec.ts
+++ b/packages/api/src/mcp/catalog/recovery.spec.ts
@@ -9,6 +9,7 @@ import {
   loadMCPServerCatalogs,
   publishMCPAuthorizationMutation,
   readMCPRecoveryGeneration,
+  readMCPRecoveryGenerationAround,
   recoverMCPServerCatalogs,
 } from './recovery';
 
@@ -65,6 +66,24 @@ describe('readMCPRecoveryGeneration', () => {
   });
 });
 
+describe('readMCPRecoveryGenerationAround', () => {
+  it('returns a generation only when both reads coherently bracket the operation', async () => {
+    const operation = jest.fn().mockResolvedValue('authorized');
+    const changedReader = jest
+      .fn()
+      .mockResolvedValueOnce('generation-1')
+      .mockResolvedValueOnce('generation-2');
+
+    await expect(
+      readMCPRecoveryGenerationAround(
+        { userId: user.id, serverName: 'oauth' },
+        changedReader,
+        operation,
+      ),
+    ).resolves.toEqual({ value: 'authorized' });
+  });
+});
+
 describe('publishMCPAuthorizationMutation', () => {
   it('retries the shared fence and clears local suppression only after it advances', async () => {
     const invalidateRecoveryGeneration = jest
@@ -116,6 +135,37 @@ describe('recoverMCPServerCatalogs', () => {
     expect(discoverServerTools).not.toHaveBeenCalled();
   });
 
+  it('does not discover custom credentials when either bracketing generation is unknown', async () => {
+    const discoverServerTools = jest.fn().mockResolvedValue({ tools: [] });
+    const getRecoveryGeneration = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('cache unavailable'))
+      .mockResolvedValueOnce('generation-2');
+
+    await recoverMCPServerCatalogs(
+      {
+        user,
+        servers: [
+          {
+            serverName: 'guarded',
+            serverConfig: withUserVars(serverConfig('guarded')),
+          },
+        ],
+      },
+      {
+        loadUserMCPAuthMap: jest.fn().mockResolvedValue({
+          [`${Constants.mcp_prefix}guarded`]: { API_KEY: 'possibly-stale' },
+        }),
+        discoverServerTools,
+        formatServerTools: jest.fn().mockReturnValue({}),
+        getRecoveryGeneration,
+        recoveryTracker,
+      },
+    );
+
+    expect(discoverServerTools).not.toHaveBeenCalled();
+  });
+
   it('discards discovery completed after its authorization generation was superseded', async () => {
     const getRecoveryGeneration = jest
       .fn()
@@ -162,6 +212,36 @@ describe('recoverMCPServerCatalogs', () => {
     expect(discoverServerTools).toHaveBeenCalledTimes(1);
   });
 
+  it('retains a known generation when a due retry runs during a cache outage', async () => {
+    let now = 1_800_000_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+    const discoverServerTools = jest.fn().mockResolvedValue({ tools: null });
+    const getRecoveryGeneration = jest
+      .fn()
+      .mockResolvedValueOnce('generation-1')
+      .mockResolvedValueOnce('generation-1')
+      .mockResolvedValueOnce('generation-1');
+    const deps = {
+      loadUserMCPAuthMap: jest.fn().mockResolvedValue({}),
+      discoverServerTools,
+      formatServerTools: jest.fn().mockReturnValue({}),
+      getRecoveryGeneration,
+      recoveryTracker,
+    };
+    const servers = [{ serverName: 'offline', serverConfig: serverConfig('offline') }];
+    const recoveryPolicy = { discoveryBackoffMs: [10, 20] };
+
+    await recoverMCPServerCatalogs({ user, servers, recoveryPolicy }, deps);
+    now += 10;
+    getRecoveryGeneration.mockRejectedValue(new Error('cache unavailable'));
+    await recoverMCPServerCatalogs({ user, servers, recoveryPolicy }, deps);
+    now += 1;
+    getRecoveryGeneration.mockResolvedValue('generation-1');
+    await recoverMCPServerCatalogs({ user, servers, recoveryPolicy }, deps);
+
+    expect(discoverServerTools).toHaveBeenCalledTimes(2);
+  });
+
   it('loads user auth once and preserves config-only lookup context for each server', async () => {
     const servers = [
       { serverName: 'alpha', serverConfig: withUserVars(serverConfig('alpha')) },
@@ -180,7 +260,12 @@ describe('recoverMCPServerCatalogs', () => {
 
     const result = await recoverMCPServerCatalogs(
       { user, servers },
-      { loadUserMCPAuthMap, discoverServerTools, formatServerTools },
+      {
+        loadUserMCPAuthMap,
+        discoverServerTools,
+        formatServerTools,
+        getRecoveryGeneration: jest.fn().mockResolvedValue('generation-1'),
+      },
     );
 
     expect(loadUserMCPAuthMap).toHaveBeenCalledTimes(1);
@@ -617,6 +702,7 @@ describe('recoverMCPServerCatalogs — bounded, skippable discovery', () => {
     loadUserMCPAuthMap: jest.fn().mockResolvedValue(userMCPAuthMap),
     discoverServerTools,
     formatServerTools: jest.fn().mockReturnValue({}),
+    getRecoveryGeneration: jest.fn().mockResolvedValue('generation-1'),
   });
 
   it('bounds each server discovery end to end rather than per attempt', async () => {

--- a/packages/api/src/mcp/catalog/recovery.spec.ts
+++ b/packages/api/src/mcp/catalog/recovery.spec.ts
@@ -102,6 +102,59 @@ describe('publishMCPAuthorizationMutation', () => {
   });
 });
 
+describe('MCPServerCatalogRecoveryTracker capacity', () => {
+  const policy = {
+    discoveryBackoffMs: [60_000],
+    reauthRetryMs: 60_000,
+    maxStateEntries: 2,
+    generationReadTimeoutMs: 500,
+    authorizationFenceRetryMs: [0],
+  };
+
+  const candidate = (serverName: string) => ({
+    serverName,
+    serverConfig: serverConfig(serverName),
+  });
+  const failed = (serverName: string) => async () => ({
+    serverName,
+    tools: null,
+    state: 'backoff' as const,
+  });
+
+  it('keeps one process-wide capacity when requests carry different limits', async () => {
+    const tracker = new MCPServerCatalogRecoveryTracker(2);
+    const discoverA = jest.fn(failed('a'));
+
+    await tracker.run(user, candidate('a'), policy, 'generation-1', discoverA);
+    await tracker.run(
+      user,
+      candidate('b'),
+      { ...policy, maxStateEntries: 1 },
+      'generation-1',
+      failed('b'),
+    );
+    await tracker.run(user, candidate('a'), policy, 'generation-1', discoverA);
+
+    expect(discoverA).toHaveBeenCalledTimes(1);
+  });
+
+  it('evicts the least recently used completed entry', async () => {
+    const tracker = new MCPServerCatalogRecoveryTracker(2);
+    const discoverA = jest.fn(failed('a'));
+    const discoverB = jest.fn(failed('b'));
+
+    await tracker.run(user, candidate('a'), policy, 'generation-1', discoverA);
+    await tracker.run(user, candidate('b'), policy, 'generation-1', discoverB);
+    await tracker.run(user, candidate('a'), policy, 'generation-1', discoverA);
+    await tracker.run(user, candidate('c'), policy, 'generation-1', failed('c'));
+    await tracker.run(user, candidate('a'), policy, 'generation-1', discoverA);
+    await tracker.run(user, candidate('b'), policy, 'generation-1', discoverB);
+
+    expect(discoverA).toHaveBeenCalledTimes(1);
+    expect(discoverB).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe('recoverMCPServerCatalogs', () => {
   it('does not discover with a credential snapshot superseded while auth was loading', async () => {
     const discoverServerTools = jest.fn().mockResolvedValue({ tools: [] });

--- a/packages/api/src/mcp/catalog/recovery.spec.ts
+++ b/packages/api/src/mcp/catalog/recovery.spec.ts
@@ -7,6 +7,8 @@ import {
   MCPCatalogCapacityError,
   MCPServerCatalogRecoveryTracker,
   loadMCPServerCatalogs,
+  publishMCPAuthorizationMutation,
+  readMCPRecoveryGeneration,
   recoverMCPServerCatalogs,
 } from './recovery';
 
@@ -39,7 +41,127 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
+describe('readMCPRecoveryGeneration', () => {
+  it('keeps recovery available when the injected shared cache is unavailable', async () => {
+    const reader = jest.fn().mockRejectedValue(new Error('cache unavailable'));
+
+    await expect(
+      readMCPRecoveryGeneration({ userId: user.id, serverName: 'oauth-server' }, reader),
+    ).resolves.toBeUndefined();
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('oauth-server'),
+      expect.any(Error),
+    );
+  });
+
+  it('returns unknown instead of waiting indefinitely for the shared cache', async () => {
+    const reader = jest.fn(() => new Promise<string>(() => undefined));
+
+    await expect(
+      readMCPRecoveryGeneration({ userId: user.id, serverName: 'slow-cache' }, reader, {
+        timeoutMs: 5,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('publishMCPAuthorizationMutation', () => {
+  it('retries the shared fence and clears local suppression only after it advances', async () => {
+    const invalidateRecoveryGeneration = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('cache unavailable'))
+      .mockResolvedValue(undefined);
+    const clearLocalRecovery = jest.fn();
+
+    await publishMCPAuthorizationMutation(
+      { userId: user.id, serverName: 'oauth' },
+      { invalidateRecoveryGeneration, clearLocalRecovery, retryDelaysMs: [0, 0] },
+    );
+
+    expect(invalidateRecoveryGeneration).toHaveBeenCalledTimes(2);
+    expect(clearLocalRecovery).toHaveBeenCalledWith(user.id, 'oauth');
+  });
+});
+
 describe('recoverMCPServerCatalogs', () => {
+  it('does not discover with a credential snapshot superseded while auth was loading', async () => {
+    const discoverServerTools = jest.fn().mockResolvedValue({ tools: [] });
+    const getRecoveryGeneration = jest
+      .fn()
+      .mockResolvedValueOnce('generation-1')
+      .mockResolvedValueOnce('generation-2');
+
+    const result = await recoverMCPServerCatalogs(
+      {
+        user,
+        servers: [
+          {
+            serverName: 'guarded',
+            serverConfig: withUserVars(serverConfig('guarded')),
+          },
+        ],
+      },
+      {
+        loadUserMCPAuthMap: jest.fn().mockResolvedValue({
+          [`${Constants.mcp_prefix}guarded`]: { API_KEY: 'old-value' },
+        }),
+        discoverServerTools,
+        formatServerTools: jest.fn().mockReturnValue({}),
+        getRecoveryGeneration,
+        recoveryTracker,
+      },
+    );
+
+    expect(result.size).toBe(0);
+    expect(discoverServerTools).not.toHaveBeenCalled();
+  });
+
+  it('discards discovery completed after its authorization generation was superseded', async () => {
+    const getRecoveryGeneration = jest
+      .fn()
+      .mockResolvedValueOnce('generation-1')
+      .mockResolvedValueOnce('generation-1')
+      .mockResolvedValueOnce('generation-2');
+
+    const result = await recoverMCPServerCatalogs(
+      { user, servers: [{ serverName: 'oauth', serverConfig: serverConfig('oauth') }] },
+      {
+        loadUserMCPAuthMap: jest.fn().mockResolvedValue({}),
+        discoverServerTools: jest.fn().mockResolvedValue({
+          tools: [{ name: 'stale', inputSchema: { type: 'object' } }],
+        }),
+        formatServerTools: jest.fn().mockReturnValue(availableTools('stale')),
+        getRecoveryGeneration,
+        recoveryTracker,
+      },
+    );
+
+    expect(result.size).toBe(0);
+  });
+
+  it('preserves backoff when generation reads intermittently fail', async () => {
+    const discoverServerTools = jest.fn().mockResolvedValue({ tools: null });
+    const getRecoveryGeneration = jest
+      .fn()
+      .mockResolvedValueOnce('generation-1')
+      .mockResolvedValueOnce('generation-1')
+      .mockResolvedValueOnce('generation-1')
+      .mockRejectedValue(new Error('cache unavailable'));
+    const deps = {
+      loadUserMCPAuthMap: jest.fn().mockResolvedValue({}),
+      discoverServerTools,
+      formatServerTools: jest.fn().mockReturnValue({}),
+      getRecoveryGeneration,
+      recoveryTracker,
+    };
+    const servers = [{ serverName: 'offline', serverConfig: serverConfig('offline') }];
+
+    await recoverMCPServerCatalogs({ user, servers }, deps);
+    await recoverMCPServerCatalogs({ user, servers }, deps);
+
+    expect(discoverServerTools).toHaveBeenCalledTimes(1);
+  });
+
   it('loads user auth once and preserves config-only lookup context for each server', async () => {
     const servers = [
       { serverName: 'alpha', serverConfig: withUserVars(serverConfig('alpha')) },

--- a/packages/api/src/mcp/catalog/recovery.spec.ts
+++ b/packages/api/src/mcp/catalog/recovery.spec.ts
@@ -1,10 +1,11 @@
 import { logger } from '@librechat/data-schemas';
 import { Constants } from 'librechat-data-provider';
-import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { ErrorCode, McpError, type Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { IUser } from '@librechat/data-schemas';
 import type { LCAvailableTools, ParsedServerConfig, ToolDiscoveryOptions } from '../types';
 import {
   MCPCatalogCapacityError,
+  clearMCPServerCatalogRecoveryState,
   loadMCPServerCatalogs,
   recoverMCPServerCatalogs,
 } from './recovery';
@@ -30,6 +31,11 @@ const availableTools = (name: string): LCAvailableTools => ({
       parameters: { type: 'object', properties: {} },
     },
   },
+});
+
+afterEach(() => {
+  clearMCPServerCatalogRecoveryState(user.id);
+  jest.restoreAllMocks();
 });
 
 describe('recoverMCPServerCatalogs', () => {
@@ -110,7 +116,8 @@ describe('recoverMCPServerCatalogs', () => {
     );
 
     expect(getServerToolFunctionsSnapshot).toHaveBeenCalledTimes(21);
-    expect(discoverServerTools).toHaveBeenCalledTimes(21);
+    expect(discoverServerTools.mock.calls.length).toBeGreaterThan(0);
+    expect(discoverServerTools.mock.calls.length).toBeLessThanOrEqual(21);
     expect(maxActive).toBe(3);
     expect(results).toHaveLength(4);
     expect(results.filter(({ status }) => status === 'fulfilled')).toHaveLength(3);
@@ -179,6 +186,86 @@ describe('recoverMCPServerCatalogs', () => {
     );
 
     expect([...result.keys()]).toEqual(['good']);
+  });
+
+  it('single-flights concurrent discovery for the same user and server', async () => {
+    let release: ((value: { tools: Tool[] }) => void) | undefined;
+    const discoverServerTools = jest.fn(
+      () =>
+        new Promise<{ tools: Tool[] }>((resolve) => {
+          release = resolve;
+        }),
+    );
+    const servers = [{ serverName: 'shared', serverConfig: serverConfig('shared') }];
+    const deps = {
+      loadUserMCPAuthMap: jest.fn().mockResolvedValue({}),
+      discoverServerTools,
+      formatServerTools: jest.fn().mockReturnValue(availableTools('shared-tool')),
+    };
+
+    const first = recoverMCPServerCatalogs({ user, servers }, deps);
+    const second = recoverMCPServerCatalogs({ user, servers }, deps);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(discoverServerTools).toHaveBeenCalledTimes(1);
+    release?.({ tools: [] });
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      new Map([['shared', availableTools('shared-tool')]]),
+      new Map([['shared', availableTools('shared-tool')]]),
+    ]);
+  });
+
+  it('retains reauthorization state and recovered public tools during the retry window', async () => {
+    const discoverServerTools = jest.fn().mockResolvedValue({
+      tools: [{ name: 'public-tool', inputSchema: { type: 'object' as const } }],
+      oauthRequired: true,
+    });
+    const servers = [{ serverName: 'oauth-server', serverConfig: serverConfig('oauth-server') }];
+    const deps = {
+      getCachedServerTools: jest.fn().mockResolvedValue(null),
+      getServerToolFunctionsSnapshot: jest.fn().mockResolvedValue({ tools: null }),
+      cacheServerTools: jest.fn(),
+      loadUserMCPAuthMap: jest.fn().mockResolvedValue({}),
+      discoverServerTools,
+      formatServerTools: jest.fn().mockReturnValue(availableTools('public-tool')),
+    };
+
+    const first = await loadMCPServerCatalogs({ user, servers }, deps);
+    const second = await loadMCPServerCatalogs({ user, servers }, deps);
+
+    expect(discoverServerTools).toHaveBeenCalledTimes(1);
+    expect(first.reauthRequiredServers).toEqual(new Set(['oauth-server']));
+    expect(first.serverTools).toEqual(new Map([['oauth-server', availableTools('public-tool')]]));
+    expect(second.reauthRequiredServers).toEqual(new Set(['oauth-server']));
+    expect(second.serverTools).toEqual(new Map());
+  });
+
+  it('backs off failed discovery progressively and resets after explicit reconnect', async () => {
+    let now = 1_800_000_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+    const discoverServerTools = jest.fn().mockRejectedValue(new Error('offline'));
+    const servers = [{ serverName: 'offline', serverConfig: serverConfig('offline') }];
+    const deps = {
+      loadUserMCPAuthMap: jest.fn().mockResolvedValue({}),
+      discoverServerTools,
+      formatServerTools: jest.fn(),
+    };
+
+    await recoverMCPServerCatalogs({ user, servers }, deps);
+    await recoverMCPServerCatalogs({ user, servers }, deps);
+    expect(discoverServerTools).toHaveBeenCalledTimes(1);
+
+    now += 5 * 60_000;
+    await recoverMCPServerCatalogs({ user, servers }, deps);
+    expect(discoverServerTools).toHaveBeenCalledTimes(2);
+
+    now += 5 * 60_000;
+    await recoverMCPServerCatalogs({ user, servers }, deps);
+    expect(discoverServerTools).toHaveBeenCalledTimes(2);
+
+    clearMCPServerCatalogRecoveryState(user.id, 'offline');
+    await recoverMCPServerCatalogs({ user, servers }, deps);
+    expect(discoverServerTools).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/packages/api/src/mcp/catalog/recovery.spec.ts
+++ b/packages/api/src/mcp/catalog/recovery.spec.ts
@@ -91,27 +91,49 @@ describe('publishMCPAuthorizationMutation', () => {
       .mockRejectedValueOnce(new Error('cache unavailable'))
       .mockResolvedValue(undefined);
     const clearLocalRecovery = jest.fn();
+    const persistPublicationRetry = jest.fn().mockResolvedValue(undefined);
+    const clearPublicationRetry = jest.fn().mockResolvedValue(undefined);
 
     await publishMCPAuthorizationMutation(
       { userId: user.id, serverName: 'oauth' },
-      { invalidateRecoveryGeneration, clearLocalRecovery, retryDelaysMs: [0, 0] },
+      {
+        invalidateRecoveryGeneration,
+        clearLocalRecovery,
+        persistPublicationRetry,
+        clearPublicationRetry,
+        retryDelaysMs: [0, 0],
+      },
     );
 
     expect(invalidateRecoveryGeneration).toHaveBeenCalledTimes(2);
+    expect(persistPublicationRetry.mock.invocationCallOrder[0]).toBeLessThan(
+      invalidateRecoveryGeneration.mock.invocationCallOrder[0],
+    );
+    expect(clearPublicationRetry).toHaveBeenCalledWith({ userId: user.id, serverName: 'oauth' });
     expect(clearLocalRecovery).toHaveBeenCalledWith(user.id, 'oauth');
   });
 
   it('bounds each shared fence attempt', async () => {
     const invalidateRecoveryGeneration = jest.fn(() => new Promise(() => undefined));
+    const persistPublicationRetry = jest.fn().mockResolvedValue(undefined);
+    const clearPublicationRetry = jest.fn();
 
     await expect(
       publishMCPAuthorizationMutation(
         { userId: user.id, serverName: 'oauth' },
-        { invalidateRecoveryGeneration, retryDelaysMs: [0], attemptTimeoutMs: 5 },
+        {
+          invalidateRecoveryGeneration,
+          persistPublicationRetry,
+          clearPublicationRetry,
+          retryDelaysMs: [0],
+          attemptTimeoutMs: 5,
+        },
       ),
     ).rejects.toThrow('MCP authorization generation publication timed out');
 
     expect(invalidateRecoveryGeneration).toHaveBeenCalledTimes(1);
+    expect(persistPublicationRetry).toHaveBeenCalledTimes(1);
+    expect(clearPublicationRetry).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/api/src/mcp/catalog/recovery.spec.ts
+++ b/packages/api/src/mcp/catalog/recovery.spec.ts
@@ -218,6 +218,7 @@ describe('recoverMCPServerCatalogs', () => {
   });
 
   it('retains reauthorization state and recovered public tools during the retry window', async () => {
+    let recoveryGeneration = 'generation-1';
     const discoverServerTools = jest.fn().mockResolvedValue({
       tools: [{ name: 'public-tool', inputSchema: { type: 'object' as const } }],
       oauthRequired: true,
@@ -232,6 +233,7 @@ describe('recoverMCPServerCatalogs', () => {
       discoverServerTools,
       formatServerTools: jest.fn().mockReturnValue(availableTools('public-tool')),
       recoveryTracker,
+      getRecoveryGeneration: jest.fn(async () => recoveryGeneration),
     };
 
     const first = await loadMCPServerCatalogs({ user, servers }, deps);
@@ -239,9 +241,17 @@ describe('recoverMCPServerCatalogs', () => {
 
     expect(discoverServerTools).toHaveBeenCalledTimes(1);
     expect(first.reauthRequiredServers).toEqual(new Set(['oauth-server']));
+    expect(first.reauthRequiredGenerations).toEqual(new Map([['oauth-server', 'generation-1']]));
     expect(first.serverTools).toEqual(new Map([['oauth-server', availableTools('public-tool')]]));
     expect(second.reauthRequiredServers).toEqual(new Set(['oauth-server']));
     expect(second.serverTools).toEqual(new Map());
+
+    recoveryGeneration = 'generation-2';
+    const afterCredentialMutation = await loadMCPServerCatalogs({ user, servers }, deps);
+    expect(discoverServerTools).toHaveBeenCalledTimes(2);
+    expect(afterCredentialMutation.reauthRequiredGenerations).toEqual(
+      new Map([['oauth-server', 'generation-2']]),
+    );
   });
 
   it('backs off non-OAuth authorization failures instead of requesting reauthorization', async () => {

--- a/packages/api/src/mcp/catalog/recovery.ts
+++ b/packages/api/src/mcp/catalog/recovery.ts
@@ -4,6 +4,7 @@ import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { IUser } from '@librechat/data-schemas';
 import type { LCAvailableTools, ParsedServerConfig, ToolDiscoveryOptions } from '../types';
 import { hasCustomUserVars, getMissingCustomUserVars } from '../utils';
+import { usesDirectOpenIDBearerRecovery } from '../openid';
 import { getServerCustomUserVars } from '../auth';
 import { mcpConfig } from '../mcpConfig';
 
@@ -19,10 +20,11 @@ let activeCatalogWork = 0;
  * authorized but whose catalog cache expired, and such a server answers well inside this window.
  */
 const RECOVERY_BUDGET_MS = 3000;
-const RECOVERY_BACKOFF_MS = [5 * 60_000, 10 * 60_000, 20 * 60_000, 30 * 60_000] as const;
-const REAUTH_RETRY_MS = 30 * 60_000;
-const MAX_RECOVERY_STATES = 10_000;
-const recoveryStates = new Map<string, RecoveryStateEntry>();
+const DEFAULT_RECOVERY_POLICY: MCPServerCatalogRecoveryPolicy = {
+  discoveryBackoffMs: [5 * 60_000, 10 * 60_000, 20 * 60_000, 30 * 60_000],
+  reauthRetryMs: 30 * 60_000,
+  maxStateEntries: 10_000,
+};
 
 export interface MCPServerCatalogRecoveryInput {
   serverName: string;
@@ -34,10 +36,19 @@ export interface MCPServerCatalogRecoveryDeps {
     userId: string,
     serverNames: readonly string[],
   ) => Promise<Record<string, Record<string, string>>>;
-  discoverServerTools: (
-    options: ToolDiscoveryOptions,
-  ) => Promise<{ tools: Tool[] | null; oauthRequired?: boolean }>;
+  discoverServerTools: (options: ToolDiscoveryOptions) => Promise<{
+    tools: Tool[] | null;
+    oauthRequired?: boolean;
+    authenticationKind?: 'oauth' | 'obo' | 'server';
+  }>;
   formatServerTools: (serverName: string, tools: Tool[]) => LCAvailableTools;
+  recoveryTracker?: MCPServerCatalogRecoveryTracker;
+}
+
+export interface MCPServerCatalogRecoveryPolicy {
+  discoveryBackoffMs: readonly number[];
+  reauthRetryMs: number;
+  maxStateEntries: number;
 }
 
 export interface MCPServerCatalogSnapshot {
@@ -135,38 +146,107 @@ function getRecoveryKey(userId: string, serverName: string): string {
   return `${userId}\u0000${serverName}`;
 }
 
-function getConfigFingerprint(serverConfig: ParsedServerConfig): string {
-  return JSON.stringify(serverConfig);
+function getRecoveryFingerprint(
+  serverConfig: ParsedServerConfig,
+  policy: MCPServerCatalogRecoveryPolicy,
+): string {
+  return JSON.stringify([serverConfig, policy]);
 }
 
-function trimRecoveryStates(): void {
-  while (recoveryStates.size > MAX_RECOVERY_STATES) {
-    let oldest: [string, RecoveryStateEntry] | undefined;
-    for (const entry of recoveryStates) {
-      if (entry[1].inFlight != null) {
-        continue;
-      }
-      if (oldest == null || entry[1].lastTouchedAt < oldest[1].lastTouchedAt) {
-        oldest = entry;
-      }
-    }
-    if (oldest == null) {
+export class MCPServerCatalogRecoveryTracker {
+  private readonly states = new Map<string, RecoveryStateEntry>();
+
+  /** Clears suppression after a credential/config mutation commits. */
+  public clear(userId: string, serverName?: string): void {
+    if (serverName != null) {
+      this.states.delete(getRecoveryKey(userId, serverName));
       return;
     }
-    recoveryStates.delete(oldest[0]);
+    const prefix = `${userId}\u0000`;
+    for (const key of this.states.keys()) {
+      if (key.startsWith(prefix)) {
+        this.states.delete(key);
+      }
+    }
   }
-}
 
-/** Clears passive discovery suppression when an explicit reconnect changes authorization state. */
-export function clearMCPServerCatalogRecoveryState(userId: string, serverName?: string): void {
-  if (serverName != null) {
-    recoveryStates.delete(getRecoveryKey(userId, serverName));
-    return;
+  public run(
+    user: IUser,
+    candidate: RecoveryCandidate,
+    policy: MCPServerCatalogRecoveryPolicy,
+    discover: () => Promise<RecoveryOutcome>,
+  ): Promise<RecoveryOutcome> {
+    const key = getRecoveryKey(user.id, candidate.serverName);
+    const configFingerprint = getRecoveryFingerprint(candidate.serverConfig, policy);
+    const now = Date.now();
+    const existing = this.states.get(key);
+    if (existing?.configFingerprint === configFingerprint) {
+      existing.lastTouchedAt = now;
+      if (existing.inFlight != null) {
+        return existing.inFlight;
+      }
+      if (existing.outcome != null && existing.nextRetryAt > now) {
+        return Promise.resolve(existing.outcome);
+      }
+    }
+
+    const entry: RecoveryStateEntry = {
+      configFingerprint,
+      failureCount: existing?.configFingerprint === configFingerprint ? existing.failureCount : 0,
+      nextRetryAt: 0,
+      lastTouchedAt: now,
+    };
+    const flight = discover()
+      .then((outcome) => {
+        if (this.states.get(key) !== entry) {
+          return outcome;
+        }
+        entry.lastTouchedAt = Date.now();
+        if (outcome.state === 'reauth_required') {
+          entry.failureCount = 0;
+          entry.nextRetryAt = entry.lastTouchedAt + policy.reauthRetryMs;
+          /** Keep the authorization decision, but never promote an unfenced discovery catalog
+           * into a cross-request cache. The configured server still appears with no tools. */
+          entry.outcome = { ...outcome, tools: null };
+        } else if (outcome.state === 'backoff') {
+          const delay =
+            policy.discoveryBackoffMs[
+              Math.min(entry.failureCount, policy.discoveryBackoffMs.length - 1)
+            ];
+          entry.failureCount += 1;
+          entry.nextRetryAt = entry.lastTouchedAt + delay;
+          entry.outcome = outcome;
+        } else {
+          this.states.delete(key);
+        }
+        return outcome;
+      })
+      .finally(() => {
+        if (this.states.get(key) === entry) {
+          entry.inFlight = undefined;
+        }
+      });
+    entry.inFlight = flight;
+    this.states.set(key, entry);
+    this.trim(policy.maxStateEntries);
+    return flight;
   }
-  const prefix = `${userId}\u0000`;
-  for (const key of recoveryStates.keys()) {
-    if (key.startsWith(prefix)) {
-      recoveryStates.delete(key);
+
+  private trim(maxStateEntries: number): void {
+    while (this.states.size > maxStateEntries) {
+      let oldest: [string, RecoveryStateEntry] | undefined;
+      for (const entry of this.states) {
+        if (entry[1].inFlight != null) {
+          continue;
+        }
+        if (oldest == null || entry[1].lastTouchedAt < oldest[1].lastTouchedAt) {
+          oldest = entry;
+        }
+      }
+      if (oldest == null) {
+        return;
+      }
+      this.states.delete(oldest[0]);
     }
   }
 }
@@ -187,11 +267,11 @@ async function discoverCandidate(
       signal,
     });
     const tools = result.tools == null ? null : deps.formatServerTools(serverName, result.tools);
-    if (result.oauthRequired === true) {
-      return { serverName, tools, state: 'reauth_required' };
-    }
     if (signal?.aborted) {
       return { serverName, tools: null };
+    }
+    if (result.oauthRequired === true && result.authenticationKind === 'oauth') {
+      return { serverName, tools, state: 'reauth_required' };
     }
     return {
       serverName,
@@ -215,66 +295,6 @@ async function discoverCandidate(
     logger.error(`[MCP catalog recovery] Failed to discover tools for ${serverName}:`, error);
     return { serverName, tools: null, state: 'backoff' };
   }
-}
-
-function discoverCandidateOnce(
-  user: IUser,
-  candidate: RecoveryCandidate,
-  deps: MCPServerCatalogRecoveryDeps,
-  signal?: AbortSignal,
-): Promise<RecoveryOutcome> {
-  const key = getRecoveryKey(user.id, candidate.serverName);
-  const configFingerprint = getConfigFingerprint(candidate.serverConfig);
-  const now = Date.now();
-  const existing = recoveryStates.get(key);
-  if (existing?.configFingerprint === configFingerprint) {
-    existing.lastTouchedAt = now;
-    if (existing.inFlight != null) {
-      return existing.inFlight;
-    }
-    if (existing.outcome != null && existing.nextRetryAt > now) {
-      return Promise.resolve(existing.outcome);
-    }
-  }
-
-  const entry: RecoveryStateEntry = {
-    configFingerprint,
-    failureCount: existing?.configFingerprint === configFingerprint ? existing.failureCount : 0,
-    nextRetryAt: 0,
-    lastTouchedAt: now,
-  };
-  const discovery = discoverCandidate(user, candidate, deps, signal)
-    .then((outcome) => {
-      if (recoveryStates.get(key) !== entry) {
-        return outcome;
-      }
-      entry.lastTouchedAt = Date.now();
-      if (outcome.state === 'reauth_required') {
-        entry.failureCount = 0;
-        entry.nextRetryAt = entry.lastTouchedAt + REAUTH_RETRY_MS;
-        /** Keep the authorization decision, but never promote an unfenced discovery catalog
-         * into a cross-request cache. The configured server still appears with no tools. */
-        entry.outcome = { ...outcome, tools: null };
-      } else if (outcome.state === 'backoff') {
-        const delay =
-          RECOVERY_BACKOFF_MS[Math.min(entry.failureCount, RECOVERY_BACKOFF_MS.length - 1)];
-        entry.failureCount += 1;
-        entry.nextRetryAt = entry.lastTouchedAt + delay;
-        entry.outcome = outcome;
-      } else {
-        recoveryStates.delete(key);
-      }
-      return outcome;
-    })
-    .finally(() => {
-      if (recoveryStates.get(key) === entry) {
-        entry.inFlight = undefined;
-      }
-    });
-  entry.inFlight = discovery;
-  recoveryStates.set(key, entry);
-  trimRecoveryStates();
-  return discovery;
 }
 
 function finishCatalogLane(lane: CatalogWorkLane): void {
@@ -366,10 +386,16 @@ async function recoverMCPServerCatalogsWithState(
     user: IUser;
     servers: readonly MCPServerCatalogRecoveryInput[];
     signal?: AbortSignal;
+    recoveryPolicy?: Partial<MCPServerCatalogRecoveryPolicy>;
   },
   deps: MCPServerCatalogRecoveryDeps,
 ): Promise<MCPServerCatalogRecoveryResult> {
   const { user, servers, signal } = params;
+  const policy = { ...DEFAULT_RECOVERY_POLICY, ...params.recoveryPolicy };
+  if (policy.discoveryBackoffMs.length === 0) {
+    policy.discoveryBackoffMs = DEFAULT_RECOVERY_POLICY.discoveryBackoffMs;
+  }
+  const tracker = deps.recoveryTracker ?? new MCPServerCatalogRecoveryTracker();
   /** Only the config tier retries a failed stub on its own clock. A `yaml`- or `user`-sourced
    *  stub has no such timer, so skipping it unconditionally would hide the server for good —
    *  exactly the state this recovery exists to escape. */
@@ -417,7 +443,16 @@ async function recoverMCPServerCatalogsWithState(
   const results: Array<RecoveryOutcome | undefined> = [];
   const admitted = await runCatalogWork(
     authorized.map((candidate, index) => async () => {
-      results[index] = await discoverCandidateOnce(user, candidate, deps, signal);
+      /** OBO and direct OpenID bearer discovery consume a request's live upstream-token closure,
+       * so they must never join another request's flight or outlive that request's cancellation. */
+      const usesRequestCredential =
+        candidate.serverConfig.obo != null ||
+        usesDirectOpenIDBearerRecovery(candidate.serverConfig);
+      results[index] = usesRequestCredential
+        ? await discoverCandidate(user, candidate, deps, signal)
+        : await tracker.run(user, candidate, policy, () =>
+            discoverCandidate(user, candidate, deps),
+          );
     }),
     signal,
   );
@@ -444,6 +479,7 @@ export async function recoverMCPServerCatalogs(
     user: IUser;
     servers: readonly MCPServerCatalogRecoveryInput[];
     signal?: AbortSignal;
+    recoveryPolicy?: Partial<MCPServerCatalogRecoveryPolicy>;
   },
   deps: MCPServerCatalogRecoveryDeps,
 ): Promise<Map<string, LCAvailableTools>> {
@@ -456,6 +492,7 @@ export async function loadMCPServerCatalogs(
     user: IUser;
     servers: readonly MCPServerCatalogRecoveryInput[];
     signal?: AbortSignal;
+    recoveryPolicy?: Partial<MCPServerCatalogRecoveryPolicy>;
   },
   deps: MCPServerCatalogLoaderDeps,
 ): Promise<MCPServerCatalogLoaderResult> {
@@ -513,7 +550,7 @@ export async function loadMCPServerCatalogs(
   if (coldServers.length > 0) {
     try {
       recovered = await recoverMCPServerCatalogsWithState(
-        { user, servers: coldServers, signal },
+        { user, servers: coldServers, signal, recoveryPolicy: params.recoveryPolicy },
         deps,
       );
     } catch (error) {
@@ -534,7 +571,7 @@ export async function loadMCPServerCatalogs(
     }
     serverTools.set(snapshot.serverName, tools);
     if (snapshot.tools != null) {
-      clearMCPServerCatalogRecoveryState(user.id, snapshot.serverName);
+      deps.recoveryTracker?.clear(user.id, snapshot.serverName);
     }
 
     if (snapshot.source !== 'snapshot' || snapshot.tools == null) {

--- a/packages/api/src/mcp/catalog/recovery.ts
+++ b/packages/api/src/mcp/catalog/recovery.ts
@@ -4,6 +4,7 @@ import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { IUser } from '@librechat/data-schemas';
 import type { LCAvailableTools, ParsedServerConfig, ToolDiscoveryOptions } from '../types';
 import { hasCustomUserVars, getMissingCustomUserVars } from '../utils';
+import { getMCPToolsChangedGeneration } from '../toolsChanged';
 import { usesDirectOpenIDBearerRecovery } from '../openid';
 import { getServerCustomUserVars } from '../auth';
 import { mcpConfig } from '../mcpConfig';
@@ -43,6 +44,7 @@ export interface MCPServerCatalogRecoveryDeps {
   }>;
   formatServerTools: (serverName: string, tools: Tool[]) => LCAvailableTools;
   recoveryTracker?: MCPServerCatalogRecoveryTracker;
+  getRecoveryGeneration?: (userId: string, serverName: string) => Promise<string | undefined>;
 }
 
 export interface MCPServerCatalogRecoveryPolicy {
@@ -83,11 +85,13 @@ export interface MCPServerCatalogLoaderResult {
   serverTools: Map<string, LCAvailableTools>;
   serversWithoutTools: string[];
   reauthRequiredServers: Set<string>;
+  reauthRequiredGenerations: Map<string, string | undefined>;
 }
 
 interface MCPServerCatalogRecoveryResult {
   serverTools: Map<string, LCAvailableTools>;
   reauthRequiredServers: Set<string>;
+  reauthRequiredGenerations: Map<string, string | undefined>;
 }
 
 interface MCPServerCatalogEntry extends MCPServerCatalogSnapshot {
@@ -104,6 +108,7 @@ type RecoveryOutcome = {
   serverName: string;
   tools: LCAvailableTools | null;
   state?: 'reauth_required' | 'backoff';
+  recoveryGeneration?: string;
 };
 
 interface RecoveryStateEntry {
@@ -133,6 +138,23 @@ export class MCPCatalogCapacityError extends Error {
   }
 }
 
+/** Reads the cross-replica credential/catalog fence without making status or recovery depend on
+ * shared-cache availability. Process-local suppression remains bounded as a fallback. */
+export async function getMCPAuthorizationGeneration(
+  userId: string,
+  serverName: string,
+): Promise<string | undefined> {
+  try {
+    return await getMCPToolsChangedGeneration({ userId, serverName });
+  } catch (error) {
+    logger.debug(
+      `[MCP catalog recovery] Could not read shared generation for ${serverName}; using process-local state`,
+      error,
+    );
+    return undefined;
+  }
+}
+
 /** Bounds one server's discovery, honouring a shorter operator `initTimeout`. */
 function resolveBudget(serverConfig: ParsedServerConfig): number {
   const { initTimeout } = serverConfig;
@@ -149,8 +171,9 @@ function getRecoveryKey(userId: string, serverName: string): string {
 function getRecoveryFingerprint(
   serverConfig: ParsedServerConfig,
   policy: MCPServerCatalogRecoveryPolicy,
+  recoveryGeneration?: string,
 ): string {
-  return JSON.stringify([serverConfig, policy]);
+  return JSON.stringify([serverConfig, policy, recoveryGeneration]);
 }
 
 export class MCPServerCatalogRecoveryTracker {
@@ -174,10 +197,15 @@ export class MCPServerCatalogRecoveryTracker {
     user: IUser,
     candidate: RecoveryCandidate,
     policy: MCPServerCatalogRecoveryPolicy,
+    recoveryGeneration: string | undefined,
     discover: () => Promise<RecoveryOutcome>,
   ): Promise<RecoveryOutcome> {
     const key = getRecoveryKey(user.id, candidate.serverName);
-    const configFingerprint = getRecoveryFingerprint(candidate.serverConfig, policy);
+    const configFingerprint = getRecoveryFingerprint(
+      candidate.serverConfig,
+      policy,
+      recoveryGeneration,
+    );
     const now = Date.now();
     const existing = this.states.get(key);
     if (existing?.configFingerprint === configFingerprint) {
@@ -203,6 +231,7 @@ export class MCPServerCatalogRecoveryTracker {
         }
         entry.lastTouchedAt = Date.now();
         if (outcome.state === 'reauth_required') {
+          outcome.recoveryGeneration = recoveryGeneration;
           entry.failureCount = 0;
           entry.nextRetryAt = entry.lastTouchedAt + policy.reauthRetryMs;
           /** Keep the authorization decision, but never promote an unfenced discovery catalog
@@ -407,7 +436,11 @@ async function recoverMCPServerCatalogsWithState(
     return false;
   });
   if (recoverable.length === 0) {
-    return { serverTools: new Map(), reauthRequiredServers: new Set() };
+    return {
+      serverTools: new Map(),
+      reauthRequiredServers: new Set(),
+      reauthRequiredGenerations: new Map(),
+    };
   }
 
   /** Only credential-bearing servers can consume the auth map, so a list without any avoids
@@ -437,7 +470,11 @@ async function recoverMCPServerCatalogsWithState(
     authorized.push({ ...candidate, customUserVars });
   }
   if (authorized.length === 0) {
-    return { serverTools: new Map(), reauthRequiredServers: new Set() };
+    return {
+      serverTools: new Map(),
+      reauthRequiredServers: new Set(),
+      reauthRequiredGenerations: new Map(),
+    };
   }
 
   const results: Array<RecoveryOutcome | undefined> = [];
@@ -448,11 +485,16 @@ async function recoverMCPServerCatalogsWithState(
       const usesRequestCredential =
         candidate.serverConfig.obo != null ||
         usesDirectOpenIDBearerRecovery(candidate.serverConfig);
-      results[index] = usesRequestCredential
-        ? await discoverCandidate(user, candidate, deps, signal)
-        : await tracker.run(user, candidate, policy, () =>
-            discoverCandidate(user, candidate, deps),
-          );
+      if (usesRequestCredential) {
+        results[index] = await discoverCandidate(user, candidate, deps, signal);
+        return;
+      }
+      const recoveryGeneration = await (
+        deps.getRecoveryGeneration ?? getMCPAuthorizationGeneration
+      )(user.id, candidate.serverName);
+      results[index] = await tracker.run(user, candidate, policy, recoveryGeneration, () =>
+        discoverCandidate(user, candidate, deps),
+      );
     }),
     signal,
   );
@@ -462,15 +504,17 @@ async function recoverMCPServerCatalogsWithState(
 
   const serverTools = new Map<string, LCAvailableTools>();
   const reauthRequiredServers = new Set<string>();
+  const reauthRequiredGenerations = new Map<string, string | undefined>();
   for (const result of results) {
     if (result?.tools != null) {
       serverTools.set(result.serverName, result.tools);
     }
     if (result?.state === 'reauth_required') {
       reauthRequiredServers.add(result.serverName);
+      reauthRequiredGenerations.set(result.serverName, result.recoveryGeneration);
     }
   }
-  return { serverTools, reauthRequiredServers };
+  return { serverTools, reauthRequiredServers, reauthRequiredGenerations };
 }
 
 /** Preserves the public recovery helper's Map contract for existing package consumers. */
@@ -546,6 +590,7 @@ export async function loadMCPServerCatalogs(
   let recovered: MCPServerCatalogRecoveryResult = {
     serverTools: new Map(),
     reauthRequiredServers: new Set(),
+    reauthRequiredGenerations: new Map(),
   };
   if (coldServers.length > 0) {
     try {
@@ -598,5 +643,6 @@ export async function loadMCPServerCatalogs(
     serverTools,
     serversWithoutTools,
     reauthRequiredServers: recovered.reauthRequiredServers,
+    reauthRequiredGenerations: recovered.reauthRequiredGenerations,
   };
 }

--- a/packages/api/src/mcp/catalog/recovery.ts
+++ b/packages/api/src/mcp/catalog/recovery.ts
@@ -19,6 +19,10 @@ let activeCatalogWork = 0;
  * authorized but whose catalog cache expired, and such a server answers well inside this window.
  */
 const RECOVERY_BUDGET_MS = 3000;
+const RECOVERY_BACKOFF_MS = [5 * 60_000, 10 * 60_000, 20 * 60_000, 30 * 60_000] as const;
+const REAUTH_RETRY_MS = 30 * 60_000;
+const MAX_RECOVERY_STATES = 10_000;
+const recoveryStates = new Map<string, RecoveryStateEntry>();
 
 export interface MCPServerCatalogRecoveryInput {
   serverName: string;
@@ -30,7 +34,9 @@ export interface MCPServerCatalogRecoveryDeps {
     userId: string,
     serverNames: readonly string[],
   ) => Promise<Record<string, Record<string, string>>>;
-  discoverServerTools: (options: ToolDiscoveryOptions) => Promise<{ tools: Tool[] | null }>;
+  discoverServerTools: (
+    options: ToolDiscoveryOptions,
+  ) => Promise<{ tools: Tool[] | null; oauthRequired?: boolean }>;
   formatServerTools: (serverName: string, tools: Tool[]) => LCAvailableTools;
 }
 
@@ -65,6 +71,12 @@ export interface MCPServerCatalogLoaderDeps extends MCPServerCatalogRecoveryDeps
 export interface MCPServerCatalogLoaderResult {
   serverTools: Map<string, LCAvailableTools>;
   serversWithoutTools: string[];
+  reauthRequiredServers: Set<string>;
+}
+
+interface MCPServerCatalogRecoveryResult {
+  serverTools: Map<string, LCAvailableTools>;
+  reauthRequiredServers: Set<string>;
 }
 
 interface MCPServerCatalogEntry extends MCPServerCatalogSnapshot {
@@ -75,6 +87,21 @@ interface MCPServerCatalogEntry extends MCPServerCatalogSnapshot {
 
 interface RecoveryCandidate extends MCPServerCatalogRecoveryInput {
   customUserVars?: Record<string, string>;
+}
+
+type RecoveryOutcome = {
+  serverName: string;
+  tools: LCAvailableTools | null;
+  state?: 'reauth_required' | 'backoff';
+};
+
+interface RecoveryStateEntry {
+  configFingerprint: string;
+  failureCount: number;
+  nextRetryAt: number;
+  lastTouchedAt: number;
+  outcome?: RecoveryOutcome;
+  inFlight?: Promise<RecoveryOutcome>;
 }
 
 interface CatalogWorkLane {
@@ -104,12 +131,52 @@ function resolveBudget(serverConfig: ParsedServerConfig): number {
   return RECOVERY_BUDGET_MS;
 }
 
+function getRecoveryKey(userId: string, serverName: string): string {
+  return `${userId}\u0000${serverName}`;
+}
+
+function getConfigFingerprint(serverConfig: ParsedServerConfig): string {
+  return JSON.stringify(serverConfig);
+}
+
+function trimRecoveryStates(): void {
+  while (recoveryStates.size > MAX_RECOVERY_STATES) {
+    let oldest: [string, RecoveryStateEntry] | undefined;
+    for (const entry of recoveryStates) {
+      if (entry[1].inFlight != null) {
+        continue;
+      }
+      if (oldest == null || entry[1].lastTouchedAt < oldest[1].lastTouchedAt) {
+        oldest = entry;
+      }
+    }
+    if (oldest == null) {
+      return;
+    }
+    recoveryStates.delete(oldest[0]);
+  }
+}
+
+/** Clears passive discovery suppression when an explicit reconnect changes authorization state. */
+export function clearMCPServerCatalogRecoveryState(userId: string, serverName?: string): void {
+  if (serverName != null) {
+    recoveryStates.delete(getRecoveryKey(userId, serverName));
+    return;
+  }
+  const prefix = `${userId}\u0000`;
+  for (const key of recoveryStates.keys()) {
+    if (key.startsWith(prefix)) {
+      recoveryStates.delete(key);
+    }
+  }
+}
+
 async function discoverCandidate(
   user: IUser,
   { serverName, serverConfig, customUserVars }: RecoveryCandidate,
   deps: MCPServerCatalogRecoveryDeps,
   signal?: AbortSignal,
-): Promise<[string, LCAvailableTools | null]> {
+): Promise<RecoveryOutcome> {
   try {
     const result = await deps.discoverServerTools({
       user,
@@ -119,11 +186,22 @@ async function discoverCandidate(
       deadlineMs: Date.now() + resolveBudget(serverConfig),
       signal,
     });
-    return [
+    const tools = result.tools == null ? null : deps.formatServerTools(serverName, result.tools);
+    if (result.oauthRequired === true) {
+      return { serverName, tools, state: 'reauth_required' };
+    }
+    if (signal?.aborted) {
+      return { serverName, tools: null };
+    }
+    return {
       serverName,
-      result.tools == null ? null : deps.formatServerTools(serverName, result.tools),
-    ];
+      tools,
+      ...(tools == null && { state: 'backoff' as const }),
+    };
   } catch (error) {
+    if (signal?.aborted) {
+      return { serverName, tools: null };
+    }
     /** Discovery raises `InvalidRequest` precisely when configuration makes the attempt
      *  impossible — domain policy, unresolved placeholders, missing runtime fields. That
      *  failure recurs on every request until an admin changes configuration, so it is
@@ -132,11 +210,71 @@ async function discoverCandidate(
       logger.debug(
         `[MCP catalog recovery] ${serverName} is not recoverable under current configuration: ${error.message}`,
       );
-      return [serverName, null];
+      return { serverName, tools: null, state: 'backoff' };
     }
     logger.error(`[MCP catalog recovery] Failed to discover tools for ${serverName}:`, error);
-    return [serverName, null];
+    return { serverName, tools: null, state: 'backoff' };
   }
+}
+
+function discoverCandidateOnce(
+  user: IUser,
+  candidate: RecoveryCandidate,
+  deps: MCPServerCatalogRecoveryDeps,
+  signal?: AbortSignal,
+): Promise<RecoveryOutcome> {
+  const key = getRecoveryKey(user.id, candidate.serverName);
+  const configFingerprint = getConfigFingerprint(candidate.serverConfig);
+  const now = Date.now();
+  const existing = recoveryStates.get(key);
+  if (existing?.configFingerprint === configFingerprint) {
+    existing.lastTouchedAt = now;
+    if (existing.inFlight != null) {
+      return existing.inFlight;
+    }
+    if (existing.outcome != null && existing.nextRetryAt > now) {
+      return Promise.resolve(existing.outcome);
+    }
+  }
+
+  const entry: RecoveryStateEntry = {
+    configFingerprint,
+    failureCount: existing?.configFingerprint === configFingerprint ? existing.failureCount : 0,
+    nextRetryAt: 0,
+    lastTouchedAt: now,
+  };
+  const discovery = discoverCandidate(user, candidate, deps, signal)
+    .then((outcome) => {
+      if (recoveryStates.get(key) !== entry) {
+        return outcome;
+      }
+      entry.lastTouchedAt = Date.now();
+      if (outcome.state === 'reauth_required') {
+        entry.failureCount = 0;
+        entry.nextRetryAt = entry.lastTouchedAt + REAUTH_RETRY_MS;
+        /** Keep the authorization decision, but never promote an unfenced discovery catalog
+         * into a cross-request cache. The configured server still appears with no tools. */
+        entry.outcome = { ...outcome, tools: null };
+      } else if (outcome.state === 'backoff') {
+        const delay =
+          RECOVERY_BACKOFF_MS[Math.min(entry.failureCount, RECOVERY_BACKOFF_MS.length - 1)];
+        entry.failureCount += 1;
+        entry.nextRetryAt = entry.lastTouchedAt + delay;
+        entry.outcome = outcome;
+      } else {
+        recoveryStates.delete(key);
+      }
+      return outcome;
+    })
+    .finally(() => {
+      if (recoveryStates.get(key) === entry) {
+        entry.inFlight = undefined;
+      }
+    });
+  entry.inFlight = discovery;
+  recoveryStates.set(key, entry);
+  trimRecoveryStates();
+  return discovery;
 }
 
 function finishCatalogLane(lane: CatalogWorkLane): void {
@@ -218,20 +356,19 @@ function runCatalogWork(
 /**
  * Passively discovers cold MCP catalogs for one request.
  *
- * A recovered catalog cannot be retained: a discovery connection owns no publication generation
- * and is disposed, and the tool cache refuses unfenced writes, so the result is served only to
- * the requesting user. Recovery therefore stays stateless and individually cheap rather than
- * scheduling around a result it is not allowed to keep — it skips only what configuration alone
- * proves pointless, and bounds everything else by a per-server budget.
+ * A recovered catalog cannot enter the authoritative tool cache: a discovery connection owns no
+ * publication generation and is disposed. Process-local recovery state therefore retains only
+ * enough information to coalesce concurrent requests and suppress repeated failed/OAuth attempts;
+ * successful ordinary catalogs remain request-local.
  */
-export async function recoverMCPServerCatalogs(
+async function recoverMCPServerCatalogsWithState(
   params: {
     user: IUser;
     servers: readonly MCPServerCatalogRecoveryInput[];
     signal?: AbortSignal;
   },
   deps: MCPServerCatalogRecoveryDeps,
-): Promise<Map<string, LCAvailableTools>> {
+): Promise<MCPServerCatalogRecoveryResult> {
   const { user, servers, signal } = params;
   /** Only the config tier retries a failed stub on its own clock. A `yaml`- or `user`-sourced
    *  stub has no such timer, so skipping it unconditionally would hide the server for good —
@@ -244,7 +381,7 @@ export async function recoverMCPServerCatalogs(
     return false;
   });
   if (recoverable.length === 0) {
-    return new Map();
+    return { serverTools: new Map(), reauthRequiredServers: new Set() };
   }
 
   /** Only credential-bearing servers can consume the auth map, so a list without any avoids
@@ -274,13 +411,13 @@ export async function recoverMCPServerCatalogs(
     authorized.push({ ...candidate, customUserVars });
   }
   if (authorized.length === 0) {
-    return new Map();
+    return { serverTools: new Map(), reauthRequiredServers: new Set() };
   }
 
-  const results: Array<[string, LCAvailableTools | null] | undefined> = [];
+  const results: Array<RecoveryOutcome | undefined> = [];
   const admitted = await runCatalogWork(
     authorized.map((candidate, index) => async () => {
-      results[index] = await discoverCandidate(user, candidate, deps, signal);
+      results[index] = await discoverCandidateOnce(user, candidate, deps, signal);
     }),
     signal,
   );
@@ -288,11 +425,29 @@ export async function recoverMCPServerCatalogs(
     throw new MCPCatalogCapacityError();
   }
 
-  return new Map(
-    results.filter(
-      (entry): entry is [string, LCAvailableTools] => entry != null && entry[1] != null,
-    ),
-  );
+  const serverTools = new Map<string, LCAvailableTools>();
+  const reauthRequiredServers = new Set<string>();
+  for (const result of results) {
+    if (result?.tools != null) {
+      serverTools.set(result.serverName, result.tools);
+    }
+    if (result?.state === 'reauth_required') {
+      reauthRequiredServers.add(result.serverName);
+    }
+  }
+  return { serverTools, reauthRequiredServers };
+}
+
+/** Preserves the public recovery helper's Map contract for existing package consumers. */
+export async function recoverMCPServerCatalogs(
+  params: {
+    user: IUser;
+    servers: readonly MCPServerCatalogRecoveryInput[];
+    signal?: AbortSignal;
+  },
+  deps: MCPServerCatalogRecoveryDeps,
+): Promise<Map<string, LCAvailableTools>> {
+  return (await recoverMCPServerCatalogsWithState(params, deps)).serverTools;
 }
 
 /** Loads cached, connected, then passive MCP catalogs for a marketplace-style list request. */
@@ -351,10 +506,16 @@ export async function loadMCPServerCatalogs(
   const coldServers = snapshots
     .filter(({ tools }) => tools == null)
     .map(({ serverName, serverConfig }) => ({ serverName, serverConfig }));
-  let recovered = new Map<string, LCAvailableTools>();
+  let recovered: MCPServerCatalogRecoveryResult = {
+    serverTools: new Map(),
+    reauthRequiredServers: new Set(),
+  };
   if (coldServers.length > 0) {
     try {
-      recovered = await recoverMCPServerCatalogs({ user, servers: coldServers, signal }, deps);
+      recovered = await recoverMCPServerCatalogsWithState(
+        { user, servers: coldServers, signal },
+        deps,
+      );
     } catch (error) {
       if (error instanceof MCPCatalogCapacityError) {
         throw error;
@@ -366,12 +527,15 @@ export async function loadMCPServerCatalogs(
   const serverTools = new Map<string, LCAvailableTools>();
   const serversWithoutTools: string[] = [];
   for (const snapshot of snapshots) {
-    const tools = snapshot.tools ?? recovered.get(snapshot.serverName);
+    const tools = snapshot.tools ?? recovered.serverTools.get(snapshot.serverName);
     if (tools == null) {
       serversWithoutTools.push(snapshot.serverName);
       continue;
     }
     serverTools.set(snapshot.serverName, tools);
+    if (snapshot.tools != null) {
+      clearMCPServerCatalogRecoveryState(user.id, snapshot.serverName);
+    }
 
     if (snapshot.source !== 'snapshot' || snapshot.tools == null) {
       continue;
@@ -393,5 +557,9 @@ export async function loadMCPServerCatalogs(
       );
   }
 
-  return { serverTools, serversWithoutTools };
+  return {
+    serverTools,
+    serversWithoutTools,
+    reauthRequiredServers: recovered.reauthRequiredServers,
+  };
 }

--- a/packages/api/src/mcp/catalog/recovery.ts
+++ b/packages/api/src/mcp/catalog/recovery.ts
@@ -19,9 +19,9 @@ let activeCatalogWork = 0;
  * long regardless of where the server stalls. Recovery targets a server that is reachable and
  * authorized but whose catalog cache expired, and such a server answers well inside this window.
  */
-const RECOVERY_BUDGET_MS = 3000;
 const DEFAULT_RECOVERY_POLICY: MCPServerCatalogRecoveryPolicy = {
   discoveryBackoffMs: [5 * 60_000, 10 * 60_000, 20 * 60_000, 30 * 60_000],
+  discoveryTimeoutMs: 3_000,
   reauthRetryMs: 30 * 60_000,
   maxStateEntries: 10_000,
   generationReadTimeoutMs: 500,
@@ -128,6 +128,7 @@ export async function publishMCPAuthorizationMutation(
 
 export interface MCPServerCatalogRecoveryPolicy {
   discoveryBackoffMs: readonly number[];
+  discoveryTimeoutMs: number;
   reauthRetryMs: number;
   maxStateEntries: number;
   generationReadTimeoutMs: number;
@@ -278,13 +279,16 @@ export async function readMCPRecoveryGenerationAround<T>(
   };
 }
 
-/** Bounds one server's discovery, honouring a shorter operator `initTimeout`. */
-function resolveBudget(serverConfig: ParsedServerConfig): number {
+/** Bounds one server's discovery, honouring the shorter configured limit. */
+function resolveBudget(
+  serverConfig: ParsedServerConfig,
+  policy: MCPServerCatalogRecoveryPolicy,
+): number {
   const { initTimeout } = serverConfig;
   if (typeof initTimeout === 'number') {
-    return Math.min(initTimeout, RECOVERY_BUDGET_MS);
+    return Math.min(initTimeout, policy.discoveryTimeoutMs);
   }
-  return RECOVERY_BUDGET_MS;
+  return policy.discoveryTimeoutMs;
 }
 
 function getRecoveryKey(userId: string, serverName: string): string {
@@ -417,6 +421,7 @@ async function discoverCandidate(
   user: IUser,
   { serverName, serverConfig, customUserVars }: RecoveryCandidate,
   deps: MCPServerCatalogRecoveryDeps,
+  policy: MCPServerCatalogRecoveryPolicy,
   signal?: AbortSignal,
 ): Promise<RecoveryOutcome> {
   try {
@@ -425,7 +430,7 @@ async function discoverCandidate(
       serverName,
       configServers: { [serverName]: serverConfig },
       customUserVars,
-      deadlineMs: Date.now() + resolveBudget(serverConfig),
+      deadlineMs: Date.now() + resolveBudget(serverConfig, policy),
       signal,
     });
     const tools = result.tools == null ? null : deps.formatServerTools(serverName, result.tools);
@@ -636,7 +641,7 @@ async function recoverMCPServerCatalogsWithState(
         candidate.serverConfig.obo != null ||
         usesDirectOpenIDBearerRecovery(candidate.serverConfig);
       if (usesRequestCredential) {
-        results[index] = await discoverCandidate(user, candidate, deps, signal);
+        results[index] = await discoverCandidate(user, candidate, deps, policy, signal);
         return;
       }
       const observedGeneration = await readMCPRecoveryGeneration(
@@ -658,7 +663,7 @@ async function recoverMCPServerCatalogsWithState(
       }
       const recoveryGeneration = observedGeneration ?? snapshotGeneration;
       const outcome = await tracker.run(user, candidate, policy, recoveryGeneration, () =>
-        discoverCandidate(user, candidate, deps),
+        discoverCandidate(user, candidate, deps, policy),
       );
       const finalGeneration = await readMCPRecoveryGeneration(
         { userId: user.id, serverName: candidate.serverName },

--- a/packages/api/src/mcp/catalog/recovery.ts
+++ b/packages/api/src/mcp/catalog/recovery.ts
@@ -293,8 +293,8 @@ export class MCPServerCatalogRecoveryTracker {
           return { serverName: candidate.serverName, tools: null };
         }
         entry.lastTouchedAt = Date.now();
+        outcome.recoveryGeneration = entry.recoveryGeneration;
         if (outcome.state === 'reauth_required') {
-          outcome.recoveryGeneration = entry.recoveryGeneration;
           entry.failureCount = 0;
           entry.nextRetryAt = entry.lastTouchedAt + policy.reauthRetryMs;
           /** Keep the authorization decision, but never promote an unfenced discovery catalog
@@ -593,10 +593,11 @@ async function recoverMCPServerCatalogsWithState(
         deps.getRecoveryGeneration,
         { timeoutMs: policy.generationReadTimeoutMs, signal },
       );
+      const outcomeGeneration = outcome.recoveryGeneration ?? recoveryGeneration;
       if (
-        recoveryGeneration != null &&
+        outcomeGeneration != null &&
         finalGeneration != null &&
-        recoveryGeneration !== finalGeneration
+        outcomeGeneration !== finalGeneration
       ) {
         tracker.clear(user.id, candidate.serverName);
         results[index] = { serverName: candidate.serverName, tools: null };

--- a/packages/api/src/mcp/catalog/recovery.ts
+++ b/packages/api/src/mcp/catalog/recovery.ts
@@ -27,6 +27,8 @@ const DEFAULT_RECOVERY_POLICY: MCPServerCatalogRecoveryPolicy = {
   generationReadTimeoutMs: 500,
   authorizationFenceRetryMs: [0, 50, 200],
   authorizationFenceTimeoutMs: 1_000,
+  authorizationFenceRetryIntervalMs: 30_000,
+  authorizationFenceRetryBatchSize: 100,
 };
 
 export interface MCPServerCatalogRecoveryInput {
@@ -65,8 +67,11 @@ export async function publishMCPAuthorizationMutation(
   deps: {
     invalidateRecoveryGeneration: (scope: MCPRecoveryGenerationScope) => Promise<unknown>;
     clearLocalRecovery?: (userId: string, serverName: string) => void;
-    persistPublicationRetry?: (scope: MCPRecoveryGenerationScope) => Promise<void>;
-    clearPublicationRetry?: (scope: MCPRecoveryGenerationScope) => Promise<void>;
+    persistPublicationRetry?: (scope: MCPRecoveryGenerationScope) => Promise<string>;
+    clearPublicationRetry?: (
+      scope: MCPRecoveryGenerationScope,
+      publicationRetryVersion: string,
+    ) => Promise<void>;
     retryDelaysMs?: readonly number[];
     attemptTimeoutMs?: number;
   },
@@ -74,7 +79,7 @@ export async function publishMCPAuthorizationMutation(
   /** Persist retry intent before touching the shared cache. A credential writer can keep this
    * inside its rollback boundary, so a cache outage never leaves a committed mutation with no
    * durable path to fence other replicas. */
-  await deps.persistPublicationRetry?.(scope);
+  const publicationRetryVersion = await deps.persistPublicationRetry?.(scope);
   let lastError: unknown;
   for (const delayMs of deps.retryDelaysMs ?? AUTHORIZATION_FENCE_RETRY_DELAYS_MS) {
     if (delayMs > 0) {
@@ -98,7 +103,9 @@ export async function publishMCPAuthorizationMutation(
         if (timeoutId != null) clearTimeout(timeoutId);
       }
       try {
-        await deps.clearPublicationRetry?.(scope);
+        if (publicationRetryVersion != null) {
+          await deps.clearPublicationRetry?.(scope, publicationRetryVersion);
+        }
       } catch (error) {
         /** A leftover retry only advances the opaque generation again and is therefore safe. */
         logger.warn(
@@ -126,6 +133,8 @@ export interface MCPServerCatalogRecoveryPolicy {
   generationReadTimeoutMs: number;
   authorizationFenceRetryMs: readonly number[];
   authorizationFenceTimeoutMs: number;
+  authorizationFenceRetryIntervalMs: number;
+  authorizationFenceRetryBatchSize: number;
 }
 
 export interface MCPServerCatalogSnapshot {

--- a/packages/api/src/mcp/catalog/recovery.ts
+++ b/packages/api/src/mcp/catalog/recovery.ts
@@ -25,6 +25,7 @@ const DEFAULT_RECOVERY_POLICY: MCPServerCatalogRecoveryPolicy = {
   reauthRetryMs: 30 * 60_000,
   maxStateEntries: 10_000,
   generationReadTimeoutMs: 500,
+  authorizationFenceRetryMs: [0, 50, 200],
 };
 
 export interface MCPServerCatalogRecoveryInput {
@@ -91,6 +92,7 @@ export interface MCPServerCatalogRecoveryPolicy {
   reauthRetryMs: number;
   maxStateEntries: number;
   generationReadTimeoutMs: number;
+  authorizationFenceRetryMs: readonly number[];
 }
 
 export interface MCPServerCatalogSnapshot {
@@ -257,6 +259,16 @@ function getRecoveryFingerprint(
 export class MCPServerCatalogRecoveryTracker {
   private readonly states = new Map<string, RecoveryStateEntry>();
 
+  constructor(private readonly maxStateEntries: number = DEFAULT_RECOVERY_POLICY.maxStateEntries) {}
+
+  private touch(key: string, entry: RecoveryStateEntry): void {
+    if (this.states.get(key) !== entry) {
+      return;
+    }
+    this.states.delete(key);
+    this.states.set(key, entry);
+  }
+
   /** Clears suppression after a credential/config mutation commits. */
   public clear(userId: string, serverName?: string): void {
     if (serverName != null) {
@@ -287,6 +299,7 @@ export class MCPServerCatalogRecoveryTracker {
       (recoveryGeneration == null || existing.recoveryGeneration === recoveryGeneration);
     if (sameObservedState) {
       existing.lastTouchedAt = now;
+      this.touch(key, existing);
       if (existing.inFlight != null) {
         return existing.inFlight;
       }
@@ -309,6 +322,7 @@ export class MCPServerCatalogRecoveryTracker {
           return { serverName: candidate.serverName, tools: null };
         }
         entry.lastTouchedAt = Date.now();
+        this.touch(key, entry);
         outcome.recoveryGeneration = entry.recoveryGeneration;
         if (outcome.state === 'reauth_required') {
           entry.failureCount = 0;
@@ -332,29 +346,27 @@ export class MCPServerCatalogRecoveryTracker {
       .finally(() => {
         if (this.states.get(key) === entry) {
           entry.inFlight = undefined;
+          this.trim();
         }
       });
     entry.inFlight = flight;
     this.states.set(key, entry);
-    this.trim(policy.maxStateEntries);
+    this.trim();
     return flight;
   }
 
-  private trim(maxStateEntries: number): void {
-    while (this.states.size > maxStateEntries) {
-      let oldest: [string, RecoveryStateEntry] | undefined;
-      for (const entry of this.states) {
-        if (entry[1].inFlight != null) {
+  private trim(): void {
+    while (this.states.size > this.maxStateEntries) {
+      let removed = false;
+      for (const [key, entry] of this.states) {
+        if (entry.inFlight != null) {
           continue;
         }
-        if (oldest == null || entry[1].lastTouchedAt < oldest[1].lastTouchedAt) {
-          oldest = entry;
-        }
+        this.states.delete(key);
+        removed = true;
+        break;
       }
-      if (oldest == null) {
-        return;
-      }
-      this.states.delete(oldest[0]);
+      if (!removed) return;
     }
   }
 }

--- a/packages/api/src/mcp/catalog/recovery.ts
+++ b/packages/api/src/mcp/catalog/recovery.ts
@@ -4,7 +4,6 @@ import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { IUser } from '@librechat/data-schemas';
 import type { LCAvailableTools, ParsedServerConfig, ToolDiscoveryOptions } from '../types';
 import { hasCustomUserVars, getMissingCustomUserVars } from '../utils';
-import { getMCPToolsChangedGeneration } from '../toolsChanged';
 import { usesDirectOpenIDBearerRecovery } from '../openid';
 import { getServerCustomUserVars } from '../auth';
 import { mcpConfig } from '../mcpConfig';
@@ -25,6 +24,7 @@ const DEFAULT_RECOVERY_POLICY: MCPServerCatalogRecoveryPolicy = {
   discoveryBackoffMs: [5 * 60_000, 10 * 60_000, 20 * 60_000, 30 * 60_000],
   reauthRetryMs: 30 * 60_000,
   maxStateEntries: 10_000,
+  generationReadTimeoutMs: 500,
 };
 
 export interface MCPServerCatalogRecoveryInput {
@@ -44,13 +44,53 @@ export interface MCPServerCatalogRecoveryDeps {
   }>;
   formatServerTools: (serverName: string, tools: Tool[]) => LCAvailableTools;
   recoveryTracker?: MCPServerCatalogRecoveryTracker;
-  getRecoveryGeneration?: (userId: string, serverName: string) => Promise<string | undefined>;
+  getRecoveryGeneration?: MCPRecoveryGenerationReader;
+}
+
+export interface MCPRecoveryGenerationScope {
+  userId: string;
+  serverName: string;
+}
+
+export type MCPRecoveryGenerationReader = (
+  scope: MCPRecoveryGenerationScope,
+) => Promise<string | undefined>;
+
+const AUTHORIZATION_FENCE_RETRY_DELAYS_MS = [0, 50, 200] as const;
+
+export async function publishMCPAuthorizationMutation(
+  scope: MCPRecoveryGenerationScope,
+  deps: {
+    invalidateRecoveryGeneration: (scope: MCPRecoveryGenerationScope) => Promise<unknown>;
+    clearLocalRecovery?: (userId: string, serverName: string) => void;
+    retryDelaysMs?: readonly number[];
+  },
+): Promise<void> {
+  let lastError: unknown;
+  for (const delayMs of deps.retryDelaysMs ?? AUTHORIZATION_FENCE_RETRY_DELAYS_MS) {
+    if (delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+    try {
+      await deps.invalidateRecoveryGeneration(scope);
+      deps.clearLocalRecovery?.(scope.userId, scope.serverName);
+      return;
+    } catch (error) {
+      lastError = error;
+      logger.warn(
+        `[MCP authorization] Failed to publish credential generation for ${scope.serverName}; retrying`,
+        error,
+      );
+    }
+  }
+  throw lastError;
 }
 
 export interface MCPServerCatalogRecoveryPolicy {
   discoveryBackoffMs: readonly number[];
   reauthRetryMs: number;
   maxStateEntries: number;
+  generationReadTimeoutMs: number;
 }
 
 export interface MCPServerCatalogSnapshot {
@@ -113,6 +153,7 @@ type RecoveryOutcome = {
 
 interface RecoveryStateEntry {
   configFingerprint: string;
+  recoveryGeneration?: string;
   failureCount: number;
   nextRetryAt: number;
   lastTouchedAt: number;
@@ -138,20 +179,43 @@ export class MCPCatalogCapacityError extends Error {
   }
 }
 
-/** Reads the cross-replica credential/catalog fence without making status or recovery depend on
- * shared-cache availability. Process-local suppression remains bounded as a fallback. */
-export async function getMCPAuthorizationGeneration(
-  userId: string,
-  serverName: string,
+/** Reads the cross-replica credential fence without making status or recovery depend on shared
+ * cache availability. The application supplies the cache implementation at its wiring boundary. */
+export async function readMCPRecoveryGeneration(
+  scope: MCPRecoveryGenerationScope,
+  reader?: MCPRecoveryGenerationReader,
+  options?: { timeoutMs?: number; signal?: AbortSignal },
 ): Promise<string | undefined> {
+  if (reader == null || options?.signal?.aborted) {
+    return undefined;
+  }
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_RECOVERY_POLICY.generationReadTimeoutMs;
+  let timeoutId: number | undefined;
+  let onAbort: (() => void) | undefined;
   try {
-    return await getMCPToolsChangedGeneration({ userId, serverName });
+    return await Promise.race([
+      reader(scope),
+      new Promise<undefined>((resolve) => {
+        timeoutId = setTimeout(resolve, timeoutMs);
+        if (options?.signal != null) {
+          onAbort = () => resolve(undefined);
+          options.signal.addEventListener('abort', onAbort, { once: true });
+        }
+      }),
+    ]);
   } catch (error) {
     logger.debug(
-      `[MCP catalog recovery] Could not read shared generation for ${serverName}; using process-local state`,
+      `[MCP catalog recovery] Could not read shared generation for ${scope.serverName}; using process-local state`,
       error,
     );
     return undefined;
+  } finally {
+    if (timeoutId != null) {
+      clearTimeout(timeoutId);
+    }
+    if (onAbort != null) {
+      options?.signal?.removeEventListener('abort', onAbort);
+    }
   }
 }
 
@@ -171,9 +235,8 @@ function getRecoveryKey(userId: string, serverName: string): string {
 function getRecoveryFingerprint(
   serverConfig: ParsedServerConfig,
   policy: MCPServerCatalogRecoveryPolicy,
-  recoveryGeneration?: string,
 ): string {
-  return JSON.stringify([serverConfig, policy, recoveryGeneration]);
+  return JSON.stringify([serverConfig, policy]);
 }
 
 export class MCPServerCatalogRecoveryTracker {
@@ -201,14 +264,13 @@ export class MCPServerCatalogRecoveryTracker {
     discover: () => Promise<RecoveryOutcome>,
   ): Promise<RecoveryOutcome> {
     const key = getRecoveryKey(user.id, candidate.serverName);
-    const configFingerprint = getRecoveryFingerprint(
-      candidate.serverConfig,
-      policy,
-      recoveryGeneration,
-    );
+    const configFingerprint = getRecoveryFingerprint(candidate.serverConfig, policy);
     const now = Date.now();
     const existing = this.states.get(key);
-    if (existing?.configFingerprint === configFingerprint) {
+    const sameObservedState =
+      existing?.configFingerprint === configFingerprint &&
+      (recoveryGeneration == null || existing.recoveryGeneration === recoveryGeneration);
+    if (sameObservedState) {
       existing.lastTouchedAt = now;
       if (existing.inFlight != null) {
         return existing.inFlight;
@@ -220,18 +282,19 @@ export class MCPServerCatalogRecoveryTracker {
 
     const entry: RecoveryStateEntry = {
       configFingerprint,
-      failureCount: existing?.configFingerprint === configFingerprint ? existing.failureCount : 0,
+      recoveryGeneration,
+      failureCount: sameObservedState ? existing.failureCount : 0,
       nextRetryAt: 0,
       lastTouchedAt: now,
     };
     const flight = discover()
       .then((outcome) => {
         if (this.states.get(key) !== entry) {
-          return outcome;
+          return { serverName: candidate.serverName, tools: null };
         }
         entry.lastTouchedAt = Date.now();
         if (outcome.state === 'reauth_required') {
-          outcome.recoveryGeneration = recoveryGeneration;
+          outcome.recoveryGeneration = entry.recoveryGeneration;
           entry.failureCount = 0;
           entry.nextRetryAt = entry.lastTouchedAt + policy.reauthRetryMs;
           /** Keep the authorization decision, but never promote an unfenced discovery catalog
@@ -443,6 +506,23 @@ async function recoverMCPServerCatalogsWithState(
     };
   }
 
+  const generationSnapshots = new Map<string, string | undefined>();
+  await Promise.all(
+    recoverable.map(async ({ serverName, serverConfig }) => {
+      if (serverConfig.obo != null || usesDirectOpenIDBearerRecovery(serverConfig)) {
+        return;
+      }
+      generationSnapshots.set(
+        serverName,
+        await readMCPRecoveryGeneration(
+          { userId: user.id, serverName },
+          deps.getRecoveryGeneration,
+          { timeoutMs: policy.generationReadTimeoutMs, signal },
+        ),
+      );
+    }),
+  );
+
   /** Only credential-bearing servers can consume the auth map, so a list without any avoids
    *  the plugin-auth round trip entirely. */
   const credentialServers = recoverable.filter(({ serverConfig }) =>
@@ -489,12 +569,40 @@ async function recoverMCPServerCatalogsWithState(
         results[index] = await discoverCandidate(user, candidate, deps, signal);
         return;
       }
-      const recoveryGeneration = await (
-        deps.getRecoveryGeneration ?? getMCPAuthorizationGeneration
-      )(user.id, candidate.serverName);
-      results[index] = await tracker.run(user, candidate, policy, recoveryGeneration, () =>
+      const observedGeneration = await readMCPRecoveryGeneration(
+        { userId: user.id, serverName: candidate.serverName },
+        deps.getRecoveryGeneration,
+        { timeoutMs: policy.generationReadTimeoutMs, signal },
+      );
+      const snapshotGeneration = generationSnapshots.get(candidate.serverName);
+      if (
+        snapshotGeneration != null &&
+        observedGeneration != null &&
+        snapshotGeneration !== observedGeneration
+      ) {
+        tracker.clear(user.id, candidate.serverName);
+        results[index] = { serverName: candidate.serverName, tools: null };
+        return;
+      }
+      const recoveryGeneration = observedGeneration ?? snapshotGeneration;
+      const outcome = await tracker.run(user, candidate, policy, recoveryGeneration, () =>
         discoverCandidate(user, candidate, deps),
       );
+      const finalGeneration = await readMCPRecoveryGeneration(
+        { userId: user.id, serverName: candidate.serverName },
+        deps.getRecoveryGeneration,
+        { timeoutMs: policy.generationReadTimeoutMs, signal },
+      );
+      if (
+        recoveryGeneration != null &&
+        finalGeneration != null &&
+        recoveryGeneration !== finalGeneration
+      ) {
+        tracker.clear(user.id, candidate.serverName);
+        results[index] = { serverName: candidate.serverName, tools: null };
+        return;
+      }
+      results[index] = outcome;
     }),
     signal,
   );

--- a/packages/api/src/mcp/catalog/recovery.ts
+++ b/packages/api/src/mcp/catalog/recovery.ts
@@ -65,10 +65,16 @@ export async function publishMCPAuthorizationMutation(
   deps: {
     invalidateRecoveryGeneration: (scope: MCPRecoveryGenerationScope) => Promise<unknown>;
     clearLocalRecovery?: (userId: string, serverName: string) => void;
+    persistPublicationRetry?: (scope: MCPRecoveryGenerationScope) => Promise<void>;
+    clearPublicationRetry?: (scope: MCPRecoveryGenerationScope) => Promise<void>;
     retryDelaysMs?: readonly number[];
     attemptTimeoutMs?: number;
   },
 ): Promise<void> {
+  /** Persist retry intent before touching the shared cache. A credential writer can keep this
+   * inside its rollback boundary, so a cache outage never leaves a committed mutation with no
+   * durable path to fence other replicas. */
+  await deps.persistPublicationRetry?.(scope);
   let lastError: unknown;
   for (const delayMs of deps.retryDelaysMs ?? AUTHORIZATION_FENCE_RETRY_DELAYS_MS) {
     if (delayMs > 0) {
@@ -90,6 +96,15 @@ export async function publishMCPAuthorizationMutation(
         ]);
       } finally {
         if (timeoutId != null) clearTimeout(timeoutId);
+      }
+      try {
+        await deps.clearPublicationRetry?.(scope);
+      } catch (error) {
+        /** A leftover retry only advances the opaque generation again and is therefore safe. */
+        logger.warn(
+          `[MCP authorization] Published generation for ${scope.serverName} but could not clear its retry intent`,
+          error,
+        );
       }
       deps.clearLocalRecovery?.(scope.userId, scope.serverName);
       return;

--- a/packages/api/src/mcp/catalog/recovery.ts
+++ b/packages/api/src/mcp/catalog/recovery.ts
@@ -26,6 +26,7 @@ const DEFAULT_RECOVERY_POLICY: MCPServerCatalogRecoveryPolicy = {
   maxStateEntries: 10_000,
   generationReadTimeoutMs: 500,
   authorizationFenceRetryMs: [0, 50, 200],
+  authorizationFenceTimeoutMs: 1_000,
 };
 
 export interface MCPServerCatalogRecoveryInput {
@@ -65,6 +66,7 @@ export async function publishMCPAuthorizationMutation(
     invalidateRecoveryGeneration: (scope: MCPRecoveryGenerationScope) => Promise<unknown>;
     clearLocalRecovery?: (userId: string, serverName: string) => void;
     retryDelaysMs?: readonly number[];
+    attemptTimeoutMs?: number;
   },
 ): Promise<void> {
   let lastError: unknown;
@@ -73,7 +75,22 @@ export async function publishMCPAuthorizationMutation(
       await new Promise((resolve) => setTimeout(resolve, delayMs));
     }
     try {
-      await deps.invalidateRecoveryGeneration(scope);
+      const attemptTimeoutMs =
+        deps.attemptTimeoutMs ?? DEFAULT_RECOVERY_POLICY.authorizationFenceTimeoutMs;
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await Promise.race([
+          deps.invalidateRecoveryGeneration(scope),
+          new Promise<never>((_, reject) => {
+            timeoutId = setTimeout(
+              () => reject(new Error('MCP authorization generation publication timed out')),
+              attemptTimeoutMs,
+            );
+          }),
+        ]);
+      } finally {
+        if (timeoutId != null) clearTimeout(timeoutId);
+      }
       deps.clearLocalRecovery?.(scope.userId, scope.serverName);
       return;
     } catch (error) {
@@ -93,6 +110,7 @@ export interface MCPServerCatalogRecoveryPolicy {
   maxStateEntries: number;
   generationReadTimeoutMs: number;
   authorizationFenceRetryMs: readonly number[];
+  authorizationFenceTimeoutMs: number;
 }
 
 export interface MCPServerCatalogSnapshot {

--- a/packages/api/src/mcp/catalog/recovery.ts
+++ b/packages/api/src/mcp/catalog/recovery.ts
@@ -219,6 +219,21 @@ export async function readMCPRecoveryGeneration(
   }
 }
 
+export async function readMCPRecoveryGenerationAround<T>(
+  scope: MCPRecoveryGenerationScope,
+  reader: MCPRecoveryGenerationReader | undefined,
+  operation: () => Promise<T>,
+  options?: { timeoutMs?: number; signal?: AbortSignal },
+): Promise<{ value: T; generation?: string }> {
+  const before = await readMCPRecoveryGeneration(scope, reader, options);
+  const value = await operation();
+  const after = await readMCPRecoveryGeneration(scope, reader, options);
+  return {
+    value,
+    ...(before != null && before === after && { generation: before }),
+  };
+}
+
 /** Bounds one server's discovery, honouring a shorter operator `initTimeout`. */
 function resolveBudget(serverConfig: ParsedServerConfig): number {
   const { initTimeout } = serverConfig;
@@ -282,7 +297,8 @@ export class MCPServerCatalogRecoveryTracker {
 
     const entry: RecoveryStateEntry = {
       configFingerprint,
-      recoveryGeneration,
+      recoveryGeneration:
+        recoveryGeneration ?? (sameObservedState ? existing?.recoveryGeneration : undefined),
       failureCount: sameObservedState ? existing.failureCount : 0,
       nextRetryAt: 0,
       lastTouchedAt: now,
@@ -575,10 +591,12 @@ async function recoverMCPServerCatalogsWithState(
         { timeoutMs: policy.generationReadTimeoutMs, signal },
       );
       const snapshotGeneration = generationSnapshots.get(candidate.serverName);
+      const requiresCredentialSnapshotFence = hasCustomUserVars(candidate.serverConfig);
       if (
-        snapshotGeneration != null &&
-        observedGeneration != null &&
-        snapshotGeneration !== observedGeneration
+        requiresCredentialSnapshotFence &&
+        (snapshotGeneration == null ||
+          observedGeneration == null ||
+          snapshotGeneration !== observedGeneration)
       ) {
         tracker.clear(user.id, candidate.serverName);
         results[index] = { serverName: candidate.serverName, tools: null };

--- a/packages/api/src/mcp/oauth/OAuthReconnectionManager.ts
+++ b/packages/api/src/mcp/oauth/OAuthReconnectionManager.ts
@@ -18,6 +18,10 @@ export class OAuthReconnectionManager {
   protected readonly flowManager: FlowStateManager<MCPOAuthTokens | null>;
   protected readonly tokenMethods: TokenMethods;
   private readonly mcpManager: MCPManager | null;
+  private readonly onOAuthCredentialsChanged?: (scope: {
+    userId: string;
+    serverName: string;
+  }) => Promise<void>;
 
   private readonly reconnectionsTracker: OAuthReconnectionTracker;
 
@@ -32,12 +36,18 @@ export class OAuthReconnectionManager {
     flowManager: FlowStateManager<MCPOAuthTokens | null>,
     tokenMethods: TokenMethods,
     reconnections?: OAuthReconnectionTracker,
+    onOAuthCredentialsChanged?: (scope: { userId: string; serverName: string }) => Promise<void>,
   ): Promise<OAuthReconnectionManager> {
     if (OAuthReconnectionManager.instance != null) {
       throw new Error('OAuthReconnectionManager already initialized');
     }
 
-    const manager = new OAuthReconnectionManager(flowManager, tokenMethods, reconnections);
+    const manager = new OAuthReconnectionManager(
+      flowManager,
+      tokenMethods,
+      reconnections,
+      onOAuthCredentialsChanged,
+    );
     OAuthReconnectionManager.instance = manager;
 
     return manager;
@@ -47,10 +57,12 @@ export class OAuthReconnectionManager {
     flowManager: FlowStateManager<MCPOAuthTokens | null>,
     tokenMethods: TokenMethods,
     reconnections?: OAuthReconnectionTracker,
+    onOAuthCredentialsChanged?: (scope: { userId: string; serverName: string }) => Promise<void>,
   ) {
     this.flowManager = flowManager;
     this.tokenMethods = tokenMethods;
     this.reconnectionsTracker = reconnections ?? new OAuthReconnectionTracker();
+    this.onOAuthCredentialsChanged = onOAuthCredentialsChanged;
 
     try {
       this.mcpManager = MCPManager.getInstance();
@@ -196,6 +208,7 @@ export class OAuthReconnectionManager {
         serverConfig: config,
         flowManager: this.flowManager,
         tokenMethods: this.tokenMethods,
+        onOAuthCredentialsChanged: this.onOAuthCredentialsChanged,
         // don't force new connection, let it reuse existing or create new as needed
         forceNew: false,
         // set a reasonable timeout for reconnection attempts

--- a/packages/api/src/mcp/oauth/OAuthReconnectionManager.ts
+++ b/packages/api/src/mcp/oauth/OAuthReconnectionManager.ts
@@ -208,7 +208,9 @@ export class OAuthReconnectionManager {
         serverConfig: config,
         flowManager: this.flowManager,
         tokenMethods: this.tokenMethods,
-        onOAuthCredentialsChanged: this.onOAuthCredentialsChanged,
+        ...(this.onOAuthCredentialsChanged && {
+          onOAuthCredentialsChanged: this.onOAuthCredentialsChanged,
+        }),
         // don't force new connection, let it reuse existing or create new as needed
         forceNew: false,
         // set a reasonable timeout for reconnection attempts

--- a/packages/api/src/mcp/oauth/OAuthReconnectionManager.ts
+++ b/packages/api/src/mcp/oauth/OAuthReconnectionManager.ts
@@ -23,6 +23,11 @@ export class OAuthReconnectionManager {
     serverName: string;
   }) => Promise<void>;
 
+  private readonly onOAuthCredentialsChanging?: (scope: {
+    userId: string;
+    serverName: string;
+  }) => Promise<() => Promise<void>>;
+
   private readonly reconnectionsTracker: OAuthReconnectionTracker;
 
   public static getInstance(): OAuthReconnectionManager {
@@ -37,6 +42,10 @@ export class OAuthReconnectionManager {
     tokenMethods: TokenMethods,
     reconnections?: OAuthReconnectionTracker,
     onOAuthCredentialsChanged?: (scope: { userId: string; serverName: string }) => Promise<void>,
+    onOAuthCredentialsChanging?: (scope: {
+      userId: string;
+      serverName: string;
+    }) => Promise<() => Promise<void>>,
   ): Promise<OAuthReconnectionManager> {
     if (OAuthReconnectionManager.instance != null) {
       throw new Error('OAuthReconnectionManager already initialized');
@@ -47,6 +56,7 @@ export class OAuthReconnectionManager {
       tokenMethods,
       reconnections,
       onOAuthCredentialsChanged,
+      onOAuthCredentialsChanging,
     );
     OAuthReconnectionManager.instance = manager;
 
@@ -58,11 +68,16 @@ export class OAuthReconnectionManager {
     tokenMethods: TokenMethods,
     reconnections?: OAuthReconnectionTracker,
     onOAuthCredentialsChanged?: (scope: { userId: string; serverName: string }) => Promise<void>,
+    onOAuthCredentialsChanging?: (scope: {
+      userId: string;
+      serverName: string;
+    }) => Promise<() => Promise<void>>,
   ) {
     this.flowManager = flowManager;
     this.tokenMethods = tokenMethods;
     this.reconnectionsTracker = reconnections ?? new OAuthReconnectionTracker();
     this.onOAuthCredentialsChanged = onOAuthCredentialsChanged;
+    this.onOAuthCredentialsChanging = onOAuthCredentialsChanging;
 
     try {
       this.mcpManager = MCPManager.getInstance();
@@ -210,6 +225,9 @@ export class OAuthReconnectionManager {
         tokenMethods: this.tokenMethods,
         ...(this.onOAuthCredentialsChanged && {
           onOAuthCredentialsChanged: this.onOAuthCredentialsChanged,
+        }),
+        ...(this.onOAuthCredentialsChanging && {
+          onOAuthCredentialsChanging: this.onOAuthCredentialsChanging,
         }),
         // don't force new connection, let it reuse existing or create new as needed
         forceNew: false,

--- a/packages/api/src/mcp/oauth/handler.ts
+++ b/packages/api/src/mcp/oauth/handler.ts
@@ -1158,7 +1158,10 @@ export class MCPOAuthHandler {
     authorizationCode: string,
     flowManager: FlowStateManager<MCPOAuthTokens>,
     oauthHeaders: Record<string, string>,
-    persistBeforeComplete?: (tokens: MCPOAuthTokens) => Promise<MCPOAuthTokens>,
+    persistBeforeComplete?: (
+      tokens: MCPOAuthTokens,
+      completePersistedFlow: (tokens: MCPOAuthTokens) => Promise<void>,
+    ) => Promise<MCPOAuthTokens>,
     rollbackPersistedTokens?: (tokens: MCPOAuthTokens) => Promise<void>,
     expectedAttempt?: { createdAt: number; state: string },
   ): Promise<MCPOAuthTokens> {
@@ -1241,22 +1244,39 @@ export class MCPOAuthHandler {
        * Persist before completing the flow so waiting connection factories cannot race the
        * callback route to write the same credential generation.
        */
+      const observedState = typeof metadata.state === 'string' ? metadata.state : '';
+      let flowCompleted = false;
+      let completionPromise: Promise<void> | undefined;
+      const completePersistedFlow = async (persistedTokens: MCPOAuthTokens): Promise<void> => {
+        completionPromise ??= (async () => {
+          const completionResult = await flowManager.completeFlowIfCurrent(
+            flowId,
+            this.FLOW_TYPE,
+            flowState.createdAt,
+            observedState,
+            persistedTokens,
+          );
+          if (completionResult !== 'updated') {
+            throw new Error('OAuth flow was cancelled before completion');
+          }
+          flowCompleted = true;
+        })();
+        await completionPromise;
+      };
+
       if (persistBeforeComplete) {
-        mcpTokens = await persistBeforeComplete(mcpTokens);
+        mcpTokens = await persistBeforeComplete(mcpTokens, completePersistedFlow);
       }
 
-      /** Now wake flow waiters with the persisted token snapshot. */
-      const observedState = typeof metadata.state === 'string' ? metadata.state : '';
-      const completionResult = await flowManager.completeFlowIfCurrent(
-        flowId,
-        this.FLOW_TYPE,
-        flowState.createdAt,
-        observedState,
-        mcpTokens,
-      );
-      if (completionResult !== 'updated') {
-        await rollbackPersistedTokens?.(mcpTokens);
-        throw new Error('OAuth flow was cancelled before completion');
+      /** Legacy persistence callbacks complete here. Transaction-aware callbacks can settle
+       *  inside their own rollback boundary by invoking `completePersistedFlow` themselves. */
+      if (!flowCompleted) {
+        try {
+          await completePersistedFlow(mcpTokens);
+        } catch (error) {
+          await rollbackPersistedTokens?.(mcpTokens);
+          throw error;
+        }
       }
 
       return mcpTokens;

--- a/packages/api/src/mcp/oauth/tokens.ts
+++ b/packages/api/src/mcp/oauth/tokens.ts
@@ -67,6 +67,8 @@ interface StoreTokensParams {
   };
   /** Runs after all token rows are written but while the rollback journal is still available. */
   onStoreCommitted?: (tokens: MCPOAuthTokens) => Promise<void>;
+  /** Runs after preflight reads and encryption, immediately before the first token-row write. */
+  onStorePreparing?: () => Promise<void>;
 }
 
 interface GetTokensParams {
@@ -100,6 +102,8 @@ interface GetTokensParams {
    * cache invalidation tied to the fresh tokens cannot be skipped by a timeout.
    */
   onRefreshSuccess?: (tokens: MCPOAuthTokens) => Promise<void>;
+  /** Creates the exact post-write callback after durable fence intent is safely stored. */
+  onRefreshPreparing?: () => Promise<(tokens?: MCPOAuthTokens) => Promise<void>>;
   /** Separates in-flight redemptions for the same named server under different OAuth bindings. */
   singleFlightScope?: string;
   /** Shared cache-backed fence used to serialize refresh persistence with server teardown. */
@@ -393,6 +397,7 @@ export class MCPTokenStorage {
     expectedCredentialSetId,
     signal,
     onStoreCommitted,
+    onStorePreparing,
   }: StoreTokensParams): Promise<MCPOAuthTokens> {
     const logPrefix = this.getLogPrefix(userId, serverName);
     const rollbackWrites: Array<() => Promise<void>> = [];
@@ -730,6 +735,8 @@ export class MCPTokenStorage {
             ]
           : plannedWrites;
 
+      await onStorePreparing?.();
+
       for (const write of orderedWrites) {
         if (signal?.aborted) {
           throw new Error('Token storage aborted by OAuth teardown');
@@ -759,8 +766,6 @@ export class MCPTokenStorage {
             : Date.now(),
         expires_at: accessTokenExpiry.getTime(),
       };
-      await onStoreCommitted?.(storedTokens);
-
       /**
        * An interactive response without a refresh token must never bind an older refresh
        * secret to the new client. Remove that stale record after the committed writes. This
@@ -791,6 +796,8 @@ export class MCPTokenStorage {
           });
         }
       }
+
+      await onStoreCommitted?.(storedTokens);
 
       logger.debug(`${logPrefix} Stored OAuth tokens`, {
         client_id: clientInfo?.client_id,
@@ -995,6 +1002,7 @@ export class MCPTokenStorage {
     refreshTokens,
     existingAccessToken,
     onRefreshSuccess,
+    onRefreshPreparing,
     signal,
     flowManager,
     leaseId,
@@ -1133,6 +1141,7 @@ export class MCPTokenStorage {
       // Pass existing token state to avoid duplicate DB calls
       let storedTokens: MCPOAuthTokens;
       try {
+        let preparedRefreshCommit: ((tokens?: MCPOAuthTokens) => Promise<void>) | undefined;
         storedTokens = await this.storeTokens({
           userId,
           serverName,
@@ -1150,7 +1159,19 @@ export class MCPTokenStorage {
           metadata: storedClientMetadata,
           expectedCredentialSetId: refreshCredentialSetId,
           signal,
-          onStoreCommitted: onRefreshSuccess,
+          onStorePreparing:
+            onRefreshPreparing == null
+              ? undefined
+              : async () => {
+                  preparedRefreshCommit = await onRefreshPreparing();
+                },
+          onStoreCommitted: async (tokens) => {
+            if (preparedRefreshCommit != null) {
+              await preparedRefreshCommit(tokens);
+            } else {
+              await onRefreshSuccess?.(tokens);
+            }
+          },
         });
       } finally {
         try {
@@ -1194,6 +1215,7 @@ export class MCPTokenStorage {
           logger.info(
             `${logPrefix} Client registration rejected during token refresh, attempting to clear stale registration and refresh token`,
           );
+          const publishPreparedCleanup = await onRefreshPreparing?.();
           const results = await Promise.allSettled([
             MCPTokenStorage.deleteClientRegistration({
               userId,
@@ -1215,6 +1237,7 @@ export class MCPTokenStorage {
               logger.warn(`${logPrefix} Failed to clear stale token data`, r.reason);
             }
           }
+          await publishPreparedCleanup?.();
           throw new ReauthenticationRequiredError(serverName, 'invalid_client');
         }
         logger.warn(
@@ -1240,6 +1263,7 @@ export class MCPTokenStorage {
     singleFlightScope,
     flowManager,
     onRefreshSuccess,
+    onRefreshPreparing,
   }: GetTokensParams): Promise<MCPOAuthTokens | null> {
     const logPrefix = this.getLogPrefix(userId, serverName);
 
@@ -1290,6 +1314,7 @@ export class MCPTokenStorage {
           singleFlightScope,
           flowManager,
           onRefreshSuccess,
+          onRefreshPreparing,
           existingAccessToken: accessTokenData,
         });
       }

--- a/packages/api/src/mcp/oauth/tokens.ts
+++ b/packages/api/src/mcp/oauth/tokens.ts
@@ -28,6 +28,15 @@ export class ReauthenticationRequiredError extends Error {
   }
 }
 
+/** Durable credentials could not be read or decrypted. This is retryable infrastructure state,
+ * never evidence that the user must authorize the server again. */
+export class MCPTokenStorageUnavailableError extends Error {
+  constructor(serverName: string, cause: unknown) {
+    super(`OAuth token storage is unavailable for "${serverName}"`, { cause });
+    this.name = 'MCPTokenStorageUnavailableError';
+  }
+}
+
 interface StoreTokensParams {
   userId: string;
   serverName: string;
@@ -1314,7 +1323,7 @@ export class MCPTokenStorage {
         throw error;
       }
       logger.error(`${logPrefix} Failed to retrieve tokens`, error);
-      return null;
+      throw new MCPTokenStorageUnavailableError(serverName, error);
     }
   }
 

--- a/packages/api/src/mcp/oauth/tokens.ts
+++ b/packages/api/src/mcp/oauth/tokens.ts
@@ -1169,7 +1169,10 @@ export class MCPTokenStorage {
       if (refreshError instanceof ReauthenticationRequiredError) {
         throw refreshError;
       }
-      if (signal.aborted) {
+      if (
+        signal.aborted &&
+        this.refreshTeardownCounts.has(this.getRefreshOwnerKey(userId, serverName))
+      ) {
         return null;
       }
       // Check if it's an unauthorized_client error (refresh not supported)

--- a/packages/api/src/mcp/oauth/tokens.ts
+++ b/packages/api/src/mcp/oauth/tokens.ts
@@ -48,6 +48,8 @@ interface StoreTokensParams {
     refreshToken?: IToken | null;
     clientInfoToken?: IToken | null;
   };
+  /** Runs after all token rows are written but while the rollback journal is still available. */
+  onStoreCommitted?: (tokens: MCPOAuthTokens) => Promise<void>;
 }
 
 interface GetTokensParams {
@@ -373,6 +375,7 @@ export class MCPTokenStorage {
     metadata,
     expectedCredentialSetId,
     signal,
+    onStoreCommitted,
   }: StoreTokensParams): Promise<MCPOAuthTokens> {
     const logPrefix = this.getLogPrefix(userId, serverName);
     const rollbackWrites: Array<() => Promise<void>> = [];
@@ -730,6 +733,17 @@ export class MCPTokenStorage {
         }
       }
 
+      const storedTokens: MCPOAuthTokens = {
+        ...tokens,
+        credential_set_id: credentialSetId,
+        obtained_at:
+          'obtained_at' in tokens && typeof tokens.obtained_at === 'number'
+            ? tokens.obtained_at
+            : Date.now(),
+        expires_at: accessTokenExpiry.getTime(),
+      };
+      await onStoreCommitted?.(storedTokens);
+
       /**
        * An interactive response without a refresh token must never bind an older refresh
        * secret to the new client. Remove that stale record after the committed writes. This
@@ -766,15 +780,7 @@ export class MCPTokenStorage {
         has_refresh_token: !!tokens.refresh_token,
         expires_at: 'expires_at' in tokens ? tokens.expires_at : 'N/A',
       });
-      return {
-        ...tokens,
-        credential_set_id: credentialSetId,
-        obtained_at:
-          'obtained_at' in tokens && typeof tokens.obtained_at === 'number'
-            ? tokens.obtained_at
-            : Date.now(),
-        expires_at: accessTokenExpiry.getTime(),
-      };
+      return storedTokens;
     } catch (error) {
       for (const rollback of rollbackWrites.reverse()) {
         try {
@@ -1127,6 +1133,7 @@ export class MCPTokenStorage {
           metadata: storedClientMetadata,
           expectedCredentialSetId: refreshCredentialSetId,
           signal,
+          onStoreCommitted: onRefreshSuccess,
         });
       } finally {
         try {
@@ -1135,27 +1142,6 @@ export class MCPTokenStorage {
           logger.warn(`${logPrefix} Failed to release OAuth refresh persistence lease`, {
             error: releaseError,
           });
-        }
-      }
-
-      if (onRefreshSuccess) {
-        try {
-          await onRefreshSuccess(storedTokens);
-        } catch (hookError) {
-          logger.warn(`${logPrefix} onRefreshSuccess callback failed`, hookError);
-          if (deleteTokens != null) {
-            await this.deleteUserTokens({
-              userId,
-              serverName,
-              deleteToken: async (filter) => {
-                await deleteTokens({
-                  ...filter,
-                  metadataCredentialSetId: storedTokens.credential_set_id,
-                });
-              },
-            });
-          }
-          throw hookError;
         }
       }
 

--- a/packages/api/src/mcp/oauth/tokens.ts
+++ b/packages/api/src/mcp/oauth/tokens.ts
@@ -1143,6 +1143,19 @@ export class MCPTokenStorage {
           await onRefreshSuccess(storedTokens);
         } catch (hookError) {
           logger.warn(`${logPrefix} onRefreshSuccess callback failed`, hookError);
+          if (deleteTokens != null) {
+            await this.deleteUserTokens({
+              userId,
+              serverName,
+              deleteToken: async (filter) => {
+                await deleteTokens({
+                  ...filter,
+                  metadataCredentialSetId: storedTokens.credential_set_id,
+                });
+              },
+            });
+          }
+          throw hookError;
         }
       }
 
@@ -1209,6 +1222,7 @@ export class MCPTokenStorage {
     refreshTokens,
     singleFlightScope,
     flowManager,
+    onRefreshSuccess,
   }: GetTokensParams): Promise<MCPOAuthTokens | null> {
     const logPrefix = this.getLogPrefix(userId, serverName);
 
@@ -1258,6 +1272,7 @@ export class MCPTokenStorage {
           refreshTokens,
           singleFlightScope,
           flowManager,
+          onRefreshSuccess,
           existingAccessToken: accessTokenData,
         });
       }

--- a/packages/api/src/mcp/oauth/tokens.ts
+++ b/packages/api/src/mcp/oauth/tokens.ts
@@ -37,6 +37,14 @@ export class MCPTokenStorageUnavailableError extends Error {
   }
 }
 
+/** The refresh credential may still be usable, but its provider could not complete this attempt. */
+export class MCPTokenRefreshUnavailableError extends Error {
+  constructor(serverName: string, cause: unknown) {
+    super(`OAuth token refresh is temporarily unavailable for "${serverName}"`, { cause });
+    this.name = 'MCPTokenRefreshUnavailableError';
+  }
+}
+
 interface StoreTokensParams {
   userId: string;
   serverName: string;
@@ -1161,14 +1169,24 @@ export class MCPTokenStorage {
       if (refreshError instanceof ReauthenticationRequiredError) {
         throw refreshError;
       }
+      if (signal.aborted) {
+        return null;
+      }
       // Check if it's an unauthorized_client error (refresh not supported)
       const errorMessage =
         refreshError instanceof Error ? refreshError.message : String(refreshError);
-      if (errorMessage.toLowerCase().includes('unauthorized_client')) {
+      const normalizedErrorMessage = errorMessage.toLowerCase();
+      if (normalizedErrorMessage.includes('unauthorized_client')) {
         logger.info(
           `${logPrefix} Server does not support refresh tokens for this client. New authentication required.`,
         );
-      } else if (isInvalidClientMessage(errorMessage)) {
+        return null;
+      }
+      if (normalizedErrorMessage.includes('invalid_grant')) {
+        logger.info(`${logPrefix} Refresh grant is no longer valid. New authentication required.`);
+        return null;
+      }
+      if (isInvalidClientMessage(errorMessage)) {
         if (deleteTokens) {
           logger.info(
             `${logPrefix} Client registration rejected during token refresh, attempting to clear stale registration and refresh token`,
@@ -1199,8 +1217,9 @@ export class MCPTokenStorage {
         logger.warn(
           `${logPrefix} Client registration rejected during token refresh but deleteTokens not available — stale registration cannot be cleared`,
         );
+        return null;
       }
-      return null;
+      throw new MCPTokenRefreshUnavailableError(serverName, refreshError);
     }
   }
 
@@ -1319,7 +1338,10 @@ export class MCPTokenStorage {
       logger.debug(`${logPrefix} Loaded existing OAuth tokens from storage`);
       return tokens;
     } catch (error) {
-      if (error instanceof ReauthenticationRequiredError) {
+      if (
+        error instanceof ReauthenticationRequiredError ||
+        error instanceof MCPTokenRefreshUnavailableError
+      ) {
         throw error;
       }
       logger.error(`${logPrefix} Failed to retrieve tokens`, error);

--- a/packages/api/src/mcp/types/index.ts
+++ b/packages/api/src/mcp/types/index.ts
@@ -336,4 +336,5 @@ export interface ToolDiscoveryResult {
   tools: Tool[] | null;
   oauthRequired: boolean;
   oauthUrl: string | null;
+  authenticationKind?: 'oauth' | 'obo' | 'server';
 }

--- a/packages/api/src/mcp/types/index.ts
+++ b/packages/api/src/mcp/types/index.ts
@@ -261,6 +261,8 @@ export interface UserConnectionContext {
    *  only a single `connect()`, so a caller that must return within a fixed budget sets this to
    *  cap every segment, including `tools/list` pagination and the unauthenticated fallback. */
   deadlineMs?: number;
+  /** Advances application authorization state after OAuth token persistence succeeds. */
+  onOAuthCredentialsChanged?: (scope: { userId: string; serverName: string }) => Promise<void>;
 }
 
 export interface RequestScopedMCPConnectionStore {
@@ -324,6 +326,7 @@ export interface ToolDiscoveryOptions {
   connectionTimeout?: number;
   /** Absolute epoch-ms bound on the whole discovery operation; see `UserConnectionContext`. */
   deadlineMs?: number;
+  onOAuthCredentialsChanged?: (scope: { userId: string; serverName: string }) => Promise<void>;
   /** Pre-resolved config-source servers for tenant-scoped lookup */
   configServers?: Record<string, ParsedServerConfig>;
   oboTokenResolver?: OboTokenResolver;

--- a/packages/api/src/mcp/types/index.ts
+++ b/packages/api/src/mcp/types/index.ts
@@ -263,6 +263,11 @@ export interface UserConnectionContext {
   deadlineMs?: number;
   /** Advances application authorization state after OAuth token persistence succeeds. */
   onOAuthCredentialsChanged?: (scope: { userId: string; serverName: string }) => Promise<void>;
+  /** Persists authorization-fence intent before OAuth token rows change and returns its publisher. */
+  onOAuthCredentialsChanging?: (scope: {
+    userId: string;
+    serverName: string;
+  }) => Promise<() => Promise<void>>;
 }
 
 export interface RequestScopedMCPConnectionStore {
@@ -327,6 +332,7 @@ export interface ToolDiscoveryOptions {
   /** Absolute epoch-ms bound on the whole discovery operation; see `UserConnectionContext`. */
   deadlineMs?: number;
   onOAuthCredentialsChanged?: (scope: { userId: string; serverName: string }) => Promise<void>;
+  onOAuthCredentialsChanging?: UserConnectionContext['onOAuthCredentialsChanging'];
   /** Pre-resolved config-source servers for tenant-scoped lookup */
   configServers?: Record<string, ParsedServerConfig>;
   oboTokenResolver?: OboTokenResolver;

--- a/packages/data-provider/src/config.spec.ts
+++ b/packages/data-provider/src/config.spec.ts
@@ -873,6 +873,8 @@ describe('allowedAddressesSchema', () => {
         generationReadTimeoutMs: 500,
         authorizationFenceRetryMs: [0, 50, 200],
         authorizationFenceTimeoutMs: 1_000,
+        authorizationFenceRetryIntervalMs: 30_000,
+        authorizationFenceRetryBatchSize: 100,
       });
 
       expect(
@@ -891,6 +893,18 @@ describe('allowedAddressesSchema', () => {
         configSchema.safeParse({
           version: '1.0',
           mcpSettings: { catalogRecovery: { authorizationFenceTimeoutMs: 0 } },
+        }).success,
+      ).toBe(false);
+      expect(
+        configSchema.safeParse({
+          version: '1.0',
+          mcpSettings: { catalogRecovery: { authorizationFenceRetryIntervalMs: 0 } },
+        }).success,
+      ).toBe(false);
+      expect(
+        configSchema.safeParse({
+          version: '1.0',
+          mcpSettings: { catalogRecovery: { authorizationFenceRetryBatchSize: 0 } },
         }).success,
       ).toBe(false);
     });

--- a/packages/data-provider/src/config.spec.ts
+++ b/packages/data-provider/src/config.spec.ts
@@ -864,6 +864,22 @@ describe('allowedAddressesSchema', () => {
       expect(result.success).toBe(true);
     });
 
+    it('defaults and validates MCP catalog recovery controls', () => {
+      const defaults = configSchema.parse({ version: '1.0', mcpSettings: {} });
+      expect(defaults.mcpSettings?.catalogRecovery).toEqual({
+        discoveryBackoffMs: [300_000, 600_000, 1_200_000, 1_800_000],
+        reauthRetryMs: 1_800_000,
+        maxStateEntries: 10_000,
+      });
+
+      expect(
+        configSchema.safeParse({
+          version: '1.0',
+          mcpSettings: { catalogRecovery: { discoveryBackoffMs: [] } },
+        }).success,
+      ).toBe(false);
+    });
+
     it('accepts the field on actions', () => {
       const result = configSchema.safeParse({
         version: '1.0',

--- a/packages/data-provider/src/config.spec.ts
+++ b/packages/data-provider/src/config.spec.ts
@@ -868,6 +868,7 @@ describe('allowedAddressesSchema', () => {
       const defaults = configSchema.parse({ version: '1.0', mcpSettings: {} });
       expect(defaults.mcpSettings?.catalogRecovery).toEqual({
         discoveryBackoffMs: [300_000, 600_000, 1_200_000, 1_800_000],
+        discoveryTimeoutMs: 3_000,
         reauthRetryMs: 1_800_000,
         maxStateEntries: 10_000,
         generationReadTimeoutMs: 500,
@@ -881,6 +882,12 @@ describe('allowedAddressesSchema', () => {
         configSchema.safeParse({
           version: '1.0',
           mcpSettings: { catalogRecovery: { discoveryBackoffMs: [] } },
+        }).success,
+      ).toBe(false);
+      expect(
+        configSchema.safeParse({
+          version: '1.0',
+          mcpSettings: { catalogRecovery: { discoveryTimeoutMs: 0 } },
         }).success,
       ).toBe(false);
       expect(

--- a/packages/data-provider/src/config.spec.ts
+++ b/packages/data-provider/src/config.spec.ts
@@ -872,6 +872,7 @@ describe('allowedAddressesSchema', () => {
         maxStateEntries: 10_000,
         generationReadTimeoutMs: 500,
         authorizationFenceRetryMs: [0, 50, 200],
+        authorizationFenceTimeoutMs: 1_000,
       });
 
       expect(
@@ -884,6 +885,12 @@ describe('allowedAddressesSchema', () => {
         configSchema.safeParse({
           version: '1.0',
           mcpSettings: { catalogRecovery: { authorizationFenceRetryMs: [-1] } },
+        }).success,
+      ).toBe(false);
+      expect(
+        configSchema.safeParse({
+          version: '1.0',
+          mcpSettings: { catalogRecovery: { authorizationFenceTimeoutMs: 0 } },
         }).success,
       ).toBe(false);
     });

--- a/packages/data-provider/src/config.spec.ts
+++ b/packages/data-provider/src/config.spec.ts
@@ -871,12 +871,19 @@ describe('allowedAddressesSchema', () => {
         reauthRetryMs: 1_800_000,
         maxStateEntries: 10_000,
         generationReadTimeoutMs: 500,
+        authorizationFenceRetryMs: [0, 50, 200],
       });
 
       expect(
         configSchema.safeParse({
           version: '1.0',
           mcpSettings: { catalogRecovery: { discoveryBackoffMs: [] } },
+        }).success,
+      ).toBe(false);
+      expect(
+        configSchema.safeParse({
+          version: '1.0',
+          mcpSettings: { catalogRecovery: { authorizationFenceRetryMs: [-1] } },
         }).success,
       ).toBe(false);
     });

--- a/packages/data-provider/src/config.spec.ts
+++ b/packages/data-provider/src/config.spec.ts
@@ -870,6 +870,7 @@ describe('allowedAddressesSchema', () => {
         discoveryBackoffMs: [300_000, 600_000, 1_200_000, 1_800_000],
         reauthRetryMs: 1_800_000,
         maxStateEntries: 10_000,
+        generationReadTimeoutMs: 500,
       });
 
       expect(

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2713,6 +2713,7 @@ export const configSchema = z.object({
             .min(1)
             .max(8)
             .default([0, 50, 200]),
+          authorizationFenceTimeoutMs: z.number().int().positive().max(30_000).default(1_000),
         })
         .default({}),
     })

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2708,6 +2708,11 @@ export const configSchema = z.object({
             .default(30 * 60_000),
           maxStateEntries: z.number().int().positive().max(1_000_000).default(10_000),
           generationReadTimeoutMs: z.number().int().positive().max(10_000).default(500),
+          authorizationFenceRetryMs: z
+            .array(z.number().int().nonnegative().max(60_000))
+            .min(1)
+            .max(8)
+            .default([0, 50, 200]),
         })
         .default({}),
     })

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2700,6 +2700,12 @@ export const configSchema = z.object({
             .min(1)
             .max(8)
             .default([5 * 60_000, 10 * 60_000, 20 * 60_000, 30 * 60_000]),
+          discoveryTimeoutMs: z
+            .number()
+            .int()
+            .positive()
+            .max(5 * 60_000)
+            .default(3_000),
           reauthRetryMs: z
             .number()
             .int()

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2687,6 +2687,28 @@ export const configSchema = z.object({
     .object({
       allowedDomains: z.array(z.string()).optional(),
       allowedAddresses: allowedAddressesSchema,
+      catalogRecovery: z
+        .object({
+          discoveryBackoffMs: z
+            .array(
+              z
+                .number()
+                .int()
+                .positive()
+                .max(24 * 60 * 60_000),
+            )
+            .min(1)
+            .max(8)
+            .default([5 * 60_000, 10 * 60_000, 20 * 60_000, 30 * 60_000]),
+          reauthRetryMs: z
+            .number()
+            .int()
+            .positive()
+            .max(24 * 60 * 60_000)
+            .default(30 * 60_000),
+          maxStateEntries: z.number().int().positive().max(1_000_000).default(10_000),
+        })
+        .default({}),
     })
     .optional(),
   interface: interfaceSchema,

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2707,6 +2707,7 @@ export const configSchema = z.object({
             .max(24 * 60 * 60_000)
             .default(30 * 60_000),
           maxStateEntries: z.number().int().positive().max(1_000_000).default(10_000),
+          generationReadTimeoutMs: z.number().int().positive().max(10_000).default(500),
         })
         .default({}),
     })

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2714,6 +2714,13 @@ export const configSchema = z.object({
             .max(8)
             .default([0, 50, 200]),
           authorizationFenceTimeoutMs: z.number().int().positive().max(30_000).default(1_000),
+          authorizationFenceRetryIntervalMs: z
+            .number()
+            .int()
+            .positive()
+            .max(60 * 60_000)
+            .default(30_000),
+          authorizationFenceRetryBatchSize: z.number().int().positive().max(10_000).default(100),
         })
         .default({}),
     })

--- a/packages/data-provider/src/types/queries.ts
+++ b/packages/data-provider/src/types/queries.ts
@@ -142,6 +142,8 @@ export type MCPServer = {
   authenticated: boolean;
   /** Passive discovery found that stored OAuth authorization must be renewed. */
   authorizationState?: 'reauth_required';
+  /** Shared credential/catalog generation observed by passive discovery. */
+  authorizationGeneration?: string;
   authConfig: s.TPluginAuthConfig[];
   tools: MCPTool[];
 };
@@ -244,6 +246,8 @@ export interface MCPServerStatus {
     | 'authorized'
     | 'needs_authorization'
     | 'error';
+  /** Shared credential/catalog generation observed by the status endpoint. */
+  authorizationGeneration?: string;
 }
 
 export interface MCPConnectionStatusResponse {
@@ -261,6 +265,7 @@ export interface MCPServerConnectionStatusResponse {
   configurationState?: MCPServerStatus['configurationState'];
   connectionStatus: 'disconnected' | 'connecting' | 'connected' | 'error';
   authorizationState?: MCPServerStatus['authorizationState'];
+  authorizationGeneration?: string;
 }
 
 export interface MCPAuthValuesResponse {

--- a/packages/data-provider/src/types/queries.ts
+++ b/packages/data-provider/src/types/queries.ts
@@ -140,6 +140,8 @@ export type MCPServer = {
   name: string;
   icon: string;
   authenticated: boolean;
+  /** Passive discovery found that stored OAuth authorization must be renewed. */
+  authorizationState?: 'reauth_required';
   authConfig: s.TPluginAuthConfig[];
   tools: MCPTool[];
 };

--- a/packages/data-schemas/src/index.ts
+++ b/packages/data-schemas/src/index.ts
@@ -41,6 +41,7 @@ export {
   recordAgentEventActorReceiptMetric,
   setAgentEventActorReceiptMetricObserver,
   MCPAuthorityProofError,
+  createMCPAuthorizationFenceRetryStorage,
   MAX_MCP_AUTHORITY_TARGETS,
   createMCPAuthorityBootRevision,
   createMCPAuthorityConfigSourceRevision,

--- a/packages/data-schemas/src/methods/index.ts
+++ b/packages/data-schemas/src/methods/index.ts
@@ -3,6 +3,10 @@ import {
   createOpenIDRefreshFlightMethods,
   type OpenIDRefreshFlightMethods,
 } from './openidRefreshFlight';
+export {
+  createMCPAuthorizationFenceRetryStorage,
+  type MCPAuthorizationFenceRetryStorage,
+} from './mcpAuthorizationFenceRetry';
 import {
   createRefreshTokenBridgeMethods,
   type RefreshTokenBridgeMethods,

--- a/packages/data-schemas/src/methods/mcpAuthorizationFenceRetry.spec.ts
+++ b/packages/data-schemas/src/methods/mcpAuthorizationFenceRetry.spec.ts
@@ -40,11 +40,11 @@ describe('MCP authorization fence retry storage', () => {
     await expect(storage.list(7)).resolves.toEqual([{ version: 'v2' }]);
 
     expect(deleteOne).toHaveBeenCalledWith({
-      _id: JSON.stringify(['tenant-a', 'user-1', 'github']),
+      _id: JSON.stringify(['tenant-a', 'user-1', 'github', 'v1']),
       version: 'v1',
     });
     expect(updateOne).toHaveBeenLastCalledWith(
-      { _id: JSON.stringify(['tenant-a', 'user-1', 'github']), version: 'v2' },
+      { _id: JSON.stringify(['tenant-a', 'user-1', 'github', 'v2']), version: 'v2' },
       { $set: { updatedAt: new Date(now.getTime() + 1) } },
     );
     expect(mockBuildIndexWithRetry).toHaveBeenCalledWith(

--- a/packages/data-schemas/src/methods/mcpAuthorizationFenceRetry.spec.ts
+++ b/packages/data-schemas/src/methods/mcpAuthorizationFenceRetry.spec.ts
@@ -45,7 +45,7 @@ describe('MCP authorization fence retry storage', () => {
     });
     expect(updateOne).toHaveBeenLastCalledWith(
       { _id: JSON.stringify(['tenant-a', 'user-1', 'github', 'v2']), version: 'v2' },
-      { $set: { updatedAt: new Date(now.getTime() + 1) } },
+      { $max: { updatedAt: new Date(now.getTime() + 1) } },
     );
     expect(mockBuildIndexWithRetry).toHaveBeenCalledWith(
       expect.any(Function),

--- a/packages/data-schemas/src/methods/mcpAuthorizationFenceRetry.spec.ts
+++ b/packages/data-schemas/src/methods/mcpAuthorizationFenceRetry.spec.ts
@@ -1,0 +1,59 @@
+import { createMCPAuthorizationFenceRetryStorage } from './mcpAuthorizationFenceRetry';
+
+const mockBuildIndexWithRetry = jest.fn(
+  async (build: () => Promise<unknown>, _label?: string, _options?: unknown) => build(),
+);
+const mockRunAsSystem = jest.fn(async (operation: () => Promise<unknown>) => operation());
+
+jest.mock('~/utils/retry', () => ({
+  buildIndexWithRetry: (build: () => Promise<unknown>, label?: string, options?: unknown) =>
+    mockBuildIndexWithRetry(build, label, options),
+}));
+jest.mock('~/config/tenantContext', () => ({
+  runAsSystem: (operation: () => Promise<unknown>) => mockRunAsSystem(operation),
+}));
+
+describe('MCP authorization fence retry storage', () => {
+  it('guards its index and preserves exact-version mutations', async () => {
+    const updateOne = jest.fn().mockResolvedValue({ acknowledged: true });
+    const deleteOne = jest.fn().mockResolvedValue({ deletedCount: 1 });
+    const toArray = jest.fn().mockResolvedValue([{ version: 'v2' }]);
+    const limit = jest.fn(() => ({ toArray }));
+    const sort = jest.fn(() => ({ limit }));
+    const createIndex = jest.fn().mockResolvedValue('updatedAt_1');
+    const collection = { updateOne, deleteOne, find: jest.fn(() => ({ sort })), createIndex };
+    const mongoose = {
+      connection: { collection: jest.fn(() => collection) },
+    } as unknown as typeof import('mongoose');
+    const storage = createMCPAuthorizationFenceRetryStorage(mongoose);
+    const scope = { userId: 'user-1', serverName: 'github' };
+    const now = new Date('2026-01-01T00:00:00.000Z');
+
+    await storage.upsert({ scope, tenantId: 'tenant-a', version: 'v2', now });
+    await storage.deleteVersion({ scope, tenantId: 'tenant-a', version: 'v1' });
+    await storage.deferVersion({
+      scope,
+      tenantId: 'tenant-a',
+      version: 'v2',
+      updatedAt: new Date(now.getTime() + 1),
+    });
+    await expect(storage.list(7)).resolves.toEqual([{ version: 'v2' }]);
+
+    expect(deleteOne).toHaveBeenCalledWith({
+      _id: JSON.stringify(['tenant-a', 'user-1', 'github']),
+      version: 'v1',
+    });
+    expect(updateOne).toHaveBeenLastCalledWith(
+      { _id: JSON.stringify(['tenant-a', 'user-1', 'github']), version: 'v2' },
+      { $set: { updatedAt: new Date(now.getTime() + 1) } },
+    );
+    expect(mockBuildIndexWithRetry).toHaveBeenCalledWith(
+      expect.any(Function),
+      'mcp_authorization_fence_retries.updatedAt_1',
+      undefined,
+    );
+    expect(createIndex).toHaveBeenCalledWith({ updatedAt: 1 }, { name: 'updatedAt_1' });
+    expect(limit).toHaveBeenCalledWith(7);
+    expect(mockRunAsSystem).toHaveBeenCalledWith(expect.any(Function));
+  });
+});

--- a/packages/data-schemas/src/methods/mcpAuthorizationFenceRetry.ts
+++ b/packages/data-schemas/src/methods/mcpAuthorizationFenceRetry.ts
@@ -1,0 +1,93 @@
+import type { Collection } from 'mongodb';
+import { runAsSystem } from '~/config/tenantContext';
+import { buildIndexWithRetry } from '~/utils/retry';
+
+const COLLECTION_NAME = 'mcp_authorization_fence_retries';
+const UPDATED_AT_INDEX = 'updatedAt_1';
+
+export interface MCPAuthorizationFenceRetryScope {
+  userId: string;
+  serverName: string;
+}
+
+export interface MCPAuthorizationFenceRetryRecord extends MCPAuthorizationFenceRetryScope {
+  _id: string;
+  tenantId?: string | null;
+  version: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+interface RetryVersionInput {
+  scope: MCPAuthorizationFenceRetryScope;
+  tenantId?: string | null;
+  version: string;
+}
+
+interface RetryUpsertInput extends RetryVersionInput {
+  now: Date;
+}
+
+interface RetryDeferInput extends RetryVersionInput {
+  updatedAt: Date;
+}
+
+function retryId(scope: MCPAuthorizationFenceRetryScope, tenantId?: string | null): string {
+  return JSON.stringify([tenantId ?? '', String(scope.userId), scope.serverName]);
+}
+
+/** Owns the raw collection and guarded index lifecycle used by durable MCP fence replay. */
+export function createMCPAuthorizationFenceRetryStorage(mongoose: typeof import('mongoose')) {
+  let indexPromise: Promise<unknown> | undefined;
+  const collection = (): Collection<MCPAuthorizationFenceRetryRecord> =>
+    mongoose.connection.collection<MCPAuthorizationFenceRetryRecord>(COLLECTION_NAME);
+
+  const ensureIndex = (): Promise<unknown> => {
+    indexPromise ??= buildIndexWithRetry(
+      () => collection().createIndex({ updatedAt: 1 }, { name: UPDATED_AT_INDEX }),
+      `${COLLECTION_NAME}.${UPDATED_AT_INDEX}`,
+    ).catch((error) => {
+      indexPromise = undefined;
+      throw error;
+    });
+    return indexPromise;
+  };
+
+  return {
+    async upsert({ scope, tenantId, version, now }: RetryUpsertInput): Promise<void> {
+      await collection().updateOne(
+        { _id: retryId(scope, tenantId) },
+        {
+          $set: {
+            userId: String(scope.userId),
+            serverName: scope.serverName,
+            tenantId: tenantId ?? null,
+            version,
+            updatedAt: now,
+          },
+          $setOnInsert: { createdAt: now },
+        },
+        { upsert: true },
+      );
+    },
+    async deleteVersion({ scope, tenantId, version }: RetryVersionInput): Promise<void> {
+      await collection().deleteOne({ _id: retryId(scope, tenantId), version });
+    },
+    async deferVersion({ scope, tenantId, version, updatedAt }: RetryDeferInput): Promise<void> {
+      await collection().updateOne(
+        { _id: retryId(scope, tenantId), version },
+        { $set: { updatedAt } },
+      );
+    },
+    async list(limit: number): Promise<MCPAuthorizationFenceRetryRecord[]> {
+      await ensureIndex();
+      return runAsSystem(async () =>
+        collection().find({}).sort({ updatedAt: 1 }).limit(limit).toArray(),
+      );
+    },
+  };
+}
+
+export type MCPAuthorizationFenceRetryStorage = ReturnType<
+  typeof createMCPAuthorizationFenceRetryStorage
+>;

--- a/packages/data-schemas/src/methods/mcpAuthorizationFenceRetry.ts
+++ b/packages/data-schemas/src/methods/mcpAuthorizationFenceRetry.ts
@@ -80,7 +80,7 @@ export function createMCPAuthorizationFenceRetryStorage(mongoose: typeof import(
     async deferVersion({ scope, tenantId, version, updatedAt }: RetryDeferInput): Promise<void> {
       await collection().updateOne(
         { _id: retryId(scope, tenantId, version), version },
-        { $set: { updatedAt } },
+        { $max: { updatedAt } },
       );
     },
     async list(limit: number): Promise<MCPAuthorizationFenceRetryRecord[]> {

--- a/packages/data-schemas/src/methods/mcpAuthorizationFenceRetry.ts
+++ b/packages/data-schemas/src/methods/mcpAuthorizationFenceRetry.ts
@@ -32,8 +32,12 @@ interface RetryDeferInput extends RetryVersionInput {
   updatedAt: Date;
 }
 
-function retryId(scope: MCPAuthorizationFenceRetryScope, tenantId?: string | null): string {
-  return JSON.stringify([tenantId ?? '', String(scope.userId), scope.serverName]);
+function retryId(
+  scope: MCPAuthorizationFenceRetryScope,
+  tenantId: string | null | undefined,
+  version: string,
+): string {
+  return JSON.stringify([tenantId ?? '', String(scope.userId), scope.serverName, version]);
 }
 
 /** Owns the raw collection and guarded index lifecycle used by durable MCP fence replay. */
@@ -56,7 +60,7 @@ export function createMCPAuthorizationFenceRetryStorage(mongoose: typeof import(
   return {
     async upsert({ scope, tenantId, version, now }: RetryUpsertInput): Promise<void> {
       await collection().updateOne(
-        { _id: retryId(scope, tenantId) },
+        { _id: retryId(scope, tenantId, version) },
         {
           $set: {
             userId: String(scope.userId),
@@ -71,11 +75,11 @@ export function createMCPAuthorizationFenceRetryStorage(mongoose: typeof import(
       );
     },
     async deleteVersion({ scope, tenantId, version }: RetryVersionInput): Promise<void> {
-      await collection().deleteOne({ _id: retryId(scope, tenantId), version });
+      await collection().deleteOne({ _id: retryId(scope, tenantId, version), version });
     },
     async deferVersion({ scope, tenantId, version, updatedAt }: RetryDeferInput): Promise<void> {
       await collection().updateOne(
-        { _id: retryId(scope, tenantId), version },
+        { _id: retryId(scope, tenantId, version), version },
         { $set: { updatedAt } },
       );
     },


### PR DESCRIPTION
## Summary

Repeated passive catalog loads could rediscover disconnected OAuth MCP integrations on every request, producing hundreds of failed discovery attempts and unstable recovery guidance. This change coalesces those attempts, applies bounded backoff, and ties every reusable authorization decision to a cross-replica credential generation.

- Coalesce concurrent passive discovery per user and server, with configurable progressive backoff and bounded process-local state.
- Return a stable `reauth_required` state for OAuth challenges while keeping OBO and direct OpenID bearer discovery request-bound.
- Read credential generations through an injected, configurable 500 ms deadline so cache failures cannot hang catalog or status requests.
- Snapshot the generation before credential loading and verify it before and after discovery; discard results superseded by credential changes.
- Preserve known-generation backoff through intermittent cache read failures.
- Persist write-ahead fence intent before OAuth callback writes, automatic token refreshes, startup reconnect refreshes, and complete or partial custom credential mutations; publish again after teardown token cleanup.
- Bound every authorization-fence write attempt with configurable deadlines and retries; replay every version-fenced intent from indexed, bounded MongoDB batches with in-flight deduplication, failed-record rotation, and bounded deferral.
- Keep server validation, generation publication, durable OAuth completion, and exact-attempt token-waiter settlement inside the token-store rollback boundary.
- Report token-store outages and transient provider refresh failures as retryable infrastructure state instead of sending users through reauthentication.
- Reconcile client catalog and connection status only when their generations are both present and equal, while delaying startup discovery until conversation hydration and suppressing passive observers for ephemeral agent contexts.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- MCP package suites: 581 tests passed; latest authorization lifecycle subset: 391 tests passed; Redis cross-replica flow integration: 6 tests passed.
- MCP server controller, route, reconnect policy, retry adapter, and tool service suites: 346 tests passed; latest affected subset: 270 tests passed.
- Client MCP polling, manager, initialization, and startup suites: 34 tests passed.
- Data-provider configuration suite: 188 tests passed; data-schema retry storage and DocumentDB guard suites: 55 tests passed.
- `packages/api`, data-provider, and client TypeScript checks passed; `packages/api` and client production builds passed.
- Scoped ESLint, Prettier, syntax checks, and `git diff --check` passed.
- Lighthouse authenticated-load regression passed on three cold runs: median LCP 3.26 s (limit 4.5 s), CLS 0.039 (limit 0.1), TBT 37 ms (limit 500 ms).

### Test configuration

- macOS
- Node.js workspace dependencies installed

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes




