### PR TITLE
🕳️ fix: Clear Nullable Queue Anchor

### DIFF
--- a/client/src/hooks/Chat/useChatFunctions.ts
+++ b/client/src/hooks/Chat/useChatFunctions.ts
@@ -647,7 +647,7 @@ export default function useChatFunctions({
       model: convo?.model,
       error: false,
       iconURL,
-      clientQueueParentMessageId: regenerateShaped ? messageId : intermediateId,
+      clientQueueParentMessageId: regenerateShaped ? (messageId ?? undefined) : intermediateId,
       /**
        * Seed the assistant placeholder with the turn's manually-invoked
        * skill names so `ContentParts` can render interim `SkillCall` cards


### PR DESCRIPTION
## Summary

Follow up #15787 with the client TypeScript correction identified by its post-merge CI run.

- Normalize the nullable regenerate message ID to `undefined` for the client-only queue anchor.
- Preserve the runtime behavior introduced by #15787 while satisfying the declared optional-string contract.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx jest src/hooks/Chat/__tests__/useChatFunctions.regenerate.spec.tsx src/hooks/Chat/__tests__/useSteering.spec.tsx --runInBand --coverage=false --config jest.config.cjs` (151 passed)
- Scoped ESLint and Prettier
- `git diff --check origin/dev...HEAD`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Existing focused regression tests pass with my changes