### PR TITLE
🎒 fix: Carry Subagent Identity Past Streaming

### DIFF
--- a/api/server/controllers/agents/callbacks.js
+++ b/api/server/controllers/agents/callbacks.js
@@ -28,6 +28,7 @@ const {
   isCodeSessionToolName,
   shouldSignalSandboxStart,
   getToolInputValidationDetails,
+  captureSubagentIdentity,
 } = require('@librechat/api');
 const { processFileCitations } = require('~/server/services/Files/Citations');
 const { processCodeOutput, runPreviewFinalize } = require('~/server/services/Files/Code/process');
@@ -762,6 +763,7 @@ function getDefaultHandlers({
           subagentAggregatorsByToolCallId.set(key, aggregator);
         }
         try {
+          captureSubagentIdentity(aggregator, data);
           feedSubagentAggregator(aggregator, data);
         } catch (err) {
           logger.warn(

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -574,6 +574,9 @@ class AgentClient extends BaseClient {
       const aggregator = buffer.get(toolCall.id);
       if (!aggregator) continue;
       try {
+        if (aggregator.subagentIdentity != null) {
+          toolCall.subagentIdentity = aggregator.subagentIdentity;
+        }
         /** `createContentAggregator` returns a sparse array (undefined
          *  slots for indices that never received content). Strip those
          *  so the persisted shape is a clean `TMessageContentParts[]`. */

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -7300,6 +7300,29 @@ describe('AgentClient - finalizeSubagentContent', () => {
     return map;
   };
 
+  it.each(['agent', 'graph'])(
+    'persists %s identity even when the child has no content',
+    async (subagentKind) => {
+      const identity = {
+        subagentKind,
+        subagentAgentId: subagentKind === 'graph' ? 'graph:agent-1' : 'agent-1',
+      };
+      const buffer = await runSubagentEvents([
+        { ...event('start', undefined), ...identity, subagentType: 'agent-1' },
+        { ...event('error', undefined), ...identity, subagentType: 'agent-1' },
+      ]);
+      const client = makeClient(buffer);
+      client.contentParts = [
+        { type: 'tool_call', tool_call: { id: 'unrelated', name: Constants.SUBAGENT } },
+        { type: 'tool_call', tool_call: { id: 'call_sub', name: Constants.SUBAGENT } },
+      ];
+      client.finalizeSubagentContent();
+      expect(client.contentParts[0].tool_call.subagentIdentity).toBeUndefined();
+      expect(client.contentParts[1].tool_call.subagentIdentity).toEqual(identity);
+      expect(buffer.size).toBe(0);
+    },
+  );
+
   it('attaches aggregated subagent_content to the matching subagent tool_call part', async () => {
     const buffer = await runSubagentEvents([
       event('run_step', {

--- a/client/src/components/Chat/Messages/Content/Part.tsx
+++ b/client/src/components/Chat/Messages/Content/Part.tsx
@@ -303,6 +303,7 @@ const Part = memo(function Part({
               runStepStatus={toolCall.runStepStatus}
               attachments={attachments}
               persistedContent={persistedContent}
+              subagentIdentity={toolCall.subagentIdentity}
               hideAttachments={hideAttachments}
             />
           );

--- a/client/src/components/Chat/Messages/Content/Parts/SubagentCall.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/SubagentCall.tsx
@@ -15,6 +15,7 @@ import {
   useSubagentProgress,
 } from '~/components/Chat/Subagents/state';
 import { adaptLivePersistedActivity } from '~/components/Chat/Subagents/adapters';
+import { resolveSubagentAgentId } from '~/components/Chat/Subagents/identity';
 import { useOpenSubagentPanel } from '~/components/Chat/Subagents/surface';
 import { MessageContext } from '~/Providers/MessageContext';
 import { useShareContext } from '~/Providers/ShareContext';
@@ -46,6 +47,7 @@ interface SubagentCallProps {
    *  runs recorded before the persistence path landed will not have this
    *  field; those fall back to the atom (or the raw `output` string). */
   persistedContent?: TMessageContentParts[];
+  subagentIdentity?: PartMetadata['subagentIdentity'];
   hideAttachments?: boolean;
 }
 
@@ -166,6 +168,7 @@ export default function SubagentCall({
   output,
   attachments,
   persistedContent,
+  subagentIdentity,
   hideAttachments = false,
 }: SubagentCallProps) {
   const localize = useLocalize();
@@ -187,8 +190,7 @@ export default function SubagentCall({
 
   const subagentType = progress?.subagentType ?? extractSubagentType(args);
   const isSelfSpawn = subagentType === 'self';
-  /** Explicit subagent types are agent IDs and remain in the saved tool arguments. */
-  const subagentAgentId = progress?.subagentAgentId ?? (isSelfSpawn ? undefined : subagentType);
+  const subagentAgentId = resolveSubagentAgentId(progress, subagentIdentity);
   const subagentAgent = subagentAgentId ? agentsMap?.[subagentAgentId] : undefined;
   /**
    * Tri-state status resolution, aligned with `ToolCall.tsx`:
@@ -322,6 +324,7 @@ export default function SubagentCall({
       toolCallId,
       partIndex,
       subagentType,
+      subagentIdentity,
       ...(prompt == null ? {} : { prompt }),
       ...(backgroundHandle == null ? { legacyOutput: output } : {}),
       ...(persistedContent == null ? {} : { persistedContent }),
@@ -352,6 +355,7 @@ export default function SubagentCall({
       runStepStatus,
       shareId,
       subagentType,
+      subagentIdentity,
       toolCallId,
     ],
   );

--- a/client/src/components/Chat/Messages/Content/Parts/SubagentCall.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/SubagentCall.tsx
@@ -187,12 +187,8 @@ export default function SubagentCall({
 
   const subagentType = progress?.subagentType ?? extractSubagentType(args);
   const isSelfSpawn = subagentType === 'self';
-  /** Avatar lookup for the header icon. We use the child's agent id when
-   *  present (explicit subagents); self-spawn falls back to the agents
-   *  map being unavailable → the Users SVG. The tool UI has a similar
-   *  icon-left-of-label pattern; this reuses `MessageIcon` so the agent's
-   *  configured avatar lands here without a separate image pipeline. */
-  const subagentAgentId = progress?.subagentAgentId;
+  /** Explicit subagent types are agent IDs and remain in the saved tool arguments. */
+  const subagentAgentId = progress?.subagentAgentId ?? (isSelfSpawn ? undefined : subagentType);
   const subagentAgent = subagentAgentId ? agentsMap?.[subagentAgentId] : undefined;
   /**
    * Tri-state status resolution, aligned with `ToolCall.tsx`:

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/SubagentCall.test.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/SubagentCall.test.tsx
@@ -3,7 +3,7 @@ import { RecoilRoot } from 'recoil';
 import { useAtomValue, useStore } from 'jotai';
 import { MemoryRouter } from 'react-router-dom';
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
-import type { SubagentUpdateEvent } from 'librechat-data-provider';
+import type { SubagentUpdateEvent, SubagentIdentity } from 'librechat-data-provider';
 import type {
   SubagentAggregatorState,
   SubagentContentPart,
@@ -120,6 +120,7 @@ function renderWithState(args: {
   progress?: SubagentProgress | null;
   output?: string;
   toolArgs?: Record<string, unknown>;
+  subagentIdentity?: SubagentIdentity;
 }) {
   const setter = { current: null as null | ((next: SubagentProgress | null) => void) };
   let selection: ActiveSubagentPanel | null = null;
@@ -155,6 +156,7 @@ function renderWithState(args: {
               isSubmitting={args.isSubmitting ?? false}
               args={args.toolArgs ?? { subagent_type: 'self', description: 'compute' }}
               output={args.output}
+              subagentIdentity={args.subagentIdentity}
             />
           </MessageContext.Provider>
         </RecoilRoot>
@@ -188,6 +190,7 @@ describe('SubagentCall', () => {
       toolCallId: 'identity',
       initialProgress: 1,
       toolArgs: { subagent_type: 'agent-1' },
+      subagentIdentity: { subagentKind: 'agent', subagentAgentId: 'agent-1' },
       progress: progressFromEvents({
         subagentRunId: 'child-run',
         subagentType: 'agent-1',
@@ -203,6 +206,23 @@ describe('SubagentCall', () => {
     expect(screen.getByRole('img', { hidden: true })).toHaveAttribute('src', '/analyst.png');
   });
 
+  it.each([undefined, { subagentKind: 'graph' as const, subagentAgentId: 'graph:agent-1' }])(
+    'does not infer a saved agent from an ambiguous graph or legacy type',
+    (subagentIdentity) => {
+      const { getSelection } = renderWithState({
+        toolCallId: 'graph-identity',
+        initialProgress: 1,
+        toolArgs: { subagent_type: 'agent-1' },
+        output: 'Graph result',
+        subagentIdentity,
+      });
+      expect(screen.queryByText('Analyst One')).not.toBeInTheDocument();
+      expect(screen.getByText('users')).toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: 'Ran agent' }));
+      expect(getSelection()?.subagentIdentity).toEqual(subagentIdentity);
+    },
+  );
+
   it.each(['agent-1', 'missing-agent', 'self'])(
     'renders saved identity %s without streaming state',
     (agentId) => {
@@ -210,6 +230,7 @@ describe('SubagentCall', () => {
         toolCallId: 'saved-identity',
         initialProgress: 1,
         toolArgs: { subagent_type: agentId },
+        subagentIdentity: { subagentKind: 'agent', subagentAgentId: agentId },
       });
       expect(screen.queryByText('Analyst One') != null).toBe(agentId === 'agent-1');
       expect(screen.queryByText('users') != null).toBe(agentId !== 'agent-1');

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/SubagentCall.test.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/SubagentCall.test.tsx
@@ -61,8 +61,17 @@ jest.mock('lucide-react', () => ({
   Users: () => <span>users</span>,
 }));
 
-jest.mock('~/Providers', () => ({ useAgentsMapContext: () => ({}) }));
-jest.mock('~/components/Share/MessageIcon', () => ({ __esModule: true, default: () => null }));
+jest.mock('~/Providers', () => ({
+  useAgentsMapContext: () => ({
+    'agent-1': { id: 'agent-1', name: 'Analyst One', avatar: { filepath: '/analyst.png' } },
+  }),
+}));
+jest.mock('~/components/Share/MessageIcon', () => ({
+  __esModule: true,
+  default: ({ agent }: { agent: { name: string; avatar: { filepath: string } } }) => (
+    <img alt={agent.name} src={agent.avatar.filepath} />
+  ),
+}));
 jest.mock('~/hooks/MCP', () => ({ useMCPServerNames: () => mockMCPServerNames }));
 jest.mock('~/utils', () => ({
   ...jest.requireActual('~/utils/toolLabels'),
@@ -174,6 +183,39 @@ const event = (
 });
 
 describe('SubagentCall', () => {
+  it('keeps the configured name and avatar after live progress is cleared', () => {
+    const { setProgress } = renderWithState({
+      toolCallId: 'identity',
+      initialProgress: 1,
+      toolArgs: { subagent_type: 'agent-1' },
+      progress: progressFromEvents({
+        subagentRunId: 'child-run',
+        subagentType: 'agent-1',
+        subagentAgentId: 'agent-1',
+        status: 'stop',
+        events: [],
+      }),
+    });
+    expect(screen.getByText('Analyst One')).toBeInTheDocument();
+    expect(screen.getByRole('img', { hidden: true })).toHaveAttribute('src', '/analyst.png');
+    setProgress(null);
+    expect(screen.getByText('Analyst One')).toBeInTheDocument();
+    expect(screen.getByRole('img', { hidden: true })).toHaveAttribute('src', '/analyst.png');
+  });
+
+  it.each(['agent-1', 'missing-agent', 'self'])(
+    'renders saved identity %s without streaming state',
+    (agentId) => {
+      renderWithState({
+        toolCallId: 'saved-identity',
+        initialProgress: 1,
+        toolArgs: { subagent_type: agentId },
+      });
+      expect(screen.queryByText('Analyst One') != null).toBe(agentId === 'agent-1');
+      expect(screen.queryByText('users') != null).toBe(agentId !== 'agent-1');
+    },
+  );
+
   it.each([
     ['Running agent', 0.3, true, 'run_step'],
     ['Ran agent', 1, false, undefined],

--- a/client/src/components/Chat/Subagents/SubagentThreadPanel.test.tsx
+++ b/client/src/components/Chat/Subagents/SubagentThreadPanel.test.tsx
@@ -473,7 +473,12 @@ describe('SubagentThreadPanel', () => {
     'resolves the saved foreground identity %s in the panel',
     (subagentType) => {
       mockUseSubagentThreadQuery.mockReturnValue({ isLoading: false, isError: false });
-      const foregroundSelection = { ...selection, durable: undefined, subagentType };
+      const foregroundSelection = {
+        ...selection,
+        durable: undefined,
+        subagentType,
+        subagentIdentity: { subagentKind: 'agent' as const, subagentAgentId: subagentType },
+      };
       render(
         <Root>
           <SubagentThreadPanel selection={foregroundSelection} />
@@ -487,6 +492,29 @@ describe('SubagentThreadPanel', () => {
       if (subagentType === 'agent-1') {
         expect(screen.getByAltText('Analyst One avatar')).toHaveAttribute('src', '/analyst.png');
       }
+    },
+  );
+
+  it.each([undefined, { subagentKind: 'graph' as const, subagentAgentId: 'graph:agent-1' }])(
+    'does not resolve graph or legacy panel types as saved agents',
+    (subagentIdentity) => {
+      mockUseSubagentThreadQuery.mockReturnValue({ isLoading: false, isError: false });
+      render(
+        <Root>
+          <SubagentThreadPanel
+            selection={{
+              ...selection,
+              durable: undefined,
+              subagentType: 'agent-1',
+              subagentIdentity,
+            }}
+          />
+        </Root>,
+      );
+      expect(
+        screen.getByRole('heading', { name: 'com_ui_subagent_dialog_title: agent-1' }),
+      ).toBeInTheDocument();
+      expect(screen.queryByAltText('Analyst One avatar')).not.toBeInTheDocument();
     },
   );
 

--- a/client/src/components/Chat/Subagents/SubagentThreadPanel.test.tsx
+++ b/client/src/components/Chat/Subagents/SubagentThreadPanel.test.tsx
@@ -106,13 +106,14 @@ jest.mock('~/hooks', () => ({
    *  runs before the panel's own React handler. Stubbing it made the panel's
    *  Escape assertions pass in both directions. */
   useFocusTrap: jest.requireActual('~/hooks/useFocusTrap').default,
-  useLocalize: () => (key: string) => key,
+  useLocalize: () => (key: string, values?: { 0: string }) =>
+    values == null ? key : `${key}: ${values[0]}`,
   useNavigateToConvo: () => ({ navigateToConvo: mockNavigateToConvo }),
 }));
 
 jest.mock('~/Providers', () => ({
   useAgentsMapContext: () => ({
-    'agent-1': { id: 'agent-1', name: 'Analyst One' },
+    'agent-1': { id: 'agent-1', name: 'Analyst One', avatar: { filepath: '/analyst.png' } },
     'agent-2': { id: 'agent-2', name: 'Analyst Two' },
   }),
 }));
@@ -467,6 +468,27 @@ describe('SubagentThreadPanel', () => {
   afterEach(() => {
     jest.restoreAllMocks();
   });
+
+  it.each(['agent-1', 'missing-agent', 'self'])(
+    'resolves the saved foreground identity %s in the panel',
+    (subagentType) => {
+      mockUseSubagentThreadQuery.mockReturnValue({ isLoading: false, isError: false });
+      const foregroundSelection = { ...selection, durable: undefined, subagentType };
+      render(
+        <Root>
+          <SubagentThreadPanel selection={foregroundSelection} />
+        </Root>,
+      );
+      const title =
+        subagentType === 'self'
+          ? 'com_ui_subagent_dialog_title_self'
+          : `com_ui_subagent_dialog_title: ${subagentType === 'agent-1' ? 'Analyst One' : subagentType}`;
+      expect(screen.getByRole('heading', { name: title })).toBeInTheDocument();
+      if (subagentType === 'agent-1') {
+        expect(screen.getByAltText('Analyst One avatar')).toHaveAttribute('src', '/analyst.png');
+      }
+    },
+  );
 
   it('renders a bounded read-only activity timeline and closes its selection', async () => {
     mockUseSubagentThreadQuery.mockReturnValue({

--- a/client/src/components/Chat/Subagents/SubagentThreadPanel.tsx
+++ b/client/src/components/Chat/Subagents/SubagentThreadPanel.tsx
@@ -144,10 +144,16 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
       selection.partIndex,
     ),
   );
+  const foregroundAgentId =
+    progress?.subagentAgentId ??
+    (selection.subagentType === 'self' ? undefined : selection.subagentType);
+  const foregroundAgent = foregroundAgentId == null ? undefined : agentsMap?.[foregroundAgentId];
   const foregroundTitle =
     selection.subagentType === 'self'
       ? localize('com_ui_subagent_dialog_title_self')
-      : localize('com_ui_subagent_dialog_title', { 0: selection.subagentType });
+      : localize('com_ui_subagent_dialog_title', {
+          0: foregroundAgent?.name || selection.subagentType,
+        });
   const threadId = selection.durable?.threadId ?? '';
   const taskId = selection.durable?.taskId ?? '';
   const controlIdentity = subagentControlStateKey(selection.parentConversationId, threadId, taskId);
@@ -838,7 +844,8 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
   }, [agentsMap, eventSiblings, selection.event, threadId]);
   const selectedActorLabel =
     actorOptions.find((option) => option.value === threadId)?.label ?? panelTitle;
-  const selectedActorAgentId = selectedEventActor?.agentId ?? threadView?.agentId;
+  const selectedActorAgentId =
+    selectedEventActor?.agentId ?? threadView?.agentId ?? foregroundAgentId;
   const selectedActorIcon = renderAgentAvatar(
     selectedActorAgentId == null ? undefined : agentsMap?.[selectedActorAgentId],
     { size: 'icon', showBorder: false },

--- a/client/src/components/Chat/Subagents/SubagentThreadPanel.tsx
+++ b/client/src/components/Chat/Subagents/SubagentThreadPanel.tsx
@@ -51,6 +51,7 @@ import { useFocusTrap, useLocalize, useNavigateToConvo } from '~/hooks';
 import { useParentSubagents } from './ParentSubagentsProvider';
 import SubagentConversation from './SubagentConversation';
 import { eventSubagentSelection } from './eventSelection';
+import { resolveSubagentAgentId } from './identity';
 import { useAgentsMapContext } from '~/Providers';
 import { isLiveSubagentStatus } from './status';
 import { renderAgentAvatar } from '~/utils';
@@ -144,9 +145,7 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
       selection.partIndex,
     ),
   );
-  const foregroundAgentId =
-    progress?.subagentAgentId ??
-    (selection.subagentType === 'self' ? undefined : selection.subagentType);
+  const foregroundAgentId = resolveSubagentAgentId(progress, selection.subagentIdentity);
   const foregroundAgent = foregroundAgentId == null ? undefined : agentsMap?.[foregroundAgentId];
   const foregroundTitle =
     selection.subagentType === 'self'

--- a/client/src/components/Chat/Subagents/identity.test.ts
+++ b/client/src/components/Chat/Subagents/identity.test.ts
@@ -1,0 +1,15 @@
+import { resolveSubagentAgentId } from './identity';
+
+describe('resolveSubagentAgentId', () => {
+  const agent = { subagentKind: 'agent' as const, subagentAgentId: 'agent-1' };
+  const graph = { subagentKind: 'graph' as const, subagentAgentId: 'agent-1' };
+  it('prefers live identity and falls back to explicit saved identity', () => {
+    expect(resolveSubagentAgentId({ ...agent, subagentAgentId: 'agent-2' }, agent)).toBe('agent-2');
+    expect(resolveSubagentAgentId(null, agent)).toBe('agent-1');
+    expect(resolveSubagentAgentId(null, undefined)).toBeUndefined();
+  });
+  it('never resolves a graph as a saved agent even when their IDs collide', () => {
+    expect(resolveSubagentAgentId(graph, agent)).toBeUndefined();
+    expect(resolveSubagentAgentId(null, graph)).toBeUndefined();
+  });
+});

--- a/client/src/components/Chat/Subagents/identity.ts
+++ b/client/src/components/Chat/Subagents/identity.ts
@@ -1,0 +1,10 @@
+import type { SubagentIdentity } from 'librechat-data-provider';
+
+export function resolveSubagentAgentId(
+  progress: Partial<SubagentIdentity> | null | undefined,
+  persisted: SubagentIdentity | undefined,
+): string | undefined {
+  if (progress?.subagentKind === 'graph') return undefined;
+  if (progress?.subagentAgentId) return progress.subagentAgentId;
+  return persisted?.subagentKind === 'agent' ? persisted.subagentAgentId : undefined;
+}

--- a/client/src/components/Chat/Subagents/state.spec.ts
+++ b/client/src/components/Chat/Subagents/state.spec.ts
@@ -34,6 +34,19 @@ const update = (overrides: Partial<SubagentUpdateEvent> = {}): SubagentUpdateEve
 });
 
 describe('reduceSubagentProgress', () => {
+  it('retains graph kind when later frames omit identity metadata', () => {
+    const first = reduceSubagentProgress(null, [update({ subagentKind: 'graph' })]);
+    const next = reduceSubagentProgress(first, [
+      update({ activityEventId: 'activity-2', subagentKind: undefined }),
+    ]);
+    expect(next?.subagentKind).toBe('graph');
+    const batched = reduceSubagentProgress(null, [
+      update({ subagentKind: 'graph' }),
+      update({ activityEventId: 'activity-2', subagentKind: undefined }),
+    ]);
+    expect(batched?.subagentKind).toBe('graph');
+  });
+
   it('folds an event delivered by both parent and detached streams only once', () => {
     const event = update();
     const first = reduceSubagentProgress(null, [event]);

--- a/client/src/components/Chat/Subagents/state.ts
+++ b/client/src/components/Chat/Subagents/state.ts
@@ -43,6 +43,7 @@ export interface SubagentProgress {
   subagentType: string;
   /** Child agent id (for avatar / name lookup in the ticker header). */
   subagentAgentId?: string;
+  subagentKind?: SubagentUpdateEvent['subagentKind'];
   /**
    * Fully aggregated child content parts. Bounded by structure (text
    * runs + reasoning runs + tool calls), not by delta volume.
@@ -259,6 +260,7 @@ const eventKey = (event: SubagentUpdateEvent): string | undefined => {
 /** One child invocation selected for the shared read-only activity panel. */
 export type ActiveSubagentPanel = {
   host: 'conversation' | 'share';
+  subagentIdentity?: PartMetadata['subagentIdentity'];
   shareId?: string;
   parentConversationId: string;
   parentMessageId: string;
@@ -540,6 +542,7 @@ const foldAcceptedSubagentEvents = (
         subagentRunId: first.subagentRunId,
         subagentType: first.subagentType,
         subagentAgentId: first.subagentAgentId,
+        subagentKind: first.subagentKind,
         contentParts: [],
         aggregatorState: initSubagentAggregatorState(),
         tickerState: initSubagentTickerState(),
@@ -572,7 +575,9 @@ const foldAcceptedSubagentEvents = (
   let contentParts = previous?.contentParts ?? [];
   let aggregatorState = previous?.aggregatorState ?? initSubagentAggregatorState();
   let tickerState = previous?.tickerState ?? initSubagentTickerState();
+  let subagentKind = previous?.subagentKind;
   for (const event of events) {
+    subagentKind = event.subagentKind ?? subagentKind;
     const foldEvent =
       event.phase === 'reasoning_delta' &&
       event.data == null &&
@@ -609,6 +614,7 @@ const foldAcceptedSubagentEvents = (
     subagentRunId: last.subagentRunId,
     subagentType: last.subagentType,
     subagentAgentId: last.subagentAgentId ?? previous?.subagentAgentId,
+    subagentKind,
     contentParts,
     aggregatorState,
     tickerState,

--- a/packages/api/src/agents/index.ts
+++ b/packages/api/src/agents/index.ts
@@ -52,6 +52,7 @@ export * from './stepBudget';
 export * from './startup';
 export * from './subagentThreads';
 export * from './subagentActivity';
+export * from './subagentIdentity';
 export * from './subagentCompletionWakeup';
 export * from './subagentTaskRouting';
 export * from './skillConfigurable';

--- a/packages/api/src/agents/subagentIdentity.spec.ts
+++ b/packages/api/src/agents/subagentIdentity.spec.ts
@@ -1,0 +1,42 @@
+import type { SubagentIdentity, SubagentUpdateEvent } from 'librechat-data-provider';
+import { captureSubagentIdentity } from './subagentIdentity';
+
+const event = (overrides: Partial<SubagentUpdateEvent> = {}): SubagentUpdateEvent => ({
+  runId: 'parent',
+  subagentRunId: 'child',
+  subagentType: 'agent-1',
+  subagentKind: 'agent',
+  subagentAgentId: 'agent-1',
+  phase: 'start',
+  timestamp: '',
+  ...overrides,
+});
+
+describe('captureSubagentIdentity', () => {
+  it('captures execution identity and retains it across frames with missing metadata', () => {
+    const target: { subagentIdentity?: SubagentIdentity } = {};
+    captureSubagentIdentity(target, event());
+    const identity = target.subagentIdentity;
+    expect(identity).toEqual({ subagentKind: 'agent', subagentAgentId: 'agent-1' });
+    captureSubagentIdentity(target, event({ phase: 'stop', subagentKind: undefined }));
+    captureSubagentIdentity(target, event());
+    expect(target.subagentIdentity).toBe(identity);
+  });
+  it('keeps graph kind and execution subject separate from a colliding type/member ID', () => {
+    const target: { subagentIdentity?: SubagentIdentity } = {};
+    captureSubagentIdentity(
+      target,
+      event({ subagentKind: 'graph', subagentAgentId: 'graph:agent-1', memberAgentId: 'agent-1' }),
+    );
+    expect(target.subagentIdentity).toEqual({
+      subagentKind: 'graph',
+      subagentAgentId: 'graph:agent-1',
+    });
+  });
+  it('does not invent identity from incomplete legacy events', () => {
+    const target: { subagentIdentity?: SubagentIdentity } = {};
+    captureSubagentIdentity(target, event({ subagentKind: undefined }));
+    captureSubagentIdentity(target, event({ subagentAgentId: '' }));
+    expect(target.subagentIdentity).toBeUndefined();
+  });
+});

--- a/packages/api/src/agents/subagentIdentity.ts
+++ b/packages/api/src/agents/subagentIdentity.ts
@@ -1,0 +1,19 @@
+import type { SubagentIdentity, SubagentUpdateEvent } from 'librechat-data-provider';
+
+/** Retain execution identity beside the existing bounded child-content buffer. */
+export function captureSubagentIdentity(
+  target: { subagentIdentity?: SubagentIdentity },
+  event: SubagentUpdateEvent,
+): void {
+  if (event.subagentKind !== 'agent' && event.subagentKind !== 'graph') return;
+  if (!event.subagentAgentId) return;
+  if (
+    target.subagentIdentity?.subagentKind === event.subagentKind &&
+    target.subagentIdentity.subagentAgentId === event.subagentAgentId
+  )
+    return;
+  target.subagentIdentity = {
+    subagentKind: event.subagentKind,
+    subagentAgentId: event.subagentAgentId,
+  };
+}

--- a/packages/data-provider/src/types/assistants.ts
+++ b/packages/data-provider/src/types/assistants.ts
@@ -2,8 +2,8 @@ import { z } from 'zod';
 import type { OpenAPIV3 } from 'openapi-types';
 import type { AssistantsEndpoint, AgentProvider, MemoryScope, SkillsScope } from 'src/schemas';
 import type { StatefulCodeEnvironment } from '../stateful-code';
+import type { ContentTypes, SubagentIdentity } from './runs';
 import type { Agents, GraphEdge } from './agents';
-import type { ContentTypes } from './runs';
 import type { TFile } from './files';
 import { ArtifactModes } from 'src/artifacts';
 export {
@@ -642,6 +642,8 @@ export enum RunStatus {
 }
 
 export type PartMetadata = {
+  /** Host-resolved execution identity for a saved subagent invocation. */
+  subagentIdentity?: SubagentIdentity;
   progress?: number;
   asset_pointer?: string;
   status?: string;

--- a/packages/data-provider/src/types/runs.ts
+++ b/packages/data-provider/src/types/runs.ts
@@ -407,6 +407,8 @@ export interface SubagentAncestryEntry {
   readonly parentToolCallId?: string;
 }
 
+export type SubagentIdentity = Pick<SubagentAncestryEntry, 'subagentKind' | 'subagentAgentId'>;
+
 /** Single streamed subagent update forwarded by the SDK's SubagentExecutor. */
 export interface SubagentUpdateEvent {
   runId: string;


### PR DESCRIPTION
## Summary

Subagent cards lost their configured name and avatar when streaming finished. Opening the foreground run panel also showed the raw agent ID and a generic icon.

Persist the SDK-resolved subagent kind and execution ID beside the existing child content, then use that identity for the card and foreground panel when live progress is unavailable. Named agents retain their configured name and avatar after completion and reload. Graph types are never treated as agent IDs, even when they collide with a graph member’s ID.

The saved metadata is optional and needs no database migration. Older records without authoritative identity keep the generic fallback. Existing self-spawn labels, unavailable-agent behavior, and durable/event identity precedence are preserved. No new database reads or dependency changes.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Passed 334 focused tests: 123 frontend, 208 AgentClient, and 3 identity-helper tests. Coverage includes graph/member-ID collisions, cleared streaming state, legacy records, batched updates, empty/error child content, and persistence association/cleanup.
- Passed client and packages/api TypeScript, data-provider build/typecheck, full frontend/package build, scoped ESLint, formatting, and import-order checks.
- Built clean before/after Docker images and captured matching browser screenshots and walkthrough videos.
- Passed 24 API probes confirming saved execution identity and unchanged owner access and unrelated-user/anonymous restrictions.
- Both browser runs completed without page errors.

Reproduction:

1. Configure a named subagent with a custom avatar.
2. Have its parent agent delegate a foreground task.
3. Observe the subagent card while streaming and after completion.
4. Open the run panel, then reload the conversation and reopen it.

Before: the name and avatar disappear at completion; the panel displays the raw agent ID and a generic icon.
<img width="3114" height="860" alt="Codex Image Sep 9, 2026, 03_33_12 PM" src="https://github.com/user-attachments/assets/68ae5800-de50-4f6f-9665-0c9e5cff470f" />
After: the configured name and avatar remain visible in the card and panel, including after reload.

### **Test Configuration**:

- Base: `4fdab5ef4`
- Fix: `24f6d476c` (the attached comparison was captured on `889c55224`; the same flow was reverified on the corrected head)
- Repository Dockerfile, Node.js 24.16.0, MongoDB 7
- Separate before/after databases on an isolated Docker network
- Chromium through Playwright, 1440×1000 viewport, DPR 2, light theme
- Repository deterministic subagent model fixture exercising the real API, streaming, persistence, and UI paths

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
