### PR TITLE
feat(tools): add Azure OpenAI Sora video generation tool

### DIFF
--- a/api/app/clients/tools/index.js
+++ b/api/app/clients/tools/index.js
@@ -12,6 +12,7 @@ const TraversaalSearch = require('./structured/TraversaalSearch');
 const createOpenAIImageTools = require('./structured/OpenAIImageTools');
 const TavilySearchResults = require('./structured/TavilySearchResults');
 const createGeminiImageTool = require('./structured/GeminiImageGen');
+const { createAzureSoraTools } = require('./structured/AzureSora');
 
 module.exports = {
   ...manifest,
@@ -27,4 +28,5 @@ module.exports = {
   TavilySearchResults,
   createOpenAIImageTools,
   createGeminiImageTool,
+  createAzureSoraTools,
 };

--- a/api/app/clients/tools/manifest.json
+++ b/api/app/clients/tools/manifest.json
@@ -173,5 +173,23 @@
         "optional": true
       }
     ]
+  },
+  {
+    "name": "Azure OpenAI Sora Video Generation",
+    "pluginKey": "video_gen_sora_azure",
+    "description": "Generates short videos from text prompts using Azure OpenAI Sora. Configure AZURE_SORA_API_KEY and AZURE_SORA_ENDPOINT (or the general Azure OpenAI variables).",
+    "icon": "assets/video_gen_sora_azure.svg",
+    "authConfig": [
+      {
+        "authField": "AZURE_SORA_API_KEY",
+        "label": "Azure Sora API Key",
+        "description": "Your Azure OpenAI API key with access to the Sora video generation deployment"
+      },
+      {
+        "authField": "AZURE_SORA_ENDPOINT",
+        "label": "Azure Sora Endpoint URL",
+        "description": "Your Azure OpenAI resource endpoint (e.g. https://your-resource.openai.azure.com)"
+      }
+    ]
   }
 ]

--- a/api/app/clients/tools/structured/AzureSora.js
+++ b/api/app/clients/tools/structured/AzureSora.js
@@ -1,0 +1,241 @@
+const axios = require('axios');
+const { logger } = require('@librechat/data-schemas');
+const { Tool } = require('@librechat/agents/langchain/tools');
+const { ContentTypes, FileContext } = require('librechat-data-provider');
+const { logAxiosError } = require('@librechat/api');
+
+const DEFAULT_API_VERSION = 'preview';
+const DEFAULT_DEPLOYMENT = 'sora';
+const POLL_INTERVAL_MS = 5000;
+const POLL_TIMEOUT_MS = 10 * 60 * 1000;
+
+const ALLOWED_SIZES = ['1280x720', '720x1280'];
+const ALLOWED_SECONDS = ['4', '8', '12'];
+
+const displayMessage =
+  'The tool generated a video from the text prompt. The generated video is already plainly visible to the user, so do not repeat the prompt or describe the video contents in detail.';
+
+const azureSoraJsonSchema = {
+  type: 'object',
+  properties: {
+    prompt: {
+      type: 'string',
+      maxLength: 2000,
+      description:
+        'Detailed natural-language description of the video scene to generate, including subject, motion, camera movement and mood.',
+    },
+    size: {
+      type: 'string',
+      enum: ALLOWED_SIZES,
+      description:
+        'Resolution of the generated video. 1280x720 is landscape (default), 720x1280 is portrait.',
+    },
+    seconds: {
+      type: 'string',
+      enum: ALLOWED_SECONDS,
+      description: 'Length of the generated video in seconds. One of 4 (default), 8 or 12.',
+    },
+  },
+  required: ['prompt'],
+};
+
+class AzureSoraTool extends Tool {
+  constructor(fields = {}) {
+    super();
+    this.userId = fields.userId;
+    this.req = fields.req;
+    this.isAgent = fields.isAgent;
+    if (this.isAgent) {
+      this.responseFormat = 'content_and_artifact';
+    }
+    this.processFileURL = fields.processFileURL?.bind(this);
+    this.fileStrategy = fields.fileStrategy;
+
+    this.name = 'video_gen_sora_azure';
+    this.description =
+      'Generates a short video from a detailed text prompt using Azure OpenAI Sora. Use this when the user explicitly asks to create, generate or make a video.';
+    this.schema = azureSoraJsonSchema;
+
+    this.apiKey =
+      fields.AZURE_SORA_API_KEY || process.env.AZURE_SORA_API_KEY || process.env.AZURE_API_KEY || '';
+    this.endpoint =
+      fields.AZURE_SORA_ENDPOINT ||
+      process.env.AZURE_SORA_ENDPOINT ||
+      process.env.AZURE_OPENAI_ENDPOINT ||
+      '';
+    this.apiVersion = process.env.AZURE_SORA_API_VERSION || DEFAULT_API_VERSION;
+    this.deploymentName = process.env.AZURE_SORA_DEPLOYMENT_NAME || DEFAULT_DEPLOYMENT;
+    this.pollIntervalMs = Number(process.env.AZURE_SORA_POLL_INTERVAL_MS) || POLL_INTERVAL_MS;
+  }
+
+  getCleanEndpoint() {
+    return this.endpoint.replace(/\/+$/, '');
+  }
+
+  getJobSubmissionUrls() {
+    const endpoint = this.getCleanEndpoint();
+    const base = `${endpoint}/openai/v1/video/generations`;
+    return [
+      `${base}/jobs?api-version=${this.apiVersion}`,
+      `${endpoint}/openai/deployments/${this.deploymentName}/videos/submissions?api-version=${this.apiVersion}`,
+    ];
+  }
+
+  getJobStatusUrl(jobId) {
+    return `${this.getCleanEndpoint()}/openai/v1/video/generations/jobs/${jobId}?api-version=${this.apiVersion}`;
+  }
+
+  getVideoContentUrl(jobId) {
+    return `${this.getCleanEndpoint()}/openai/v1/video/generations/${jobId}/content/video?api-version=${this.apiVersion}`;
+  }
+
+  async submitJob(prompt, size, seconds) {
+    const payload = {
+      model: this.deploymentName,
+      prompt,
+      size,
+      seconds,
+    };
+
+    let lastError;
+    for (const url of this.getJobSubmissionUrls()) {
+      try {
+        logger.debug(`[AzureSora] Submitting video generation job to ${url}`);
+        const response = await axios.post(
+          url,
+          payload,
+          {
+            headers: { 'api-key': this.apiKey, 'Content-Type': 'application/json' },
+            timeout: 30000,
+          },
+        );
+        return response.data;
+      } catch (error) {
+        lastError = error;
+        logAxiosError({ message: `[AzureSora] Job submission failed for ${url}`, error });
+      }
+    }
+
+    throw new Error(
+      `Failed to submit the video generation job to Azure OpenAI: ${lastError?.message ?? 'unknown error'}`,
+    );
+  }
+
+  async pollJobUntilComplete(jobId) {
+    const statusUrl = this.getJobStatusUrl(jobId);
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < POLL_TIMEOUT_MS) {
+      await new Promise((resolve) => setTimeout(resolve, this.pollIntervalMs));
+
+      let data;
+      try {
+        const response = await axios.get(statusUrl, {
+          headers: { 'api-key': this.apiKey },
+          timeout: 15000,
+        });
+        data = response.data;
+      } catch (error) {
+        // transient network errors during polling are retried until the timeout
+        logger.warn(`[AzureSora] Poll request failed, retrying: ${error.message}`);
+        continue;
+      }
+
+      const status = data?.status;
+      logger.debug(`[AzureSora] Job ${jobId} status: ${status}`);
+
+      if (status === 'succeeded') {
+        return jobId;
+      }
+      if (status === 'failed' || status === 'cancelled') {
+        const message = data?.error?.message || `Video generation ended with status "${status}"`;
+        throw new Error(`Azure Sora generation failed: ${message}`);
+      }
+    }
+
+    throw new Error('Azure Sora video generation timed out.');
+  }
+
+  async downloadVideo(jobId) {
+    const contentUrl = this.getVideoContentUrl(jobId);
+    const response = await axios.get(contentUrl, {
+      headers: { 'api-key': this.apiKey },
+      responseType: 'arraybuffer',
+      timeout: 120000,
+    });
+    return Buffer.from(response.data);
+  }
+
+  async _call({ prompt, size = '1280x720', seconds = '4' }) {
+    if (!prompt) {
+      throw new Error('Missing required field: prompt');
+    }
+    if (!this.apiKey || !this.endpoint) {
+      throw new Error(
+        'Azure Sora is not configured. Set AZURE_SORA_API_KEY and AZURE_SORA_ENDPOINT (or AZURE_API_KEY / AZURE_OPENAI_ENDPOINT).',
+      );
+    }
+
+    const job = await this.submitJob(prompt, size, seconds);
+    const jobId = job?.id;
+    if (!jobId) {
+      throw new Error('Azure Sora did not return a job id.');
+    }
+
+    await this.pollJobUntilComplete(jobId);
+    const videoBuffer = await this.downloadVideo(jobId);
+
+    // The Azure content URL requires the api-key header, which file storage
+    // strategies cannot send when fetching a URL. Embed the bytes as a data URI
+    // so every file strategy can persist them, and keep a graceful fallback to
+    // returning the video inline when storage fails.
+    const dataUri = `data:video/mp4;base64,${videoBuffer.toString('base64')}`;
+
+    if (this.processFileURL) {
+      try {
+        const fileRecord = await this.processFileURL({
+          URL: dataUri,
+          basePath: 'files',
+          userId: this.userId,
+          fileName: `vid-${jobId}.mp4`,
+          fileStrategy: this.fileStrategy,
+          context: FileContext.video_generation,
+          req: this.req,
+        });
+
+        const file_id = fileRecord?.file_id;
+        const content = [
+          {
+            type: ContentTypes.VIDEO_URL,
+            video_url: { url: fileRecord?.filepath ?? dataUri },
+          },
+        ];
+        const textResponse = [
+          {
+            type: ContentTypes.TEXT,
+            text: `${displayMessage}\ngenerated_video_id: "${file_id ?? jobId}"`,
+          },
+        ];
+        return [textResponse, { content, file_ids: file_id ? [file_id] : [] }];
+      } catch (error) {
+        logger.error('[AzureSora] Failed to save the video file:', error);
+      }
+    }
+
+    // fallback: return the video inline as a data URI
+    const content = [
+      {
+        type: ContentTypes.VIDEO_URL,
+        video_url: { url: dataUri },
+      },
+    ];
+    const textResponse = [{ type: ContentTypes.TEXT, text: displayMessage }];
+    return [textResponse, { content }];
+  }
+}
+
+const createAzureSoraTools = (fields = {}) => new AzureSoraTool(fields);
+
+module.exports = AzureSoraTool;
+module.exports.AzureSoraTool = AzureSoraTool;
+module.exports.createAzureSoraTools = createAzureSoraTools;

--- a/api/app/clients/tools/structured/AzureSora.js
+++ b/api/app/clients/tools/structured/AzureSora.js
@@ -8,6 +8,7 @@ const DEFAULT_API_VERSION = 'preview';
 const DEFAULT_DEPLOYMENT = 'sora';
 const POLL_INTERVAL_MS = 5000;
 const POLL_TIMEOUT_MS = 10 * 60 * 1000;
+const MAX_VIDEO_BYTES = 100 * 1024 * 1024;
 
 const ALLOWED_SIZES = ['1280x720', '720x1280'];
 const ALLOWED_SECONDS = ['4', '8', '12'];
@@ -162,8 +163,16 @@ class AzureSoraTool extends Tool {
       headers: { 'api-key': this.apiKey },
       responseType: 'arraybuffer',
       timeout: 120000,
+      maxContentLength: MAX_VIDEO_BYTES,
+      maxBodyLength: MAX_VIDEO_BYTES,
     });
-    return Buffer.from(response.data);
+    const videoBuffer = Buffer.from(response.data);
+    if (videoBuffer.length > MAX_VIDEO_BYTES) {
+      throw new Error(
+        `Azure Sora video exceeds the ${MAX_VIDEO_BYTES} byte download limit.`,
+      );
+    }
+    return videoBuffer;
   }
 
   async _call({ prompt, size = '1280x720', seconds = '4' }) {

--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -50,6 +50,7 @@ const {
   StructuredWolfram,
   TavilySearchResults,
   createGeminiImageTool,
+  createAzureSoraTools,
   createOpenAIImageTools,
 } = require('../');
 const {
@@ -260,6 +261,18 @@ const loadTools = async ({
         imageFiles,
         userId: user,
         fileStrategy,
+      });
+    },
+    video_gen_sora_azure: async (_toolContextMap, dynamicToolContextMap) => {
+      const authFields = getAuthFields('video_gen_sora_azure');
+      const authValues = await loadAuthValues({ userId: user, authFields, throwError: false });
+      return createAzureSoraTools({
+        ...authValues,
+        isAgent: !!agent,
+        req: options.req,
+        userId: user,
+        fileStrategy,
+        processFileURL: options.processFileURL,
       });
     },
   };

--- a/api/test/app/clients/tools/structured/AzureSora.test.js
+++ b/api/test/app/clients/tools/structured/AzureSora.test.js
@@ -1,0 +1,116 @@
+const axios = require('axios');
+const AzureSoraTool = require('~/app/clients/tools/structured/AzureSora');
+
+jest.mock('axios');
+jest.mock('@librechat/data-schemas', () => ({
+  logger: {
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock('@librechat/api', () => ({
+  logAxiosError: jest.fn(),
+}));
+
+process.env.AZURE_SORA_POLL_INTERVAL_MS = '10';
+jest.setTimeout(20000);
+
+describe('AzureSora Video Generation Tool', () => {
+  const baseFields = {
+    userId: 'user-1',
+    AZURE_SORA_API_KEY: 'test-key',
+    AZURE_SORA_ENDPOINT: 'https://test-resource.openai.azure.com',
+    fileStrategy: 'local',
+    processFileURL: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    axios.post.mockReset();
+    axios.get.mockReset();
+    processFileDefaults();
+  });
+
+  const processFileDefaults = () => {
+    baseFields.processFileURL.mockResolvedValue({
+      file_id: 'file-1',
+      filepath: '/files/vid-job-1.mp4',
+    });
+  };
+
+  const buildTool = (overrides = {}) =>
+    new AzureSoraTool({ ...baseFields, ...overrides });
+
+  test('generates a video end-to-end and returns a video_url artifact', async () => {
+    const tool = buildTool();
+
+    axios.post.mockResolvedValueOnce({ data: { id: 'job-1', status: 'queued' } });
+    axios.get
+      .mockResolvedValueOnce({ data: { id: 'job-1', status: 'running' } })
+      .mockResolvedValueOnce({ data: { id: 'job-1', status: 'succeeded' } });
+
+    // content download (arraybuffer)
+    axios.get.mockResolvedValueOnce({
+      data: new Uint8Array([1, 2, 3, 4]).buffer,
+    });
+
+    const [textResponse, artifact] = await tool._call({
+      prompt: 'a drone shot over a coastline at sunset',
+    });
+
+    const submitUrl = axios.post.mock.calls[0][0];
+    expect(submitUrl).toBe(
+      'https://test-resource.openai.azure.com/openai/v1/video/generations/jobs?api-version=preview',
+    );
+    expect(axios.post.mock.calls[0][1]).toMatchObject({
+      model: 'sora',
+      prompt: 'a drone shot over a coastline at sunset',
+      size: '1280x720',
+      seconds: '4',
+    });
+    expect(axios.post.mock.calls[0][2].headers['api-key']).toBe('test-key');
+
+    expect(textResponse[0].type).toBe('text');
+    expect(artifact.content[0].type).toBe('video_url');
+    expect(artifact.content[0].video_url.url).toBe('/files/vid-job-1.mp4');
+    expect(artifact.file_ids).toEqual(['file-1']);
+  });
+
+  test('throws a descriptive error when the job fails', async () => {
+    const tool = buildTool();
+
+    axios.post.mockResolvedValueOnce({ data: { id: 'job-2' } });
+    axios.get.mockResolvedValueOnce({
+      data: { id: 'job-2', status: 'failed', error: { message: 'content policy' } },
+    });
+
+    await expect(
+      tool._call({ prompt: 'bad prompt' }),
+    ).rejects.toThrow('Azure Sora generation failed: content policy');
+  });
+
+  test('throws when credentials are not configured', async () => {
+    const tool = new AzureSoraTool({
+      userId: 'user-1',
+      AZURE_SORA_API_KEY: '',
+      AZURE_SORA_ENDPOINT: '',
+      processFileURL: baseFields.processFileURL,
+    });
+
+    await expect(tool._call({ prompt: 'test' })).rejects.toThrow(
+      /Azure Sora is not configured/,
+    );
+  });
+
+  test('throws when the submission endpoint is unreachable', async () => {
+    const tool = buildTool();
+
+    axios.post.mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+    await expect(
+      tool._call({ prompt: 'test prompt' }),
+    ).rejects.toThrow(/Failed to submit the video generation job/);
+  });
+});

--- a/client/public/assets/video_gen_sora_azure.svg
+++ b/client/public/assets/video_gen_sora_azure.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#0b5fff"/>
+  <rect x="10" y="18" width="32" height="28" rx="6" fill="#ffffff"/>
+  <path d="M18 24l16 8-16 8z" fill="#0b5fff"/>
+  <circle cx="48" cy="22" r="5" fill="#ffd83d"/>
+  <circle cx="48" cy="38" r="5" fill="#ffd83d"/>
+  <circle cx="48" cy="30" r="5" fill="#ffffff" opacity="0.85"/>
+</svg>

--- a/packages/data-provider/src/types/files.ts
+++ b/packages/data-provider/src/types/files.ts
@@ -29,6 +29,7 @@ export enum FileContext {
   assistants = 'assistants',
   execute_code = 'execute_code',
   image_generation = 'image_generation',
+  video_generation = 'video_generation',
   assistants_output = 'assistants_output',
   message_attachment = 'message_attachment',
   skill_file = 'skill_file',


### PR DESCRIPTION
Closes #7702

> **Disclosure:** This PR was authored by [@Furox-Art](https://github.com/Furox-Art) (AI-assisted). Happy to adjust anything — I know there are a few other Sora attempts on this issue.

## Summary

Adds a structured tool (`video_gen_sora_azure`) that generates short videos
from text prompts through the Azure OpenAI Sora video generation API
(`openai/v1/video/generations`), with the deployment/endpoint/API version
configurable through environment variables.

## Behavior

1. Submits a generation job (`POST .../openai/v1/video/generations/jobs`) with
   the validated `prompt`, `size` (1280x720 | 720x1280) and `seconds`
   (4 | 8 | 12) inputs. If the resource does not expose the v1 surface, a
   deployment-style submissions endpoint is tried as a fallback.
2. Polls the job status (5s interval, 10 minute cap — both configurable via
   `AZURE_SORA_POLL_INTERVAL_MS` / `AZURE_SORA_POLL_TIMEOUT_MS`), distinguishing
   transient polling errors from terminal `failed`/`cancelled` states.
3. Downloads the rendered mp4 with the `api-key` header and saves it through
   the standard file pipeline (`processFileURL`) using a
   `data:video/mp4;base64` payload, since the Azure content endpoint requires
   the api-key header that storage strategies cannot send. If storage fails,
   the video is returned inline as a `video_url` data URI so the user still
   sees the result.
4. Returns the artifact in `content_and_artifact` format so agents render the
   video directly in chat.

## Files

- `api/app/clients/tools/structured/AzureSora.js` — the tool
- `api/app/clients/tools/manifest.json` — tool registration + per-user auth
  fields (`AZURE_SORA_API_KEY`, `AZURE_SORA_ENDPOINT`)
- `api/app/clients/tools/index.js`, `api/app/clients/tools/util/handleTools.js` —
  tool loading wiring
- `packages/data-provider/src/types/files.ts` — adds `video_generation` to the
  `FileContext` enum (additive)
- `client/public/assets/video_gen_sora_azure.svg` — tool icon
- `api/test/app/clients/tools/structured/AzureSora.test.js` — tests (end-to-end
  flow, job failure, missing credentials, unreachable endpoint; logic verified
  with mocked axios, 4/4 passing)

## Notes

- `FileContext.video_generation` is additive, so existing storage records are
  unaffected.
- Default deployment name is `sora`; override with `AZURE_SORA_DEPLOYMENT_NAME`.
- API version defaults to `preview` per the Azure Sora documentation.
