### PR TITLE
🏮 docs: Relight the Helm AI Setup Link

### DIFF
--- a/helm/librechat/readme.md
+++ b/helm/librechat/readme.md
@@ -24,7 +24,7 @@ stringData:
   MEILI_MASTER_KEY: <generated value>
 ```
 2. Add Credentials to the Secret
-Dependant of the Model you want to use, [create Credentials in your provider](https://docs.librechat.ai/install/configuration/ai_setup.html) and add them to the Secret:
+Dependant of the Model you want to use, [create Credentials in your provider](https://www.librechat.ai/docs/configuration/pre_configured_ai) and add them to the Secret:
 ```yaml
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
The credentials-setup link in `helm/librechat/readme.md` (`https://docs.librechat.ai/install/configuration/ai_setup.html`) 301-redirects to the generic docs homepage instead of the intended page.

Verified with `curl -sI -L`: the old URL returns a 301 to `https://www.librechat.ai/docs`, while `https://www.librechat.ai/docs/configuration/pre_configured_ai` returns 200 and is titled "AI Setup | LibreChat" — the page's new location.

Updated the link to point to the current page.

---
This pull request was prepared with AI assistance (Claude Code).