### PR TITLE
🥼 feat: Expose BYOM Cancellation Diagnostics

### DIFF
--- a/packages/api/src/agents/handlers.spec.ts
+++ b/packages/api/src/agents/handlers.spec.ts
@@ -3,6 +3,9 @@ jest.mock('./prewarm', () => ({
 }));
 
 import { Readable } from 'stream';
+import { once } from 'node:events';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { Constants } from '@librechat/agents';
 import { logger } from '@librechat/data-schemas';
 import type {
@@ -20,6 +23,7 @@ import {
 import { markSandboxReady } from './prewarm';
 import { ContentFilterError } from '../middleware/contentFilter';
 import { WorkspaceToolHttpError } from '../code/workspace';
+import { createAttachedWorkspaceBashTool } from '../code/command';
 import { createCodeApiUploadRegistry } from '~/utils';
 
 function createMockTool(
@@ -462,6 +466,58 @@ describe('createToolExecuteHandler', () => {
       expect(tool.invoke.mock.calls[0][1].signal).toBe(controller.signal);
       expect(results).toHaveLength(1);
       expect(results[0].status).toBe('error');
+    });
+
+    it('closes the real command HTTP connection on foreground host cancellation', async () => {
+      let markStarted!: () => void;
+      let markDisconnected!: () => void;
+      const started = new Promise<void>((resolve) => {
+        markStarted = resolve;
+      });
+      const disconnected = new Promise<void>((resolve) => {
+        markDisconnected = resolve;
+      });
+      const server = createServer(async (req, res) => {
+        for await (const _chunk of req) {
+          /* Wait for the full command request. */
+        }
+        res.once('close', () => {
+          if (!res.writableEnded) markDisconnected();
+        });
+        markStarted();
+      });
+      server.listen(0, '127.0.0.1');
+      await once(server, 'listening');
+      const { port } = server.address() as AddressInfo;
+      const tool = createAttachedWorkspaceBashTool({
+        baseUrl: `http://127.0.0.1:${port}/v1`,
+        authHeaders: () => ({}),
+        workspaceId: 'project-a',
+      });
+      const controller = new AbortController();
+      const handler = createToolExecuteHandler({
+        loadTools: async () => ({ loadedTools: [tool] }),
+        runSignal: controller.signal,
+        foregroundRunId: 'foreground-run',
+      });
+      try {
+        const result = new Promise<ToolExecuteResult[]>((resolve, reject) => {
+          handler.handle('on_tool_execute', {
+            toolCalls: [{ id: 'call-http', name: tool.name, args: { command: 'sleep 30' } }],
+            metadata: { run_id: 'foreground-run' },
+            resolve,
+            reject,
+          } as ToolExecuteBatchRequest);
+        });
+        await started;
+        controller.abort();
+        expect((await result)[0].status).toBe('error');
+        await disconnected;
+      } finally {
+        server.closeAllConnections();
+        server.close();
+        await once(server, 'close');
+      }
     });
 
     it('composes host cancellation with an SDK event circuit-breaker signal', async () => {

--- a/packages/api/src/code/command.spec.ts
+++ b/packages/api/src/code/command.spec.ts
@@ -66,6 +66,50 @@ function commandResponse(overrides: Record<string, unknown> = {}): Response {
 }
 
 describe('createAttachedWorkspaceBashTool', () => {
+  test('disconnects the actual HTTP request when an invoked command is cancelled', async () => {
+    let markStarted!: () => void;
+    let markDisconnected!: () => void;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const disconnected = new Promise<void>((resolve) => {
+      markDisconnected = resolve;
+    });
+    const server = createServer(async (req, res) => {
+      for await (const _chunk of req) {
+        /* Consume the complete request before cancellation. */
+      }
+      res.once('close', () => {
+        if (!res.writableEnded) markDisconnected();
+      });
+      markStarted();
+    });
+    server.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+    const { port } = server.address() as AddressInfo;
+    const bashTool = createAttachedWorkspaceBashTool({
+      baseUrl: `http://127.0.0.1:${port}/v1`,
+      authHeaders: () => ({}),
+      workspaceId: 'project-a',
+    });
+    const controller = new AbortController();
+    try {
+      const invocation = bashTool.invoke({ command: 'sleep 30' }, { signal: controller.signal });
+      const settled = invocation.then(
+        () => ({ rejected: false }),
+        () => ({ rejected: true }),
+      );
+      await started;
+      controller.abort();
+      expect((await settled).rejected).toBe(true);
+      await disconnected;
+    } finally {
+      server.closeAllConnections();
+      server.close();
+      await once(server, 'close');
+    }
+  });
+
   test('executes in the selected workspace and relative working directory', async () => {
     const fetchImpl: CodeBridgeFetch = jest.fn(async () => commandResponse());
     const authHeaders = jest.fn().mockResolvedValue({

--- a/packages/api/src/code/command.ts
+++ b/packages/api/src/code/command.ts
@@ -1,5 +1,5 @@
-import { tool } from '@librechat/agents/langchain/tools';
 import { logger } from '@librechat/data-schemas';
+import { tool } from '@librechat/agents/langchain/tools';
 import {
   BashExecutionToolDefinition,
   BashToolOutputReferencesGuide,

--- a/packages/api/src/code/command.ts
+++ b/packages/api/src/code/command.ts
@@ -1,4 +1,5 @@
 import { tool } from '@librechat/agents/langchain/tools';
+import { logger } from '@librechat/data-schemas';
 import {
   BashExecutionToolDefinition,
   BashToolOutputReferencesGuide,
@@ -212,25 +213,45 @@ export function createAttachedWorkspaceBashTool({
       );
       const timeoutMs =
         rawInput.timeoutMs ?? Math.min(WORKSPACE_COMMAND_DEFAULT_TIMEOUT_MS, effectiveMaxTimeoutMs);
-      const result = await executeWorkspaceTool({
-        baseURL: baseUrl,
-        authHeaders: await authHeaders(),
-        request: {
-          protocolVersion: 1,
-          operation: 'execute_command',
-          workspaceId,
-          command,
-          ...(rawInput.cwd ? { cwd: rawInput.cwd } : {}),
-          timeoutMs,
-          maxOutputBytes: DEFAULT_OUTPUT_BYTES,
-        },
-        signal: config?.signal,
-        fetchImpl,
-      });
-      if (result.operation !== 'execute_command') {
-        throw new Error('Attached workspace returned an unexpected command result.');
+      const signal = config?.signal;
+      const trace = {
+        runId: config?.metadata?.run_id,
+        workspaceId,
+        signalPresent: signal != null,
+      };
+      const onAbort = (): void => {
+        logger.debug('[BYOMCommand] invocation signal aborted', trace);
+      };
+      signal?.addEventListener('abort', onAbort, { once: true });
+      logger.debug('[BYOMCommand] dispatch', { ...trace, aborted: signal?.aborted === true });
+      try {
+        const result = await executeWorkspaceTool({
+          baseURL: baseUrl,
+          authHeaders: await authHeaders(),
+          request: {
+            protocolVersion: 1,
+            operation: 'execute_command',
+            workspaceId,
+            command,
+            ...(rawInput.cwd ? { cwd: rawInput.cwd } : {}),
+            timeoutMs,
+            maxOutputBytes: DEFAULT_OUTPUT_BYTES,
+          },
+          signal,
+          fetchImpl,
+        });
+        if (result.operation !== 'execute_command') {
+          throw new Error('Attached workspace returned an unexpected command result.');
+        }
+        logger.debug('[BYOMCommand] transport completed', trace);
+        return [formatCommandResult(result), {}];
+      } finally {
+        signal?.removeEventListener('abort', onAbort);
+        logger.debug('[BYOMCommand] transport settled', {
+          ...trace,
+          aborted: signal?.aborted === true,
+        });
       }
-      return [formatCommandResult(result), {}];
     },
     {
       name: BashExecutionToolDefinition.name,


### PR DESCRIPTION
## Purpose
Investigate the deployed BYOM Stop failure without claiming another speculative cancellation fix.

## Changes
- Add real HTTP connection-close regression coverage through the Bash tool and foreground execution handler.
- Add debug-only command signal dispatch, abort-event, completion, and settlement diagnostics. No command text, credentials, output, or file contents are logged; listeners are removed on settlement.
- No policy, deadline, worker, or deployment changes.

## Verification
24 focused command/cancellation tests pass, including both real HTTP tests, using the published Agents SDK 3.8.5 artifact. Other dependencies are reused locally; CI must verify the complete lockfile environment. ESLint and diff checks pass. Codegraph selection authentication was unavailable, so local selection was source-based; full suites remain CI responsibility.

## What this establishes
The local foreground handler -> actual Bash tool -> fetch path closes a direct HTTP connection on cancellation. This does not yet reproduce approval resume or the deployed proxy route. Code API already handles response close as well as request abort.

## Next live correlation
Capture the BYOMCommand debug records for one disposable approved command followed by Stop, together with the abort endpoint timestamp and Code API outcome. An invocation-signal-aborted event with transport settlement on LibreChat but completed upstream would require inspecting proxy disconnect forwarding. No abort event means trace the resumed job/controller identity upstream. This PR is diagnostic coverage, not resolution of the live cancellation defect.