### PR TITLE
🧾 feat: Enforce Quotas on Skill Files

### DIFF
--- a/api/server/routes/skills.js
+++ b/api/server/routes/skills.js
@@ -22,7 +22,6 @@ const {
   createSkill,
   getSkillById,
   deleteSkill,
-  upsertSkillFile,
   getSkillFileByPath,
   getRoleByName,
 } = require('~/models');
@@ -31,6 +30,7 @@ const { grantPermission } = require('~/server/services/PermissionService');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { createFileLimiters } = require('~/server/middleware/limiters/uploadLimiters');
 const { maybeRunGitHubSkillSyncForRequest } = require('~/server/services/Skills/sync');
+const { upsertSkillFileWithQuota } = require('~/server/services/Skills/quota');
 const configMiddleware = require('~/server/middleware/config/app');
 const { getFileStrategy } = require('~/server/utils/getFileStrategy');
 
@@ -117,34 +117,35 @@ function resolveSkillStorage(req, { isImage = false } = {}) {
 // ---------------------------------------------------------------------------
 // Import handler (zip/md/skill → create skill + files)
 // ---------------------------------------------------------------------------
-const importHandler = createImportHandler({
-  limits: (req) => ({
-    maxZipBytes: getSkillImportSizeLimit(req),
-  }),
-  createSkill,
-  getSkillById,
-  deleteSkill,
-  upsertSkillFile,
-  saveBuffer: (req, { userId, buffer, fileName, basePath, isImage, tenantId }) => {
-    const requestTenantId = tenantId ?? resolveRequestTenantId(req);
-    const storage = resolveSkillStorage(req, { isImage });
-    return storage
-      .saveBuffer({ userId, buffer, fileName, basePath, tenantId: requestTenantId })
-      .then((filepath) => ({
-        filepath,
-        source: storage.source,
-        ...getStorageMetadata({ filepath, source: storage.source }),
-      }));
-  },
-  deleteFile: (req, file) => {
-    const { deleteFile } = getStrategyFunctions(file.source);
-    if (deleteFile) {
-      return deleteFile(req, file);
-    }
-    return Promise.resolve();
-  },
-  grantPermission,
-});
+const importHandler = (req, res, next) =>
+  createImportHandler({
+    limits: (req) => ({
+      maxZipBytes: getSkillImportSizeLimit(req),
+    }),
+    createSkill,
+    getSkillById,
+    deleteSkill,
+    upsertSkillFile: (row) => upsertSkillFileWithQuota(req, row),
+    saveBuffer: (req, { userId, buffer, fileName, basePath, isImage, tenantId }) => {
+      const requestTenantId = tenantId ?? resolveRequestTenantId(req);
+      const storage = resolveSkillStorage(req, { isImage });
+      return storage
+        .saveBuffer({ userId, buffer, fileName, basePath, tenantId: requestTenantId })
+        .then((filepath) => ({
+          filepath,
+          source: storage.source,
+          ...getStorageMetadata({ filepath, source: storage.source }),
+        }));
+    },
+    deleteFile: (req, file) => {
+      const { deleteFile } = getStrategyFunctions(file.source);
+      if (deleteFile) {
+        return deleteFile(req, file);
+      }
+      return Promise.resolve();
+    },
+    grantPermission,
+  })(req, res, next);
 
 // ---------------------------------------------------------------------------
 // Per-file upload handler (add a single file to an existing skill)
@@ -205,7 +206,7 @@ async function uploadFileHandler(req, res) {
 
     let result;
     try {
-      result = await upsertSkillFile({
+      result = await upsertSkillFileWithQuota(req, {
         skillId,
         relativePath,
         file_id: fileId,

--- a/api/server/routes/skills.js
+++ b/api/server/routes/skills.js
@@ -219,10 +219,18 @@ async function uploadFileHandler(req, res) {
           mimeType: file.mimetype || 'application/octet-stream',
           bytes: file.size,
           isExecutable: false,
-          author: req.user._id,
+          author: String(req.user._id ?? req.user.id),
           tenantId,
         },
-        existingFile,
+        existingFile
+          ? {
+              skillId: String(existingFile.skillId),
+              relativePath: existingFile.relativePath,
+              author: String(existingFile.author),
+              tenantId: existingFile.tenantId,
+              bytes: existingFile.bytes,
+            }
+          : null,
       );
     } catch (dbError) {
       // Clean up the stored blob so it doesn't leak on DB failure

--- a/api/server/routes/skills.js
+++ b/api/server/routes/skills.js
@@ -125,7 +125,7 @@ const importHandler = (req, res, next) =>
     createSkill,
     getSkillById,
     deleteSkill,
-    upsertSkillFile: (row) => upsertSkillFileWithQuota(req, row),
+    upsertSkillFile: (row) => upsertSkillFileWithQuota(req, row, null),
     saveBuffer: (req, { userId, buffer, fileName, basePath, isImage, tenantId }) => {
       const requestTenantId = tenantId ?? resolveRequestTenantId(req);
       const storage = resolveSkillStorage(req, { isImage });
@@ -206,20 +206,24 @@ async function uploadFileHandler(req, res) {
 
     let result;
     try {
-      result = await upsertSkillFileWithQuota(req, {
-        skillId,
-        relativePath,
-        file_id: fileId,
-        filename,
-        filepath,
-        ...storageMetadata,
-        source: storage.source,
-        mimeType: file.mimetype || 'application/octet-stream',
-        bytes: file.size,
-        isExecutable: false,
-        author: req.user._id,
-        tenantId,
-      });
+      result = await upsertSkillFileWithQuota(
+        req,
+        {
+          skillId,
+          relativePath,
+          file_id: fileId,
+          filename,
+          filepath,
+          ...storageMetadata,
+          source: storage.source,
+          mimeType: file.mimetype || 'application/octet-stream',
+          bytes: file.size,
+          isExecutable: false,
+          author: req.user._id,
+          tenantId,
+        },
+        existingFile,
+      );
     } catch (dbError) {
       // Clean up the stored blob so it doesn't leak on DB failure
       try {

--- a/api/server/services/Endpoints/agents/skillDeps.js
+++ b/api/server/services/Endpoints/agents/skillDeps.js
@@ -102,20 +102,24 @@ async function saveSkillFileContent({ req, skillId, relativePath, content, mimeT
 
   let result;
   try {
-    result = await upsertSkillFileWithQuota(req, {
-      skillId,
-      relativePath,
-      file_id: fileId,
-      filename,
-      filepath,
-      ...storageMetadata,
-      source: storage.source,
-      mimeType,
-      bytes: buffer.length,
-      isExecutable: false,
-      author: req.user._id ?? req.user.id,
-      tenantId,
-    });
+    result = await upsertSkillFileWithQuota(
+      req,
+      {
+        skillId,
+        relativePath,
+        file_id: fileId,
+        filename,
+        filepath,
+        ...storageMetadata,
+        source: storage.source,
+        mimeType,
+        bytes: buffer.length,
+        isExecutable: false,
+        author: req.user._id ?? req.user.id,
+        tenantId,
+      },
+      existingFile,
+    );
     if (!result) {
       const error = new Error('Skill file save failed to persist metadata');
       error.code = 'SKILL_FILE_UPSERT_NOT_FOUND';

--- a/api/server/services/Endpoints/agents/skillDeps.js
+++ b/api/server/services/Endpoints/agents/skillDeps.js
@@ -38,6 +38,7 @@ const {
 } = require('librechat-data-provider');
 const { checkPermission, grantPermission } = require('~/server/services/PermissionService');
 const { getFileStrategy } = require('~/server/utils/getFileStrategy');
+const { upsertSkillFileWithQuota } = require('~/server/services/Skills/quota');
 const db = require('~/models');
 
 const deploymentSkillMethods = createDeploymentSkillMethods({
@@ -101,7 +102,7 @@ async function saveSkillFileContent({ req, skillId, relativePath, content, mimeT
 
   let result;
   try {
-    result = await db.upsertSkillFile({
+    result = await upsertSkillFileWithQuota(req, {
       skillId,
       relativePath,
       file_id: fileId,

--- a/api/server/services/Endpoints/agents/skillDeps.js
+++ b/api/server/services/Endpoints/agents/skillDeps.js
@@ -115,10 +115,18 @@ async function saveSkillFileContent({ req, skillId, relativePath, content, mimeT
         mimeType,
         bytes: buffer.length,
         isExecutable: false,
-        author: req.user._id ?? req.user.id,
+        author: String(req.user._id ?? req.user.id),
         tenantId,
       },
-      existingFile,
+      existingFile
+        ? {
+            skillId: String(existingFile.skillId),
+            relativePath: existingFile.relativePath,
+            author: String(existingFile.author),
+            tenantId: existingFile.tenantId,
+            bytes: existingFile.bytes,
+          }
+        : null,
     );
     if (!result) {
       const error = new Error('Skill file save failed to persist metadata');

--- a/api/server/services/Endpoints/agents/skillDeps.spec.js
+++ b/api/server/services/Endpoints/agents/skillDeps.spec.js
@@ -11,6 +11,7 @@ const mockListWorkspaceFiles = jest.fn();
 const mockWriteWorkspaceFile = jest.fn();
 const mockPreviewWorkspaceEdit = jest.fn();
 const mockEditWorkspaceFile = jest.fn();
+const mockUpsertSkillFileWithQuota = jest.fn((_req, row) => mockDb.upsertSkillFile(row));
 
 jest.mock('~/server/services/Files/strategies', () => ({
   getStrategyFunctions: (...args) => mockGetStrategyFunctions(...args),
@@ -62,6 +63,10 @@ jest.mock('~/server/services/PermissionService', () => ({
 
 jest.mock('~/server/utils/getFileStrategy', () => ({
   getFileStrategy: (...args) => mockGetFileStrategy(...args),
+}));
+
+jest.mock('~/server/services/Skills/quota', () => ({
+  upsertSkillFileWithQuota: (...args) => mockUpsertSkillFileWithQuota(...args),
 }));
 
 const mockDb = {

--- a/api/server/services/Skills/quota.js
+++ b/api/server/services/Skills/quota.js
@@ -14,6 +14,7 @@ const {
     const committed = await db.getSkillFileByPath(row.skillId, row.relativePath);
     return committed?.file_id === row.file_id ? committed : null;
   },
+  repairCommittedSkillFile: async (row) => db.reconcileSkillFileCount(row.skillId),
   getUserStorageUsage: db.getUserStorageUsage,
   onCleanupError: (error) => logger.error('[upsertSkillFileWithQuota] Cleanup failed:', error),
 });

--- a/api/server/services/Skills/quota.js
+++ b/api/server/services/Skills/quota.js
@@ -10,6 +10,10 @@ const {
 } = createSkillFileQuotaPersistence({
   resolveScope: resolveStorageScope,
   upsertSkillFile: db.upsertSkillFile,
+  recoverCommittedSkillFile: async (row) => {
+    const committed = await db.getSkillFileByPath(row.skillId, row.relativePath);
+    return committed?.file_id === row.file_id ? committed : null;
+  },
   getUserStorageUsage: db.getUserStorageUsage,
   onCleanupError: (error) => logger.error('[upsertSkillFileWithQuota] Cleanup failed:', error),
 });

--- a/api/server/services/Skills/quota.js
+++ b/api/server/services/Skills/quota.js
@@ -1,26 +1,13 @@
-const { persistSkillFileWithQuota, resolveStorageScope } = require('@librechat/api');
+const { createSkillFileQuotaPersistence, resolveStorageScope } = require('@librechat/api');
 const { logger } = require('@librechat/data-schemas');
 const db = require('~/models');
 
-/**
- * Quota-checks a SkillFile replacement against the requester's ledger.
- * Blob cleanup stays with the caller because each write workflow already owns the
- * surrounding multi-file rollback journal.
- */
-async function upsertSkillFileWithQuota(req, row) {
-  const replacing = await db.getSkillFileByPath(row.skillId, row.relativePath);
-  return persistSkillFileWithQuota(
-    {
-      scope: resolveStorageScope(req),
-      row,
-      write: db.upsertSkillFile,
-      rollback: null,
-      getUserStorageUsage: db.getUserStorageUsage,
-      replacing,
-      replacedBytes: replacing?.bytes,
-    },
-    (error) => logger.error('[upsertSkillFileWithQuota] Cleanup failed:', error),
-  );
-}
+const { persistSkillFile: upsertSkillFileWithQuota, runWithSharedScope } =
+  createSkillFileQuotaPersistence({
+    resolveScope: resolveStorageScope,
+    upsertSkillFile: db.upsertSkillFile,
+    getUserStorageUsage: db.getUserStorageUsage,
+    onCleanupError: (error) => logger.error('[upsertSkillFileWithQuota] Cleanup failed:', error),
+  });
 
-module.exports = { upsertSkillFileWithQuota };
+module.exports = { upsertSkillFileWithQuota, runWithSharedScope };

--- a/api/server/services/Skills/quota.js
+++ b/api/server/services/Skills/quota.js
@@ -2,22 +2,37 @@ const { createSkillFileQuotaPersistence, resolveStorageScope } = require('@libre
 const { logger } = require('@librechat/data-schemas');
 const db = require('~/models');
 
-const {
-  getSharedValue,
-  invalidateSharedScope,
-  persistSkillFile: upsertSkillFileWithQuota,
-  runWithSharedScope,
-} = createSkillFileQuotaPersistence({
-  resolveScope: resolveStorageScope,
-  upsertSkillFile: db.upsertSkillFile,
-  recoverCommittedSkillFile: async (row) => {
-    const committed = await db.getSkillFileByPath(row.skillId, row.relativePath);
-    return committed?.file_id === row.file_id ? committed : null;
-  },
-  repairCommittedSkillFile: async (row) => db.reconcileSkillFileCount(row.skillId),
-  getUserStorageUsage: db.getUserStorageUsage,
-  onCleanupError: (error) => logger.error('[upsertSkillFileWithQuota] Cleanup failed:', error),
-});
+const { getSharedValue, invalidateSharedScope, persistSkillFile, runWithSharedScope } =
+  createSkillFileQuotaPersistence({
+    resolveScope: resolveStorageScope,
+    upsertSkillFile: db.upsertSkillFile,
+    recoverCommittedSkillFile: async (row) => {
+      const committed = await db.getSkillFileByPath(row.skillId, row.relativePath);
+      return committed?.file_id === row.file_id ? committed : null;
+    },
+    repairCommittedSkillFile: async (row) => db.reconcileSkillFileCount(row.skillId),
+    getUserStorageUsage: db.getUserStorageUsage,
+    onCleanupError: (error) => logger.error('[upsertSkillFileWithQuota] Cleanup failed:', error),
+  });
+
+const normalizeIdentity = (value) => (value == null ? undefined : String(value));
+
+const upsertSkillFileWithQuota = (req, row, replacing) =>
+  persistSkillFile(
+    req,
+    {
+      ...row,
+      skillId: normalizeIdentity(row.skillId),
+      author: normalizeIdentity(row.author),
+    },
+    replacing
+      ? {
+          ...replacing,
+          skillId: normalizeIdentity(replacing.skillId),
+          author: normalizeIdentity(replacing.author),
+        }
+      : null,
+  );
 
 module.exports = {
   getSharedQuotaValue: getSharedValue,

--- a/api/server/services/Skills/quota.js
+++ b/api/server/services/Skills/quota.js
@@ -2,12 +2,21 @@ const { createSkillFileQuotaPersistence, resolveStorageScope } = require('@libre
 const { logger } = require('@librechat/data-schemas');
 const db = require('~/models');
 
-const { persistSkillFile: upsertSkillFileWithQuota, runWithSharedScope } =
-  createSkillFileQuotaPersistence({
-    resolveScope: resolveStorageScope,
-    upsertSkillFile: db.upsertSkillFile,
-    getUserStorageUsage: db.getUserStorageUsage,
-    onCleanupError: (error) => logger.error('[upsertSkillFileWithQuota] Cleanup failed:', error),
-  });
+const {
+  getSharedValue,
+  invalidateSharedScope,
+  persistSkillFile: upsertSkillFileWithQuota,
+  runWithSharedScope,
+} = createSkillFileQuotaPersistence({
+  resolveScope: resolveStorageScope,
+  upsertSkillFile: db.upsertSkillFile,
+  getUserStorageUsage: db.getUserStorageUsage,
+  onCleanupError: (error) => logger.error('[upsertSkillFileWithQuota] Cleanup failed:', error),
+});
 
-module.exports = { upsertSkillFileWithQuota, runWithSharedScope };
+module.exports = {
+  getSharedQuotaValue: getSharedValue,
+  invalidateSharedQuotaScope: invalidateSharedScope,
+  upsertSkillFileWithQuota,
+  runWithSharedScope,
+};

--- a/api/server/services/Skills/quota.js
+++ b/api/server/services/Skills/quota.js
@@ -1,0 +1,26 @@
+const { persistSkillFileWithQuota, resolveStorageScope } = require('@librechat/api');
+const { logger } = require('@librechat/data-schemas');
+const db = require('~/models');
+
+/**
+ * Quota-checks a SkillFile replacement against the requester's ledger.
+ * Blob cleanup stays with the caller because each write workflow already owns the
+ * surrounding multi-file rollback journal.
+ */
+async function upsertSkillFileWithQuota(req, row) {
+  const replacing = await db.getSkillFileByPath(row.skillId, row.relativePath);
+  return persistSkillFileWithQuota(
+    {
+      scope: resolveStorageScope(req),
+      row,
+      write: db.upsertSkillFile,
+      rollback: null,
+      getUserStorageUsage: db.getUserStorageUsage,
+      replacing,
+      replacedBytes: replacing?.bytes,
+    },
+    (error) => logger.error('[upsertSkillFileWithQuota] Cleanup failed:', error),
+  );
+}
+
+module.exports = { upsertSkillFileWithQuota };

--- a/api/server/services/Skills/quota.spec.js
+++ b/api/server/services/Skills/quota.spec.js
@@ -11,6 +11,7 @@ const mockCreateSkillFileQuotaPersistence = jest.fn((dependencies) => {
 const mockResolveStorageScope = jest.fn();
 const mockUpsertSkillFile = jest.fn();
 const mockGetUserStorageUsage = jest.fn();
+const mockGetSkillFileByPath = jest.fn();
 
 jest.mock('@librechat/api', () => ({
   createSkillFileQuotaPersistence: (...args) => mockCreateSkillFileQuotaPersistence(...args),
@@ -22,6 +23,7 @@ jest.mock('@librechat/data-schemas', () => ({ logger: { error: jest.fn() } }));
 jest.mock('~/models', () => ({
   upsertSkillFile: mockUpsertSkillFile,
   getUserStorageUsage: mockGetUserStorageUsage,
+  getSkillFileByPath: mockGetSkillFileByPath,
 }));
 
 const { upsertSkillFileWithQuota, runWithSharedScope } = require('./quota');
@@ -39,9 +41,18 @@ describe('upsertSkillFileWithQuota', () => {
         resolveScope: mockResolveStorageScope,
         upsertSkillFile: mockUpsertSkillFile,
         getUserStorageUsage: mockGetUserStorageUsage,
+        recoverCommittedSkillFile: expect.any(Function),
       }),
     );
     expect(mockPersistSkillFile).toHaveBeenCalledWith(req, row, replacing);
+    mockGetSkillFileByPath.mockResolvedValueOnce({ file_id: 'committed-file' });
+    await expect(
+      capturedDependencies.recoverCommittedSkillFile({
+        skillId: 'skill-1',
+        relativePath: 'references/a.txt',
+        file_id: 'committed-file',
+      }),
+    ).resolves.toEqual({ file_id: 'committed-file' });
     expect(runWithSharedScope).toBe(mockRunWithSharedScope);
   });
 });

--- a/api/server/services/Skills/quota.spec.js
+++ b/api/server/services/Skills/quota.spec.js
@@ -1,46 +1,47 @@
-const mockPersistSkillFileWithQuota = jest.fn();
+const mockPersistSkillFile = jest.fn();
+const mockRunWithSharedScope = jest.fn();
+let capturedDependencies;
+const mockCreateSkillFileQuotaPersistence = jest.fn((dependencies) => {
+  capturedDependencies = dependencies;
+  return {
+    persistSkillFile: mockPersistSkillFile,
+    runWithSharedScope: mockRunWithSharedScope,
+  };
+});
 const mockResolveStorageScope = jest.fn();
-const mockGetSkillFileByPath = jest.fn();
 const mockUpsertSkillFile = jest.fn();
 const mockGetUserStorageUsage = jest.fn();
 
 jest.mock('@librechat/api', () => ({
-  persistSkillFileWithQuota: (...args) => mockPersistSkillFileWithQuota(...args),
-  resolveStorageScope: (...args) => mockResolveStorageScope(...args),
+  createSkillFileQuotaPersistence: (...args) => mockCreateSkillFileQuotaPersistence(...args),
+  resolveStorageScope: mockResolveStorageScope,
 }));
 
 jest.mock('@librechat/data-schemas', () => ({ logger: { error: jest.fn() } }));
 
 jest.mock('~/models', () => ({
-  getSkillFileByPath: (...args) => mockGetSkillFileByPath(...args),
-  upsertSkillFile: (...args) => mockUpsertSkillFile(...args),
-  getUserStorageUsage: (...args) => mockGetUserStorageUsage(...args),
+  upsertSkillFile: mockUpsertSkillFile,
+  getUserStorageUsage: mockGetUserStorageUsage,
 }));
 
-const { upsertSkillFileWithQuota } = require('./quota');
+const { upsertSkillFileWithQuota, runWithSharedScope } = require('./quota');
 
 describe('upsertSkillFileWithQuota', () => {
-  it('charges only the replacement delta on the requester scope', async () => {
+  it('keeps the CJS service as dependency wiring for the package boundary', async () => {
     const req = { user: { id: 'user-1' } };
     const row = { skillId: 'skill-1', relativePath: 'references/a.txt', bytes: 120 };
     const replacing = { author: 'user-1', bytes: 40 };
-    const scope = { userId: 'user-1' };
-    mockGetSkillFileByPath.mockResolvedValueOnce(replacing);
-    mockResolveStorageScope.mockReturnValueOnce(scope);
-    mockPersistSkillFileWithQuota.mockResolvedValueOnce({ ...row, author: 'user-1' });
 
-    await upsertSkillFileWithQuota(req, row);
+    await upsertSkillFileWithQuota(req, row, replacing);
 
-    expect(mockPersistSkillFileWithQuota).toHaveBeenCalledWith(
+    expect(capturedDependencies).toEqual(
       expect.objectContaining({
-        scope,
-        row,
-        write: expect.any(Function),
-        rollback: null,
-        replacing,
-        replacedBytes: 40,
+        resolveScope: mockResolveStorageScope,
+        upsertSkillFile: mockUpsertSkillFile,
+        getUserStorageUsage: mockGetUserStorageUsage,
       }),
-      expect.any(Function),
     );
+    expect(mockPersistSkillFile).toHaveBeenCalledWith(req, row, replacing);
+    expect(runWithSharedScope).toBe(mockRunWithSharedScope);
   });
 });

--- a/api/server/services/Skills/quota.spec.js
+++ b/api/server/services/Skills/quota.spec.js
@@ -1,0 +1,46 @@
+const mockPersistSkillFileWithQuota = jest.fn();
+const mockResolveStorageScope = jest.fn();
+const mockGetSkillFileByPath = jest.fn();
+const mockUpsertSkillFile = jest.fn();
+const mockGetUserStorageUsage = jest.fn();
+
+jest.mock('@librechat/api', () => ({
+  persistSkillFileWithQuota: (...args) => mockPersistSkillFileWithQuota(...args),
+  resolveStorageScope: (...args) => mockResolveStorageScope(...args),
+}));
+
+jest.mock('@librechat/data-schemas', () => ({ logger: { error: jest.fn() } }));
+
+jest.mock('~/models', () => ({
+  getSkillFileByPath: (...args) => mockGetSkillFileByPath(...args),
+  upsertSkillFile: (...args) => mockUpsertSkillFile(...args),
+  getUserStorageUsage: (...args) => mockGetUserStorageUsage(...args),
+}));
+
+const { upsertSkillFileWithQuota } = require('./quota');
+
+describe('upsertSkillFileWithQuota', () => {
+  it('charges only the replacement delta on the requester scope', async () => {
+    const req = { user: { id: 'user-1' } };
+    const row = { skillId: 'skill-1', relativePath: 'references/a.txt', bytes: 120 };
+    const replacing = { author: 'user-1', bytes: 40 };
+    const scope = { userId: 'user-1' };
+    mockGetSkillFileByPath.mockResolvedValueOnce(replacing);
+    mockResolveStorageScope.mockReturnValueOnce(scope);
+    mockPersistSkillFileWithQuota.mockResolvedValueOnce({ ...row, author: 'user-1' });
+
+    await upsertSkillFileWithQuota(req, row);
+
+    expect(mockPersistSkillFileWithQuota).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope,
+        row,
+        write: expect.any(Function),
+        rollback: null,
+        replacing,
+        replacedBytes: 40,
+      }),
+      expect.any(Function),
+    );
+  });
+});

--- a/api/server/services/Skills/quota.spec.js
+++ b/api/server/services/Skills/quota.spec.js
@@ -12,6 +12,7 @@ const mockResolveStorageScope = jest.fn();
 const mockUpsertSkillFile = jest.fn();
 const mockGetUserStorageUsage = jest.fn();
 const mockGetSkillFileByPath = jest.fn();
+const mockReconcileSkillFileCount = jest.fn();
 
 jest.mock('@librechat/api', () => ({
   createSkillFileQuotaPersistence: (...args) => mockCreateSkillFileQuotaPersistence(...args),
@@ -24,6 +25,7 @@ jest.mock('~/models', () => ({
   upsertSkillFile: mockUpsertSkillFile,
   getUserStorageUsage: mockGetUserStorageUsage,
   getSkillFileByPath: mockGetSkillFileByPath,
+  reconcileSkillFileCount: mockReconcileSkillFileCount,
 }));
 
 const { upsertSkillFileWithQuota, runWithSharedScope } = require('./quota');
@@ -42,6 +44,7 @@ describe('upsertSkillFileWithQuota', () => {
         upsertSkillFile: mockUpsertSkillFile,
         getUserStorageUsage: mockGetUserStorageUsage,
         recoverCommittedSkillFile: expect.any(Function),
+        repairCommittedSkillFile: expect.any(Function),
       }),
     );
     expect(mockPersistSkillFile).toHaveBeenCalledWith(req, row, replacing);
@@ -53,6 +56,8 @@ describe('upsertSkillFileWithQuota', () => {
         file_id: 'committed-file',
       }),
     ).resolves.toEqual({ file_id: 'committed-file' });
+    await capturedDependencies.repairCommittedSkillFile({ skillId: 'skill-1' });
+    expect(mockReconcileSkillFileCount).toHaveBeenCalledWith('skill-1');
     expect(runWithSharedScope).toBe(mockRunWithSharedScope);
   });
 });

--- a/api/server/services/Skills/sync.js
+++ b/api/server/services/Skills/sync.js
@@ -111,9 +111,12 @@ function createRunner({ getConfig, loadAppConfig, allowServerCredentials = true 
     upsertSkillFile: async (row, replacing) =>
       upsertSkillFileWithQuota(await getQuotaReq(row), row, replacing),
     restoreSkillFile: async (row) => {
-      const req = await getQuotaReq(row);
       await db.upsertSkillFile(row);
-      invalidateSharedQuotaScope(req);
+      try {
+        invalidateSharedQuotaScope(await getQuotaReq(row));
+      } catch (error) {
+        logger.error('[GitHubSkillSync] Failed to invalidate restored quota scope:', error);
+      }
     },
     deleteSkillFile: db.deleteSkillFile,
     invalidateQuotaScope: async (owner) => invalidateSharedQuotaScope(await getQuotaReq(owner)),

--- a/api/server/services/Skills/sync.js
+++ b/api/server/services/Skills/sync.js
@@ -10,7 +10,7 @@ const db = require('~/models');
 const { getAppConfig } = require('~/server/services/Config');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { getFileStrategy } = require('~/server/utils/getFileStrategy');
-const { upsertSkillFileWithQuota } = require('./quota');
+const { upsertSkillFileWithQuota, runWithSharedScope } = require('./quota');
 
 const SYSTEM_USER_ID = '000000000000000000000000';
 
@@ -47,7 +47,9 @@ async function resolveSkillStorage({ isImage = false, loadAppConfig = loadCurren
 }
 
 async function getSyntheticReq({ userId = SYSTEM_USER_ID, tenantId, loadAppConfig } = {}) {
-  const appConfig = await (loadAppConfig ?? loadCurrentAppConfig)();
+  const appConfig = loadAppConfig
+    ? await loadAppConfig({ userId, tenantId })
+    : await getAppConfig({ userId, tenantId, failClosed: true });
   return {
     config: appConfig,
     user: {
@@ -94,15 +96,16 @@ function createRunner({ getConfig, loadAppConfig, allowServerCredentials = true 
     listSkillsBySource: db.listSkillsBySource,
     listSkillFiles: db.listSkillFiles,
     getSkillFileByPath: db.getSkillFileByPath,
-    upsertSkillFile: async (row) =>
+    upsertSkillFile: async (row, replacing) =>
       upsertSkillFileWithQuota(
         await getSyntheticReq({
           userId: row.author?.toString?.() ?? row.author ?? SYSTEM_USER_ID,
           tenantId: row.tenantId,
-          loadAppConfig: resolveAppConfig,
         }),
         row,
+        replacing,
       ),
+    restoreSkillFile: db.upsertSkillFile,
     deleteSkillFile: db.deleteSkillFile,
     deleteSkill: db.deleteSkill,
     grantPermission: async ({
@@ -170,7 +173,7 @@ function createRunner({ getConfig, loadAppConfig, allowServerCredentials = true 
   });
   return {
     getStatus: createdRunner.getStatus,
-    runOnce: createdRunner.runOnce,
+    runOnce: (...args) => runWithSharedScope(() => createdRunner.runOnce(...args)),
   };
 }
 

--- a/api/server/services/Skills/sync.js
+++ b/api/server/services/Skills/sync.js
@@ -10,7 +10,12 @@ const db = require('~/models');
 const { getAppConfig } = require('~/server/services/Config');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { getFileStrategy } = require('~/server/utils/getFileStrategy');
-const { upsertSkillFileWithQuota, runWithSharedScope } = require('./quota');
+const {
+  getSharedQuotaValue,
+  invalidateSharedQuotaScope,
+  upsertSkillFileWithQuota,
+  runWithSharedScope,
+} = require('./quota');
 
 const SYSTEM_USER_ID = '000000000000000000000000';
 
@@ -79,6 +84,13 @@ function withBaseSkillSyncConfig(req, baseConfig) {
 function createRunner({ getConfig, loadAppConfig, allowServerCredentials = true } = {}) {
   const resolveAppConfig = loadAppConfig ?? loadCurrentAppConfig;
   const resolveConfig = getConfig ?? (() => getSyncConfig(resolveAppConfig));
+  const getQuotaReq = (row) => {
+    const userId = row.author?.toString?.() ?? row.author ?? SYSTEM_USER_ID;
+    const tenantId = row.tenantId;
+    return getSharedQuotaValue(`${userId}\0${tenantId ?? ''}`, () =>
+      getSyntheticReq({ userId, tenantId }),
+    );
+  };
   const createdRunner = createGitHubSkillSyncRunner({
     getConfig: resolveConfig,
     getCredentialToken: db.getSkillSyncCredentialToken,
@@ -97,15 +109,12 @@ function createRunner({ getConfig, loadAppConfig, allowServerCredentials = true 
     listSkillFiles: db.listSkillFiles,
     getSkillFileByPath: db.getSkillFileByPath,
     upsertSkillFile: async (row, replacing) =>
-      upsertSkillFileWithQuota(
-        await getSyntheticReq({
-          userId: row.author?.toString?.() ?? row.author ?? SYSTEM_USER_ID,
-          tenantId: row.tenantId,
-        }),
-        row,
-        replacing,
-      ),
-    restoreSkillFile: db.upsertSkillFile,
+      upsertSkillFileWithQuota(await getQuotaReq(row), row, replacing),
+    restoreSkillFile: async (row) => {
+      const req = await getQuotaReq(row);
+      await db.upsertSkillFile(row);
+      invalidateSharedQuotaScope(req);
+    },
     deleteSkillFile: db.deleteSkillFile,
     deleteSkill: db.deleteSkill,
     grantPermission: async ({

--- a/api/server/services/Skills/sync.js
+++ b/api/server/services/Skills/sync.js
@@ -10,6 +10,7 @@ const db = require('~/models');
 const { getAppConfig } = require('~/server/services/Config');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { getFileStrategy } = require('~/server/utils/getFileStrategy');
+const { upsertSkillFileWithQuota } = require('./quota');
 
 const SYSTEM_USER_ID = '000000000000000000000000';
 
@@ -93,7 +94,15 @@ function createRunner({ getConfig, loadAppConfig, allowServerCredentials = true 
     listSkillsBySource: db.listSkillsBySource,
     listSkillFiles: db.listSkillFiles,
     getSkillFileByPath: db.getSkillFileByPath,
-    upsertSkillFile: db.upsertSkillFile,
+    upsertSkillFile: async (row) =>
+      upsertSkillFileWithQuota(
+        await getSyntheticReq({
+          userId: row.author?.toString?.() ?? row.author ?? SYSTEM_USER_ID,
+          tenantId: row.tenantId,
+          loadAppConfig: resolveAppConfig,
+        }),
+        row,
+      ),
     deleteSkillFile: db.deleteSkillFile,
     deleteSkill: db.deleteSkill,
     grantPermission: async ({

--- a/api/server/services/Skills/sync.js
+++ b/api/server/services/Skills/sync.js
@@ -116,6 +116,7 @@ function createRunner({ getConfig, loadAppConfig, allowServerCredentials = true 
       invalidateSharedQuotaScope(req);
     },
     deleteSkillFile: db.deleteSkillFile,
+    invalidateQuotaScope: async (owner) => invalidateSharedQuotaScope(await getQuotaReq(owner)),
     deleteSkill: db.deleteSkill,
     grantPermission: async ({
       principalType,

--- a/api/server/services/Skills/sync.test.js
+++ b/api/server/services/Skills/sync.test.js
@@ -4,6 +4,7 @@ const mockGetFileStrategy = jest.fn();
 const mockFindRoleByIdentifier = jest.fn();
 const mockGrantPermission = jest.fn();
 const mockUpsertSkillFileWithQuota = jest.fn();
+const mockInvalidateSharedQuotaScope = jest.fn();
 let mockRunnerDeps;
 let mockRunnerStatus;
 const mockCreatedRunners = [];
@@ -13,6 +14,8 @@ jest.mock('~/server/services/Config', () => ({
 }));
 
 jest.mock('./quota', () => ({
+  getSharedQuotaValue: (_key, load) => load(),
+  invalidateSharedQuotaScope: (...args) => mockInvalidateSharedQuotaScope(...args),
   upsertSkillFileWithQuota: (...args) => mockUpsertSkillFileWithQuota(...args),
   runWithSharedScope: (operation) => operation(),
 }));
@@ -188,6 +191,26 @@ describe('GitHub skill sync service', () => {
       expect.objectContaining({ config: effectiveConfig }),
       row,
       replacing,
+    );
+  });
+
+  it('invalidates cached quota usage after restoring a pre-sync file row', async () => {
+    const baseConfig = { skillSync: { github: { enabled: false, sources: [] } } };
+    const effectiveConfig = { ...baseConfig, fileConfig: { storageLimit: 5 } };
+    mockGetAppConfig.mockImplementation(async (options) =>
+      options?.baseOnly ? baseConfig : effectiveConfig,
+    );
+    const { upsertSkillFile } = require('~/models');
+    upsertSkillFile.mockResolvedValue({ file_id: 'file-1' });
+
+    const service = require('./sync');
+    service.initializeGitHubSkillSync(baseConfig);
+    const row = { author: 'user-1', tenantId: 'tenant-a', file_id: 'file-1' };
+    await mockRunnerDeps.restoreSkillFile(row);
+
+    expect(upsertSkillFile).toHaveBeenCalledWith(row);
+    expect(mockInvalidateSharedQuotaScope).toHaveBeenCalledWith(
+      expect.objectContaining({ config: effectiveConfig }),
     );
   });
 

--- a/api/server/services/Skills/sync.test.js
+++ b/api/server/services/Skills/sync.test.js
@@ -3,12 +3,17 @@ const mockGetStrategyFunctions = jest.fn();
 const mockGetFileStrategy = jest.fn();
 const mockFindRoleByIdentifier = jest.fn();
 const mockGrantPermission = jest.fn();
+const mockUpsertSkillFileWithQuota = jest.fn();
 let mockRunnerDeps;
 let mockRunnerStatus;
 const mockCreatedRunners = [];
 
 jest.mock('~/server/services/Config', () => ({
   getAppConfig: mockGetAppConfig,
+}));
+
+jest.mock('./quota', () => ({
+  upsertSkillFileWithQuota: (...args) => mockUpsertSkillFileWithQuota(...args),
 }));
 
 jest.mock('@librechat/api', () => {

--- a/api/server/services/Skills/sync.test.js
+++ b/api/server/services/Skills/sync.test.js
@@ -14,6 +14,7 @@ jest.mock('~/server/services/Config', () => ({
 
 jest.mock('./quota', () => ({
   upsertSkillFileWithQuota: (...args) => mockUpsertSkillFileWithQuota(...args),
+  runWithSharedScope: (operation) => operation(),
 }));
 
 jest.mock('@librechat/api', () => {
@@ -162,6 +163,32 @@ describe('GitHub skill sync service', () => {
 
     expect(result).toBeUndefined();
     expect(mockGetAppConfig).toHaveBeenCalledWith({ baseOnly: true });
+  });
+
+  it('resolves effective author config and forwards the loaded replacement for quota writes', async () => {
+    const baseConfig = { skillSync: { github: { enabled: false, sources: [] } } };
+    const effectiveConfig = { ...baseConfig, fileConfig: { storageLimit: 5 } };
+    mockGetAppConfig.mockImplementation(async (options) =>
+      options?.baseOnly ? baseConfig : effectiveConfig,
+    );
+    mockUpsertSkillFileWithQuota.mockResolvedValue({ file_id: 'file-1' });
+
+    const service = require('./sync');
+    service.initializeGitHubSkillSync(baseConfig);
+    const row = { author: 'user-1', tenantId: 'tenant-a', file_id: 'file-1' };
+    const replacing = { file_id: 'old-file', bytes: 10 };
+    await mockRunnerDeps.upsertSkillFile(row, replacing);
+
+    expect(mockGetAppConfig).toHaveBeenCalledWith({
+      userId: 'user-1',
+      tenantId: 'tenant-a',
+      failClosed: true,
+    });
+    expect(mockUpsertSkillFileWithQuota).toHaveBeenCalledWith(
+      expect.objectContaining({ config: effectiveConfig }),
+      row,
+      replacing,
+    );
   });
 
   it('does not let user skill-list sync use server credentials from resolved config', async () => {
@@ -315,7 +342,7 @@ describe('GitHub skill sync service', () => {
     });
     const config = await mockCreatedRunners[0].deps.getConfig();
 
-    expect(runner.runOnce).toBe(mockCreatedRunners[0].runner.runOnce);
+    expect(runner.runOnce).toEqual(expect.any(Function));
     expect(runner.getStatus).toBe(mockCreatedRunners[0].runner.getStatus);
     expect(mockCreatedRunners[0].deps.allowServerCredentials).toBe(true);
     expect(config.github.runOnStartup).toBe(true);

--- a/packages/api/src/files/quota.spec.ts
+++ b/packages/api/src/files/quota.spec.ts
@@ -1078,7 +1078,7 @@ describe('persistSkillFileWithQuota', () => {
 });
 
 describe('createSkillFileQuotaPersistence', () => {
-  it('reuses one ledger read only inside an explicit sync scope', async () => {
+  it('refreshes ledger usage for every write inside an explicit sync scope', async () => {
     const row = {
       bytes: 10,
       skillId: '64f000000000000000000002',
@@ -1106,14 +1106,14 @@ describe('createSkillFileQuotaPersistence', () => {
       );
     });
 
-    expect(getUserStorageUsage).toHaveBeenCalledTimes(1);
+    expect(getUserStorageUsage).toHaveBeenCalledTimes(2);
 
     await persistence.persistSkillFile(
       makeReq({ storageLimitMb: 1, requestTenantId: 'tenant-a' }),
       { ...row, relativePath: 'scripts/c.sh' },
       null,
     );
-    expect(getUserStorageUsage).toHaveBeenCalledTimes(2);
+    expect(getUserStorageUsage).toHaveBeenCalledTimes(3);
   });
 
   it('reloads ledger usage after a compensating restore invalidates the shared scope', async () => {

--- a/packages/api/src/files/quota.spec.ts
+++ b/packages/api/src/files/quota.spec.ts
@@ -1143,6 +1143,24 @@ describe('createSkillFileQuotaPersistence', () => {
     expect(getUserStorageUsage).toHaveBeenCalledTimes(2);
   });
 
+  it('keeps the quota charge when an ambiguous upsert failure already committed the row', async () => {
+    const row = { bytes: 10, skillId: 'skill-a', relativePath: 'scripts/a.sh', file_id: 'file-a' };
+    const committed = { ...row, _id: 'mongo-id' };
+    const persistence = createSkillFileQuotaPersistence({
+      resolveScope: resolveStorageScope,
+      upsertSkillFile: jest.fn(async () => {
+        throw new Error('parent version update failed');
+      }),
+      recoverCommittedSkillFile: jest.fn(async () => committed),
+      getUserStorageUsage: usageOf(0),
+      onCleanupError: noRollbackErrors,
+    });
+
+    await expect(
+      persistence.persistSkillFile(makeReq({ storageLimitMb: 1 }), row, null),
+    ).resolves.toBe(committed);
+  });
+
   it('caches effective configuration promises only inside the explicit run scope', async () => {
     const load = jest.fn(async () => ({ fileConfig: { storageLimit: 1 } }));
     const persistence = createSkillFileQuotaPersistence({

--- a/packages/api/src/files/quota.spec.ts
+++ b/packages/api/src/files/quota.spec.ts
@@ -1166,6 +1166,28 @@ describe('createSkillFileQuotaPersistence', () => {
     );
   });
 
+  it('preserves an ambiguous write when its recovery read also fails', async () => {
+    const row = { bytes: 10, skillId: 'skill-a', relativePath: 'scripts/a.sh', file_id: 'file-a' };
+    const recoveryError = new Error('database unavailable during recovery');
+    const onCleanupError = jest.fn();
+    const persistence = createSkillFileQuotaPersistence({
+      resolveScope: resolveStorageScope,
+      upsertSkillFile: jest.fn(async () => {
+        throw new Error('ambiguous upsert failure');
+      }),
+      recoverCommittedSkillFile: jest.fn(async () => {
+        throw recoveryError;
+      }),
+      getUserStorageUsage: usageOf(0),
+      onCleanupError,
+    });
+
+    await expect(
+      persistence.persistSkillFile(makeReq({ storageLimitMb: 1 }), row, null),
+    ).resolves.toEqual(expect.objectContaining(row));
+    expect(onCleanupError).toHaveBeenCalledWith(recoveryError);
+  });
+
   it('caches effective configuration promises only inside the explicit run scope', async () => {
     const load = jest.fn(async () => ({ fileConfig: { storageLimit: 1 } }));
     const persistence = createSkillFileQuotaPersistence({

--- a/packages/api/src/files/quota.spec.ts
+++ b/packages/api/src/files/quota.spec.ts
@@ -1,6 +1,7 @@
 import type { UserStorageUsageParams } from '@librechat/data-schemas';
 import type { GetUserStorageUsage, StorageScope } from './quota';
 import {
+  createSkillFileQuotaPersistence,
   FILE_STORAGE_LIMIT_ERROR_CODE,
   FileStorageLimitError,
   isFileStorageLimitError,
@@ -1073,6 +1074,46 @@ describe('persistSkillFileWithQuota', () => {
     );
 
     expect(write).toHaveBeenCalledWith(expect.objectContaining({ tenantId: 'request-tenant' }));
+  });
+});
+
+describe('createSkillFileQuotaPersistence', () => {
+  it('reuses one ledger read only inside an explicit sync scope', async () => {
+    const row = {
+      bytes: 10,
+      skillId: '64f000000000000000000002',
+      relativePath: 'scripts/a.sh',
+    };
+    const getUserStorageUsage = usageOf(0);
+    const upsertSkillFile = jest.fn(async (row) => row);
+    const persistence = createSkillFileQuotaPersistence({
+      resolveScope: resolveStorageScope,
+      upsertSkillFile,
+      getUserStorageUsage,
+      onCleanupError: noRollbackErrors,
+    });
+
+    await persistence.runWithSharedScope(async () => {
+      await persistence.persistSkillFile(
+        makeReq({ storageLimitMb: 1, requestTenantId: 'tenant-a' }),
+        row,
+        null,
+      );
+      await persistence.persistSkillFile(
+        makeReq({ storageLimitMb: 1, requestTenantId: 'tenant-a' }),
+        { ...row, relativePath: 'scripts/b.sh' },
+        null,
+      );
+    });
+
+    expect(getUserStorageUsage).toHaveBeenCalledTimes(1);
+
+    await persistence.persistSkillFile(
+      makeReq({ storageLimitMb: 1, requestTenantId: 'tenant-a' }),
+      { ...row, relativePath: 'scripts/c.sh' },
+      null,
+    );
+    expect(getUserStorageUsage).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/packages/api/src/files/quota.spec.ts
+++ b/packages/api/src/files/quota.spec.ts
@@ -1146,12 +1146,14 @@ describe('createSkillFileQuotaPersistence', () => {
   it('keeps the quota charge when an ambiguous upsert failure already committed the row', async () => {
     const row = { bytes: 10, skillId: 'skill-a', relativePath: 'scripts/a.sh', file_id: 'file-a' };
     const committed = { ...row, _id: 'mongo-id' };
+    const repairCommittedSkillFile = jest.fn(async () => undefined);
     const persistence = createSkillFileQuotaPersistence({
       resolveScope: resolveStorageScope,
       upsertSkillFile: jest.fn(async () => {
         throw new Error('parent version update failed');
       }),
       recoverCommittedSkillFile: jest.fn(async () => committed),
+      repairCommittedSkillFile,
       getUserStorageUsage: usageOf(0),
       onCleanupError: noRollbackErrors,
     });
@@ -1159,6 +1161,9 @@ describe('createSkillFileQuotaPersistence', () => {
     await expect(
       persistence.persistSkillFile(makeReq({ storageLimitMb: 1 }), row, null),
     ).resolves.toBe(committed);
+    expect(repairCommittedSkillFile).toHaveBeenCalledWith(
+      expect.objectContaining({ skillId: 'skill-a', file_id: 'file-a' }),
+    );
   });
 
   it('caches effective configuration promises only inside the explicit run scope', async () => {

--- a/packages/api/src/files/quota.spec.ts
+++ b/packages/api/src/files/quota.spec.ts
@@ -1115,6 +1115,51 @@ describe('createSkillFileQuotaPersistence', () => {
     );
     expect(getUserStorageUsage).toHaveBeenCalledTimes(2);
   });
+
+  it('reloads ledger usage after a compensating restore invalidates the shared scope', async () => {
+    const req = makeReq({ storageLimitMb: 1, requestTenantId: 'tenant-a' });
+    const getUserStorageUsage = usageOf(0);
+    const persistence = createSkillFileQuotaPersistence({
+      resolveScope: resolveStorageScope,
+      upsertSkillFile: jest.fn(async (row) => row),
+      getUserStorageUsage,
+      onCleanupError: noRollbackErrors,
+    });
+
+    await persistence.runWithSharedScope(async () => {
+      await persistence.persistSkillFile(
+        req,
+        { bytes: 10, skillId: 'skill-a', relativePath: 'scripts/a.sh' },
+        null,
+      );
+      persistence.invalidateSharedScope(req);
+      await persistence.persistSkillFile(
+        req,
+        { bytes: 10, skillId: 'skill-a', relativePath: 'scripts/b.sh' },
+        null,
+      );
+    });
+
+    expect(getUserStorageUsage).toHaveBeenCalledTimes(2);
+  });
+
+  it('caches effective configuration promises only inside the explicit run scope', async () => {
+    const load = jest.fn(async () => ({ fileConfig: { storageLimit: 1 } }));
+    const persistence = createSkillFileQuotaPersistence({
+      resolveScope: resolveStorageScope,
+      upsertSkillFile: jest.fn(async (row) => row),
+      getUserStorageUsage: usageOf(0),
+      onCleanupError: noRollbackErrors,
+    });
+
+    await persistence.runWithSharedScope(async () => {
+      await persistence.getSharedValue('user-a\0tenant-a', load);
+      await persistence.getSharedValue('user-a\0tenant-a', load);
+    });
+    await persistence.getSharedValue('user-a\0tenant-a', load);
+
+    expect(load).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('isFileStorageLimitError', () => {

--- a/packages/api/src/files/quota.ts
+++ b/packages/api/src/files/quota.ts
@@ -522,15 +522,15 @@ export function createFileQuotaPersistence<TRequest, TResult>(
 }
 
 export type SkillFileRow = LedgerRow & {
-  skillId?: { toString(): string } | string;
+  skillId?: string;
   relativePath?: string;
-  author?: { toString(): string } | string;
+  author?: string;
 };
 
 export type SkillFileReplacement = {
-  skillId?: { toString(): string } | string;
+  skillId?: string;
   relativePath?: string;
-  author?: unknown;
+  author?: string;
   tenantId?: string | null;
   bytes?: number | null;
 };
@@ -606,7 +606,17 @@ export function createSkillFileQuotaPersistence<TRequest, TResult>(
             try {
               return await dependencies.upsertSkillFile(scopedRow);
             } catch (error) {
-              const committed = await dependencies.recoverCommittedSkillFile?.(scopedRow);
+              let committed: TResult | null | undefined;
+              try {
+                committed = await dependencies.recoverCommittedSkillFile?.(scopedRow);
+              } catch (recoveryError) {
+                /** The database cannot currently distinguish a rejected write from one
+                 * that committed before its parent side effect failed. Conservatively
+                 * preserve both the charge and blob until a later read can establish
+                 * the outcome; treating it as rejected would create a dangling row. */
+                dependencies.onCleanupError(recoveryError);
+                return scopedRow as unknown as TResult;
+              }
               if (committed != null) {
                 await dependencies.repairCommittedSkillFile?.(scopedRow);
                 return committed;

--- a/packages/api/src/files/quota.ts
+++ b/packages/api/src/files/quota.ts
@@ -538,6 +538,10 @@ export type SkillFileReplacement = {
 export type SkillFileQuotaPersistenceDependencies<TRequest, TResult> = {
   resolveScope: (req: TRequest) => StorageScope;
   upsertSkillFile: (row: SkillFileRow) => Promise<TResult>;
+  /** Re-read an exact attempted row after an ambiguous upsert failure. If the
+   *  row committed before a later side effect failed, returning it prevents
+   *  quota release and blob rollback for storage Mongo now references. */
+  recoverCommittedSkillFile?: (row: SkillFileRow) => Promise<TResult | null>;
   getUserStorageUsage: GetUserStorageUsage;
   onCleanupError: (error: unknown) => void;
 };
@@ -596,7 +600,17 @@ export function createSkillFileQuotaPersistence<TRequest, TResult>(
         {
           scope: getScope(req),
           row,
-          write: dependencies.upsertSkillFile,
+          write: async (scopedRow) => {
+            try {
+              return await dependencies.upsertSkillFile(scopedRow);
+            } catch (error) {
+              const committed = await dependencies.recoverCommittedSkillFile?.(scopedRow);
+              if (committed != null) {
+                return committed;
+              }
+              throw error;
+            }
+          },
           rollback: null,
           getUserStorageUsage: dependencies.getUserStorageUsage,
           replacing,

--- a/packages/api/src/files/quota.ts
+++ b/packages/api/src/files/quota.ts
@@ -542,6 +542,8 @@ export type SkillFileQuotaPersistenceDependencies<TRequest, TResult> = {
    *  row committed before a later side effect failed, returning it prevents
    *  quota release and blob rollback for storage Mongo now references. */
   recoverCommittedSkillFile?: (row: SkillFileRow) => Promise<TResult | null>;
+  /** Repairs parent metadata whose side effect may have failed after the row commit. */
+  repairCommittedSkillFile?: (row: SkillFileRow) => Promise<void>;
   getUserStorageUsage: GetUserStorageUsage;
   onCleanupError: (error: unknown) => void;
 };
@@ -606,6 +608,7 @@ export function createSkillFileQuotaPersistence<TRequest, TResult>(
             } catch (error) {
               const committed = await dependencies.recoverCommittedSkillFile?.(scopedRow);
               if (committed != null) {
+                await dependencies.repairCommittedSkillFile?.(scopedRow);
                 return committed;
               }
               throw error;

--- a/packages/api/src/files/quota.ts
+++ b/packages/api/src/files/quota.ts
@@ -548,7 +548,14 @@ export type SkillFileQuotaPersistence<TRequest, TResult> = {
     row: TRow,
     replacing: SkillFileReplacement | null,
   ) => Promise<TResult>;
+  getSharedValue: <T>(key: string, load: () => Promise<T>) => Promise<T>;
+  invalidateSharedScope: (req: TRequest) => void;
   runWithSharedScope: <T>(operation: () => Promise<T>) => Promise<T>;
+};
+
+type SharedSkillFileQuotaState = {
+  scopes: Map<string, StorageScope>;
+  values: Map<string, Promise<unknown>>;
 };
 
 /**
@@ -559,20 +566,23 @@ export type SkillFileQuotaPersistence<TRequest, TResult> = {
 export function createSkillFileQuotaPersistence<TRequest, TResult>(
   dependencies: SkillFileQuotaPersistenceDependencies<TRequest, TResult>,
 ): SkillFileQuotaPersistence<TRequest, TResult> {
-  const scopeStorage = new AsyncLocalStorage<Map<string, StorageScope>>();
+  const scopeStorage = new AsyncLocalStorage<SharedSkillFileQuotaState>();
+
+  const getScopeKey = (scope: StorageScope): string =>
+    `${scope.userId}\u0000${scope.tenantId ?? ''}\u0000${scope.storageLimit ?? ''}`;
 
   const getScope = (req: TRequest): StorageScope => {
     const resolved = dependencies.resolveScope(req);
-    const scopes = scopeStorage.getStore();
-    if (!scopes) {
+    const state = scopeStorage.getStore();
+    if (!state) {
       return resolved;
     }
-    const key = `${resolved.userId}\u0000${resolved.tenantId ?? ''}\u0000${resolved.storageLimit ?? ''}`;
-    const existing = scopes.get(key);
+    const key = getScopeKey(resolved);
+    const existing = state.scopes.get(key);
     if (existing) {
       return existing;
     }
-    scopes.set(key, resolved);
+    state.scopes.set(key, resolved);
     return resolved;
   };
 
@@ -594,8 +604,33 @@ export function createSkillFileQuotaPersistence<TRequest, TResult>(
         },
         dependencies.onCleanupError,
       ),
+    getSharedValue: <T>(key: string, load: () => Promise<T>): Promise<T> => {
+      const state = scopeStorage.getStore();
+      if (!state) {
+        return load();
+      }
+      const existing = state.values.get(key) as Promise<T> | undefined;
+      if (existing) {
+        return existing;
+      }
+      const value = load();
+      state.values.set(key, value);
+      return value;
+    },
+    invalidateSharedScope: (req: TRequest): void => {
+      const state = scopeStorage.getStore();
+      if (!state) {
+        return;
+      }
+      const scope = dependencies.resolveScope(req);
+      scope.currentUsage = undefined;
+      scope.pendingRead = undefined;
+      scope.replacementBytes = undefined;
+      scope.replacementLocks = undefined;
+      state.scopes.delete(getScopeKey(scope));
+    },
     runWithSharedScope: <T>(operation: () => Promise<T>): Promise<T> =>
-      scopeStorage.run(new Map(), operation),
+      scopeStorage.run({ scopes: new Map(), values: new Map() }, operation),
   };
 }
 

--- a/packages/api/src/files/quota.ts
+++ b/packages/api/src/files/quota.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { megabyte, mergeFileConfig } from 'librechat-data-provider';
 
 export const FILE_STORAGE_LIMIT_ERROR_CODE = 'FILE_STORAGE_LIMIT_EXCEEDED';
@@ -526,6 +527,78 @@ export type SkillFileRow = LedgerRow & {
   author?: { toString(): string } | string;
 };
 
+export type SkillFileReplacement = {
+  skillId?: { toString(): string } | string;
+  relativePath?: string;
+  author?: unknown;
+  tenantId?: string | null;
+  bytes?: number | null;
+};
+
+export type SkillFileQuotaPersistenceDependencies<TRequest, TResult> = {
+  resolveScope: (req: TRequest) => StorageScope;
+  upsertSkillFile: (row: SkillFileRow) => Promise<TResult>;
+  getUserStorageUsage: GetUserStorageUsage;
+  onCleanupError: (error: unknown) => void;
+};
+
+export type SkillFileQuotaPersistence<TRequest, TResult> = {
+  persistSkillFile: <TRow extends SkillFileRow>(
+    req: TRequest,
+    row: TRow,
+    replacing: SkillFileReplacement | null,
+  ) => Promise<TResult>;
+  runWithSharedScope: <T>(operation: () => Promise<T>) => Promise<T>;
+};
+
+/**
+ * Builds the SkillFile write boundary. A sync run may opt into shared scopes so its
+ * serial file writes reuse one usage read per owner/tenant without leaking cached
+ * usage into later runs or concurrent async chains.
+ */
+export function createSkillFileQuotaPersistence<TRequest, TResult>(
+  dependencies: SkillFileQuotaPersistenceDependencies<TRequest, TResult>,
+): SkillFileQuotaPersistence<TRequest, TResult> {
+  const scopeStorage = new AsyncLocalStorage<Map<string, StorageScope>>();
+
+  const getScope = (req: TRequest): StorageScope => {
+    const resolved = dependencies.resolveScope(req);
+    const scopes = scopeStorage.getStore();
+    if (!scopes) {
+      return resolved;
+    }
+    const key = `${resolved.userId}\u0000${resolved.tenantId ?? ''}\u0000${resolved.storageLimit ?? ''}`;
+    const existing = scopes.get(key);
+    if (existing) {
+      return existing;
+    }
+    scopes.set(key, resolved);
+    return resolved;
+  };
+
+  return {
+    persistSkillFile: <TRow extends SkillFileRow>(
+      req: TRequest,
+      row: TRow,
+      replacing: SkillFileReplacement | null,
+    ): Promise<TResult> =>
+      persistSkillFileWithQuota(
+        {
+          scope: getScope(req),
+          row,
+          write: dependencies.upsertSkillFile,
+          rollback: null,
+          getUserStorageUsage: dependencies.getUserStorageUsage,
+          replacing,
+          replacedBytes: replacing?.bytes,
+        },
+        dependencies.onCleanupError,
+      ),
+    runWithSharedScope: <T>(operation: () => Promise<T>): Promise<T> =>
+      scopeStorage.run(new Map(), operation),
+  };
+}
+
 /**
  * Persists a `File` row under this request's storage scope.
  *
@@ -573,12 +646,7 @@ export function persistFileWithQuota<TRow extends FileRow, TResult>(
  */
 export function persistSkillFileWithQuota<TRow extends SkillFileRow, TResult>(
   params: PersistParams<TRow, TResult> & {
-    replacing?: {
-      skillId?: { toString(): string } | string;
-      relativePath?: string;
-      author?: unknown;
-      tenantId?: string | null;
-    } | null;
+    replacing?: SkillFileReplacement | null;
   },
   onRollbackError: (error: unknown) => void,
 ): Promise<TResult> {

--- a/packages/api/src/skills/sync/github.spec.ts
+++ b/packages/api/src/skills/sync/github.spec.ts
@@ -2933,6 +2933,7 @@ describe('createGitHubSkillSyncRunner', () => {
       filepath: '/uploads/old.sh',
     };
     const deleteSkillFile = jest.fn(async () => ({ deleted: true }));
+    const invalidateQuotaScope = jest.fn(async () => {});
     const saveBuffer = jest.fn(async () => ({
       filepath: '/uploads/file-id__run.sh',
       source: 'local',
@@ -2942,6 +2943,7 @@ describe('createGitHubSkillSyncRunner', () => {
       getSkillById: jest.fn(async () => existing),
       listSkillFiles: jest.fn(async () => [staleFile]),
       deleteSkillFile,
+      invalidateQuotaScope,
       saveBuffer,
       updateSkill: jest.fn(async () => ({
         status: 'updated' as const,
@@ -2954,6 +2956,10 @@ describe('createGitHubSkillSyncRunner', () => {
 
     expect(result.status).toBe('completed');
     expect(deps.deleteSkillFile).toHaveBeenCalledWith(existing._id, 'scripts/old.sh');
+    expect(invalidateQuotaScope).toHaveBeenCalledWith({
+      author: staleFile.author,
+      tenantId: staleFile.tenantId,
+    });
     expect(deleteSkillFile.mock.invocationCallOrder[0]).toBeLessThan(
       saveBuffer.mock.invocationCallOrder[0],
     );

--- a/packages/api/src/skills/sync/github.spec.ts
+++ b/packages/api/src/skills/sync/github.spec.ts
@@ -305,22 +305,7 @@ function createDeps(
         author: new Types.ObjectId(),
       } as ISkillFile & { _id: Types.ObjectId };
     }),
-    restoreSkillFile: jest.fn(async () => {
-      return {
-        _id: new Types.ObjectId(),
-        skillId: new Types.ObjectId(),
-        relativePath: 'scripts/run.sh',
-        file_id: 'file-id',
-        filename: 'run.sh',
-        filepath: '/uploads/file-id__run.sh',
-        source: 'local',
-        mimeType: 'application/x-sh',
-        bytes: 7,
-        category: 'script',
-        isExecutable: false,
-        author: new Types.ObjectId(),
-      } as ISkillFile & { _id: Types.ObjectId };
-    }),
+    restoreSkillFile: jest.fn(async () => undefined),
     deleteSkillFile: jest.fn(async () => ({ deleted: true })),
     deleteSkill: jest.fn(async () => ({ deleted: true })),
     saveBuffer: jest.fn(async () => ({ filepath: '/uploads/file-id__run.sh', source: 'local' })),
@@ -2923,6 +2908,57 @@ describe('createGitHubSkillSyncRunner', () => {
     expect(deps.updateSkill).not.toHaveBeenCalled();
   });
 
+  it('deletes stale paths before admitting newly added paths', async () => {
+    const existing = makeSkill({
+      name: 'research',
+      description: 'Old description',
+      body: 'Old body',
+      author: new Types.ObjectId(),
+      authorName: 'GitHub Sync',
+      source: 'github',
+      sourceMetadata: {
+        provider: 'github',
+        sourceId: 'librechat-skills',
+        upstreamId: 'librechat-skills:skills/research',
+        owner: 'LibreChat',
+        repo: 'skills',
+        ref: 'main',
+        skillPath: 'skills/research',
+      },
+    }) as ISkill & { _id: Types.ObjectId };
+    const staleFile = {
+      ...makeSkillFile(existing),
+      relativePath: 'scripts/old.sh',
+      filename: 'old.sh',
+      filepath: '/uploads/old.sh',
+    };
+    const deleteSkillFile = jest.fn(async () => ({ deleted: true }));
+    const saveBuffer = jest.fn(async () => ({
+      filepath: '/uploads/file-id__run.sh',
+      source: 'local',
+    }));
+    const deps = createDeps({
+      findSkillBySourceIdentity: jest.fn(async () => existing),
+      getSkillById: jest.fn(async () => existing),
+      listSkillFiles: jest.fn(async () => [staleFile]),
+      deleteSkillFile,
+      saveBuffer,
+      updateSkill: jest.fn(async () => ({
+        status: 'updated' as const,
+        skill: { ...existing, version: existing.version + 1 },
+        warnings: [],
+      })),
+    });
+
+    const result = await createGitHubSkillSyncRunner(deps).runOnce();
+
+    expect(result.status).toBe('completed');
+    expect(deps.deleteSkillFile).toHaveBeenCalledWith(existing._id, 'scripts/old.sh');
+    expect(deleteSkillFile.mock.invocationCallOrder[0]).toBeLessThan(
+      saveBuffer.mock.invocationCallOrder[0],
+    );
+  });
+
   it('restores existing skill files when the skill update fails after file sync', async () => {
     const existing = makeSkill({
       name: 'research',
@@ -2980,7 +3016,12 @@ describe('createGitHubSkillSyncRunner', () => {
       ),
       listSkillFiles: jest.fn(async () => Array.from(files.values())),
       upsertSkillFile,
-      restoreSkillFile: upsertSkillFile,
+      restoreSkillFile: jest.fn(async (row) => {
+        await upsertSkillFile({
+          ...row,
+          author: new Types.ObjectId(row.author),
+        });
+      }),
       deleteSkillFile: jest.fn(async (_skillId, relativePath) => ({
         deleted: files.delete(relativePath),
       })),
@@ -3494,6 +3535,23 @@ describe('repository adapter seam', () => {
   });
 
   it('re-downloads a file only when the adapter reports a new content id', async () => {
+    const existingFile = {
+      _id: new Types.ObjectId(),
+      skillId: new Types.ObjectId(),
+      relativePath: 'scripts/run.sh',
+      file_id: 'existing-file-id',
+      filename: 'run.sh',
+      filepath: '/uploads/existing-file-id__run.sh',
+      source: 'local',
+      sourceMetadata: { blobSha: 'skills/research/scripts/run.sh@1' },
+      mimeType: 'application/x-sh',
+      bytes: 7,
+      category: 'script' as const,
+      isExecutable: false,
+      author: new Types.ObjectId(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
     const deps = createDeps({
       createAdapter: () =>
         createFakeAdapter({
@@ -3501,23 +3559,7 @@ describe('repository adapter seam', () => {
             '---\nname: research\ndescription: Research things\n---\nBody',
           'skills/research/scripts/run.sh': 'echo hi',
         }),
-      getSkillFileByPath: jest.fn(async () => ({
-        _id: new Types.ObjectId(),
-        skillId: new Types.ObjectId(),
-        relativePath: 'scripts/run.sh',
-        file_id: 'existing-file-id',
-        filename: 'run.sh',
-        filepath: '/uploads/existing-file-id__run.sh',
-        source: 'local',
-        sourceMetadata: { blobSha: 'skills/research/scripts/run.sh@1' },
-        mimeType: 'application/x-sh',
-        bytes: 7,
-        category: 'script' as const,
-        isExecutable: false,
-        author: new Types.ObjectId(),
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      })),
+      listSkillFiles: jest.fn(async () => [existingFile]),
     });
 
     const result = await createGitHubSkillSyncRunner(deps).runOnce();

--- a/packages/api/src/skills/sync/github.spec.ts
+++ b/packages/api/src/skills/sync/github.spec.ts
@@ -305,6 +305,22 @@ function createDeps(
         author: new Types.ObjectId(),
       } as ISkillFile & { _id: Types.ObjectId };
     }),
+    restoreSkillFile: jest.fn(async () => {
+      return {
+        _id: new Types.ObjectId(),
+        skillId: new Types.ObjectId(),
+        relativePath: 'scripts/run.sh',
+        file_id: 'file-id',
+        filename: 'run.sh',
+        filepath: '/uploads/file-id__run.sh',
+        source: 'local',
+        mimeType: 'application/x-sh',
+        bytes: 7,
+        category: 'script',
+        isExecutable: false,
+        author: new Types.ObjectId(),
+      } as ISkillFile & { _id: Types.ObjectId };
+    }),
     deleteSkillFile: jest.fn(async () => ({ deleted: true })),
     deleteSkill: jest.fn(async () => ({ deleted: true })),
     saveBuffer: jest.fn(async () => ({ filepath: '/uploads/file-id__run.sh', source: 'local' })),
@@ -354,6 +370,7 @@ describe('createGitHubSkillSyncRunner', () => {
           commitSha: 'commit-sha',
         }),
       }),
+      null,
     );
     expect(deps.grantPermission).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1249,6 +1266,7 @@ describe('createGitHubSkillSyncRunner', () => {
           path: 'skills/engineering/tdd/tests.md',
         }),
       }),
+      null,
     );
   });
 
@@ -2962,6 +2980,7 @@ describe('createGitHubSkillSyncRunner', () => {
       ),
       listSkillFiles: jest.fn(async () => Array.from(files.values())),
       upsertSkillFile,
+      restoreSkillFile: upsertSkillFile,
       deleteSkillFile: jest.fn(async (_skillId, relativePath) => ({
         deleted: files.delete(relativePath),
       })),
@@ -3470,6 +3489,7 @@ describe('repository adapter seam', () => {
           blobSha: 'skills/research/scripts/run.sh@1',
         }),
       }),
+      null,
     );
   });
 
@@ -3526,6 +3546,7 @@ describe('files whose paths cannot be mirrored', () => {
     expect(deps.createSkill).toHaveBeenCalledTimes(1);
     expect(deps.upsertSkillFile).toHaveBeenCalledWith(
       expect.objectContaining({ relativePath: 'scripts/run.sh' }),
+      null,
     );
     expect(deps.upsertStatus).toHaveBeenLastCalledWith(
       expect.objectContaining({

--- a/packages/api/src/skills/sync/github.ts
+++ b/packages/api/src/skills/sync/github.ts
@@ -155,6 +155,8 @@ type RestorableSkillFile = {
 };
 
 type SkillFileReplacement = {
+  skillId?: { toString(): string } | string;
+  relativePath?: string;
   author?: unknown;
   tenantId?: string | null;
   bytes?: number | null;

--- a/packages/api/src/skills/sync/github.ts
+++ b/packages/api/src/skills/sync/github.ts
@@ -154,6 +154,12 @@ type RestorableSkillFile = {
   tenantId?: string;
 };
 
+type SkillFileReplacement = {
+  author?: unknown;
+  tenantId?: string | null;
+  bytes?: number | null;
+};
+
 type DeletedSyncedSkillJournal = {
   skill: ISkill & { _id: Types.ObjectId };
   files: Array<ISkillFile & { _id: Types.ObjectId }>;
@@ -224,7 +230,7 @@ export type GitHubSkillSyncDeps = {
   ) => Promise<(ISkillFile & { _id: Types.ObjectId }) | null>;
   upsertSkillFile: (
     row: UpsertSkillFileInput,
-    replacing: (ISkillFile & { _id: Types.ObjectId }) | null,
+    replacing: SkillFileReplacement | null,
   ) => Promise<ISkillFile & { _id: Types.ObjectId }>;
   /** Restores rows that already existed before this run without admitting new storage. */
   restoreSkillFile: (row: RestorableSkillFile) => Promise<void>;
@@ -1309,6 +1315,13 @@ async function deleteNameConflictingStaleSkill(params: {
     throw makeStaleDeletionFailure(error);
   });
   const staleSkillId = staleSkill._id.toString();
+  for (const file of deletedSkill.files) {
+    try {
+      await params.deps.invalidateQuotaScope?.({ author: file.author, tenantId: file.tenantId });
+    } catch (error) {
+      logger.error('[GitHubSkillSync] Failed to invalidate deleted skill quota scope:', error);
+    }
+  }
 
   return {
     remainingSkills: params.existingSyncedSkills.filter(

--- a/packages/api/src/skills/sync/github.ts
+++ b/packages/api/src/skills/sync/github.ts
@@ -201,7 +201,12 @@ export type GitHubSkillSyncDeps = {
     skillId: string | Types.ObjectId,
     relativePath: string,
   ) => Promise<(ISkillFile & { _id: Types.ObjectId }) | null>;
-  upsertSkillFile: (row: UpsertSkillFileInput) => Promise<ISkillFile & { _id: Types.ObjectId }>;
+  upsertSkillFile: (
+    row: UpsertSkillFileInput,
+    replacing: (ISkillFile & { _id: Types.ObjectId }) | null,
+  ) => Promise<ISkillFile & { _id: Types.ObjectId }>;
+  /** Restores rows that already existed before this run without admitting new storage. */
+  restoreSkillFile: (row: UpsertSkillFileInput) => Promise<ISkillFile & { _id: Types.ObjectId }>;
   deleteSkillFile: (
     skillId: string | Types.ObjectId,
     relativePath: string,
@@ -1057,7 +1062,7 @@ async function restoreExistingSkillFiles(params: {
     await deps.deleteSkillFile(skill._id, file.relativePath);
   }
   for (const file of previousFiles) {
-    await deps.upsertSkillFile(toSkillFileInput(file));
+    await deps.restoreSkillFile(toSkillFileInput(file));
   }
   await cleanupStoredFiles({
     deps,
@@ -1085,7 +1090,7 @@ async function restoreDeletedSyncedSkill(
 ): Promise<void> {
   const restored = await deps.createSkill(toCreateSkillInput(deleted.skill));
   for (const file of deleted.files) {
-    await deps.upsertSkillFile({
+    await deps.restoreSkillFile({
       ...toSkillFileInput(file),
       skillId: restored.skill._id,
     });
@@ -1339,29 +1344,32 @@ async function syncSkillFiles(params: {
     });
     const savedFile = toStoredFileRef({ saved, author: skill.author, tenantId: skill.tenantId });
     try {
-      await deps.upsertSkillFile({
-        skillId: skill._id,
-        relativePath,
-        file_id: fileId,
-        filename,
-        filepath: saved.filepath,
-        storageKey: saved.storageKey,
-        storageRegion: saved.storageRegion,
-        source: saved.source,
-        sourceMetadata: {
-          provider: PROVIDER,
-          sourceId: source.id,
-          upstreamId: makeUpstreamId(source, discovered.rootPath),
-          commitSha: commit.id,
-          blobSha: entry.id,
-          path: entry.path,
+      await deps.upsertSkillFile(
+        {
+          skillId: skill._id,
+          relativePath,
+          file_id: fileId,
+          filename,
+          filepath: saved.filepath,
+          storageKey: saved.storageKey,
+          storageRegion: saved.storageRegion,
+          source: saved.source,
+          sourceMetadata: {
+            provider: PROVIDER,
+            sourceId: source.id,
+            upstreamId: makeUpstreamId(source, discovered.rootPath),
+            commitSha: commit.id,
+            blobSha: entry.id,
+            path: entry.path,
+          },
+          mimeType,
+          bytes: buffer.length,
+          isExecutable: false,
+          author: skill.author,
+          tenantId: skill.tenantId,
         },
-        mimeType,
-        bytes: buffer.length,
-        isExecutable: false,
-        author: skill.author,
-        tenantId: skill.tenantId,
-      });
+        existing,
+      );
     } catch (error) {
       await cleanupFile(deps, savedFile).catch((cleanupError) => {
         logger.error('[GitHubSkillSync] Failed to clean up orphaned synced file:', cleanupError);

--- a/packages/api/src/skills/sync/github.ts
+++ b/packages/api/src/skills/sync/github.ts
@@ -155,9 +155,9 @@ type RestorableSkillFile = {
 };
 
 type SkillFileReplacement = {
-  skillId?: { toString(): string } | string;
-  relativePath?: string;
-  author?: unknown;
+  skillId: string;
+  relativePath: string;
+  author: string;
   tenantId?: string | null;
   bytes?: number | null;
 };
@@ -1425,7 +1425,15 @@ async function syncSkillFiles(params: {
           author: skill.author,
           tenantId: skill.tenantId,
         },
-        existing,
+        existing
+          ? {
+              skillId: existing.skillId.toString(),
+              relativePath: existing.relativePath,
+              author: existing.author.toString(),
+              tenantId: existing.tenantId,
+              bytes: existing.bytes,
+            }
+          : null,
       );
     } catch (error) {
       await cleanupFile(deps, savedFile).catch((cleanupError) => {

--- a/packages/api/src/skills/sync/github.ts
+++ b/packages/api/src/skills/sync/github.ts
@@ -24,7 +24,11 @@ import type {
   SkillSyncCredentialSummary,
   SkillSyncStatusInput,
 } from '@librechat/data-schemas';
-import type { SkillSyncConfig, SkillSyncGitHubSourceConfig } from 'librechat-data-provider';
+import type {
+  SkillSyncConfig,
+  SkillSourceMetadata,
+  SkillSyncGitHubSourceConfig,
+} from 'librechat-data-provider';
 import type {
   RepoCommit,
   RepoTreeEntry,
@@ -133,6 +137,23 @@ type StoredSkillFileRef = {
   tenantId?: string;
 };
 
+type RestorableSkillFile = {
+  skillId: string;
+  relativePath: string;
+  file_id: string;
+  filename: string;
+  filepath: string;
+  storageKey?: string;
+  storageRegion?: string;
+  source: string;
+  sourceMetadata?: SkillSourceMetadata;
+  mimeType: string;
+  bytes: number;
+  isExecutable?: boolean;
+  author: string;
+  tenantId?: string;
+};
+
 type DeletedSyncedSkillJournal = {
   skill: ISkill & { _id: Types.ObjectId };
   files: Array<ISkillFile & { _id: Types.ObjectId }>;
@@ -206,7 +227,7 @@ export type GitHubSkillSyncDeps = {
     replacing: (ISkillFile & { _id: Types.ObjectId }) | null,
   ) => Promise<ISkillFile & { _id: Types.ObjectId }>;
   /** Restores rows that already existed before this run without admitting new storage. */
-  restoreSkillFile: (row: UpsertSkillFileInput) => Promise<ISkillFile & { _id: Types.ObjectId }>;
+  restoreSkillFile: (row: RestorableSkillFile) => Promise<void>;
   deleteSkillFile: (
     skillId: string | Types.ObjectId,
     relativePath: string,
@@ -968,9 +989,9 @@ function toStoredFileRef(params: {
   };
 }
 
-function toSkillFileInput(file: ISkillFile & { _id: Types.ObjectId }): UpsertSkillFileInput {
+function toSkillFileInput(file: ISkillFile & { _id: Types.ObjectId }): RestorableSkillFile {
   return {
-    skillId: file.skillId,
+    skillId: file.skillId.toString(),
     relativePath: file.relativePath,
     file_id: file.file_id,
     filename: file.filename,
@@ -978,11 +999,11 @@ function toSkillFileInput(file: ISkillFile & { _id: Types.ObjectId }): UpsertSki
     storageKey: file.storageKey,
     storageRegion: file.storageRegion,
     source: file.source,
-    sourceMetadata: file.sourceMetadata,
+    sourceMetadata: file.sourceMetadata as SkillSourceMetadata | undefined,
     mimeType: file.mimeType,
     bytes: file.bytes,
     isExecutable: file.isExecutable,
-    author: file.author,
+    author: file.author.toString(),
     tenantId: file.tenantId,
   };
 }
@@ -1092,7 +1113,7 @@ async function restoreDeletedSyncedSkill(
   for (const file of deleted.files) {
     await deps.restoreSkillFile({
       ...toSkillFileInput(file),
-      skillId: restored.skill._id,
+      skillId: restored.skill._id.toString(),
     });
   }
   await ensurePublicViewer(deps, restored.skill._id);
@@ -1311,12 +1332,12 @@ async function syncSkillFiles(params: {
   const { deps, adapter, commit, source, skill, discovered, assertNotCancelled } = params;
   const journal = params.journal ?? { staleFiles: [], savedFiles: [] };
   const remotePaths = new Set<string>();
+  const syncEntries: Array<{ entry: RepoTreeEntry; relativePath: string }> = [];
   let syncedFileCount = 0;
   let deletedFileCount = 0;
   let totalFileBytes = 0;
 
   for (const entry of discovered.files) {
-    assertNotCancelled();
     const relativePath = getDiscoveredRelativePath(discovered, entry);
     if (!isSafeRelativePath(relativePath) || relativePath.toUpperCase() === 'SKILL.MD') {
       continue;
@@ -1324,7 +1345,26 @@ async function syncSkillFiles(params: {
     totalFileBytes += assertGitHubBlobSize(entry, relativePath);
     assertCumulativeGitHubFileSize(totalFileBytes);
     remotePaths.add(relativePath);
-    const existing = await deps.getSkillFileByPath(skill._id, relativePath);
+    syncEntries.push({ entry, relativePath });
+  }
+
+  const existingFiles = await deps.listSkillFiles(skill._id);
+  const existingByPath = new Map(existingFiles.map((file) => [file.relativePath, file]));
+  for (const file of existingFiles) {
+    assertNotCancelled();
+    if (remotePaths.has(file.relativePath)) {
+      continue;
+    }
+    const result = await deps.deleteSkillFile(skill._id, file.relativePath);
+    if (result.deleted) {
+      deletedFileCount++;
+      journal.staleFiles.push(file);
+    }
+  }
+
+  for (const { entry, relativePath } of syncEntries) {
+    assertNotCancelled();
+    const existing = existingByPath.get(relativePath) ?? null;
     if (existing && getSourceMetadataString(existing, 'blobSha') === entry.id) {
       continue;
     }
@@ -1381,19 +1421,6 @@ async function syncSkillFiles(params: {
     journal.savedFiles.push(savedFile);
     if (existing && existing.filepath !== saved.filepath) {
       journal.staleFiles.push(existing);
-    }
-  }
-
-  const existingFiles = await deps.listSkillFiles(skill._id);
-  for (const file of existingFiles) {
-    assertNotCancelled();
-    if (remotePaths.has(file.relativePath)) {
-      continue;
-    }
-    const result = await deps.deleteSkillFile(skill._id, file.relativePath);
-    if (result.deleted) {
-      deletedFileCount++;
-      journal.staleFiles.push(file);
     }
   }
   return { syncedFileCount, deletedFileCount, ...journal };

--- a/packages/api/src/skills/sync/github.ts
+++ b/packages/api/src/skills/sync/github.ts
@@ -232,6 +232,7 @@ export type GitHubSkillSyncDeps = {
     skillId: string | Types.ObjectId,
     relativePath: string,
   ) => Promise<{ deleted: boolean }>;
+  invalidateQuotaScope?: (owner: { author: unknown; tenantId?: string | null }) => Promise<void>;
   deleteSkill: (id: string) => Promise<{ deleted: boolean }>;
   saveBuffer: (params: {
     userId: string;
@@ -1359,6 +1360,7 @@ async function syncSkillFiles(params: {
     if (result.deleted) {
       deletedFileCount++;
       journal.staleFiles.push(file);
+      await deps.invalidateQuotaScope?.({ author: file.author, tenantId: file.tenantId });
     }
   }
 

--- a/packages/data-schemas/src/methods/skill.ts
+++ b/packages/data-schemas/src/methods/skill.ts
@@ -1071,6 +1071,7 @@ export function createSkillMethods(
     skillId: Types.ObjectId | string,
   ) => Promise<Array<ISkillFile & { _id: Types.ObjectId }>>;
   upsertSkillFile: (row: UpsertSkillFileInput) => Promise<ISkillFile & { _id: Types.ObjectId }>;
+  reconcileSkillFileCount: (skillId: Types.ObjectId | string) => Promise<void>;
   deleteSkillFile: (
     skillId: Types.ObjectId | string,
     relativePath: string,
@@ -1867,6 +1868,19 @@ export function createSkillMethods(
     return current;
   }
 
+  async function reconcileSkillFileCount(skillId: Types.ObjectId | string): Promise<void> {
+    const Skill = mongoose.models.Skill as Model<ISkillDocument>;
+    const SkillFile = mongoose.models.SkillFile as Model<ISkillFileDocument>;
+    const fileCount = await SkillFile.countDocuments({ skillId });
+    const updated = await Skill.findByIdAndUpdate(skillId, {
+      $set: { fileCount },
+      $inc: { version: 1 },
+    });
+    if (!updated) {
+      throw new Error('Cannot reconcile files for a missing skill');
+    }
+  }
+
   async function deleteSkillFile(
     skillId: Types.ObjectId | string,
     relativePath: string,
@@ -1953,6 +1967,7 @@ export function createSkillMethods(
     listSkillsBySource,
     listSkillFiles,
     upsertSkillFile,
+    reconcileSkillFileCount,
     deleteSkillFile,
     getSkillFileByPath,
     updateSkillFileContent,


### PR DESCRIPTION
## Summary

This PR routes every server-owned `SkillFile` upsert through the storage-quota ledger, including direct uploads, archive imports, agent skill authoring, and GitHub synchronization.

- Add one quota-aware SkillFile persistence boundary with replacement-delta accounting.
- Normalize direct and CommonJS adapter identities before quota accounting and recovery.
- Charge bytes to the authenticated author and resolved tenant scope.
- Preserve each workflow's blob and multi-file rollback ownership.
- Wrap request imports with request-bound persistence dependencies.
- Build authenticated synthetic scopes for scheduled GitHub sync writes.
- Invalidate shared run usage after stale-file deletion.
- Recover rows that committed before a later parent-version side effect failed without misclassifying the committed write.

Depends on #15222. Final response propagation, Code outputs, provider cleanup, and enforcement guards are in #15789.

Known follow-up: very large GitHub skill synchronizations currently perform serial primary usage/replacement reads per file. This is correct and bounded by the durable ledger, but batched accounting is a worthwhile performance optimization in a later focused PR.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Final top-of-stack focused run: package API 4 suites / 253 tests, data schemas 2 suites / 113 tests, server API 12 suites / 439 tests.
- TypeScript and package builds pass across data-provider, data-schemas, packages API, server API, and client.
- Targeted lint/format/import checks and `git diff --check` pass.
- Restacked on current #15222 after rebasing the full chain onto `origin/dev` at `ac2307b2ef`.
- Required CI is the authoritative broad matrix.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
