### PR TITLE
🧷 ci: Await durable finalization in conversation-management mock e2e

### DIFF
--- a/e2e/specs/mock/conversation-management.spec.ts
+++ b/e2e/specs/mock/conversation-management.spec.ts
@@ -7,7 +7,7 @@ import {
   replyPrompt,
   replyText,
   selectMockEndpoint,
-  sendMessage,
+  sendMessageAndWaitForCompletion,
 } from './helpers';
 
 const firstConversation = (page: Page) => page.getByTestId('convo-item').first();
@@ -24,7 +24,7 @@ async function openMockChat(page: Page) {
 async function sendAndExpectReply(page: Page, label: string) {
   const prompt = replyPrompt(label);
   const reply = replyText(label);
-  const response = await sendMessage(page, prompt);
+  const response = await sendMessageAndWaitForCompletion(page, prompt);
   expect(response.ok()).toBeTruthy();
   await expect(messagesView(page).getByText(prompt)).toBeVisible();
   await expect(messagesView(page).getByText(reply)).toBeVisible();
@@ -48,6 +48,7 @@ async function renameConversation(page: Page, conversation: Locator, title: stri
 
 test.describe('conversation management', () => {
   test('loads a past sidebar conversation with its message history', async ({ page }) => {
+    test.setTimeout(90000);
     const firstLabel = uniqueLabel('sidebar-history-first');
     const secondLabel = uniqueLabel('sidebar-history-second');
 
@@ -73,6 +74,7 @@ test.describe('conversation management', () => {
   });
 
   test('renames a conversation from the sidebar', async ({ page }) => {
+    test.setTimeout(60000);
     const label = uniqueLabel('sidebar-rename');
     const renamedTitle = `Renamed ${label}`;
 
@@ -87,6 +89,7 @@ test.describe('conversation management', () => {
   test('deletes a conversation, clears its messages, and blocks direct URL access', async ({
     page,
   }) => {
+    test.setTimeout(60000);
     const label = uniqueLabel('sidebar-delete');
     const renamedTitle = `Delete ${label}`;
 


### PR DESCRIPTION
## Summary

`conversation-management.spec.ts` sends two turns into one conversation, but `sendAndExpectReply` returned as soon as the reply text was visible — which happens before the stream emits `FINAL`. The second `Enter` was therefore pressed while the composer was still locked on the in-flight turn, the keypress was dropped with no request and no error, and `sendMessage`'s `page.waitForResponse` waited out its 30s budget on a POST that was never issued. The spec now sends through `sendMessageAndWaitForCompletion`, so each turn is durably finalized before the next one is typed.

Fixes #15790

This spec was last touched by #14270, just before #14740 introduced `sendMessageAndWaitForCompletion` and moved `agent-handoffs`, `agents`, `chat`, `mcp`, `model-switching`, `streaming` and `subagent-results` onto it. It was the remaining multi-turn mock spec still on the lower-level helper.

## How it works

The helper swap is the whole mechanism:

```diff
-  const response = await sendMessage(page, prompt);
+  const response = await sendMessageAndWaitForCompletion(page, prompt);
```

Awaiting finalization costs real wall-clock per turn, so the three tests get explicit budgets, matching what #14740 gave the equivalent tests in `chat.spec.ts` (60s for one send, 90s for two):

```text
loads a past sidebar conversation with its message history   2 sends -> setTimeout(90000)
renames a conversation from the sidebar                      1 send  -> setTimeout(60000)
deletes a conversation, clears its messages, ...             1 send  -> setTimeout(60000)
```

Without those, the 30s default would turn an intermittent dropped keypress into a reliable timeout.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

`sendMessage` is left untouched, so the seven specs already migrated by #14740 and the tests that deliberately observe live, paused, aborted or failed runs are unaffected. The change is confined to one spec file: the imported helper, one call site inside `sendAndExpectReply`, and three `test.setTimeout` calls.

Please run the model-free mock suite on CI to confirm. Locally the case is best exercised with retries disabled so the race is not absorbed:

```bash
npx playwright test --config e2e/playwright.config.mock.ts conversation-management.spec.ts --repeat-each=10
```

### **Test Configuration**:

Chromium, `e2e/playwright.config.mock.ts` (model-free mock server), `retries: 0` for reproduction.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
