### PR TITLE
🫆 fix: Preserve Durable Parents for Queued Turns

### DIFF
--- a/client/src/hooks/Chat/__tests__/useChatFunctions.regenerate.spec.tsx
+++ b/client/src/hooks/Chat/__tests__/useChatFunctions.regenerate.spec.tsx
@@ -1,5 +1,5 @@
 import { renderHook, act } from '@testing-library/react';
-import { Constants, EModelEndpoint } from 'librechat-data-provider';
+import { Constants, ContentTypes, EModelEndpoint, createPayload } from 'librechat-data-provider';
 import type {
   CodeWorkspaceSelection,
   TConversation,
@@ -167,6 +167,24 @@ describe('useChatFunctions ask', () => {
 
     const submission = setSubmission.mock.calls.at(-1)?.[0] as TSubmission;
     expect(submission.codeApprovalMode).toBe('acceptEdits');
+  });
+
+  it('preallocates a durable Agents user id for the optimistic response anchor', () => {
+    const { result, setSubmission } = renderAsk([]);
+
+    act(() => {
+      result.current.ask({ text: 'Queue safely', conversationId: 'conversation-1' });
+    });
+
+    const submission = setSubmission.mock.calls.at(-1)?.[0] as TSubmission;
+    const userMessageId = submission.userMessage.messageId;
+    expect(submission.endpointOption.overrideUserMessageId).toBe(
+      `${userMessageId}${Constants.COMMON_DIVIDER}0`,
+    );
+    expect(createPayload(submission).payload.overrideUserMessageId).toBe(
+      `${userMessageId}${Constants.COMMON_DIVIDER}0`,
+    );
+    expect(submission.initialResponse?.clientQueueParentMessageId).toBe(userMessageId);
   });
 
   it('submits the latest validated workspace selection', () => {
@@ -350,6 +368,7 @@ describe('useChatFunctions regenerate', () => {
     expect(submission.userMessage.responseMessageId).toBe('assistant-1_');
     expect(submission.initialResponse?.messageId).toBe('assistant-1_');
     expect(submission.initialResponse?.parentMessageId).toBe('user-1');
+    expect(submission.initialResponse?.clientQueueParentMessageId).toBe('user-1');
     expect(submission.messages.map((message) => message.messageId)).toEqual(['user-1']);
     expect(submission.regenerateMessages?.map((message) => message.messageId)).toEqual([
       'user-1',
@@ -364,6 +383,38 @@ describe('useChatFunctions regenerate', () => {
     ).toEqual(['user-1', 'assistant-1_']);
     expect(messages.at(-1)?.messageId).toBe('assistant-1_');
   });
+
+  it.each(['assistant-1', 'assistant_1_'])(
+    'marks an edited optimistic response %s with its durable user anchor',
+    (responseMessageId) => {
+      const parent = userMessage('user-1');
+      const response = {
+        ...assistantMessage(responseMessageId, parent.messageId),
+        content: [{ type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'before' }],
+      } as TMessage;
+      const { result, setSubmission } = renderAsk([parent, response]);
+
+      act(() => {
+        result.current.ask(
+          { ...parent },
+          {
+            isRegenerate: true,
+            isEdited: true,
+            editedMessageId: responseMessageId,
+            editedContent: {
+              index: 0,
+              type: ContentTypes.TEXT,
+              [ContentTypes.TEXT]: 'after',
+            },
+          },
+        );
+      });
+
+      const submission = setSubmission.mock.calls.at(-1)?.[0] as TSubmission;
+      expect(submission.initialResponse?.messageId).toBe(responseMessageId);
+      expect(submission.initialResponse?.clientQueueParentMessageId).toBe('user-1');
+    },
+  );
 });
 
 describe('useChatFunctions ask attachments', () => {

--- a/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
+++ b/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
@@ -341,6 +341,7 @@ describe('useSteering', () => {
     it.each([
       ['new response', 'user-message_'],
       ['regenerated response', 'old-assistant_'],
+      ['edited response', 'old-assistant'],
     ])('anchors an optimistic %s through its durable user parent', async (_label, messageId) => {
       mockMessages = [
         {
@@ -365,6 +366,7 @@ describe('useSteering', () => {
           messageId,
           parentMessageId: 'user-message',
           isCreatedByUser: false,
+          clientQueueParentMessageId: 'user-message',
         } as TMessage,
       ];
       const { result } = setupServerQueue();
@@ -389,8 +391,6 @@ describe('useSteering', () => {
           messageId: 'persisted-assistant_',
           parentMessageId: 'user-message',
           isCreatedByUser: false,
-          createdAt: '2026-09-09T12:00:01.000Z',
-          updatedAt: '2026-09-09T12:00:01.000Z',
         } as TMessage,
       ];
       const { result } = setupServerQueue();

--- a/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
+++ b/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
@@ -338,6 +338,77 @@ describe('useSteering', () => {
       );
     });
 
+    it.each([
+      ['new response', 'user-message_'],
+      ['regenerated response', 'old-assistant_'],
+    ])('anchors an optimistic %s through its durable user parent', async (_label, messageId) => {
+      mockMessages = [
+        {
+          messageId: 'user-message',
+          parentMessageId: Constants.NO_PARENT,
+          isCreatedByUser: true,
+          createdAt: '2026-09-09T12:00:00.000Z',
+          updatedAt: '2026-09-09T12:00:00.000Z',
+        } as TMessage,
+        ...(messageId === 'old-assistant_'
+          ? [
+              {
+                messageId: 'old-assistant',
+                parentMessageId: 'user-message',
+                isCreatedByUser: false,
+                createdAt: '2026-09-09T12:00:01.000Z',
+                updatedAt: '2026-09-09T12:00:01.000Z',
+              } as TMessage,
+            ]
+          : []),
+        {
+          messageId,
+          parentMessageId: 'user-message',
+          isCreatedByUser: false,
+        } as TMessage,
+      ];
+      const { result } = setupServerQueue();
+
+      await act(async () => {
+        expect(result.current.steering.queueFromComposer('follow the pending answer')).toBe(true);
+        await Promise.resolve();
+      });
+
+      expect(mockEnqueueQueuedTurn).toHaveBeenCalledWith(
+        expect.objectContaining({ parentMessageId: 'user-message' }),
+        expect.any(Object),
+      );
+      expect(result.current.queue).toEqual([
+        expect.objectContaining({ parentMessageId: 'user-message' }),
+      ]);
+    });
+
+    it('preserves an exact persisted assistant id ending in an underscore', async () => {
+      mockMessages = [
+        {
+          messageId: 'persisted-assistant_',
+          parentMessageId: 'user-message',
+          isCreatedByUser: false,
+          createdAt: '2026-09-09T12:00:01.000Z',
+          updatedAt: '2026-09-09T12:00:01.000Z',
+        } as TMessage,
+      ];
+      const { result } = setupServerQueue();
+
+      await act(async () => {
+        expect(result.current.steering.queueFromComposer('keep the exact branch')).toBe(true);
+        await Promise.resolve();
+      });
+
+      expect(mockEnqueueQueuedTurn).toHaveBeenCalledWith(
+        expect.objectContaining({ parentMessageId: 'persisted-assistant_' }),
+        expect.any(Object),
+      );
+      expect(result.current.queue).toEqual([
+        expect.objectContaining({ parentMessageId: 'persisted-assistant_' }),
+      ]);
+    });
+
     it('applies an admitted POST replay to the consumed predecessor set', async () => {
       mockEnqueueQueuedTurn.mockImplementation((input, options) => {
         options.onSuccess({

--- a/client/src/hooks/Chat/useChatFunctions.ts
+++ b/client/src/hooks/Chat/useChatFunctions.ts
@@ -526,7 +526,11 @@ export default function useChatFunctions({
         endpoint,
         endpointType,
         overrideConvoId,
-        overrideUserMessageId,
+        overrideUserMessageId:
+          overrideUserMessageId ??
+          (endpoint === EModelEndpoint.agents && !regenerateShaped && !isContinued
+            ? `${intermediateId}${Constants.COMMON_DIVIDER}0`
+            : undefined),
       },
       convo,
       chatProjectId ? { chatProjectId } : {},
@@ -642,6 +646,7 @@ export default function useChatFunctions({
       model: convo?.model,
       error: false,
       iconURL,
+      clientQueueParentMessageId: regenerateShaped ? messageId : intermediateId,
       /**
        * Seed the assistant placeholder with the turn's manually-invoked
        * skill names so `ContentParts` can render interim `SkillCall` cards

--- a/client/src/hooks/Chat/useSteering.ts
+++ b/client/src/hooks/Chat/useSteering.ts
@@ -146,11 +146,29 @@ interface LiveMessageState {
   parentMessageId?: string;
 }
 
+function optimisticAssistantParent(message: TMessage): string | undefined {
+  const parentMessageId = message.parentMessageId;
+  /** Hydrated message rows always receive both timestamps from the message
+   * schema. Their joint absence is the client-only proof that this suffixed
+   * assistant is the placeholder built by `useChatFunctions`. */
+  if (
+    message.isCreatedByUser === false &&
+    typeof message.messageId === 'string' &&
+    message.messageId.endsWith('_') &&
+    message.createdAt == null &&
+    message.updatedAt == null &&
+    typeof parentMessageId === 'string' &&
+    parentMessageId.length > 0
+  ) {
+    return parentMessageId;
+  }
+}
+
 function selectLiveMessageState(message: TMessage | null): LiveMessageState {
-  const parentMessageId =
-    message?.isCreatedByUser === false && typeof message.messageId === 'string'
-      ? message.messageId
-      : undefined;
+  let parentMessageId: string | undefined;
+  if (message?.isCreatedByUser === false && typeof message.messageId === 'string') {
+    parentMessageId = optimisticAssistantParent(message) ?? message.messageId;
+  }
   return { approval: hasLiveToolApproval(message), parentMessageId };
 }
 
@@ -695,8 +713,9 @@ export default function useSteering({
     }
   }, [pendingSteers, queueKey]);
 
-  /** The exact visible assistant tail is captured into a server queued turn,
-   * while the approval bit keeps the steering controls honest. */
+  /** Capture a durable branch anchor into a server queued turn. Optimistic
+   * assistant placeholders are siblings of their eventual persisted response,
+   * so they anchor through their stable user parent. */
   const latestMessage = useLatestMessage(index, hasRealConvoId ? conversationId : null);
   const liveMessageState = useMemo(() => selectLiveMessageState(latestMessage), [latestMessage]);
   /** Both approval cards and `ask_user_question` suspend the current

--- a/client/src/hooks/Chat/useSteering.ts
+++ b/client/src/hooks/Chat/useSteering.ts
@@ -146,28 +146,10 @@ interface LiveMessageState {
   parentMessageId?: string;
 }
 
-function optimisticAssistantParent(message: TMessage): string | undefined {
-  const parentMessageId = message.parentMessageId;
-  /** Hydrated message rows always receive both timestamps from the message
-   * schema. Their joint absence is the client-only proof that this suffixed
-   * assistant is the placeholder built by `useChatFunctions`. */
-  if (
-    message.isCreatedByUser === false &&
-    typeof message.messageId === 'string' &&
-    message.messageId.endsWith('_') &&
-    message.createdAt == null &&
-    message.updatedAt == null &&
-    typeof parentMessageId === 'string' &&
-    parentMessageId.length > 0
-  ) {
-    return parentMessageId;
-  }
-}
-
 function selectLiveMessageState(message: TMessage | null): LiveMessageState {
   let parentMessageId: string | undefined;
   if (message?.isCreatedByUser === false && typeof message.messageId === 'string') {
-    parentMessageId = optimisticAssistantParent(message) ?? message.messageId;
+    parentMessageId = message.clientQueueParentMessageId ?? message.messageId;
   }
   return { approval: hasLiveToolApproval(message), parentMessageId };
 }

--- a/packages/api/src/agents/queuedTurns.spec.ts
+++ b/packages/api/src/agents/queuedTurns.spec.ts
@@ -492,7 +492,7 @@ describe('Agent queued-turn continuation', () => {
     );
   });
 
-  it('resolves an optimistic response placeholder from its persisted user message', async () => {
+  it('does not reinterpret a missing underscore-suffixed anchor', async () => {
     const { methods, spies } = resolverMethods();
     const queued = claim();
     queued.parentMessageId = 'user-1_';
@@ -518,42 +518,41 @@ describe('Agent queued-turn continuation', () => {
       claimBy: 'worker-1',
     });
 
-    await expect(resolve(envelope(), { idempotencyKey: 'trigger-1' })).resolves.toMatchObject({
-      status: 'ready',
-      parentMessageId: 'assistant-1',
+    await expect(resolve(envelope(), { idempotencyKey: 'trigger-1' })).rejects.toMatchObject({
+      code: 'PARENT_NOT_FOUND',
     });
-    expect(spies.releaseAgentQueuedTurn).not.toHaveBeenCalled();
+    expect(spies.releaseAgentQueuedTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queuedTurnId: queued.queuedTurnId,
+        disposition: 'dead',
+        failure: expect.objectContaining({ code: 'PARENT_NOT_FOUND' }),
+      }),
+    );
   });
 
-  it('prefers an exact persisted anchor over placeholder normalization', async () => {
+  it('continues after the newest regenerated response under a durable user anchor', async () => {
     const { methods, spies } = resolverMethods();
     const queued = claim();
-    queued.parentMessageId = 'user-1_';
+    queued.parentMessageId = 'user-1';
     spies.claimNextAgentQueuedTurn.mockResolvedValueOnce({ outcome: 'acquired', claim: queued });
     spies.getMessages.mockResolvedValueOnce([
       persistedMessage({
         messageId: 'user-1',
         parentMessageId: 'root',
         isCreatedByUser: true,
+        createdAt: new Date(NOW - 3_000),
+      }),
+      persistedMessage({
+        messageId: 'old-assistant',
+        parentMessageId: 'user-1',
+        isCreatedByUser: false,
         createdAt: new Date(NOW - 2_000),
       }),
       persistedMessage({
-        messageId: 'stripped-branch',
+        messageId: 'regenerated-assistant',
         parentMessageId: 'user-1',
         isCreatedByUser: false,
         createdAt: new Date(NOW),
-      }),
-      persistedMessage({
-        messageId: 'user-1_',
-        parentMessageId: 'root',
-        isCreatedByUser: true,
-        createdAt: new Date(NOW - 1_000),
-      }),
-      persistedMessage({
-        messageId: 'exact-branch',
-        parentMessageId: 'user-1_',
-        isCreatedByUser: false,
-        createdAt: new Date(NOW - 500),
       }),
     ]);
     const resolve = createAgentQueuedTurnResolver({
@@ -565,7 +564,7 @@ describe('Agent queued-turn continuation', () => {
 
     await expect(resolve(envelope(), { idempotencyKey: 'trigger-1' })).resolves.toMatchObject({
       status: 'ready',
-      parentMessageId: 'exact-branch',
+      parentMessageId: 'regenerated-assistant',
     });
   });
 

--- a/packages/api/src/agents/queuedTurns.spec.ts
+++ b/packages/api/src/agents/queuedTurns.spec.ts
@@ -492,6 +492,83 @@ describe('Agent queued-turn continuation', () => {
     );
   });
 
+  it('resolves an optimistic response placeholder from its persisted user message', async () => {
+    const { methods, spies } = resolverMethods();
+    const queued = claim();
+    queued.parentMessageId = 'user-1_';
+    spies.claimNextAgentQueuedTurn.mockResolvedValueOnce({ outcome: 'acquired', claim: queued });
+    spies.getMessages.mockResolvedValueOnce([
+      persistedMessage({
+        messageId: 'user-1',
+        parentMessageId: 'root',
+        isCreatedByUser: true,
+        createdAt: new Date(NOW - 1_000),
+      }),
+      persistedMessage({
+        messageId: 'assistant-1',
+        parentMessageId: 'user-1',
+        isCreatedByUser: false,
+        createdAt: new Date(NOW),
+      }),
+    ]);
+    const resolve = createAgentQueuedTurnResolver({
+      methods,
+      getGenerationJob: async () => null,
+      now: () => NOW,
+      claimBy: 'worker-1',
+    });
+
+    await expect(resolve(envelope(), { idempotencyKey: 'trigger-1' })).resolves.toMatchObject({
+      status: 'ready',
+      parentMessageId: 'assistant-1',
+    });
+    expect(spies.releaseAgentQueuedTurn).not.toHaveBeenCalled();
+  });
+
+  it('prefers an exact persisted anchor over placeholder normalization', async () => {
+    const { methods, spies } = resolverMethods();
+    const queued = claim();
+    queued.parentMessageId = 'user-1_';
+    spies.claimNextAgentQueuedTurn.mockResolvedValueOnce({ outcome: 'acquired', claim: queued });
+    spies.getMessages.mockResolvedValueOnce([
+      persistedMessage({
+        messageId: 'user-1',
+        parentMessageId: 'root',
+        isCreatedByUser: true,
+        createdAt: new Date(NOW - 2_000),
+      }),
+      persistedMessage({
+        messageId: 'stripped-branch',
+        parentMessageId: 'user-1',
+        isCreatedByUser: false,
+        createdAt: new Date(NOW),
+      }),
+      persistedMessage({
+        messageId: 'user-1_',
+        parentMessageId: 'root',
+        isCreatedByUser: true,
+        createdAt: new Date(NOW - 1_000),
+      }),
+      persistedMessage({
+        messageId: 'exact-branch',
+        parentMessageId: 'user-1_',
+        isCreatedByUser: false,
+        createdAt: new Date(NOW - 500),
+      }),
+    ]);
+    const resolve = createAgentQueuedTurnResolver({
+      methods,
+      getGenerationJob: async () => null,
+      now: () => NOW,
+      claimBy: 'worker-1',
+    });
+
+    await expect(resolve(envelope(), { idempotencyKey: 'trigger-1' })).resolves.toMatchObject({
+      status: 'ready',
+      parentMessageId: 'exact-branch',
+    });
+  });
+
   it('dead-letters a legacy admission order that cannot be reconstructed safely', async () => {
     const { methods, spies } = resolverMethods();
     (

--- a/packages/api/src/agents/queuedTurns.ts
+++ b/packages/api/src/agents/queuedTurns.ts
@@ -356,10 +356,20 @@ function timestamp(message: IMessage): number {
  * the turn was queued. Unrelated branch activity can never retarget the turn. */
 function latestAssistantDescendant(messages: IMessage[], anchorId: string): IMessage | undefined {
   const byId = new Map(messages.map((message) => [message.messageId, message]));
-  if (!byId.has(anchorId)) {
+  const placeholderBaseId = anchorId.replace(/_+$/, '');
+  let resolvedAnchorId = byId.has(anchorId) ? anchorId : undefined;
+  if (
+    resolvedAnchorId == null &&
+    placeholderBaseId.length > 0 &&
+    placeholderBaseId !== anchorId &&
+    byId.has(placeholderBaseId)
+  ) {
+    resolvedAnchorId = placeholderBaseId;
+  }
+  if (resolvedAnchorId == null) {
     return;
   }
-  const memo = new Map<string, boolean>([[anchorId, true]]);
+  const memo = new Map<string, boolean>([[resolvedAnchorId, true]]);
   const reachesAnchor = (message: IMessage, visiting = new Set<string>()): boolean => {
     const known = memo.get(message.messageId);
     if (known != null) {

--- a/packages/api/src/agents/queuedTurns.ts
+++ b/packages/api/src/agents/queuedTurns.ts
@@ -356,20 +356,10 @@ function timestamp(message: IMessage): number {
  * the turn was queued. Unrelated branch activity can never retarget the turn. */
 function latestAssistantDescendant(messages: IMessage[], anchorId: string): IMessage | undefined {
   const byId = new Map(messages.map((message) => [message.messageId, message]));
-  const placeholderBaseId = anchorId.replace(/_+$/, '');
-  let resolvedAnchorId = byId.has(anchorId) ? anchorId : undefined;
-  if (
-    resolvedAnchorId == null &&
-    placeholderBaseId.length > 0 &&
-    placeholderBaseId !== anchorId &&
-    byId.has(placeholderBaseId)
-  ) {
-    resolvedAnchorId = placeholderBaseId;
-  }
-  if (resolvedAnchorId == null) {
+  if (!byId.has(anchorId)) {
     return;
   }
-  const memo = new Map<string, boolean>([[resolvedAnchorId, true]]);
+  const memo = new Map<string, boolean>([[anchorId, true]]);
   const reachesAnchor = (message: IMessage, visiting = new Set<string>()): boolean => {
     const known = memo.get(message.messageId);
     if (known != null) {

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -1064,6 +1064,8 @@ export type TMessage = z.input<typeof tMessageSchema> & {
   siblingIndex?: number;
   attachments?: TAttachment[];
   clientTimestamp?: string;
+  /** Client-only durable branch anchor while this message is an optimistic response. */
+  clientQueueParentMessageId?: string;
   feedback?: TFeedback;
 };
 


### PR DESCRIPTION
## Summary

I fixed queued agent turns that dead-lettered with `PARENT_NOT_FOUND` while the active response still used client-only identities.

- Preallocate the optimistic user message ID as the durable Agents user-row ID before the `created` event.
- Stamp optimistic assistant responses with an explicit client-only durable queue anchor instead of inferring placeholder state from ID suffixes or timestamps.
- Anchor new, regenerated, and edited responses through their durable user parent so delivery selects the completed response sibling.
- Preserve exact persisted/custom assistant IDs, including IDs ending in underscores.
- Keep the server resolver fail-closed for absent anchors instead of inferring identity from naming conventions.
- Add focused client and API coverage for pre-hydration sends, response edits, regeneration, exact underscore IDs, and ambiguous missing anchors.

Fixes #15786

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx jest src/hooks/Chat/__tests__/useChatFunctions.regenerate.spec.tsx src/hooks/Chat/__tests__/useSteering.spec.tsx --runInBand --coverage=false --config jest.config.cjs` (151 passed)
- `npx jest src/agents/queuedTurns.spec.ts --runInBand --coverage=false -t "missing underscore-suffixed anchor|newest regenerated response|dead-letters a queued turn whose predecessor|latest admitted queued generation"` (5 passed)
- `npx tsc -p tsconfig.build.json` in `packages/data-provider`
- Scoped Prettier and ESLint on all changed files

### **Test Configuration**:

- macOS
- Node.js repository toolchain
- Focused client submission/queue and API queue-resolver tests

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of the code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes