### PR TITLE
🛡️ feat: Complete Storage Quota Enforcement

### DIFF
--- a/api/server/routes/files/files.agents.test.js
+++ b/api/server/routes/files/files.agents.test.js
@@ -73,7 +73,7 @@ jest.mock('fs', () => {
 });
 
 const { processAgentFileUpload } = require('~/server/services/Files/process');
-const { UninspectableFileError } = require('@librechat/api');
+const { FileStorageLimitError, UninspectableFileError } = require('@librechat/api');
 
 // Import the router
 const router = require('~/server/routes/files/files');
@@ -1283,6 +1283,34 @@ describe('File Routes - Agent Files Endpoint', () => {
 
       expect(response.status).toBe(400);
       expect(response.body).toEqual({ message: legacyMessage });
+    });
+
+    it('does not expose an upstream provider status as an application auth failure', async () => {
+      processAgentFileUpload.mockRejectedValueOnce(
+        Object.assign(new Error('provider rejected credentials'), { status: 401 }),
+      );
+      const testApp = createAppWithUser(otherUserId);
+
+      const response = await request(testApp).post('/files').send({
+        endpoint: 'agents',
+        file_id: uuidv4(),
+      });
+
+      expect(response.status).toBe(500);
+      expect(response.body).toEqual({ message: 'Error processing file' });
+    });
+
+    it('returns 413 only for the application storage quota error', async () => {
+      processAgentFileUpload.mockRejectedValueOnce(new FileStorageLimitError(100, 100));
+      const testApp = createAppWithUser(otherUserId);
+
+      const response = await request(testApp).post('/files').send({
+        endpoint: 'agents',
+        file_id: uuidv4(),
+      });
+
+      expect(response.status).toBe(413);
+      expect(response.body.message).toMatch(/storage limit/i);
     });
 
     it.each([

--- a/api/server/routes/files/images.agents.test.js
+++ b/api/server/routes/files/images.agents.test.js
@@ -49,7 +49,7 @@ const fs = require('fs');
 const { processAgentFileUpload, processImageFile } = require('~/server/services/Files/process');
 const { resolveEffectiveToolResource } = require('~/server/services/Files/routing');
 const { filterFile } = require('~/server/services/Files/process');
-const { UninspectableFileError } = require('@librechat/api');
+const { FileStorageLimitError, UninspectableFileError } = require('@librechat/api');
 
 const router = require('~/server/routes/files/images');
 
@@ -729,6 +729,32 @@ describe('POST /images - Agent Upload Permission Check (Integration)', () => {
 
     expect(response.status).toBe(500);
     expect(response.body).toEqual({ message: legacyMessage });
+  });
+
+  it('returns 413 only for the typed storage quota error', async () => {
+    processImageFile.mockRejectedValueOnce(new FileStorageLimitError(100, 100));
+    const app = createAppWithUser(otherUserId);
+
+    const response = await request(app).post('/images').send({
+      endpoint: 'agents',
+      file_id: uuidv4(),
+    });
+
+    expect(response.status).toBe(413);
+  });
+
+  it('does not trust an unrelated provider status of 413', async () => {
+    processImageFile.mockRejectedValueOnce(
+      Object.assign(new Error('provider rejected'), { status: 413 }),
+    );
+    const app = createAppWithUser(otherUserId);
+
+    const response = await request(app).post('/images').send({
+      endpoint: 'agents',
+      file_id: uuidv4(),
+    });
+
+    expect(response.status).toBe(500);
   });
 
   it.each([

--- a/api/server/routes/skills.js
+++ b/api/server/routes/skills.js
@@ -9,6 +9,7 @@ const {
   getStorageMetadata,
   resolveRequestTenantId,
   restoreTenantContextFromReq,
+  isFileStorageLimitError,
 } = require('@librechat/api');
 const { logger } = require('@librechat/data-schemas');
 const {
@@ -259,7 +260,7 @@ async function uploadFileHandler(req, res) {
 
     return res.status(200).json(result);
   } catch (error) {
-    if (error?.status === 413) {
+    if (isFileStorageLimitError(error)) {
       return res.status(413).json({ error: error.message, code: error.code });
     }
     if (error.code === 'SKILL_FILE_VALIDATION_FAILED') {

--- a/api/server/routes/skills.js
+++ b/api/server/routes/skills.js
@@ -259,6 +259,9 @@ async function uploadFileHandler(req, res) {
 
     return res.status(200).json(result);
   } catch (error) {
+    if (error?.status === 413) {
+      return res.status(413).json({ error: error.message, code: error.code });
+    }
     if (error.code === 'SKILL_FILE_VALIDATION_FAILED') {
       return res.status(400).json({ error: error.message });
     }

--- a/api/server/routes/skills.test.js
+++ b/api/server/routes/skills.test.js
@@ -31,7 +31,7 @@ const {
   PrincipalType,
   PermissionBits,
 } = require('librechat-data-provider');
-const { CONTENT_TRAVERSAL_MAX_DEPTH } = require('@librechat/api');
+const { CONTENT_TRAVERSAL_MAX_DEPTH, FileStorageLimitError } = require('@librechat/api');
 
 let mockFileConfig;
 let mockFilters;
@@ -93,6 +93,7 @@ jest.mock('~/models', () => {
   return {
     ...methods,
     getRoleByName: jest.fn(),
+    upsertSkillFile: jest.fn(methods.upsertSkillFile),
   };
 });
 
@@ -748,6 +749,42 @@ describe('Skill routes', () => {
       const res = await request(app).post(`/api/skills/${created.body._id}/files`);
       expect(res.status).toBe(400);
       expect(res.body.error).toMatch(/no file/i);
+    });
+
+    it('returns 413 for an application storage quota rejection', async () => {
+      const created = await createSkillAsOwner();
+      const { upsertSkillFile } = require('~/models');
+      upsertSkillFile.mockRejectedValueOnce(new FileStorageLimitError(100, 100));
+
+      const res = await request(app)
+        .post(`/api/skills/${created.body._id}/files`)
+        .field('relativePath', 'references/notes.txt')
+        .attach('file', Buffer.from('notes'), {
+          filename: 'notes.txt',
+          contentType: 'text/plain',
+        });
+
+      expect(res.status).toBe(413);
+      expect(res.body.code).toBe('FILE_STORAGE_LIMIT_EXCEEDED');
+    });
+
+    it('does not convert an unrelated upstream 413 into a quota response', async () => {
+      const created = await createSkillAsOwner();
+      const { upsertSkillFile } = require('~/models');
+      upsertSkillFile.mockRejectedValueOnce(
+        Object.assign(new Error('upstream payload rejected'), { status: 413 }),
+      );
+
+      const res = await request(app)
+        .post(`/api/skills/${created.body._id}/files`)
+        .field('relativePath', 'references/notes.txt')
+        .attach('file', Buffer.from('notes'), {
+          filename: 'notes.txt',
+          contentType: 'text/plain',
+        });
+
+      expect(res.status).toBe(500);
+      expect(res.body).toEqual({ error: 'Failed to upload file' });
     });
 
     it('blocks text file content before storage', async () => {

--- a/api/server/services/Files/Azure/crud.js
+++ b/api/server/services/Files/Azure/crud.js
@@ -131,7 +131,7 @@ async function deleteFileFromAzure(req, file) {
 
   try {
     const containerClient = await getAzureContainerClient(AZURE_CONTAINER_NAME);
-    const blobPath = file.filepath.split(`${AZURE_CONTAINER_NAME}/`)[1];
+    const blobPath = file.filepath.split(`${AZURE_CONTAINER_NAME}/`)[1]?.split('?')[0];
     if (!blobPath.includes(req.user.id)) {
       throw new Error('User ID not found in blob path');
     }

--- a/api/server/services/Files/Azure/crud.spec.js
+++ b/api/server/services/Files/Azure/crud.spec.js
@@ -1,12 +1,13 @@
 const mockDownload = jest.fn();
-const mockGetBlockBlobClient = jest.fn(() => ({ download: mockDownload }));
+const mockDelete = jest.fn();
+const mockGetBlockBlobClient = jest.fn(() => ({ download: mockDownload, delete: mockDelete }));
 const mockGetAzureContainerClient = jest.fn(async () => ({
   url: 'https://account.blob.core.windows.net/files',
   getBlockBlobClient: mockGetBlockBlobClient,
 }));
 
 jest.mock('@librechat/data-schemas', () => ({
-  logger: { error: jest.fn() },
+  logger: { debug: jest.fn(), error: jest.fn() },
 }));
 
 jest.mock('@librechat/api', () => ({
@@ -18,7 +19,7 @@ jest.mock('@librechat/api', () => ({
   assertRemoteFileContentLength: jest.fn(),
 }));
 
-const { getAzureFileStream } = require('./crud');
+const { deleteFileFromAzure, getAzureFileStream } = require('./crud');
 
 describe('getAzureFileStream', () => {
   it('downloads private blobs through the authenticated Azure client', async () => {
@@ -53,5 +54,21 @@ describe('getAzureFileStream', () => {
 
     expect(mockGetAzureContainerClient).toHaveBeenCalledWith();
     expect(mockGetBlockBlobClient).toHaveBeenCalledWith('uploads/user/report one.pdf');
+  });
+});
+
+describe('deleteFileFromAzure', () => {
+  it('removes cache-busting query parameters from the blob key', async () => {
+    mockDelete.mockResolvedValue(undefined);
+
+    await deleteFileFromAzure(
+      { user: { id: 'user-1' } },
+      {
+        filepath: 'https://account.blob.core.windows.net/files/uploads/user-1/generated.webp?v=123',
+      },
+    );
+
+    expect(mockGetBlockBlobClient).toHaveBeenCalledWith('uploads/user-1/generated.webp');
+    expect(mockDelete).toHaveBeenCalled();
   });
 });

--- a/api/server/services/Files/Code/__tests__/process-traversal.spec.js
+++ b/api/server/services/Files/Code/__tests__/process-traversal.spec.js
@@ -26,6 +26,13 @@ jest.mock('@librechat/api', () => {
     sanitizeArtifactPath: mockSanitizeArtifactPath,
     flattenArtifactPath: mockFlattenArtifactPath,
     createAxiosInstance: jest.fn(() => mockAxios),
+    resolveStorageScope: jest.fn((req) => ({
+      userId: req.user.id,
+      tenantId: req.user.tenantId ?? null,
+      storageLimitBytes: null,
+    })),
+    createFileQuotaCommitter: () => async (_req, row, write) => write(row),
+    isFilePersistenceNotCommittedError: jest.fn(() => false),
     getCodeApiAuthHeaders: jest.fn(async () => ({})),
     codeExecutionHeaders: jest.fn(() => ({})),
     getCodeExecutionBaseUrl: jest.fn(() => 'http://localhost:8000'),
@@ -78,6 +85,8 @@ jest.mock('~/models', () => ({
   getFiles: jest.fn().mockResolvedValue([]),
   updateFile: jest.fn(),
   claimCodeFile: jest.fn().mockResolvedValue({ file_id: 'mock-uuid', usage: 0 }),
+  getUserStorageUsage: jest.fn().mockResolvedValue(0),
+  deleteFileByFilter: jest.fn().mockResolvedValue(null),
 }));
 
 const mockSaveBuffer = jest.fn().mockResolvedValue('/uploads/user123/mock-uuid__output.csv');
@@ -105,7 +114,7 @@ jest.mock('~/server/services/Files/retention', () => ({
 }));
 
 const { getRetentionExpiry } = require('~/server/services/Files/retention');
-const { createFile } = require('~/models');
+const { updateFile } = require('~/models');
 const { processCodeOutput } = require('../process');
 
 const baseParams = {
@@ -144,14 +153,14 @@ describe('processCodeOutput path traversal protection', () => {
     const call = mockSaveBuffer.mock.calls[0][0];
     /* `flattenArtifactPath` is identity for already-flat names; the assert
      * is against the storage-key composition (`<file_id>__<flat>`). */
-    expect(call.fileName).toBe('mock-uuid__sanitized-name.txt');
+    expect(call.fileName).toBe('mock-uuid-mock-uuid__sanitized-name.txt');
   });
 
   test('sanitized name is stored as filename in the file record', async () => {
     mockSanitizeArtifactPath.mockReturnValueOnce('safe-output.csv');
     await processCodeOutput({ ...baseParams, name: 'unsafe/../../output.csv' });
 
-    const fileArg = createFile.mock.calls[0][0];
+    const fileArg = updateFile.mock.calls[0][0];
     expect(fileArg.filename).toBe('safe-output.csv');
     expect(fileArg.tenantId).toBe('tenantA');
   });
@@ -173,7 +182,7 @@ describe('processCodeOutput path traversal protection', () => {
     await processCodeOutput({ ...baseParams, name: '../../../chart.png' });
 
     expect(mockSanitizeArtifactPath).toHaveBeenCalledWith('../../../chart.png');
-    const fileArg = createFile.mock.calls[0][0];
+    const fileArg = updateFile.mock.calls[0][0];
     expect(fileArg.filename).toBe('safe-chart.png');
     expect(fileArg.tenantId).toBe('tenantA');
   });

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -866,8 +866,9 @@ const processCodeOutput = async ({
     const commitCodeFile = async (fileData) => {
       const { deleteFile: deleteNewFile } = getStrategyFunctions(fileData.source);
       const cleanupNewBlob = deleteNewFile ? () => deleteNewFile(req, fileData) : null;
+      let replaced;
       try {
-        await persistCodeFile(
+        replaced = await persistCodeFile(
           req,
           fileData,
           (scopedRow) =>
@@ -881,9 +882,11 @@ const processCodeOutput = async ({
                       { 'metadata.sourceDispatchedAt': { $lte: sourceDispatchedAt } },
                     ],
                   },
+              { returnPrevious: true },
             ),
           null,
           isUpdate ? claimed.bytes : 0,
+          isUpdate ? claimed : null,
         );
       } catch (error) {
         if (cleanupNewBlob) {
@@ -921,10 +924,10 @@ const processCodeOutput = async ({
         );
         return false;
       }
-      if (isUpdate && claimed.filepath && claimed.filepath !== fileData.filepath) {
-        const { deleteFile: deleteReplacedFile } = getStrategyFunctions(claimed.source);
+      if (isUpdate && replaced.filepath && replaced.filepath !== fileData.filepath) {
+        const { deleteFile: deleteReplacedFile } = getStrategyFunctions(replaced.source);
         if (deleteReplacedFile) {
-          await deleteReplacedFile(req, claimed).catch((error) =>
+          await deleteReplacedFile(req, replaced).catch((error) =>
             logger.error('[processCodeOutput] Failed to clean up replaced output:', error),
           );
         }

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -63,12 +63,11 @@ const {
 } = require('librechat-data-provider');
 const { filterFilesByAgentAccess } = require('~/server/services/Files/permissions');
 const {
-  createFile,
   getFiles,
   updateFile,
   claimCodeFile,
   getUserStorageUsage,
-  deleteFile: deleteFileRecord,
+  deleteFileByFilter,
 } = require('~/models');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { convertImage } = require('~/server/services/Files/images/convert');
@@ -798,7 +797,7 @@ const processCodeOutput = async ({
      * a single record instead of creating duplicates (TOCTOU race fix).
      *
      * Claim by `safeName` (not raw `name`) so the claim and the eventual
-     * `createFile` agree on the filename column — otherwise weird inputs
+     * claim agree on the filename column — otherwise weird inputs
      * (e.g. `"proj name/file@v1.txt"`) would claim under the raw name and
      * then write under the sanitized one, leaving the claim row orphaned.
      */
@@ -811,6 +810,7 @@ const processCodeOutput = async ({
      * content write lands.
      */
     const sourceDispatchedAt = freshClaimAfter ?? Date.now();
+    const outputClaimRevision = freshClaimAfter == null ? v4() : undefined;
     const storageScope = resolveStorageScope(req);
 
     const newFileId = v4();
@@ -821,6 +821,7 @@ const processCodeOutput = async ({
       user: req.user.id,
       tenantId: storageScope.tenantId,
       sourceDispatchedAt,
+      outputClaimRevision,
     });
     const file_id = claimed.file_id;
     const isUpdate = file_id !== newFileId;
@@ -857,10 +858,10 @@ const processCodeOutput = async ({
      * the update's filter, so check and write are one atomic operation — a
      * stale harvest's commit simply misses and its attachment is skipped.
      * The row always exists here (the claim inserted it), so the non-upsert
-     * `updateFile` matches `createFile(data, true)` semantics ($set + TTL
-     * unset). Bytes a loser may have already uploaded to the shared storage
+     * `updateFile` applies the completed row and removes its TTL. Bytes a
+     * loser may have already uploaded to the shared storage
      * key are a narrow residual that per-file locking would be needed to
-     * close. Foreground writes keep the unconditional `createFile` path.
+     * close. Foreground writes use a per-claim revision as their CAS token.
      */
     const commitCodeFile = async (fileData) => {
       const { deleteFile: deleteNewFile } = getStrategyFunctions(fileData.source);
@@ -870,14 +871,17 @@ const processCodeOutput = async ({
           req,
           fileData,
           (scopedRow) =>
-            freshClaimAfter == null
-              ? createFile(scopedRow, true)
-              : updateFile(scopedRow, {
-                  $or: [
-                    { 'metadata.sourceDispatchedAt': { $exists: false } },
-                    { 'metadata.sourceDispatchedAt': { $lte: sourceDispatchedAt } },
-                  ],
-                }),
+            updateFile(
+              scopedRow,
+              freshClaimAfter == null
+                ? { 'metadata.outputClaimRevision': outputClaimRevision }
+                : {
+                    $or: [
+                      { 'metadata.sourceDispatchedAt': { $exists: false } },
+                      { 'metadata.sourceDispatchedAt': { $lte: sourceDispatchedAt } },
+                    ],
+                  },
+            ),
           null,
           isUpdate ? claimed.bytes : 0,
         );
@@ -891,7 +895,18 @@ const processCodeOutput = async ({
           );
         }
         if (!isUpdate) {
-          await deleteFileRecord(file_id).catch((cleanupError) =>
+          const claimFilter = outputClaimRevision
+            ? {
+                file_id,
+                'metadata.outputClaimRevision': outputClaimRevision,
+                filepath: { $exists: false },
+              }
+            : {
+                file_id,
+                'metadata.sourceDispatchedAt': sourceDispatchedAt,
+                filepath: { $exists: false },
+              };
+          await deleteFileByFilter(claimFilter).catch((cleanupError) =>
             logger.error(
               '[processCodeOutput] Failed to remove rejected output claim:',
               cleanupError,
@@ -1132,7 +1147,7 @@ const processCodeOutput = async ({
     const file = {
       ...baseFile,
       // Always set explicitly so an update which produces a binary or
-      // oversized artifact clears any previously cached text — createFile
+      // oversized artifact clears any previously cached text — updateFile
       // uses findOneAndUpdate with $set semantics.
       text: text ?? null,
       textFormat: textFormat ?? null,

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -40,7 +40,8 @@ const {
   normalizeArtifactDeliveryFailure,
   resolveDownloadPath,
   resolveStorageScope,
-  persistFileWithQuota,
+  createFileQuotaCommitter,
+  isFilePersistenceNotCommittedError,
 } = require('@librechat/api');
 const {
   Tools,
@@ -67,6 +68,7 @@ const {
   updateFile,
   claimCodeFile,
   getUserStorageUsage,
+  deleteFile: deleteFileRecord,
 } = require('~/models');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { convertImage } = require('~/server/services/Files/images/convert');
@@ -75,18 +77,12 @@ const { determineFileType } = require('~/server/utils');
 
 const axios = createAxiosInstance();
 
-const persistCodeFile = (req, row, write, rollback, replacedBytes) =>
-  persistFileWithQuota(
-    {
-      scope: resolveStorageScope(req),
-      row,
-      write,
-      rollback,
-      replacedBytes,
-      getUserStorageUsage,
-    },
-    (error) => logger.error('[processCodeOutput] Failed to clean up rejected output:', error),
-  );
+const persistCodeFile = createFileQuotaCommitter({
+  resolveScope: resolveStorageScope,
+  getUserStorageUsage,
+  onCleanupError: (error) =>
+    logger.error('[processCodeOutput] Failed to clean up rejected output:', error),
+});
 
 /** Request-scoped references to buffers already fetched by artifact preflight.
  * The request object is the ownership boundary, and WeakMap keeps completed
@@ -815,6 +811,7 @@ const processCodeOutput = async ({
      * content write lands.
      */
     const sourceDispatchedAt = freshClaimAfter ?? Date.now();
+    const storageScope = resolveStorageScope(req);
 
     const newFileId = v4();
     const claimed = await claimCodeFile({
@@ -822,7 +819,7 @@ const processCodeOutput = async ({
       conversationId,
       file_id: newFileId,
       user: req.user.id,
-      tenantId: req.user.tenantId,
+      tenantId: storageScope.tenantId,
       sourceDispatchedAt,
     });
     const file_id = claimed.file_id;
@@ -866,38 +863,56 @@ const processCodeOutput = async ({
      * close. Foreground writes keep the unconditional `createFile` path.
      */
     const commitCodeFile = async (fileData) => {
-      const { deleteFile } = getStrategyFunctions(fileData.source);
-      const rollback = deleteFile ? () => deleteFile(req, fileData) : null;
-      const committed = await persistCodeFile(
-        req,
-        fileData,
-        (scopedRow) =>
-          freshClaimAfter == null
-            ? createFile(scopedRow, true).then(() => true)
-            : updateFile(scopedRow, {
-                $or: [
-                  { 'metadata.sourceDispatchedAt': { $exists: false } },
-                  { 'metadata.sourceDispatchedAt': { $lte: sourceDispatchedAt } },
-                ],
-              }),
-        rollback,
-        isUpdate ? claimed.bytes : 0,
-      );
-      if (!committed) {
-        if (rollback) {
-          await rollback().catch((error) =>
-            logger.error('[processCodeOutput] Failed to clean up stale output:', error),
+      const { deleteFile: deleteNewFile } = getStrategyFunctions(fileData.source);
+      const cleanupNewBlob = deleteNewFile ? () => deleteNewFile(req, fileData) : null;
+      try {
+        await persistCodeFile(
+          req,
+          fileData,
+          (scopedRow) =>
+            freshClaimAfter == null
+              ? createFile(scopedRow, true)
+              : updateFile(scopedRow, {
+                  $or: [
+                    { 'metadata.sourceDispatchedAt': { $exists: false } },
+                    { 'metadata.sourceDispatchedAt': { $lte: sourceDispatchedAt } },
+                  ],
+                }),
+          null,
+          isUpdate ? claimed.bytes : 0,
+        );
+      } catch (error) {
+        if (cleanupNewBlob) {
+          await cleanupNewBlob().catch((cleanupError) =>
+            logger.error(
+              '[processCodeOutput] Failed to clean up uncommitted output:',
+              cleanupError,
+            ),
           );
+        }
+        if (!isUpdate) {
+          await deleteFileRecord(file_id).catch((cleanupError) =>
+            logger.error(
+              '[processCodeOutput] Failed to remove rejected output claim:',
+              cleanupError,
+            ),
+          );
+        }
+        if (!isFilePersistenceNotCommittedError(error)) {
+          throw error;
         }
         logger.warn(
           `[processCodeOutput] Skipping stale background output "${safeName}" (${file_id}): a newer run owns this filename`,
         );
         return false;
       }
-      if (isUpdate && claimed.filepath && claimed.filepath !== fileData.filepath && deleteFile) {
-        await deleteFile(req, claimed).catch((error) =>
-          logger.error('[processCodeOutput] Failed to clean up replaced output:', error),
-        );
+      if (isUpdate && claimed.filepath && claimed.filepath !== fileData.filepath) {
+        const { deleteFile: deleteReplacedFile } = getStrategyFunctions(claimed.source);
+        if (deleteReplacedFile) {
+          await deleteReplacedFile(req, claimed).catch((error) =>
+            logger.error('[processCodeOutput] Failed to clean up replaced output:', error),
+          );
+        }
       }
       return true;
     };
@@ -947,7 +962,7 @@ const processCodeOutput = async ({
         conversationId,
         executionProfile,
         user: req.user.id,
-        tenantId: req.user.tenantId,
+        tenantId: storageScope.tenantId,
         type: `image/${appConfig.imageOutputType}`,
         createdAt: isUpdate ? claimed.createdAt : formattedDate,
         updatedAt: formattedDate,
@@ -1008,14 +1023,17 @@ const processCodeOutput = async ({
      * the conservative cross-platform NAME_MAX (Linux ext4, NTFS, APFS).
      */
     const NAME_MAX = 255;
-    const flatName = flattenArtifactPath(safeName, NAME_MAX - file_id.length - 2);
+    const flatName = flattenArtifactPath(
+      safeName,
+      NAME_MAX - file_id.length - storageRevision.length - 3,
+    );
     const fileName = `${file_id}-${storageRevision}__${flatName}`;
     const filepath = await saveBuffer({
       userId: req.user.id,
       buffer,
       fileName,
       basePath: 'uploads',
-      tenantId: req.user.tenantId,
+      tenantId: storageScope.tenantId,
     });
     const storageMetadata = getStorageMetadata({
       filepath,
@@ -1054,7 +1072,7 @@ const processCodeOutput = async ({
       type: mimeType,
       conversationId,
       user: req.user.id,
-      tenantId: req.user.tenantId,
+      tenantId: storageScope.tenantId,
       bytes: buffer.length,
       updatedAt: formattedDate,
       metadata: codeEnvMetadata,

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -39,6 +39,8 @@ const {
   sortCodeFilesByDestinationPriority,
   normalizeArtifactDeliveryFailure,
   resolveDownloadPath,
+  resolveStorageScope,
+  persistFileWithQuota,
 } = require('@librechat/api');
 const {
   Tools,
@@ -59,13 +61,32 @@ const {
   resolveSandboxFilename,
 } = require('librechat-data-provider');
 const { filterFilesByAgentAccess } = require('~/server/services/Files/permissions');
-const { createFile, getFiles, updateFile, claimCodeFile } = require('~/models');
+const {
+  createFile,
+  getFiles,
+  updateFile,
+  claimCodeFile,
+  getUserStorageUsage,
+} = require('~/models');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { convertImage } = require('~/server/services/Files/images/convert');
 const { getRetentionExpiry } = require('~/server/services/Files/retention');
 const { determineFileType } = require('~/server/utils');
 
 const axios = createAxiosInstance();
+
+const persistCodeFile = (req, row, write, rollback, replacedBytes) =>
+  persistFileWithQuota(
+    {
+      scope: resolveStorageScope(req),
+      row,
+      write,
+      rollback,
+      replacedBytes,
+      getUserStorageUsage,
+    },
+    (error) => logger.error('[processCodeOutput] Failed to clean up rejected output:', error),
+  );
 
 /** Request-scoped references to buffers already fetched by artifact preflight.
  * The request object is the ownership boundary, and WeakMap keeps completed
@@ -845,21 +866,38 @@ const processCodeOutput = async ({
      * close. Foreground writes keep the unconditional `createFile` path.
      */
     const commitCodeFile = async (fileData) => {
-      if (freshClaimAfter == null) {
-        await createFile(fileData, true);
-        return true;
-      }
-      const committed = await updateFile(fileData, {
-        $or: [
-          { 'metadata.sourceDispatchedAt': { $exists: false } },
-          { 'metadata.sourceDispatchedAt': { $lte: sourceDispatchedAt } },
-        ],
-      });
+      const { deleteFile } = getStrategyFunctions(fileData.source);
+      const rollback = deleteFile ? () => deleteFile(req, fileData) : null;
+      const committed = await persistCodeFile(
+        req,
+        fileData,
+        (scopedRow) =>
+          freshClaimAfter == null
+            ? createFile(scopedRow, true).then(() => true)
+            : updateFile(scopedRow, {
+                $or: [
+                  { 'metadata.sourceDispatchedAt': { $exists: false } },
+                  { 'metadata.sourceDispatchedAt': { $lte: sourceDispatchedAt } },
+                ],
+              }),
+        rollback,
+        isUpdate ? claimed.bytes : 0,
+      );
       if (!committed) {
+        if (rollback) {
+          await rollback().catch((error) =>
+            logger.error('[processCodeOutput] Failed to clean up stale output:', error),
+          );
+        }
         logger.warn(
           `[processCodeOutput] Skipping stale background output "${safeName}" (${file_id}): a newer run owns this filename`,
         );
         return false;
+      }
+      if (isUpdate && claimed.filepath && claimed.filepath !== fileData.filepath && deleteFile) {
+        await deleteFile(req, claimed).catch((error) =>
+          logger.error('[processCodeOutput] Failed to clean up replaced output:', error),
+        );
       }
       return true;
     };
@@ -882,9 +920,15 @@ const processCodeOutput = async ({
       sourceDispatchedAt,
     };
 
+    const storageRevision = v4();
     if (isImage) {
       const usage = isUpdate ? (claimed.usage ?? 0) + 1 : 1;
-      const _file = await convertImage(req, buffer, 'high', `${file_id}${fileExt}`);
+      const _file = await convertImage(
+        req,
+        buffer,
+        'high',
+        `${file_id}-${storageRevision}${fileExt}`,
+      );
       const filepath = usage > 1 ? `${_file.filepath}?v=${Date.now()}` : _file.filepath;
       const storageMetadata = getStorageMetadata({
         filepath: _file.filepath,
@@ -965,7 +1009,7 @@ const processCodeOutput = async ({
      */
     const NAME_MAX = 255;
     const flatName = flattenArtifactPath(safeName, NAME_MAX - file_id.length - 2);
-    const fileName = `${file_id}__${flatName}`;
+    const fileName = `${file_id}-${storageRevision}__${flatName}`;
     const filepath = await saveBuffer({
       userId: req.user.id,
       buffer,

--- a/api/server/services/Files/Code/process.spec.js
+++ b/api/server/services/Files/Code/process.spec.js
@@ -66,6 +66,12 @@ jest.mock('@librechat/api', () => {
   const http = require('http');
   const https = require('https');
   return {
+    resolveStorageScope: (req) => ({
+      userId: req.user.id,
+      tenantId: req.tenantId ?? req.user.tenantId,
+    }),
+    persistFileWithQuota: ({ scope, row, write }) =>
+      write({ ...row, user: scope.userId, tenantId: scope.tenantId }),
     resolveDownloadPath: (file) => file.storageKey || file.filepath,
     logAxiosError: jest.fn(),
     /* Behaviourally identical to the real predicate in
@@ -650,7 +656,7 @@ describe('Code Process', () => {
           mockReq,
           imageBuffer,
           'high',
-          'mock-uuid-1234.png',
+          'mock-uuid-1234-mock-uuid-1234.png',
         );
         expect(result.type).toBe('image/webp');
         expect(result.context).toBe(FileContext.execute_code);
@@ -698,7 +704,7 @@ describe('Code Process', () => {
           mockReq,
           imageBuffer,
           'high',
-          'existing-img-id.png',
+          'existing-img-id-mock-uuid-1234.png',
         );
         expect(result.file_id).toBe('existing-img-id');
         expect(result.usage).toBe(2);
@@ -723,8 +729,9 @@ describe('Code Process', () => {
         expect(mockSaveBuffer).toHaveBeenCalledWith({
           userId: 'user-123',
           buffer: smallBuffer,
-          fileName: 'mock-uuid-1234__test-file.txt',
+          fileName: 'mock-uuid-1234-mock-uuid-1234__test-file.txt',
           basePath: 'uploads',
+          tenantId: undefined,
         });
         expect(result.type).toBe('text/plain');
         expect(result.filepath).toBe('/uploads/saved-file.txt');
@@ -845,7 +852,7 @@ describe('Code Process', () => {
         // accidentally create real subdirectories under uploads/.
         expect(mockSaveBuffer).toHaveBeenCalledWith(
           expect.objectContaining({
-            fileName: 'mock-uuid-1234__test_folder__test_file.txt',
+            fileName: 'mock-uuid-1234-mock-uuid-1234__test_folder__test_file.txt',
           }),
         );
         // DB row keeps the nested path verbatim — that's what primeFiles

--- a/api/server/services/Files/Code/process.spec.js
+++ b/api/server/services/Files/Code/process.spec.js
@@ -70,8 +70,20 @@ jest.mock('@librechat/api', () => {
       userId: req.user.id,
       tenantId: req.tenantId ?? req.user.tenantId,
     }),
-    persistFileWithQuota: ({ scope, row, write }) =>
-      write({ ...row, user: scope.userId, tenantId: scope.tenantId }),
+    createFileQuotaCommitter:
+      ({ resolveScope }) =>
+      async (req, row, write) => {
+        const scope = resolveScope(req);
+        const result = await write({ ...row, user: scope.userId, tenantId: scope.tenantId });
+        if (result == null) {
+          const error = new Error('not committed');
+          error.name = 'FilePersistenceNotCommittedError';
+          throw error;
+        }
+        return result;
+      },
+    isFilePersistenceNotCommittedError: (error) =>
+      error?.name === 'FilePersistenceNotCommittedError',
     resolveDownloadPath: (file) => file.storageKey || file.filepath,
     logAxiosError: jest.fn(),
     /* Behaviourally identical to the real predicate in
@@ -244,11 +256,13 @@ jest.mock('@librechat/agents', () => ({
 // Mock models
 const mockClaimCodeFile = jest.fn();
 const mockUpdateFile = jest.fn();
+const mockDeleteFileRecord = jest.fn();
 jest.mock('~/models', () => ({
   createFile: jest.fn().mockResolvedValue({}),
   getFiles: jest.fn(),
   updateFile: mockUpdateFile,
   claimCodeFile: (...args) => mockClaimCodeFile(...args),
+  deleteFile: (...args) => mockDeleteFileRecord(...args),
 }));
 
 // Mock permissions (must be before process.js import)
@@ -335,6 +349,7 @@ describe('Code Process', () => {
       file_id: 'mock-uuid-1234',
       user: 'user-123',
     });
+    mockDeleteFileRecord.mockResolvedValue(undefined);
     getFiles.mockResolvedValue(null);
     createFile.mockResolvedValue({});
     getStrategyFunctions.mockReturnValue({
@@ -553,6 +568,11 @@ describe('Code Process', () => {
       });
       mockUpdateFile.mockResolvedValueOnce(null);
       mockAxios.mockResolvedValue({ data: Buffer.alloc(100) });
+      const deleteStoredFile = jest.fn().mockResolvedValue(undefined);
+      getStrategyFunctions.mockReturnValue({
+        saveBuffer: jest.fn().mockResolvedValue('/uploads/rejected-file.txt'),
+        deleteFile: deleteStoredFile,
+      });
 
       const result = await processCodeOutput({
         ...baseParams,
@@ -572,6 +592,56 @@ describe('Code Process', () => {
             },
           ],
         },
+      );
+      expect(deleteStoredFile).toHaveBeenCalledWith(
+        mockReq,
+        expect.objectContaining({ file_id: 'mock-uuid-1234' }),
+      );
+      expect(mockDeleteFileRecord).toHaveBeenCalledWith('mock-uuid-1234');
+    });
+
+    it('cleans the new revision and inserted claim when the database write fails', async () => {
+      const deleteStoredFile = jest.fn().mockResolvedValue(undefined);
+      getStrategyFunctions.mockReturnValue({
+        saveBuffer: jest.fn().mockResolvedValue('/uploads/uncommitted-file.txt'),
+        deleteFile: deleteStoredFile,
+      });
+      createFile.mockRejectedValueOnce(new Error('database unavailable'));
+      mockAxios.mockResolvedValue({ data: Buffer.alloc(100) });
+
+      await processCodeOutput(baseParams);
+
+      expect(deleteStoredFile).toHaveBeenCalledWith(
+        mockReq,
+        expect.objectContaining({
+          file_id: 'mock-uuid-1234',
+          filepath: '/uploads/uncommitted-file.txt',
+        }),
+      );
+      expect(mockDeleteFileRecord).toHaveBeenCalledWith('mock-uuid-1234');
+    });
+
+    it('deletes a replaced blob through the storage strategy that originally owned it', async () => {
+      const deleteOldFile = jest.fn().mockResolvedValue(undefined);
+      mockClaimCodeFile.mockResolvedValue({
+        file_id: 'existing-file-id',
+        filename: 'test-file.txt',
+        filepath: '/old/object.txt',
+        source: 's3',
+        bytes: 50,
+      });
+      mockAxios.mockResolvedValue({ data: Buffer.alloc(100) });
+      getStrategyFunctions.mockImplementation((source) =>
+        source === 's3'
+          ? { deleteFile: deleteOldFile }
+          : { saveBuffer: jest.fn().mockResolvedValue('/uploads/new-object.txt') },
+      );
+
+      await processCodeOutput(baseParams);
+
+      expect(deleteOldFile).toHaveBeenCalledWith(
+        mockReq,
+        expect.objectContaining({ source: 's3', filepath: '/old/object.txt' }),
       );
     });
 
@@ -664,7 +734,11 @@ describe('Code Process', () => {
       });
 
       it('persists tenantId on image code output records when present', async () => {
-        const tenantReq = { ...mockReq, user: { ...mockReq.user, tenantId: 'tenantA' } };
+        const tenantReq = {
+          ...mockReq,
+          tenantId: 'tenantA',
+          user: { ...mockReq.user, tenantId: 'staleTenant' },
+        };
         const imageBuffer = Buffer.alloc(500);
         mockAxios.mockResolvedValue({ data: imageBuffer });
         convertImage.mockResolvedValue({
@@ -803,7 +877,11 @@ describe('Code Process', () => {
       });
 
       it('passes and persists tenantId for non-image code output records', async () => {
-        const tenantReq = { ...mockReq, user: { ...mockReq.user, tenantId: 'tenantA' } };
+        const tenantReq = {
+          ...mockReq,
+          tenantId: 'tenantA',
+          user: { ...mockReq.user, tenantId: 'staleTenant' },
+        };
         const smallBuffer = Buffer.alloc(100);
         mockAxios.mockResolvedValue({ data: smallBuffer });
 
@@ -886,9 +964,9 @@ describe('Code Process', () => {
 
         // The handler should call flattenArtifactPath with both the
         // safeName AND a budget = NAME_MAX (255) minus the prefix
-        // (`${file_id}__`). file_id mock is `mock-uuid-1234` (14 chars),
-        // so the budget should be 255 - 14 - 2 = 239.
-        expect(flattenSpy).toHaveBeenCalledWith(expect.any(String), 239);
+        // (`${file_id}-${revision}__`). Both mocked UUIDs are 14 chars, so the
+        // budget is 255 - 14 - 14 - 3 = 224.
+        expect(flattenSpy).toHaveBeenCalledWith(expect.any(String), 224);
       });
 
       it('passes the basename (not the full nested path) to classifyCodeArtifact and extractCodeArtifactText', async () => {

--- a/api/server/services/Files/Code/process.spec.js
+++ b/api/server/services/Files/Code/process.spec.js
@@ -256,13 +256,13 @@ jest.mock('@librechat/agents', () => ({
 // Mock models
 const mockClaimCodeFile = jest.fn();
 const mockUpdateFile = jest.fn();
-const mockDeleteFileRecord = jest.fn();
+const mockDeleteFileByFilter = jest.fn();
 jest.mock('~/models', () => ({
   createFile: jest.fn().mockResolvedValue({}),
   getFiles: jest.fn(),
   updateFile: mockUpdateFile,
   claimCodeFile: (...args) => mockClaimCodeFile(...args),
-  deleteFile: (...args) => mockDeleteFileRecord(...args),
+  deleteFileByFilter: (...args) => mockDeleteFileByFilter(...args),
 }));
 
 // Mock permissions (must be before process.js import)
@@ -291,7 +291,7 @@ jest.mock('~/server/utils', () => ({
 
 const http = require('http');
 const https = require('https');
-const { createFile, getFiles } = require('~/models');
+const { getFiles } = require('~/models');
 const { getRetentionExpiry } = require('~/server/services/Files/retention');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { convertImage } = require('~/server/services/Files/images/convert');
@@ -349,9 +349,9 @@ describe('Code Process', () => {
       file_id: 'mock-uuid-1234',
       user: 'user-123',
     });
-    mockDeleteFileRecord.mockResolvedValue(undefined);
+    mockDeleteFileByFilter.mockResolvedValue(undefined);
+    mockUpdateFile.mockResolvedValue({});
     getFiles.mockResolvedValue(null);
-    createFile.mockResolvedValue({});
     getStrategyFunctions.mockReturnValue({
       saveBuffer: jest.fn().mockResolvedValue('/uploads/mock-file-path.txt'),
     });
@@ -383,7 +383,7 @@ describe('Code Process', () => {
         },
       });
       expect(mockClaimCodeFile).not.toHaveBeenCalled();
-      expect(createFile).not.toHaveBeenCalled();
+      expect(mockUpdateFile).not.toHaveBeenCalled();
       expect(getStrategyFunctions).not.toHaveBeenCalled();
     });
 
@@ -394,7 +394,7 @@ describe('Code Process', () => {
 
       expect(mockAxios).not.toHaveBeenCalled();
       expect(mockClaimCodeFile).toHaveBeenCalledTimes(1);
-      expect(createFile).toHaveBeenCalledTimes(1);
+      expect(mockUpdateFile).toHaveBeenCalledTimes(1);
     });
 
     it('enforces a caller-provided aggregate inspection budget while downloading', async () => {
@@ -414,7 +414,7 @@ describe('Code Process', () => {
         }),
       );
       expect(mockClaimCodeFile).not.toHaveBeenCalled();
-      expect(createFile).not.toHaveBeenCalled();
+      expect(mockUpdateFile).not.toHaveBeenCalled();
     });
 
     it('extracts text bytes even when the generated filename spoofs an image extension', async () => {
@@ -454,7 +454,7 @@ describe('Code Process', () => {
       });
       expect(mockAxios).not.toHaveBeenCalled();
       expect(mockClaimCodeFile).not.toHaveBeenCalled();
-      expect(createFile).not.toHaveBeenCalled();
+      expect(mockUpdateFile).not.toHaveBeenCalled();
     });
   });
 
@@ -477,7 +477,9 @@ describe('Code Process', () => {
         conversationId: 'conv-123',
         file_id: 'mock-uuid-1234',
         user: 'user-123',
+        tenantId: undefined,
         sourceDispatchedAt: expect.any(Number),
+        outputClaimRevision: expect.any(String),
       });
 
       expect(result.file_id).toBe('existing-file-id');
@@ -597,7 +599,39 @@ describe('Code Process', () => {
         mockReq,
         expect.objectContaining({ file_id: 'mock-uuid-1234' }),
       );
-      expect(mockDeleteFileRecord).toHaveBeenCalledWith('mock-uuid-1234');
+      expect(mockDeleteFileByFilter).toHaveBeenCalledWith({
+        file_id: 'mock-uuid-1234',
+        'metadata.sourceDispatchedAt': new Date('2024-01-01T00:00:00.000Z').getTime(),
+        filepath: { $exists: false },
+      });
+    });
+
+    it('does not let an overtaken foreground claimant commit or delete the winning claim', async () => {
+      mockClaimCodeFile.mockResolvedValue({
+        file_id: 'mock-uuid-1234',
+        user: 'user-123',
+      });
+      mockUpdateFile.mockResolvedValueOnce(null);
+      mockAxios.mockResolvedValue({ data: Buffer.alloc(100) });
+      const deleteStoredFile = jest.fn().mockResolvedValue(undefined);
+      getStrategyFunctions.mockReturnValue({
+        saveBuffer: jest.fn().mockResolvedValue('/uploads/overtaken-file.txt'),
+        deleteFile: deleteStoredFile,
+      });
+
+      const result = await processCodeOutput(baseParams);
+
+      expect(result).toBeNull();
+      expect(mockUpdateFile).toHaveBeenCalledWith(
+        expect.objectContaining({ file_id: 'mock-uuid-1234' }),
+        { 'metadata.outputClaimRevision': 'mock-uuid-1234' },
+      );
+      expect(deleteStoredFile).toHaveBeenCalled();
+      expect(mockDeleteFileByFilter).toHaveBeenCalledWith({
+        file_id: 'mock-uuid-1234',
+        'metadata.outputClaimRevision': 'mock-uuid-1234',
+        filepath: { $exists: false },
+      });
     });
 
     it('cleans the new revision and inserted claim when the database write fails', async () => {
@@ -606,7 +640,7 @@ describe('Code Process', () => {
         saveBuffer: jest.fn().mockResolvedValue('/uploads/uncommitted-file.txt'),
         deleteFile: deleteStoredFile,
       });
-      createFile.mockRejectedValueOnce(new Error('database unavailable'));
+      mockUpdateFile.mockRejectedValueOnce(new Error('database unavailable'));
       mockAxios.mockResolvedValue({ data: Buffer.alloc(100) });
 
       await processCodeOutput(baseParams);
@@ -618,7 +652,11 @@ describe('Code Process', () => {
           filepath: '/uploads/uncommitted-file.txt',
         }),
       );
-      expect(mockDeleteFileRecord).toHaveBeenCalledWith('mock-uuid-1234');
+      expect(mockDeleteFileByFilter).toHaveBeenCalledWith({
+        file_id: 'mock-uuid-1234',
+        'metadata.outputClaimRevision': expect.any(String),
+        filepath: { $exists: false },
+      });
     });
 
     it('deletes a replaced blob through the storage strategy that originally owned it', async () => {
@@ -754,9 +792,9 @@ describe('Code Process', () => {
         expect(mockClaimCodeFile).toHaveBeenCalledWith(
           expect.objectContaining({ tenantId: 'tenantA' }),
         );
-        expect(createFile).toHaveBeenCalledWith(
+        expect(mockUpdateFile).toHaveBeenCalledWith(
           expect.objectContaining({ tenantId: 'tenantA' }),
-          true,
+          expect.objectContaining({ 'metadata.outputClaimRevision': expect.any(String) }),
         );
       });
 
@@ -862,7 +900,7 @@ describe('Code Process', () => {
           storageRegion: 'us-east-2',
           status: 'pending',
         });
-        expect(createFile).toHaveBeenCalledWith(
+        expect(mockUpdateFile).toHaveBeenCalledWith(
           expect.objectContaining({
             file_id: 'mock-uuid-1234',
             user: 'user-123',
@@ -871,7 +909,7 @@ describe('Code Process', () => {
             storageKey,
             storageRegion: 'us-east-2',
           }),
-          true,
+          expect.objectContaining({ 'metadata.outputClaimRevision': expect.any(String) }),
         );
         expect(typeof finalize).toBe('function');
       });
@@ -901,9 +939,9 @@ describe('Code Process', () => {
         expect(mockSaveBuffer).toHaveBeenCalledWith(
           expect.objectContaining({ tenantId: 'tenantA' }),
         );
-        expect(createFile).toHaveBeenCalledWith(
+        expect(mockUpdateFile).toHaveBeenCalledWith(
           expect.objectContaining({ tenantId: 'tenantA' }),
-          true,
+          expect.objectContaining({ 'metadata.outputClaimRevision': expect.any(String) }),
         );
       });
 
@@ -1035,9 +1073,9 @@ describe('Code Process', () => {
           'utf8-text',
         );
         expect(result.text).toBe('hello world\n');
-        expect(createFile).toHaveBeenCalledWith(
+        expect(mockUpdateFile).toHaveBeenCalledWith(
           expect.objectContaining({ text: 'hello world\n' }),
-          true,
+          expect.objectContaining({ 'metadata.outputClaimRevision': expect.any(String) }),
         );
       });
 
@@ -1051,7 +1089,7 @@ describe('Code Process', () => {
         const { file: result } = await processCodeOutput({ ...baseParams, name: 'archive.zip' });
 
         expect(result.text).toBeNull();
-        const createCall = createFile.mock.calls[0][0];
+        const createCall = mockUpdateFile.mock.calls[0][0];
         expect(createCall.text).toBeNull();
       });
 
@@ -1073,7 +1111,7 @@ describe('Code Process', () => {
         await processCodeOutput({ ...baseParams, name: 'output.bin' });
 
         // null (not omitted) so $set clears any prior `text` value.
-        const createCall = createFile.mock.calls[0][0];
+        const createCall = mockUpdateFile.mock.calls[0][0];
         expect(createCall).toHaveProperty('text', null);
       });
 
@@ -1107,7 +1145,7 @@ describe('Code Process', () => {
 
         await processCodeOutput({ ...baseParams, name: 'output.txt' });
 
-        const createCall = createFile.mock.calls[0][0];
+        const createCall = mockUpdateFile.mock.calls[0][0];
         expect(createCall).toHaveProperty('status', null);
         expect(createCall).toHaveProperty('previewError', null);
         expect(createCall).toHaveProperty('previewRevision', null);
@@ -1128,7 +1166,7 @@ describe('Code Process', () => {
           }),
         );
         expect(mockClaimCodeFile).toHaveBeenCalledTimes(1);
-        expect(createFile).toHaveBeenCalledTimes(1);
+        expect(mockUpdateFile).toHaveBeenCalledTimes(1);
       });
 
       it('should fallback to download URL when file exceeds size limit', async () => {
@@ -1149,8 +1187,8 @@ describe('Code Process', () => {
         expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('exceeds size limit'));
         expect(result.filepath).toContain('/api/files/code/download/session-123/file-id-123');
         expect(result.expiresAt).toBeDefined();
-        // Should not call createFile for oversized files (fallback path)
-        expect(createFile).not.toHaveBeenCalled();
+        // Oversized files take the fallback path without a database write.
+        expect(mockUpdateFile).not.toHaveBeenCalled();
 
         // Reset to default for other tests
         fileSizeLimitConfig.value = 20 * 1024 * 1024;
@@ -1167,7 +1205,7 @@ describe('Code Process', () => {
           expect.stringContaining('Generated file exceeds size limit'),
         );
         expect(mockClaimCodeFile).not.toHaveBeenCalled();
-        expect(createFile).not.toHaveBeenCalled();
+        expect(mockUpdateFile).not.toHaveBeenCalled();
 
         fileSizeLimitConfig.value = 20 * 1024 * 1024;
       });
@@ -1380,18 +1418,18 @@ describe('Code Process', () => {
         expect(result.messageId).toBe('msg-123');
       });
 
-      it('should call createFile with upsert enabled', async () => {
+      it('commits through the claimed foreground revision', async () => {
         const smallBuffer = Buffer.alloc(100);
         mockAxios.mockResolvedValue({ data: smallBuffer });
 
         await processCodeOutput(baseParams);
 
-        expect(createFile).toHaveBeenCalledWith(
+        expect(mockUpdateFile).toHaveBeenCalledWith(
           expect.objectContaining({
             file_id: 'mock-uuid-1234',
             context: FileContext.execute_code,
           }),
-          true, // upsert flag
+          { 'metadata.outputClaimRevision': expect.any(String) },
         );
       });
     });
@@ -1419,16 +1457,16 @@ describe('Code Process', () => {
        */
 
       /**
-       * `processCodeOutput` mutates the file object after `createFile` returns
+       * `processCodeOutput` mutates the file object after `updateFile` returns
        * (`Object.assign(file, { messageId, toolCallId })`) so the runtime
        * caller sees the live messageId on the response. Reading
-       * `createFile.mock.calls[0][0]` directly would therefore reflect the
+       * `updateFile.mock.calls[0][0]` directly would therefore reflect the
        * post-mutation state because JS captures by reference. To assert
        * what was actually PERSISTED, snapshot the args at call time.
        */
-      function snapshotCreateFileArgs() {
+      function snapshotPersistedFileArgs() {
         const snapshots = [];
-        createFile.mockImplementation(async (file) => {
+        mockUpdateFile.mockImplementation(async (file) => {
           snapshots.push({ ...file });
           return {};
         });
@@ -1443,7 +1481,7 @@ describe('Code Process', () => {
           createdAt: '2024-01-01T00:00:00.000Z',
           messageId: 'turn-1-original-msg',
         });
-        const persisted = snapshotCreateFileArgs();
+        const persisted = snapshotPersistedFileArgs();
 
         const smallBuffer = Buffer.alloc(100);
         mockAxios.mockResolvedValue({ data: smallBuffer });
@@ -1466,7 +1504,7 @@ describe('Code Process', () => {
           createdAt: '2024-01-01T00:00:00.000Z',
           // messageId intentionally absent
         });
-        const persisted = snapshotCreateFileArgs();
+        const persisted = snapshotPersistedFileArgs();
 
         const smallBuffer = Buffer.alloc(100);
         mockAxios.mockResolvedValue({ data: smallBuffer });
@@ -1485,7 +1523,7 @@ describe('Code Process', () => {
           file_id: 'mock-uuid-1234',
           user: 'user-123',
         });
-        const persisted = snapshotCreateFileArgs();
+        const persisted = snapshotPersistedFileArgs();
 
         const smallBuffer = Buffer.alloc(100);
         mockAxios.mockResolvedValue({ data: smallBuffer });
@@ -1509,7 +1547,7 @@ describe('Code Process', () => {
           createdAt: '2024-01-01T00:00:00.000Z',
           messageId: 'turn-1-original-msg',
         });
-        const persisted = snapshotCreateFileArgs();
+        const persisted = snapshotPersistedFileArgs();
 
         const smallBuffer = Buffer.alloc(100);
         mockAxios.mockResolvedValue({ data: smallBuffer });
@@ -1536,7 +1574,7 @@ describe('Code Process', () => {
           createdAt: '2024-01-01T00:00:00.000Z',
           messageId: 'turn-1-image-msg',
         });
-        const persisted = snapshotCreateFileArgs();
+        const persisted = snapshotPersistedFileArgs();
 
         const imageBuffer = Buffer.alloc(500);
         mockAxios.mockResolvedValue({ data: imageBuffer });
@@ -1717,9 +1755,9 @@ describe('Code Process', () => {
         // Extractor MUST NOT have been called yet — that's deferred preview work.
         expect(mockExtractCodeArtifactText).not.toHaveBeenCalled();
         // Persisted record with the pending status.
-        expect(createFile).toHaveBeenCalledWith(
+        expect(mockUpdateFile).toHaveBeenCalledWith(
           expect.objectContaining({ status: 'pending', text: null, textFormat: null }),
-          true,
+          expect.objectContaining({ 'metadata.outputClaimRevision': expect.any(String) }),
         );
       });
 
@@ -1812,7 +1850,9 @@ describe('Code Process', () => {
         });
         mockExtractCodeArtifactText.mockResolvedValueOnce('<table></table>');
         mockGetExtractedTextFormat.mockReturnValueOnce('html');
-        updateFile.mockRejectedValueOnce(new Error('mongo down'));
+        updateFile
+          .mockResolvedValueOnce({ file_id: 'mock-uuid-1234', status: 'pending' })
+          .mockRejectedValueOnce(new Error('mongo down'));
 
         const { finalize } = await processCodeOutput({ ...baseParams, name: 'data.xlsx' });
         await expect(finalize()).resolves.toBeNull();

--- a/api/server/services/Files/Code/process.spec.js
+++ b/api/server/services/Files/Code/process.spec.js
@@ -594,6 +594,7 @@ describe('Code Process', () => {
             },
           ],
         },
+        { returnPrevious: true },
       );
       expect(deleteStoredFile).toHaveBeenCalledWith(
         mockReq,
@@ -625,6 +626,7 @@ describe('Code Process', () => {
       expect(mockUpdateFile).toHaveBeenCalledWith(
         expect.objectContaining({ file_id: 'mock-uuid-1234' }),
         { 'metadata.outputClaimRevision': 'mock-uuid-1234' },
+        { returnPrevious: true },
       );
       expect(deleteStoredFile).toHaveBeenCalled();
       expect(mockDeleteFileByFilter).toHaveBeenCalledWith({
@@ -664,6 +666,12 @@ describe('Code Process', () => {
       mockClaimCodeFile.mockResolvedValue({
         file_id: 'existing-file-id',
         filename: 'test-file.txt',
+        filepath: '/old/object.txt',
+        source: 's3',
+        bytes: 50,
+      });
+      mockUpdateFile.mockResolvedValue({
+        file_id: 'existing-file-id',
         filepath: '/old/object.txt',
         source: 's3',
         bytes: 50,
@@ -795,6 +803,7 @@ describe('Code Process', () => {
         expect(mockUpdateFile).toHaveBeenCalledWith(
           expect.objectContaining({ tenantId: 'tenantA' }),
           expect.objectContaining({ 'metadata.outputClaimRevision': expect.any(String) }),
+          { returnPrevious: true },
         );
       });
 
@@ -910,6 +919,7 @@ describe('Code Process', () => {
             storageRegion: 'us-east-2',
           }),
           expect.objectContaining({ 'metadata.outputClaimRevision': expect.any(String) }),
+          { returnPrevious: true },
         );
         expect(typeof finalize).toBe('function');
       });
@@ -942,6 +952,7 @@ describe('Code Process', () => {
         expect(mockUpdateFile).toHaveBeenCalledWith(
           expect.objectContaining({ tenantId: 'tenantA' }),
           expect.objectContaining({ 'metadata.outputClaimRevision': expect.any(String) }),
+          { returnPrevious: true },
         );
       });
 
@@ -1076,6 +1087,7 @@ describe('Code Process', () => {
         expect(mockUpdateFile).toHaveBeenCalledWith(
           expect.objectContaining({ text: 'hello world\n' }),
           expect.objectContaining({ 'metadata.outputClaimRevision': expect.any(String) }),
+          { returnPrevious: true },
         );
       });
 
@@ -1430,6 +1442,7 @@ describe('Code Process', () => {
             context: FileContext.execute_code,
           }),
           { 'metadata.outputClaimRevision': expect.any(String) },
+          { returnPrevious: true },
         );
       });
     });
@@ -1758,6 +1771,7 @@ describe('Code Process', () => {
         expect(mockUpdateFile).toHaveBeenCalledWith(
           expect.objectContaining({ status: 'pending', text: null, textFormat: null }),
           expect.objectContaining({ 'metadata.outputClaimRevision': expect.any(String) }),
+          { returnPrevious: true },
         );
       });
 

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -653,6 +653,7 @@ const uploadImageBuffer = async ({ req, context, metadata = {}, resize = true })
  */
 const processFileUpload = async ({ req, res, metadata, sseStream, openai: providedOpenAI }) => {
   const retentionExpiryPromise = getRetentionExpiry(req);
+  const storageScope = resolveStorageScope(req);
   const appConfig = req.config;
   const isAssistantUpload = isAssistantsEndpoint(metadata.endpoint);
   const assistantSource =
@@ -780,7 +781,7 @@ const processFileUpload = async ({ req, res, metadata, sseStream, openai: provid
       metadata: secondaryStorageSource ? { secondaryStorageSource } : undefined,
       height,
       width,
-      tenantId: req.user.tenantId,
+      tenantId: storageScope.tenantId,
     },
     isAssistantUpload
       ? async () => {
@@ -1443,7 +1444,7 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
       source: storedSource,
       height,
       width,
-      tenantId: req.user.tenantId,
+      tenantId: storageScope.tenantId,
       llmDeliveryPath,
     }),
     ...retentionExpiry,

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -678,6 +678,29 @@ const processFileUpload = async ({ req, res, metadata, sseStream, openai: provid
   });
   let bytes = providerBytes;
 
+  const rollbackAssistantProviderUpload = async () => {
+    const cleanup = [];
+    if (!metadata.message_file && !metadata.tool_resource) {
+      cleanup.push(openai.beta.assistants.files.del(metadata.assistant_id, id));
+    } else if (!metadata.message_file) {
+      cleanup.push(
+        deleteResourceFileId({
+          req,
+          openai,
+          file_id: id,
+          assistant_id: metadata.assistant_id,
+          tool_resource: metadata.tool_resource,
+        }),
+      );
+    }
+    cleanup.push(openai.files.del(id));
+    const results = await Promise.allSettled(cleanup);
+    const failed = results.find((result) => result.status === 'rejected');
+    if (failed) {
+      throw failed.reason;
+    }
+  };
+
   if (isAssistantUpload && !metadata.message_file && !metadata.tool_resource) {
     /** Authorized at the route before any bytes are sent — see
      *  `assertLegacyAssistantUploadAllowed` in `~/server/routes/files/files`. */
@@ -696,6 +719,7 @@ const processFileUpload = async ({ req, res, metadata, sseStream, openai: provid
 
   let filepath = isAssistantUpload ? `${openai.baseURL}/files/${id}` : _filepath;
   let secondaryStoredFile;
+  let persistedSource = source;
   let storageMetadata = getStorageMetadata({
     filepath,
     source,
@@ -712,6 +736,7 @@ const processFileUpload = async ({ req, res, metadata, sseStream, openai: provid
     secondaryStoredFile = result;
     bytes = providerBytes + (result.bytes ?? 0);
     filepath = result.filepath;
+    persistedSource = result.source;
     storageMetadata = getStorageMetadata({
       filepath,
       source: result.source,
@@ -741,15 +766,24 @@ const processFileUpload = async ({ req, res, metadata, sseStream, openai: provid
       type: file.mimetype,
       ...(await retentionExpiryPromise),
       embedded,
-      source,
+      source: persistedSource,
       height,
       width,
       tenantId: req.user.tenantId,
     },
-    /* The converted image is a distinct app-storage object. The provider-side
-     * cleanup is completed by the final enforcement PR, while this scoped write
-     * owns and removes the converted copy when admission rejects it. */
-    rollbackStoredFile,
+    isAssistantUpload
+      ? async () => {
+          const cleanup = [rollbackAssistantProviderUpload()];
+          if (secondaryStoredFile) {
+            cleanup.push(deleteStoredBlob(req, secondaryStoredFile));
+          }
+          const results = await Promise.allSettled(cleanup);
+          const failed = results.find((item) => item.status === 'rejected');
+          if (failed) {
+            throw failed.reason;
+          }
+        }
+      : rollbackStoredFile,
   );
   sendUploadSuccess(res, sseStream, 'File uploaded and processed successfully', result);
 };
@@ -1404,9 +1438,28 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
     ...retentionExpiry,
   };
 
-  const result = await persistFile(req, fileInfo, () =>
-    deleteStoredBlob(req, { source: storedSource, filepath, ...storageMetadata }),
-  );
+  const result = await persistFile(req, fileInfo, async () => {
+    const cleanup = [deleteStoredBlob(req, fileInfo)];
+    if (hasCodeEnvRef(fileInfo)) {
+      const { deleteFile: deleteCodeEnvFile } = getStrategyFunctions(FileSources.execute_code);
+      if (deleteCodeEnvFile) {
+        cleanup.push(deleteCodeEnvFile(req, fileInfo));
+      }
+    }
+    if (!messageAttachment && effectiveToolResource) {
+      cleanup.push(
+        db.removeAgentResourceFiles({
+          agent_id,
+          files: [{ file_id, tool_resource: effectiveToolResource }],
+        }),
+      );
+    }
+    const results = await Promise.allSettled(cleanup);
+    const failed = results.find((item) => item.status === 'rejected');
+    if (failed) {
+      throw failed.reason;
+    }
+  });
 
   sendUploadSuccess(res, sseStream, 'Agent file uploaded and processed successfully', result);
 };

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -198,6 +198,16 @@ const getDeleteMethod = ({ source, deletionMethods }) => {
 const createDeleteFileWithSecondaryStorage = ({ source, deleteFile, deletionMethods }) => {
   return async (req, file, openai) => {
     const secondaryDeleteMethods = [];
+    const secondaryStorageSource = file.metadata?.secondaryStorageSource;
+    if (secondaryStorageSource && secondaryStorageSource !== source) {
+      const deleteSecondaryStorage = getDeleteMethod({
+        source: secondaryStorageSource,
+        deletionMethods,
+      });
+      secondaryDeleteMethods.push((req, file) =>
+        deleteSecondaryStorage(req, { ...file, source: secondaryStorageSource }),
+      );
+    }
     if (file.embedded === true && source !== FileSources.vectordb) {
       secondaryDeleteMethods.push(
         getDeleteMethod({ source: FileSources.vectordb, deletionMethods }),
@@ -719,7 +729,7 @@ const processFileUpload = async ({ req, res, metadata, sseStream, openai: provid
 
   let filepath = isAssistantUpload ? `${openai.baseURL}/files/${id}` : _filepath;
   let secondaryStoredFile;
-  let persistedSource = source;
+  let secondaryStorageSource;
   let storageMetadata = getStorageMetadata({
     filepath,
     source,
@@ -736,7 +746,7 @@ const processFileUpload = async ({ req, res, metadata, sseStream, openai: provid
     secondaryStoredFile = result;
     bytes = providerBytes + (result.bytes ?? 0);
     filepath = result.filepath;
-    persistedSource = result.source;
+    secondaryStorageSource = result.source;
     storageMetadata = getStorageMetadata({
       filepath,
       source: result.source,
@@ -766,7 +776,8 @@ const processFileUpload = async ({ req, res, metadata, sseStream, openai: provid
       type: file.mimetype,
       ...(await retentionExpiryPromise),
       embedded,
-      source: persistedSource,
+      source,
+      metadata: secondaryStorageSource ? { secondaryStorageSource } : undefined,
       height,
       width,
       tenantId: req.user.tenantId,

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -1446,6 +1446,12 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
         cleanup.push(deleteCodeEnvFile(req, fileInfo));
       }
     }
+    if (fileInfo.embedded) {
+      const { deleteFile: deleteVectorFile } = getStrategyFunctions(FileSources.vectordb);
+      if (deleteVectorFile) {
+        cleanup.push(deleteVectorFile(req, fileInfo));
+      }
+    }
     if (!messageAttachment && effectiveToolResource) {
       cleanup.push(
         db.removeAgentResourceFiles({

--- a/api/server/services/Files/process.spec.js
+++ b/api/server/services/Files/process.spec.js
@@ -511,6 +511,7 @@ describe('upload retention scheduling', () => {
         : { handleImageUpload: imageUpload, deleteFile: deleteImage },
     );
     const req = makeReq({ mimetype: 'image/png', body: { endpoint: 'assistants' } });
+    req.config.imageOutputType = 'webp';
     const openai = {
       baseURL: 'https://api.openai.test',
       files: { del: jest.fn() },
@@ -545,6 +546,55 @@ describe('upload retention scheduling', () => {
     expect(deleteImage).toHaveBeenCalledWith(
       req,
       expect.objectContaining({ filepath: '/images/user-123/upload.webp' }),
+    );
+  });
+
+  it('preserves provider ownership when an assistant image also creates an app-storage copy', async () => {
+    const providerUpload = jest.fn().mockResolvedValue({
+      id: 'provider-file-id',
+      bytes: 42,
+      filename: 'upload.png',
+      filepath: 'https://api.openai.test/files/provider-file-id',
+    });
+    const imageUpload = jest.fn().mockResolvedValue({
+      filepath: '/images/user-123/upload.webp',
+      source: FileSources.local,
+      bytes: 40,
+      width: 10,
+      height: 10,
+    });
+    getStrategyFunctions.mockImplementation((source) =>
+      source === FileSources.openai
+        ? { handleFileUpload: providerUpload }
+        : { handleImageUpload: imageUpload },
+    );
+    const req = makeReq({ mimetype: 'image/png', body: { endpoint: 'assistants' } });
+    req.config.imageOutputType = 'webp';
+    const openai = {
+      baseURL: 'https://api.openai.test',
+      files: { del: jest.fn() },
+      beta: { assistants: { files: { create: jest.fn() } } },
+    };
+
+    await processFileUpload({
+      req,
+      res: mockRes,
+      metadata: {
+        endpoint: 'assistants',
+        assistant_id: 'assistant-1',
+        file_id: 'temp-file-id',
+      },
+      openai,
+    });
+
+    expect(db.createFile).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        file_id: 'provider-file-id',
+        source: FileSources.openai,
+        filepath: '/images/user-123/upload.webp',
+        metadata: { secondaryStorageSource: FileSources.local },
+      }),
+      true,
     );
   });
 });
@@ -2800,6 +2850,35 @@ describe('processDeleteRequest', () => {
     expect(vectorDelete).toHaveBeenCalledWith(req, file);
     expect(db.deleteFiles).toHaveBeenCalledWith(['embedded-file']);
     expect(result).toEqual({ deletedFileIds: ['embedded-file'], failedFileIds: [] });
+  });
+
+  it('deletes both provider storage and the secondary image copy', async () => {
+    const { LB_QueueAsyncCall } = require('~/server/utils/queue');
+    LB_QueueAsyncCall.mockImplementation((operation, args, callback) => {
+      operation(...args).then((result) => callback(null, result), callback);
+    });
+    const providerDelete = jest.fn().mockResolvedValue(undefined);
+    const imageDelete = jest.fn().mockResolvedValue(undefined);
+    getStrategyFunctions.mockImplementation((source) => ({
+      deleteFile: source === FileSources.openai ? providerDelete : imageDelete,
+    }));
+    db.deleteFiles.mockResolvedValue({ deletedCount: 1 });
+    const req = {
+      body: {},
+      config: {},
+      user: { id: 'user-123', tenantId: 'tenant-a' },
+    };
+    const file = {
+      file_id: 'provider-file-id',
+      filepath: '/images/user-123/upload.webp',
+      source: FileSources.openai,
+      metadata: { secondaryStorageSource: FileSources.local },
+    };
+    const result = await processDeleteRequest({ req, files: [file] });
+
+    expect(providerDelete).toHaveBeenCalledWith(req, file, undefined);
+    expect(imageDelete).toHaveBeenCalledWith(req, { ...file, source: FileSources.local });
+    expect(result).toEqual({ deletedFileIds: ['provider-file-id'], failedFileIds: [] });
   });
 
   it('keeps embedded file metadata when vector deletion fails', async () => {

--- a/api/server/services/Files/process.spec.js
+++ b/api/server/services/Files/process.spec.js
@@ -1922,7 +1922,6 @@ describe('processAgentFileUpload', () => {
         },
       });
       const req = makeReq({ mimetype: 'text/markdown', ocrConfig: null });
-
       await processAgentFileUpload({
         req,
         res: mockRes,
@@ -2244,6 +2243,8 @@ describe('processAgentFileUpload', () => {
         makeFileConfig({ textSupportedMimeTypes: ['text/markdown'] }),
       );
       const req = makeReq({ mimetype: 'text/markdown', ocrConfig: null });
+      req.tenantId = 'request-tenant';
+      req.user.tenantId = 'stale-user-tenant';
 
       try {
         await expect(
@@ -2255,7 +2256,10 @@ describe('processAgentFileUpload', () => {
 
       expect(deleteFile).toHaveBeenCalledWith(
         req,
-        expect.objectContaining({ filepath: '/uploads/user-123/upload.bin' }),
+        expect.objectContaining({
+          filepath: '/uploads/user-123/upload.bin',
+          tenantId: 'request-tenant',
+        }),
       );
       expect(db.removeAgentResourceFiles).toHaveBeenCalledWith({
         agent_id: 'agent-abc',

--- a/api/server/services/Files/quota-boundaries.spec.js
+++ b/api/server/services/Files/quota-boundaries.spec.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+
+const read = (relativePath) => fs.readFileSync(path.resolve(__dirname, relativePath), 'utf8');
+
+describe('storage quota write boundaries', () => {
+  it('keeps core File writes behind the package quota seam', () => {
+    const source = read('./process.js');
+    expect(source).not.toMatch(/db\.createFile\(/);
+    expect(source).toContain('createFileQuotaPersistence({');
+    expect(source).toContain('createFile: db.createFile');
+  });
+
+  it('keeps Code output row commits inside the quota callback', () => {
+    const source = read('./Code/process.js');
+    expect(source.match(/^\s*\? createFile\(/gm)).toHaveLength(1);
+    expect(source).toContain('const committed = await persistCodeFile(');
+    expect(source).toContain('? createFile(scopedRow, true)');
+  });
+
+  it('keeps server SkillFile writes behind the shared quota service', () => {
+    const routes = read('../../routes/skills.js');
+    const skillDeps = read('../Endpoints/agents/skillDeps.js');
+    const sync = read('../Skills/sync.js');
+    expect(routes).not.toMatch(/\bupsertSkillFile\s*\(/);
+    expect(skillDeps).not.toMatch(/db\.upsertSkillFile\s*\(/);
+    expect(sync).not.toMatch(/upsertSkillFile:\s*db\.upsertSkillFile/);
+  });
+});

--- a/api/server/services/Files/quota-boundaries.spec.js
+++ b/api/server/services/Files/quota-boundaries.spec.js
@@ -14,7 +14,8 @@ describe('storage quota write boundaries', () => {
   it('keeps Code output row commits inside the quota callback', () => {
     const source = read('./Code/process.js');
     expect(source.match(/^\s*\? createFile\(/gm)).toHaveLength(1);
-    expect(source).toContain('const committed = await persistCodeFile(');
+    expect(source).toContain('const persistCodeFile = createFileQuotaCommitter({');
+    expect(source).toContain('await persistCodeFile(');
     expect(source).toContain('? createFile(scopedRow, true)');
   });
 

--- a/api/server/services/Files/quota-boundaries.spec.js
+++ b/api/server/services/Files/quota-boundaries.spec.js
@@ -13,10 +13,11 @@ describe('storage quota write boundaries', () => {
 
   it('keeps Code output row commits inside the quota callback', () => {
     const source = read('./Code/process.js');
-    expect(source.match(/^\s*\? createFile\(/gm)).toHaveLength(1);
+    expect(source).not.toMatch(/\bcreateFile\(/);
     expect(source).toContain('const persistCodeFile = createFileQuotaCommitter({');
     expect(source).toContain('await persistCodeFile(');
-    expect(source).toContain('? createFile(scopedRow, true)');
+    expect(source).toContain("? { 'metadata.outputClaimRevision': outputClaimRevision }");
+    expect(source).toContain('updateFile(');
   });
 
   it('keeps server SkillFile writes behind the shared quota service', () => {

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -1042,6 +1042,7 @@ endpoints:
 #     tokens: 2000 # Also preserve up to this many recent tokens
 
 # fileConfig:
+#   storageLimit: 1024  # Per-user stored File + authored SkillFile quota in MB; omit to disable
 #   fileContextSizeLimit: 128  # Maximum aggregate model-bound attachment size in one agent turn (MB)
 #   fileContextCharLimit: 1000000  # Maximum aggregate extracted-text characters in one agent turn
 #   endpoints:

--- a/packages/api/src/files/quota.spec.ts
+++ b/packages/api/src/files/quota.spec.ts
@@ -1210,6 +1210,26 @@ describe('createSkillFileQuotaPersistence', () => {
 });
 
 describe('createFileQuotaCommitter', () => {
+  it('forwards the replaced row identity for safe replacement credit', async () => {
+    const write = jest.fn(async (row) => row);
+    const committer = createFileQuotaCommitter<TestRequest>({
+      resolveScope: resolveStorageScope,
+      getUserStorageUsage: usageOf(megabyte - 2),
+      onCleanupError: noRollbackErrors,
+    });
+
+    await committer(
+      makeReq({ storageLimitMb: 1 }),
+      { bytes: 8, file_id: 'file-a' },
+      write,
+      null,
+      6,
+      { file_id: 'file-a', user: userId },
+    );
+
+    expect(write).toHaveBeenCalled();
+  });
+
   it('stamps the resolved tenant and classifies a conditional persistence miss', async () => {
     const committer = createFileQuotaCommitter<TestRequest>({
       resolveScope: resolveStorageScope,

--- a/packages/api/src/files/quota.spec.ts
+++ b/packages/api/src/files/quota.spec.ts
@@ -1,9 +1,11 @@
 import type { UserStorageUsageParams } from '@librechat/data-schemas';
 import type { GetUserStorageUsage, StorageScope } from './quota';
 import {
+  createFileQuotaCommitter,
   createSkillFileQuotaPersistence,
   FILE_STORAGE_LIMIT_ERROR_CODE,
   FileStorageLimitError,
+  isFilePersistenceNotCommittedError,
   isFileStorageLimitError,
   persistFileWithQuota,
   persistSkillFileWithQuota,
@@ -1204,6 +1206,27 @@ describe('createSkillFileQuotaPersistence', () => {
     await persistence.getSharedValue('user-a\0tenant-a', load);
 
     expect(load).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('createFileQuotaCommitter', () => {
+  it('stamps the resolved tenant and classifies a conditional persistence miss', async () => {
+    const committer = createFileQuotaCommitter<TestRequest>({
+      resolveScope: resolveStorageScope,
+      getUserStorageUsage: usageOf(0),
+      onCleanupError: noRollbackErrors,
+    });
+    const write = jest.fn().mockResolvedValue(null);
+
+    const error = await committer(
+      makeReq({ storageLimitMb: 1, requestTenantId: 'request-tenant' }),
+      { bytes: 10, file_id: 'file-a', tenantId: 'stale-tenant' },
+      write,
+      null,
+    ).catch((caught: Error) => caught);
+
+    expect(write).toHaveBeenCalledWith(expect.objectContaining({ tenantId: 'request-tenant' }));
+    expect(isFilePersistenceNotCommittedError(error)).toBe(true);
   });
 });
 

--- a/packages/api/src/files/quota.ts
+++ b/packages/api/src/files/quota.ts
@@ -493,6 +493,7 @@ export type FileQuotaCommitter<TRequest> = <TRow extends FileRow, TResult>(
   write: (row: TRow) => Promise<TResult>,
   rollback: StorageRollback,
   replacedBytes?: number | null,
+  replacing?: { file_id?: string; user?: unknown; tenantId?: string | null } | null,
 ) => Promise<TResult>;
 
 /** Creates a dependency-wired quota committer for nonstandard File write paths. */
@@ -507,6 +508,7 @@ export function createFileQuotaCommitter<TRequest>(dependencies: {
     write: (row: TRow) => Promise<TResult>,
     rollback: StorageRollback,
     replacedBytes?: number | null,
+    replacing?: { file_id?: string; user?: unknown; tenantId?: string | null } | null,
   ): Promise<TResult> =>
     persistFileWithQuota(
       {
@@ -515,6 +517,7 @@ export function createFileQuotaCommitter<TRequest>(dependencies: {
         write,
         rollback,
         replacedBytes,
+        replacing,
         getUserStorageUsage: dependencies.getUserStorageUsage,
       },
       dependencies.onCleanupError,

--- a/packages/api/src/files/quota.ts
+++ b/packages/api/src/files/quota.ts
@@ -35,6 +35,19 @@ export function isFileStorageLimitError(error: unknown): error is FileStorageLim
   );
 }
 
+export class FilePersistenceNotCommittedError extends Error {
+  constructor() {
+    super('Quota-bearing persistence callback completed without committing a row');
+    this.name = 'FilePersistenceNotCommittedError';
+  }
+}
+
+export function isFilePersistenceNotCommittedError(
+  error: unknown,
+): error is FilePersistenceNotCommittedError {
+  return error instanceof Error && error.name === 'FilePersistenceNotCommittedError';
+}
+
 declare const storageScopeBrand: unique symbol;
 
 /**
@@ -377,7 +390,7 @@ async function persistWithQuota<TRow extends LedgerRow, TResult>(
       try {
         const result = await write(scopedRow);
         if (result == null) {
-          throw new Error('Quota-bearing persistence callback completed without committing a row');
+          throw new FilePersistenceNotCommittedError();
         }
         try {
           await assertHeld();
@@ -473,6 +486,40 @@ export type FileQuotaPersistence<TRequest, TResult> = {
     },
   ) => Promise<TResult>;
 };
+
+export type FileQuotaCommitter<TRequest> = <TRow extends FileRow, TResult>(
+  req: TRequest,
+  row: TRow,
+  write: (row: TRow) => Promise<TResult>,
+  rollback: StorageRollback,
+  replacedBytes?: number | null,
+) => Promise<TResult>;
+
+/** Creates a dependency-wired quota committer for nonstandard File write paths. */
+export function createFileQuotaCommitter<TRequest>(dependencies: {
+  resolveScope: (req: TRequest) => StorageScope;
+  getUserStorageUsage: GetUserStorageUsage;
+  onCleanupError: (error: unknown) => void;
+}): FileQuotaCommitter<TRequest> {
+  return <TRow extends FileRow, TResult>(
+    req: TRequest,
+    row: TRow,
+    write: (row: TRow) => Promise<TResult>,
+    rollback: StorageRollback,
+    replacedBytes?: number | null,
+  ): Promise<TResult> =>
+    persistFileWithQuota(
+      {
+        scope: dependencies.resolveScope(req),
+        row,
+        write,
+        rollback,
+        replacedBytes,
+        getUserStorageUsage: dependencies.getUserStorageUsage,
+      },
+      dependencies.onCleanupError,
+    );
+}
 
 /**
  * Builds the application-facing File persistence boundary. The legacy service only

--- a/packages/api/src/utils/files.ts
+++ b/packages/api/src/utils/files.ts
@@ -95,13 +95,17 @@ export function appendLeafSuffix(leaf: string, suffix: string, maxBytes: number)
  * without exposing provider, filesystem, filename, or submitted-content details.
  */
 export function resolveUploadErrorMessage(
-  error: { message?: string } | null | undefined,
+  error: { code?: string; message?: string } | null | undefined,
   defaultMessage = 'Error processing file',
   redactDetails = false,
 ): string {
   const errorMessage = error?.message;
   if (!errorMessage) {
     return defaultMessage;
+  }
+
+  if (error.code === 'FILE_STORAGE_LIMIT_EXCEEDED') {
+    return errorMessage;
   }
 
   if (errorMessage.includes('file_ids')) {

--- a/packages/data-provider/src/types/files.ts
+++ b/packages/data-provider/src/types/files.ts
@@ -182,6 +182,8 @@ export type TFile = {
     codeEnvRefs?: CodeEnvRefMap;
     /** Dispatch-order stamp for the current source artifact generation. */
     sourceDispatchedAt?: number;
+    /** Per-attempt ownership token for foreground generated-file writes. */
+    outputClaimRevision?: string;
     /** Vector namespaces this file has been embedded into. */
     embeddedEntities?: string[];
     /** The user named this destination, so absent ones were declined. */

--- a/packages/data-provider/src/types/files.ts
+++ b/packages/data-provider/src/types/files.ts
@@ -190,6 +190,8 @@ export type TFile = {
     destinationChosen?: boolean;
     /** The type the delivery route was resolved against, when conversion changed it. */
     routingMimeType?: string;
+    /** Backing-store strategy for an additional retained copy. */
+    secondaryStorageSource?: string;
   };
   llmDeliveryPath?: 'provider' | 'text' | 'none';
   createdAt?: string | Date;

--- a/packages/data-schemas/src/methods/file.spec.ts
+++ b/packages/data-schemas/src/methods/file.spec.ts
@@ -215,6 +215,41 @@ describe('File Methods', () => {
       ).toBe(111);
     });
 
+    it('rotates foreground claim ownership without changing the content timestamp', async () => {
+      const userId = new mongoose.Types.ObjectId().toString();
+      const File = mongoose.models.File;
+      await fileMethods.claimCodeFile({
+        filename: 'foreground.csv',
+        conversationId: 'conversation-foreground-claim',
+        file_id: 'foreground-file',
+        user: userId,
+        sourceDispatchedAt: 111,
+        outputClaimRevision: 'claim-a',
+      });
+      const written = new Date('2024-01-01T00:00:00.000Z');
+      await File.updateOne(
+        { file_id: 'foreground-file' },
+        { $set: { updatedAt: written } },
+        { timestamps: false },
+      );
+
+      const reclaimed = await fileMethods.claimCodeFile({
+        filename: 'foreground.csv',
+        conversationId: 'conversation-foreground-claim',
+        file_id: 'unused-file-id',
+        user: userId,
+        sourceDispatchedAt: 222,
+        outputClaimRevision: 'claim-b',
+      });
+
+      expect(reclaimed.file_id).toBe('foreground-file');
+      expect((reclaimed.metadata as { outputClaimRevision?: string }).outputClaimRevision).toBe(
+        'claim-b',
+      );
+      expect((reclaimed.metadata as { sourceDispatchedAt?: number }).sourceDispatchedAt).toBe(222);
+      expect(new Date(reclaimed.updatedAt as unknown as string).getTime()).toBe(written.getTime());
+    });
+
     it('keeps non-tenant code output claims in the legacy namespace', async () => {
       const userId = new mongoose.Types.ObjectId().toString();
 

--- a/packages/data-schemas/src/methods/file.spec.ts
+++ b/packages/data-schemas/src/methods/file.spec.ts
@@ -116,11 +116,13 @@ describe('File Methods', () => {
         metadata: {
           codeEnvRef: defaultRef,
           codeEnvRefs: { default: defaultRef, stateful: statefulRef },
+          secondaryStorageSource: 's3',
         },
       });
 
       expect(file?.metadata?.codeEnvRefs?.default?.file_id).toBe('default-file');
       expect(file?.metadata?.codeEnvRefs?.stateful?.file_id).toBe('stateful-file');
+      expect(file?.metadata?.secondaryStorageSource).toBe('s3');
     });
   });
 

--- a/packages/data-schemas/src/methods/file.spec.ts
+++ b/packages/data-schemas/src/methods/file.spec.ts
@@ -1765,6 +1765,28 @@ describe('File Methods', () => {
       expect(updated?.expiresAt).toBeUndefined();
     });
 
+    it('can return the immediately replaced revision for storage cleanup', async () => {
+      const fileId = uuidv4();
+      const userId = new mongoose.Types.ObjectId();
+      await fileMethods.createFile({
+        file_id: fileId,
+        user: userId,
+        filename: 'output.txt',
+        filepath: '/uploads/revision-a.txt',
+        type: 'text/plain',
+        bytes: 100,
+      });
+
+      const replaced = await fileMethods.updateFile(
+        { file_id: fileId, filepath: '/uploads/revision-b.txt', bytes: 200 },
+        undefined,
+        { returnPrevious: true },
+      );
+
+      expect(replaced?.filepath).toBe('/uploads/revision-a.txt');
+      expect((await fileMethods.findFileById(fileId))?.filepath).toBe('/uploads/revision-b.txt');
+    });
+
     /* The optional `extraFilter` enables conditional updates — used by
      * the deferred-preview render's `finalizePreview` to guard against
      * an older render of the same `file_id` overwriting a newer turn's

--- a/packages/data-schemas/src/methods/file.ts
+++ b/packages/data-schemas/src/methods/file.ts
@@ -107,6 +107,7 @@ export function createFileMethods(mongoose: typeof import('mongoose')): {
   updateFile: (
     data: Partial<IMongoFile> & { file_id: string },
     extraFilter?: FilterQuery<IMongoFile>,
+    options?: { returnPrevious?: boolean },
   ) => Promise<IMongoFile | null>;
   updateFileCodeEnvRef: (data: {
     file_id: string;
@@ -828,6 +829,7 @@ export function createFileMethods(mongoose: typeof import('mongoose')): {
   async function updateFile(
     data: Partial<IMongoFile> & { file_id: string },
     extraFilter?: FilterQuery<IMongoFile>,
+    options?: { returnPrevious?: boolean },
   ): Promise<IMongoFile | null> {
     const File = mongoose.models.File as Model<IMongoFile>;
     const { file_id, ...update } = data;
@@ -837,7 +839,7 @@ export function createFileMethods(mongoose: typeof import('mongoose')): {
     };
     const query: FilterQuery<IMongoFile> = extraFilter ? { file_id, ...extraFilter } : { file_id };
     return File.findOneAndUpdate(query, updateOperation, {
-      new: true,
+      new: options?.returnPrevious !== true,
     }).lean<IMongoFile>();
   }
 

--- a/packages/data-schemas/src/methods/file.ts
+++ b/packages/data-schemas/src/methods/file.ts
@@ -98,6 +98,10 @@ export function createFileMethods(mongoose: typeof import('mongoose')): {
     user: string;
     tenantId?: string | null;
     sourceDispatchedAt?: number;
+    /** Per-attempt ownership token for foreground writers. The eventual
+     *  content update must match this value so a superseded claimant cannot
+     *  commit bytes or remove the winning placeholder. */
+    outputClaimRevision?: string;
   }) => Promise<IMongoFile>;
   createFile: (data: Partial<IMongoFile>, disableTTL?: boolean) => Promise<IMongoFile | null>;
   updateFile: (
@@ -732,6 +736,7 @@ export function createFileMethods(mongoose: typeof import('mongoose')): {
      *  freshly claimed (not-yet-written) row still carries an ownership
      *  signal for the background harvest's stale-output guard. */
     sourceDispatchedAt?: number;
+    outputClaimRevision?: string;
   }): Promise<IMongoFile> {
     const File = mongoose.models.File as Model<IMongoFile>;
     const tenantFilter = data.tenantId ? { tenantId: data.tenantId } : { tenantId: null };
@@ -739,8 +744,8 @@ export function createFileMethods(mongoose: typeof import('mongoose')): {
       file_id: data.file_id,
       user: data.user,
       ...(data.tenantId ? { tenantId: data.tenantId } : {}),
-      ...(data.sourceDispatchedAt != null
-        ? { metadata: { sourceDispatchedAt: data.sourceDispatchedAt } }
+      ...(data.sourceDispatchedAt != null && !data.outputClaimRevision
+        ? { 'metadata.sourceDispatchedAt': data.sourceDispatchedAt }
         : {}),
     };
     const result = await File.findOneAndUpdate(
@@ -750,7 +755,19 @@ export function createFileMethods(mongoose: typeof import('mongoose')): {
         context: FileContext.execute_code,
         ...tenantFilter,
       },
-      { $setOnInsert: insertData },
+      {
+        $setOnInsert: insertData,
+        ...(data.outputClaimRevision
+          ? {
+              $set: {
+                'metadata.outputClaimRevision': data.outputClaimRevision,
+                ...(data.sourceDispatchedAt != null
+                  ? { 'metadata.sourceDispatchedAt': data.sourceDispatchedAt }
+                  : {}),
+              },
+            }
+          : {}),
+      },
       /** `timestamps: false`: a claim is an id reservation, not a content
        *  write — bumping `updatedAt` here would make the row look freshly
        *  written to the background harvest's out-of-order guard, which

--- a/packages/data-schemas/src/schema/file.ts
+++ b/packages/data-schemas/src/schema/file.ts
@@ -161,6 +161,12 @@ const file: Schema<IMongoFile> = new Schema(
         type: String,
         default: undefined,
       },
+      /** Backing-store strategy for a second retained copy, when the provider-facing
+       * source remains the primary File identity. */
+      secondaryStorageSource: {
+        type: String,
+        default: undefined,
+      },
     },
     llmDeliveryPath: {
       /* What upload time inferred about delivery, from the endpoint and MIME type it saw.

--- a/packages/data-schemas/src/schema/file.ts
+++ b/packages/data-schemas/src/schema/file.ts
@@ -134,6 +134,12 @@ const file: Schema<IMongoFile> = new Schema(
         type: Number,
         default: undefined,
       },
+      /** Per-attempt ownership token used to conditionally commit a
+       *  foreground generated-file write. */
+      outputClaimRevision: {
+        type: String,
+        default: undefined,
+      },
       /** Vector namespaces this file has been embedded into. Vectors are stored per
        *  entity, so a duplicated agent needs its own embedding even though the record
        *  is shared. */

--- a/packages/data-schemas/src/types/file.ts
+++ b/packages/data-schemas/src/types/file.ts
@@ -81,6 +81,8 @@ export interface IMongoFile extends Omit<Document, 'model'> {
     destinationChosen?: boolean;
     /** The type the delivery route was resolved against, when conversion changed it. */
     routingMimeType?: string;
+    /** Backing-store strategy for an additional retained copy. */
+    secondaryStorageSource?: string;
   };
   /** Upload-time inference, not a durable contract. See the schema field for why. */
   llmDeliveryPath?: string;

--- a/packages/data-schemas/src/types/file.ts
+++ b/packages/data-schemas/src/types/file.ts
@@ -73,6 +73,8 @@ export interface IMongoFile extends Omit<Document, 'model'> {
     codeEnvRefs?: CodeEnvRefMap;
     /** Dispatch-order stamp for the current source artifact generation. */
     sourceDispatchedAt?: number;
+    /** Per-attempt ownership token for foreground generated-file writes. */
+    outputClaimRevision?: string;
     /** Vector namespaces this file has been embedded into. */
     embeddedEntities?: string[];
     /** The user named this destination, so absent ones were declined. */


### PR DESCRIPTION
## Summary

This PR completes the storage-quota enforcement stack by covering Code outputs, propagating actionable upload responses, cleaning up provider and secondary resources, and adding regression guards plus operator configuration guidance.

- Route generated image, binary, text, and office-preview Code output commits through the quota ledger.
- Store Code replacements under revisioned keys so rejected or stale replacements cannot destroy the previous object.
- Delete the immediate predecessor only after the conditional database commit succeeds.
- Return HTTP/SSE `413` with the safe quota message for file, image, and SkillFile uploads.
- Detach and delete request-created OpenAI/Azure assistant files when enforcement rejects their row.
- Remove agent references, vector resources, code-environment resources, and request-owned blobs on rejected uploads.
- Reject returning OpenAI image outputs when their metadata row was not persisted.
- Add source guards preventing core File, Code-output, and SkillFile paths from bypassing their quota seams.
- Add `fileConfig.storageLimit` to `librechat.example.yaml`; detailed documentation is in LibreChat-AI/librechat.ai#765.

Depends on #15788.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

- Final top-of-stack focused run: package API 4 suites / 253 tests, data schemas 2 suites / 113 tests, server API 12 suites / 439 tests.
- Built `packages/data-provider`, `packages/data-schemas`, and `packages/api`; TypeScript checks pass for packages API and client.
- Targeted lint/format/import checks and `git diff --check` pass.
- Restacked on current #15788; the full chain begins at `origin/dev` commit `ac2307b2ef`.
- Required CI is the authoritative broad matrix.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
