### PR TITLE
🛖 fix: Restore Saved Attached Workspaces

### DIFF
--- a/api/server/controllers/agents/__tests__/request.partialDisconnect.spec.js
+++ b/api/server/controllers/agents/__tests__/request.partialDisconnect.spec.js
@@ -64,6 +64,7 @@ jest.mock('@librechat/api', () => ({
   buildMessageFiles: jest.fn(() => []),
   resolveTitleTiming: jest.fn(() => 'immediate'),
   resolveConversationAnchor: jest.requireActual('@librechat/api').resolveConversationAnchor,
+  resolveRunCodeWorkspaces: jest.requireActual('@librechat/api').resolveRunCodeWorkspaces,
   GenerationJobManager: mockGenerationJobManager,
   getReferencedQuotes: jest.fn(() => null),
   cleanupMCPRequestContext: jest.fn(),

--- a/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
+++ b/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
@@ -273,6 +273,7 @@ jest.mock('@librechat/api', () => ({
   buildMessageFiles: jest.fn(() => []),
   resolveTitleTiming: jest.fn(() => 'immediate'),
   resolveConversationAnchor: jest.requireActual('@librechat/api').resolveConversationAnchor,
+  resolveRunCodeWorkspaces: jest.requireActual('@librechat/api').resolveRunCodeWorkspaces,
   getCodeWorkspaceSelectionErrorDetails:
     jest.requireActual('@librechat/api').getCodeWorkspaceSelectionErrorDetails,
   GenerationJobManager: mockGenerationJobManager,

--- a/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
+++ b/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
@@ -4252,7 +4252,7 @@ describe('ResumableAgentController resume metadata', () => {
     );
   });
 
-  it.each(['submitted', 'persisted'])(
+  it.each(['submitted', 'persisted', 'overridden'])(
     'preserves %s workspace selections in the runtime envelope',
     async (source) => {
       mockGenerationJobManager.claimGeneration.mockResolvedValue(wonGenerationClaim());
@@ -4260,9 +4260,12 @@ describe('ResumableAgentController resume metadata', () => {
       const codeWorkspaces = [{ environmentId: 'machine-a', workspaceId: 'project-b' }];
       const req = {
         user: { id: 'user-123' },
-        ...(source === 'persisted' ? { resolvedConversation: { codeWorkspaces } } : {}),
+        ...(source !== 'submitted'
+          ? { resolvedConversation: { conversationId: 'conversation-123', codeWorkspaces } }
+          : {}),
         body: {
           ...(source === 'submitted' ? { codeWorkspaces } : {}),
+          ...(source === 'overridden' ? { overrideConvoId: 'target-conversation' } : {}),
           text: 'Fresh submission.',
           messageId: 'user-msg',
           clientRequestId: 'req-abc',
@@ -4284,8 +4287,13 @@ describe('ResumableAgentController resume metadata', () => {
 
       expect(initializeClient).toHaveBeenCalledWith(
         expect.objectContaining({
-          requestBody: expect.objectContaining({ codeWorkspaces }),
+          requestBody: expect.objectContaining({
+            conversationId: source === 'overridden' ? 'target-conversation' : 'conversation-123',
+          }),
         }),
+      );
+      expect(initializeClient.mock.calls[0][0].requestBody.codeWorkspaces).toEqual(
+        source === 'overridden' ? undefined : codeWorkspaces,
       );
       expect(mockCheckAndIncrementPendingRequest).toHaveBeenCalledWith('user-123');
       expect(mockGenerationJobManager.createJob).toHaveBeenCalledWith(

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -29,6 +29,7 @@ const {
   deleteAgentCheckpoint,
   getAttachmentTitleText,
   createMCPRuntimeRequestBody,
+  resolveRunCodeWorkspaces,
   isAgentEventRetentionActive,
   createAgentEventActorTurn,
   createAgentEventActorDetachedActionLifecycle,
@@ -1485,7 +1486,11 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
   const mcpRequestBody = createMCPRuntimeRequestBody({
     messageId: preallocatedResponseMessageId,
     conversationId: effectiveConversationId,
-    codeWorkspaces: req.body.codeWorkspaces ?? req.resolvedConversation?.codeWorkspaces,
+    codeWorkspaces: resolveRunCodeWorkspaces({
+      conversationId: effectiveConversationId,
+      requestedSelections: req.body.codeWorkspaces,
+      conversation: req.resolvedConversation,
+    }),
     parentMessageId:
       editedContent != null ? preallocatedResponseMessageId : preallocatedUserMessageId,
   });

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -2,6 +2,7 @@ const { logger } = require('@librechat/data-schemas');
 const { createContentAggregator, GraphNodeKeys } = require('@librechat/agents');
 const {
   resolveSender,
+  resolveRunConversation,
   createConcurrencyLimiter,
   loadSkillStates,
   initializeAgent,
@@ -191,14 +192,13 @@ const initializeClient = async ({
   /** The normal controller resolves this once for timestamp anchoring. Reuse
    * that trusted document for child-thread execution policy; resume and direct
    * callers fall back to the same owner-scoped lookup. */
-  const conversationId = req.body?.conversationId;
   const runtimeRequestBody = requestBody ?? req.body;
-  let requestConversationPromise = Promise.resolve(null);
-  if (Object.prototype.hasOwnProperty.call(req, 'resolvedConversation')) {
-    requestConversationPromise = Promise.resolve(req.resolvedConversation);
-  } else if (typeof conversationId === 'string' && conversationId !== '') {
-    requestConversationPromise = db.getConvo(req.user.id, conversationId);
-  }
+  const conversationId = runtimeRequestBody?.conversationId;
+  const requestConversationPromise = resolveRunConversation({
+    request: req,
+    conversationId,
+    loadConversation: (conversationId) => db.getConvo(req.user.id, conversationId),
+  });
   const startupTelemetry = getAgentStartupTelemetry(req);
 
   /** @type {string | null} */
@@ -557,9 +557,7 @@ const initializeClient = async ({
     toolRoleGrantsPromise,
   ]);
   /** Preserve the owner-scoped fallback for loaders that share this request. */
-  if (!Object.prototype.hasOwnProperty.call(req, 'resolvedConversation')) {
-    req.resolvedConversation = requestConversation;
-  }
+  req.resolvedConversation = requestConversation;
   delete endpointOption.agent;
 
   /** The deployment switch AND the role grant. `initializeAgent` rebuilds

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -1039,7 +1039,7 @@ const initializeClient = async ({
       ? await resolveCodeExecutionWorkspaceContext({
           context: baseCodeExecutionContext,
           requestedSelections: runtimeRequestBody?.codeWorkspaces,
-          persistedSelections: req.resolvedConversation?.codeWorkspaces,
+          persistedSelections: requestConversation?.codeWorkspaces,
           environments: configuredCodeEnvironments,
           getAppConfig,
         })

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -556,6 +556,10 @@ const initializeClient = async ({
     requestConversationPromise,
     toolRoleGrantsPromise,
   ]);
+  /** Preserve the owner-scoped fallback for loaders that share this request. */
+  if (!Object.prototype.hasOwnProperty.call(req, 'resolvedConversation')) {
+    req.resolvedConversation = requestConversation;
+  }
   delete endpointOption.agent;
 
   /** The deployment switch AND the role grant. `initializeAgent` rebuilds

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -1480,6 +1480,8 @@ describe('initializeClient — subagent loading', () => {
     [true, 'request'],
     [false, 'request'],
     [true, 'fallback'],
+    [true, 'override'],
+    [true, 'override-resolved'],
     [true, 'resolved'],
     [false, 'resolved-null'],
     [false, 'other-owner'],
@@ -1523,6 +1525,7 @@ describe('initializeClient — subagent loading', () => {
       if (source === 'request' && !registered) {
         req.body.codeWorkspaces[0].workspaceId = 'removed-project';
       }
+      let requestBody;
       if (source !== 'request') {
         const conversation = await mongoose.model('Conversation').create({
           conversationId: req.body.conversationId,
@@ -1533,6 +1536,20 @@ describe('initializeClient — subagent loading', () => {
         delete req.body.codeWorkspaces;
         if (source === 'resolved') req.resolvedConversation = conversation.toObject();
         else if (source !== 'resolved-null') delete req.resolvedConversation;
+        if (source.startsWith('override')) {
+          conversation.codeWorkspaces = [
+            { environmentId: 'attached-vm', workspaceId: 'wrong-source' },
+          ];
+          await conversation.save();
+          if (source === 'override-resolved') req.resolvedConversation = conversation.toObject();
+          requestBody = { ...req.body, conversationId: 'effective-target' };
+          await mongoose.model('Conversation').create({
+            conversationId: requestBody.conversationId,
+            endpoint: 'agents',
+            user: req.user.id,
+            codeWorkspaces: [{ environmentId: 'attached-vm', workspaceId: 'project-b' }],
+          });
+        }
       }
       mockGetAppConfig.mockResolvedValue(req.config);
       process.env.TEST_LAZY_WORKSPACE_TOKEN = 'test-token';
@@ -1560,6 +1577,7 @@ describe('initializeClient — subagent loading', () => {
       try {
         const initialization = initializeClient({
           req,
+          requestBody,
           res: {},
           signal: new AbortController().signal,
           endpointOption: makeEndpointOption(),
@@ -1572,7 +1590,7 @@ describe('initializeClient — subagent loading', () => {
           return;
         }
         await initialization;
-        if (source === 'fallback') {
+        if (source === 'fallback' || source.startsWith('override')) {
           mockInitializeAgent.mockImplementationOnce(async (params) => {
             expect(params.req.resolvedConversation.codeWorkspaces).toEqual([
               { environmentId: 'attached-vm', workspaceId: 'project-b' },

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -1572,6 +1572,27 @@ describe('initializeClient — subagent loading', () => {
           return;
         }
         await initialization;
+        if (source === 'fallback') {
+          mockInitializeAgent.mockImplementationOnce(async (params) => {
+            expect(params.req.resolvedConversation.codeWorkspaces).toEqual([
+              { environmentId: 'attached-vm', workspaceId: 'project-b' },
+            ]);
+            await params.loadTools({ ...subAgent, agentId: SUBAGENT_ID });
+            return makeSubagentConfig(SUBAGENT_ID);
+          });
+          await agentClientArgs.agent.lazySubagentConfigs[0].resolve({
+            signal: new AbortController().signal,
+          });
+          expect(loadAgentTools).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              req: expect.objectContaining({
+                resolvedConversation: expect.objectContaining({
+                  codeWorkspaces: [{ environmentId: 'attached-vm', workspaceId: 'project-b' }],
+                }),
+              }),
+            }),
+          );
+        }
       } finally {
         fetchSpy.mockRestore();
         delete process.env.TEST_LAZY_WORKSPACE_TOKEN;

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -1476,9 +1476,16 @@ describe('initializeClient — subagent loading', () => {
     expect(mockInitializeAgent).toHaveBeenCalledTimes(1);
   });
 
-  it.each([true, false])(
-    'validates the lazy subagent workspace before exposure: registered=%s',
-    async (registered) => {
+  it.each([
+    [true, 'request'],
+    [false, 'request'],
+    [true, 'fallback'],
+    [true, 'resolved'],
+    [false, 'resolved-null'],
+    [false, 'other-owner'],
+  ])(
+    'validates the lazy subagent workspace before exposure: registered=%s source=%s',
+    async (registered, source) => {
       const subAgent = await createAgent({
         id: SUBAGENT_ID,
         name: 'Attached Stateful Subagent',
@@ -1513,7 +1520,20 @@ describe('initializeClient — subagent loading', () => {
         ],
       };
       req.body.codeWorkspaces = [{ environmentId: 'attached-vm', workspaceId: 'project-b' }];
-      if (!registered) req.body.codeWorkspaces[0].workspaceId = 'removed-project';
+      if (source === 'request' && !registered) {
+        req.body.codeWorkspaces[0].workspaceId = 'removed-project';
+      }
+      if (source !== 'request') {
+        const conversation = await mongoose.model('Conversation').create({
+          conversationId: req.body.conversationId,
+          endpoint: 'agents',
+          user: source === 'other-owner' ? new mongoose.Types.ObjectId().toString() : req.user.id,
+          codeWorkspaces: req.body.codeWorkspaces,
+        });
+        delete req.body.codeWorkspaces;
+        if (source === 'resolved') req.resolvedConversation = conversation.toObject();
+        else if (source !== 'resolved-null') delete req.resolvedConversation;
+      }
       mockGetAppConfig.mockResolvedValue(req.config);
       process.env.TEST_LAZY_WORKSPACE_TOKEN = 'test-token';
       const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue(

--- a/packages/api/src/agents/conversation.spec.ts
+++ b/packages/api/src/agents/conversation.spec.ts
@@ -1,4 +1,77 @@
-import { resolveConversationAnchor } from './conversation';
+import {
+  resolveRunConversation,
+  resolveConversationAnchor,
+  resolveRunCodeWorkspaces,
+} from './conversation';
+
+describe('resolveRunCodeWorkspaces', () => {
+  const saved = [{ environmentId: 'machine', workspaceId: 'source-project' }];
+  const conversation = { conversationId: 'source', codeWorkspaces: saved };
+  it('retains a saved selection only for the same conversation', () => {
+    expect(resolveRunCodeWorkspaces({ conversationId: 'source', conversation })).toBe(saved);
+    expect(resolveRunCodeWorkspaces({ conversationId: 'target', conversation })).toBeUndefined();
+  });
+  it.each([
+    { requestedSelections: [] },
+    { requestedSelections: [{ environmentId: 'machine', workspaceId: 'chosen-project' }] },
+  ])(
+    'preserves an explicit choice, including clearing selections',
+    ({ requestedSelections }) => {
+      expect(
+        resolveRunCodeWorkspaces({ conversationId: 'target', conversation, requestedSelections }),
+      ).toBe(requestedSelections);
+    },
+  );
+});
+
+describe('resolveRunConversation', () => {
+  it.each([null, undefined, { conversationId: 'source' }])(
+    'preserves authoritative same-conversation state: %s',
+    async (resolvedConversation) => {
+      const loadConversation = jest.fn();
+      expect(
+        await resolveRunConversation({
+          request: { body: { conversationId: 'source' }, resolvedConversation },
+          conversationId: 'source',
+          loadConversation,
+        }),
+      ).toBe(resolvedConversation);
+      expect(loadConversation).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    {},
+    { resolvedConversation: null },
+    { resolvedConversation: { conversationId: 'source' } },
+  ])('loads the effective target instead of source state: %s', async (state) => {
+    const target = { conversationId: 'target' };
+    const loadConversation = jest.fn().mockResolvedValue(target);
+    expect(
+      await resolveRunConversation({
+        request: { body: { conversationId: 'source' }, ...state },
+        conversationId: 'target',
+        loadConversation,
+      }),
+    ).toBe(target);
+    expect(loadConversation).toHaveBeenCalledTimes(1);
+    expect(loadConversation).toHaveBeenCalledWith('target');
+  });
+
+  it('does not fall back to a source when the effective conversation is absent', async () => {
+    const loadConversation = jest.fn();
+    expect(
+      await resolveRunConversation({
+        request: {
+          body: { conversationId: 'source' },
+          resolvedConversation: { conversationId: 'source' },
+        },
+        loadConversation,
+      }),
+    ).toBeNull();
+    expect(loadConversation).not.toHaveBeenCalled();
+  });
+});
 
 describe('resolveConversationAnchor', () => {
   const fallback = new Date('2026-07-24T12:00:00.000Z');

--- a/packages/api/src/agents/conversation.spec.ts
+++ b/packages/api/src/agents/conversation.spec.ts
@@ -14,14 +14,11 @@ describe('resolveRunCodeWorkspaces', () => {
   it.each([
     { requestedSelections: [] },
     { requestedSelections: [{ environmentId: 'machine', workspaceId: 'chosen-project' }] },
-  ])(
-    'preserves an explicit choice, including clearing selections',
-    ({ requestedSelections }) => {
-      expect(
-        resolveRunCodeWorkspaces({ conversationId: 'target', conversation, requestedSelections }),
-      ).toBe(requestedSelections);
-    },
-  );
+  ])('preserves an explicit choice, including clearing selections', ({ requestedSelections }) => {
+    expect(
+      resolveRunCodeWorkspaces({ conversationId: 'target', conversation, requestedSelections }),
+    ).toBe(requestedSelections);
+  });
 });
 
 describe('resolveRunConversation', () => {

--- a/packages/api/src/agents/conversation.ts
+++ b/packages/api/src/agents/conversation.ts
@@ -1,3 +1,46 @@
+import type { TConversation, CodeWorkspaceSelection } from 'librechat-data-provider';
+
+/** Never turn another conversation's stored workspace into an explicit run selection. */
+export function resolveRunCodeWorkspaces({
+  conversationId,
+  requestedSelections,
+  conversation,
+}: {
+  conversationId: string;
+  requestedSelections?: CodeWorkspaceSelection[] | null;
+  conversation?: Pick<TConversation, 'conversationId' | 'codeWorkspaces'> | null;
+}): CodeWorkspaceSelection[] | undefined {
+  return (
+    requestedSelections ??
+    (conversation?.conversationId === conversationId ? conversation.codeWorkspaces : undefined)
+  );
+}
+
+/** Reuse resolved state only for the conversation the run will actually execute. */
+export async function resolveRunConversation<TConversation>({
+  request,
+  conversationId,
+  loadConversation,
+}: {
+  request: {
+    body?: { conversationId?: string };
+    resolvedConversation?: TConversation | null;
+  };
+  conversationId?: string;
+  loadConversation: (conversationId: string) => Promise<TConversation | null | undefined>;
+}): Promise<TConversation | null | undefined> {
+  if (
+    conversationId === request.body?.conversationId &&
+    Object.prototype.hasOwnProperty.call(request, 'resolvedConversation')
+  ) {
+    return request.resolvedConversation;
+  }
+  if (typeof conversationId !== 'string' || conversationId === '') {
+    return null;
+  }
+  return loadConversation(conversationId);
+}
+
 export interface ConversationAnchorSource {
   createdAt?: Date | string | number | null;
 }


### PR DESCRIPTION
## Summary

I fixed attached-workspace restoration when the owner conversation is loaded during agent initialization. Previously, a saved selection could pass lazy-agent validation but disappear during actual tool loading. Conversation overrides could also carry the source conversation's project into the target run.

- Resolve the effective runtime conversation through the existing parallel, owner-scoped lookup.
- Preserve that resolved document for lazy initialization and deferred tools.
- Prevent request construction from promoting a different conversation's saved workspace into an explicit selection.
- Preserve explicit user choices, empty selections, and authoritative same-conversation null results.
- Keep resolution policy in portable TypeScript with an injected database lookup; keep CJS as wiring.

```text
Request / saved selection → effective conversation identity
  → owner-scoped resolution → lazy agent validation → deferred tool loading
```

Addresses https://github.com/ClickHouse/LibreChat/issues/451. No dependency on #15812 and no storage migration or permission expansion.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Run ten focused conversation identity/selection cases and eight real-Mongo initializer cases, including actual lazy resolution and deferred loading.
- Run the persistence-reconciliation case and four partial-disconnect controller cases with the real resolver retained in their module fixtures.
- Pass API TypeScript checks, scoped ESLint, and Prettier against a clean lockfile install.
- Pass isolated Lighthouse: median LCP 3243 ms, CLS 0.039, TBT 33 ms, within unchanged budgets.
- Pass local real-worker browser acceptance for foreground/background cancellation and subsequent workspace write/read reuse. The model is deterministic; approval, authentication, jobs, bridge and sandbox are real.

Full suites run in CI, not locally. Codegraph selector authentication was unavailable; focused local selection used source/dependency inspection.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
