### PR TITLE
🔌 fix: Close Leaked HTTP Server in Server Specs

### DIFF
--- a/api/server/csp.spec.js
+++ b/api/server/csp.spec.js
@@ -1,5 +1,7 @@
 const fs = require('fs');
 const path = require('path');
+const { promisify } = require('util');
+const express = require('express');
 const request = require('supertest');
 const { MongoMemoryServer } = require('mongodb-memory-server');
 const mongoose = require('mongoose');
@@ -76,6 +78,7 @@ describe('Content Security Policy', () => {
 
   let mongoServer;
   let app;
+  let server;
 
   const originalReadFileSync = fs.readFileSync;
 
@@ -105,8 +108,12 @@ describe('Content Security Policy', () => {
     /* A cacheable override that CSP must refuse for the shell. */
     process.env.INDEX_CACHE_CONTROL = 'public, max-age=3600';
 
+    /* index.js listens at module scope and exports only the app, so capture the server to close it. */
+    const listenSpy = jest.spyOn(express.application, 'listen');
     app = require('~/server');
     await healthCheckPoll(app);
+    server = listenSpy.mock.results[0].value;
+    listenSpy.mockRestore();
   });
 
   afterAll(async () => {
@@ -115,6 +122,7 @@ describe('Content Security Policy', () => {
     delete process.env.CSP_REPORT_ONLY;
     delete process.env.CSP_CONNECT_SRC_EXTRA;
     delete process.env.INDEX_CACHE_CONTROL;
+    await promisify(server.close).call(server);
     await mongoServer.stop();
     await mongoose.disconnect();
   });

--- a/api/server/index.metrics.spec.js
+++ b/api/server/index.metrics.spec.js
@@ -1,4 +1,6 @@
 const fs = require('fs');
+const { promisify } = require('util');
+const express = require('express');
 const request = require('supertest');
 const { MongoMemoryServer } = require('mongodb-memory-server');
 const mongoose = require('mongoose');
@@ -47,6 +49,7 @@ describe('Server metrics route', () => {
 
   let mongoServer;
   let app;
+  let server;
 
   const originalReadFileSync = fs.readFileSync;
 
@@ -83,9 +86,13 @@ describe('Server metrics route', () => {
     process.env.MONGO_URI = mongoServer.getUri();
     process.env.PORT = '0';
     process.env.METRICS_SECRET = 'test-secret';
+    /* index.js listens at module scope and exports only the app, so capture the server to close it. */
+    const listenSpy = jest.spyOn(express.application, 'listen');
     app = require('~/server');
 
     await healthCheckPoll(app);
+    server = listenSpy.mock.results[0].value;
+    listenSpy.mockRestore();
   });
 
   afterEach(() => {
@@ -94,6 +101,7 @@ describe('Server metrics route', () => {
 
   afterAll(async () => {
     delete process.env.METRICS_SECRET;
+    await promisify(server.close).call(server);
     await mongoServer.stop();
     await mongoose.disconnect();
   });

--- a/api/server/index.spec.js
+++ b/api/server/index.spec.js
@@ -1,5 +1,7 @@
 const fs = require('fs');
 const path = require('path');
+const { promisify } = require('util');
+const express = require('express');
 const request = require('supertest');
 const { MongoMemoryServer } = require('mongodb-memory-server');
 const mongoose = require('mongoose');
@@ -225,6 +227,7 @@ describe('Server Configuration', () => {
 
   let mongoServer;
   let app;
+  let server;
 
   /** Mocked fs.readFileSync for index.html */
   const originalReadFileSync = fs.readFileSync;
@@ -262,13 +265,18 @@ describe('Server Configuration', () => {
     mongoServer = await MongoMemoryServer.create();
     process.env.MONGO_URI = mongoServer.getUri();
     process.env.PORT = '0'; // Use a random available port
+    /* index.js listens at module scope and exports only the app, so capture the server to close it. */
+    const listenSpy = jest.spyOn(express.application, 'listen');
     app = require('~/server');
 
     // Wait for the app to be healthy
     await healthCheckPoll(app);
+    server = listenSpy.mock.results[0].value;
+    listenSpy.mockRestore();
   });
 
   afterAll(async () => {
+    await promisify(server.close).call(server);
     await mongoServer.stop();
     await mongoose.disconnect();
   });


### PR DESCRIPTION
## Summary

Fixes #15820

`api/server/csp.spec.js`, `api/server/index.spec.js` and `api/server/index.metrics.spec.js` boot the real server with `app = require('~/server')`. `index.js` calls `app.listen(...)` at module scope and exports only `app`, so the specs never had a handle on the `http.Server`, and their `afterAll` only stopped `MongoMemoryServer` and disconnected mongoose. The listening socket survived the suite; when Jest runs in-band (`--runInBand`, or `maxWorkers: '50%'` on a 2-vCPU runner such as GitHub-hosted runners for private forks) it keeps the main process alive, so every test passes and then `Jest did not exit one second after the test run has completed.` until the workflow timeout kills the job. Each spec now captures the server that `index.js` opens and awaits `server.close()` before tearing down Mongo, and Jest exits on its own in both worker and in-band mode.

## How it works

`express()` copies `express.application`'s methods onto the app when it is created, so the spy is installed before `require('~/server')` and restored once the server is captured. Supertest wraps the app with `http.createServer(app)` and never goes through `express.application.listen`, so `mock.results[0]` is the server created by `index.js`. The spy keeps Express's real implementation; nothing in `index.js` changes.

```diff
+    const listenSpy = jest.spyOn(express.application, 'listen');
     app = require('~/server');
     await healthCheckPoll(app);
+    server = listenSpy.mock.results[0].value;
+    listenSpy.mockRestore();
   });

   afterAll(async () => {
+    await promisify(server.close).call(server);
     await mongoServer.stop();
     await mongoose.disconnect();
   });
```

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Before the change, each of the three suites run alone with `npx jest --ci --runInBand <spec>` passes all tests and then hangs with `Jest did not exit one second after the test run has completed.`; a `globalTeardown` probe printing `process._getActiveHandles()` shows a single `Server listening=true` handle.

After the change (Node.js v24.14.1, `dev` @ b356c3d87e, `api/`):

- `npx jest --ci --runInBand server/csp.spec.js server/index.spec.js server/index.metrics.spec.js` → 3 suites / 41 tests passed, exit 0 in 15 s, no `Jest did not exit` warning (before the change each suite hangs after its tests pass).
- `npx jest --ci --runInBand --detectOpenHandles` on the same three files → 3 suites / 41 tests passed, exit 0 in 19 s, no open handles reported (before the change `--detectOpenHandles` hangs without printing a report).
- The same probe now prints `active handles (0)`.
- `npx prettier --check`, `npx eslint --max-warnings=0` and `node scripts/sort-imports.mts --check` are clean on the three files.

The full `api` suite in the fork's CI (`Tests: api`, 3 shards) is green with the equivalent change.

### **Test Configuration**:

- Node.js v24.14.1, macOS; jest via the `api` workspace config with `api/test/.env.test` copied from the example.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
