### PR TITLE
🧵 ci: Keep a Floor of Two Jest Workers in CI

### DIFF
--- a/api/jest.config.js
+++ b/api/jest.config.js
@@ -1,3 +1,5 @@
+const { maxWorkers } = require('../config/jest.workers.cjs');
+
 const esModules = [
   'openid-client',
   'oauth4webapi',
@@ -21,7 +23,7 @@ module.exports = {
   clearMocks: true,
   roots: ['<rootDir>'],
   coverageDirectory: 'coverage',
-  maxWorkers: '50%',
+  maxWorkers,
   testTimeout: 30000, // 30 seconds timeout for all tests
   setupFiles: ['./test/jestSetup.js', './test/__mocks__/logger.js'],
   moduleNameMapper: {

--- a/client/jest.config.cjs
+++ b/client/jest.config.cjs
@@ -1,4 +1,6 @@
 /** v0.8.8-rc2 */
+const { maxWorkers } = require('../config/jest.workers.cjs');
+
 module.exports = {
   roots: ['<rootDir>/src'],
   testEnvironment: 'jsdom',
@@ -34,7 +36,7 @@ module.exports = {
     '^librechat-data-provider/react-query$':
       '<rootDir>/../node_modules/librechat-data-provider/src/react-query',
   },
-  maxWorkers: '50%',
+  maxWorkers,
   /** Coverage maps accumulate for the life of a worker, so a long run can push
    * a worker past a gigabyte and get it killed by the OS, which fails whatever
    * suite it was holding. Recycling bloated workers also avoids swap thrash. */

--- a/config/jest.workers.cjs
+++ b/config/jest.workers.cjs
@@ -1,0 +1,30 @@
+/**
+ * Jest worker count shared by every workspace config.
+ *
+ * Jest runs in band as soon as it resolves to a single worker, and in band a test
+ * file that leaves a server listening or a timer armed keeps the main process alive
+ * after "Ran all test suites" until the CI job hits its timeout. `'50%'` resolves to
+ * exactly one worker on the 2-vCPU GitHub-hosted runners that private repositories
+ * (forks, mirrors) get, so CI keeps a floor of two workers: a leaked handle then
+ * stays inside a worker process, which Jest terminates — the same shape the 4-vCPU
+ * public runners already get from `'50%'`. Local runs keep the percentage so the
+ * pool tracks the machine.
+ */
+const os = require('node:os');
+
+const CI_MIN_WORKERS = 2;
+
+function cpuCount() {
+  return typeof os.availableParallelism === 'function'
+    ? os.availableParallelism()
+    : os.cpus().length;
+}
+
+function resolveMaxWorkers() {
+  if (!process.env.CI) {
+    return '50%';
+  }
+  return Math.max(CI_MIN_WORKERS, Math.floor(cpuCount() / 2));
+}
+
+module.exports = { maxWorkers: resolveMaxWorkers() };

--- a/packages/api/jest.config.mjs
+++ b/packages/api/jest.config.mjs
@@ -1,3 +1,5 @@
+import { maxWorkers } from '../../config/jest.workers.cjs';
+
 const esModules = [
   '@langchain/langgraph',
   '@langchain/langgraph-checkpoint',
@@ -52,7 +54,7 @@ export default {
   //   },
   // },
   setupFiles: ['<rootDir>/jest.setup.cjs', '<rootDir>/../../config/jest.setup.logging.cjs'],
-  maxWorkers: '50%',
+  maxWorkers,
   restoreMocks: true,
   testTimeout: 15000,
 };

--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -1,3 +1,5 @@
+import { maxWorkers } from '../../config/jest.workers.cjs';
+
 export default {
   collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!<rootDir>/node_modules/'],
   coveragePathIgnorePatterns: ['/node_modules/', '/dist/'],
@@ -16,7 +18,7 @@ export default {
   //     lines: 57,
   //   },
   // },
-  maxWorkers: '50%',
+  maxWorkers,
   restoreMocks: true,
   testTimeout: 15000,
   // React component testing requires jsdom environment

--- a/packages/data-provider/jest.config.js
+++ b/packages/data-provider/jest.config.js
@@ -1,3 +1,5 @@
+const { maxWorkers } = require('../../config/jest.workers.cjs');
+
 module.exports = {
   collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!<rootDir>/node_modules/'],
   coveragePathIgnorePatterns: ['/node_modules/', '/dist/'],
@@ -14,6 +16,6 @@ module.exports = {
   //     lines: 57,
   //   },
   // },
-  maxWorkers: '50%',
+  maxWorkers,
   restoreMocks: true,
 };

--- a/packages/data-schemas/jest.config.mjs
+++ b/packages/data-schemas/jest.config.mjs
@@ -1,3 +1,5 @@
+import { maxWorkers } from '../../config/jest.workers.cjs';
+
 export default {
   collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!<rootDir>/node_modules/'],
   coveragePathIgnorePatterns: ['/node_modules/', '/dist/'],
@@ -23,7 +25,7 @@ export default {
   // cache the parallel downloads race their final rename and fail whole suites.
   globalSetup: '<rootDir>/jest.globalSetup.mjs',
   setupFiles: ['<rootDir>/../../config/jest.setup.logging.cjs'],
-  maxWorkers: '50%',
+  maxWorkers,
   restoreMocks: true,
   testTimeout: 15000,
 };


### PR DESCRIPTION
## Summary

Fixes #15818

Every workspace Jest config sets `maxWorkers: '50%'`. On a 2-vCPU runner — what GitHub-hosted `ubuntu-latest` gives private repositories — that resolves to one worker, Jest switches to in-band execution, and any test file that leaves a handle open (a listening `http.Server`, a timer, a DB connection) keeps the main process alive after `Ran all test suites.` until the job's `timeout-minutes` cancels it. All tests pass; the job still fails. Upstream CI never sees this because public runners have 4 vCPUs, so `'50%'` is two workers and the leak dies with the worker process.

This change keeps `'50%'` for local runs and gives CI a floor of two workers, computed in one shared helper instead of six copies of the same expression. On 4-vCPU runners the value is identical to what `'50%'` already produced, so upstream CI behaviour does not change; on 2-vCPU runners Jest now uses worker processes the same way it does upstream.

## How it works

```js
// config/jest.workers.cjs
function resolveMaxWorkers() {
  if (!process.env.CI) {
    return '50%';
  }
  return Math.max(CI_MIN_WORKERS, Math.floor(cpuCount() / 2));
}
```

```diff
 // api/jest.config.js, client/jest.config.cjs, packages/{api,client,data-provider,data-schemas}/jest.config.*
+const { maxWorkers } = require('../config/jest.workers.cjs');   // or `import` in the ESM configs
 ...
-  maxWorkers: '50%',
+  maxWorkers,
```

Resolved values (`process.env.CI` set):

| vCPUs | before (`'50%'`) | after |
|---|---|---|
| 2 | 1 → in band | 2 |
| 4 (public `ubuntu-latest`) | 2 | 2 |
| 8 | 4 | 4 |

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Loaded all six configs with Node 24 with and without `CI`: local resolves to `'50%'`, CI resolves to `max(2, floor(cpus / 2))` (verified with `os.availableParallelism` stubbed to 1, 2, 3, 4, 8 and 14 → 2, 2, 2, 2, 4, 7).
- Ran a small suite in each workspace with `CI=true` (`api`, `client`, `packages/api`, `packages/client`, `packages/data-provider`, `packages/data-schemas`) to confirm Jest accepts the shared helper from both CommonJS and ESM configs.
- `prettier --check` and `eslint --max-warnings=0` clean on the seven files.
- Real-world before/after on a private fork's 2-vCPU runner: `Tests: api (shard 2/3)` went from `cancelled` after 15 min (`Jest did not exit one second after the test run has completed.`) to `success` in 2m33s with the worker floor, with the same test files.

Reproduction without a 2-vCPU machine: `cd api && npx jest --ci --runInBand --shard=2/3` passes every suite and never exits; `--maxWorkers=2` on the same shard exits normally.

### **Test Configuration**:

- Node.js v24, Jest via each workspace's config.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works (configuration-only change; verified as described above)
- [x] Local unit tests pass with my changes
