### PR TITLE
🈳 fix: Treat Blank Mongo Index Settings as Unset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,9 +38,11 @@ MONGO_MAX_CONNECTING=
 MONGO_MAX_IDLE_TIME_MS=
 #The maximum time in milliseconds that a thread can wait for a connection to become available. */
 MONGO_WAIT_QUEUE_TIMEOUT_MS=
-# Set to false to disable automatic index creation for all models associated with this connection. */
+# Set to false to disable automatic index creation for all models associated with this connection.
+# Leave empty (unset) to use Mongoose's default — an empty value is not treated as false. */
 MONGO_AUTO_INDEX=
-# Set to `false` to disable Mongoose automatically calling `createCollection()` on every model created on this connection. */
+# Set to `false` to disable Mongoose automatically calling `createCollection()` on every model created on this connection.
+# Leave empty (unset) to use Mongoose's default — an empty value is not treated as false. */
 MONGO_AUTO_CREATE=
 
 DOMAIN_CLIENT=http://localhost:3080

--- a/api/db/connect.js
+++ b/api/db/connect.js
@@ -1,5 +1,5 @@
 require('dotenv').config();
-const { isEnabled, instrumentMongooseQueryMetrics } = require('@librechat/api');
+const { optionalEnabled, instrumentMongooseQueryMetrics } = require('@librechat/api');
 const { logger } = require('@librechat/data-schemas');
 
 const mongoose = require('mongoose');
@@ -21,16 +21,10 @@ const maxIdleTimeMS = parseInt(process.env.MONGO_MAX_IDLE_TIME_MS) || undefined;
 /** The maximum time in milliseconds that a thread can wait for a connection to become available. */
 const waitQueueTimeoutMS = parseInt(process.env.MONGO_WAIT_QUEUE_TIMEOUT_MS) || undefined;
 /** Set to false to disable automatic index creation for all models associated with this connection. */
-const autoIndex =
-  process.env.MONGO_AUTO_INDEX != undefined
-    ? isEnabled(process.env.MONGO_AUTO_INDEX) || false
-    : undefined;
+const autoIndex = optionalEnabled(process.env.MONGO_AUTO_INDEX);
 
 /** Set to `false` to disable Mongoose automatically calling `createCollection()` on every model created on this connection. */
-const autoCreate =
-  process.env.MONGO_AUTO_CREATE != undefined
-    ? isEnabled(process.env.MONGO_AUTO_CREATE) || false
-    : undefined;
+const autoCreate = optionalEnabled(process.env.MONGO_AUTO_CREATE);
 /**
  * Global is used here to maintain a cached connection across hot reloads
  * in development. This prevents connections growing exponentially

--- a/packages/api/src/utils/common.spec.ts
+++ b/packages/api/src/utils/common.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { isEnabled } from './common';
+import { isEnabled, optionalEnabled } from './common';
 
 describe('isEnabled', () => {
   test('should return true when input is "true"', () => {
@@ -51,5 +51,43 @@ describe('isEnabled', () => {
   test('should return false when input is an array', () => {
     // @ts-expect-error
     expect(isEnabled([])).toBe(false);
+  });
+});
+
+describe('optionalEnabled', () => {
+  test('should return undefined when input is missing', () => {
+    expect(optionalEnabled()).toBeUndefined();
+  });
+
+  test('should return undefined when input is null', () => {
+    expect(optionalEnabled(null)).toBeUndefined();
+  });
+
+  test('should return undefined when input is an empty string', () => {
+    expect(optionalEnabled('')).toBeUndefined();
+  });
+
+  test('should return undefined when input is whitespace', () => {
+    expect(optionalEnabled('   ')).toBeUndefined();
+  });
+
+  test('should return true when input is "true"', () => {
+    expect(optionalEnabled('true')).toBe(true);
+  });
+
+  test('should return true when input is "TRUE"', () => {
+    expect(optionalEnabled('TRUE')).toBe(true);
+  });
+
+  test('should return true when input is true', () => {
+    expect(optionalEnabled(true)).toBe(true);
+  });
+
+  test('should return false when input is "false"', () => {
+    expect(optionalEnabled('false')).toBe(false);
+  });
+
+  test('should return false when input is false', () => {
+    expect(optionalEnabled(false)).toBe(false);
   });
 });

--- a/packages/api/src/utils/common.ts
+++ b/packages/api/src/utils/common.ts
@@ -31,9 +31,7 @@ export function isEnabled(value?: string | boolean | null | undefined): boolean 
  * Like {@link isEnabled}, but missing or blank values stay unset so the caller
  * can apply its own default instead of forcing `false`.
  */
-export function optionalEnabled(
-  value?: string | boolean | null | undefined,
-): boolean | undefined {
+export function optionalEnabled(value?: string | boolean | null | undefined): boolean | undefined {
   if (typeof value === 'boolean') {
     return value;
   }

--- a/packages/api/src/utils/common.ts
+++ b/packages/api/src/utils/common.ts
@@ -28,6 +28,22 @@ export function isEnabled(value?: string | boolean | null | undefined): boolean 
 }
 
 /**
+ * Like {@link isEnabled}, but missing or blank values stay unset so the caller
+ * can apply its own default instead of forcing `false`.
+ */
+export function optionalEnabled(
+  value?: string | boolean | null | undefined,
+): boolean | undefined {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value !== 'string' || value.trim() === '') {
+    return undefined;
+  }
+  return isEnabled(value);
+}
+
+/**
  * Checks if the provided value is 'user_provided'.
  *
  * @param value - The value to check.

--- a/packages/data-schemas/src/methods/schedule.ts
+++ b/packages/data-schemas/src/methods/schedule.ts
@@ -333,10 +333,10 @@ export function createScheduleMethods(mongoose: typeof import('mongoose')): Sche
   const ScheduleRun = () => mongoose.models.ScheduleRun as Model<IScheduleRunDocument>;
 
   /**
-   * Explicitly builds the Schedule/ScheduleRun indexes. Required because the
-   * standard production setting `MONGO_AUTO_INDEX=` (empty) disables Mongoose's
-   * automatic index creation — without this the unique idempotency index and the
-   * TTL retention index would never exist. Called once before the engine starts.
+   * Explicitly builds the Schedule/ScheduleRun indexes. Required because
+   * `MONGO_AUTO_INDEX=false` disables Mongoose's automatic index creation —
+   * without this the unique idempotency index and the TTL retention index would
+   * never exist. Called once before the engine starts.
    */
   async function ensureScheduleIndexes(): Promise<void> {
     await createIndexesWithRetry(Schedule());


### PR DESCRIPTION
Fixes #15792

## Summary

Empty `MONGO_AUTO_INDEX=` (as in `.env.example`) is loaded by dotenv as `''`. The previous `!= undefined` gate treated that as set, so `isEnabled('')` became `false` and Mongoose got `autoIndex: false` — copying the example env silently disabled auto-indexing.

## Changes

- Add `optionalEnabled` in `packages/api` (blank/whitespace → `undefined`; real true/false still via `isEnabled`)
- Wire it in `api/db/connect.js` for `MONGO_AUTO_INDEX` and `MONGO_AUTO_CREATE`
- Clarify `.env.example` comments; tweak related schedule-index docstring
- Do not change `isEnabled` itself (other callers unchanged)

## Test plan

- [x] `packages/api` jest for `common.spec.ts` (incl. empty / true / false)
- [x] `tsc --noEmit` on affected packages in agent run
