### PR TITLE
🏷️ fix: Name Artifact Downloads After the Document

### DIFF
--- a/client/src/components/Artifacts/DownloadArtifact.tsx
+++ b/client/src/components/Artifacts/DownloadArtifact.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Download, CircleCheckBig } from 'lucide';
 import { Button, MorphIcon } from '@librechat/client';
 import type { Artifact } from '~/common';
@@ -6,8 +6,8 @@ import {
   useAttachmentLink,
   isLocallyStoredSource,
 } from '~/components/Chat/Messages/Content/Parts/LogLink';
+import { isPreviewOnlyArtifact, getArtifactDownloadFilename } from '~/utils/artifacts';
 import useArtifactProps from '~/hooks/Artifacts/useArtifactProps';
-import { isPreviewOnlyArtifact } from '~/utils/artifacts';
 import { useCodeState } from '~/Providers/EditorContext';
 import { useLocalize } from '~/hooks';
 
@@ -15,7 +15,17 @@ const DownloadArtifact = ({ artifact }: { artifact: Artifact }) => {
   const localize = useLocalize();
   const { currentCode } = useCodeState();
   const [isDownloaded, setIsDownloaded] = useState(false);
-  const { fileKey: fileName } = useArtifactProps({ artifact });
+  const { fileKey } = useArtifactProps({ artifact });
+  /* `fileKey` names the file INSIDE the Sandpack preview and is a
+   * constant per bucket ('content.md', 'index.html'). Handing it to
+   * `link.download` made every markdown document in every conversation
+   * save as `content.md`. Derive the saved name from the artifact title
+   * or the document's own heading instead, and keep `fileKey` as the
+   * last-resort fallback. */
+  const fileName = useMemo(
+    () => getArtifactDownloadFilename(artifact, fileKey),
+    [artifact, fileKey],
+  );
 
   /* Office artifacts (pptx/xlsx/docx) render a server-generated HTML
    * preview in `content`, not the binary file — serializing that blob
@@ -40,7 +50,7 @@ const DownloadArtifact = ({ artifact }: { artifact: Artifact }) => {
   const downloadOriginalFile = isPreviewOnlyArtifact(artifact.type) && hasUsableRoute;
   const { handleDownload: downloadAttachment } = useAttachmentLink({
     href: download?.filepath ?? '',
-    filename: artifact.title ?? fileName,
+    filename: fileName,
     file_id: download?.file_id,
     user: download?.user,
     source: download?.source,

--- a/client/src/components/Artifacts/__tests__/DownloadArtifact.test.tsx
+++ b/client/src/components/Artifacts/__tests__/DownloadArtifact.test.tsx
@@ -13,9 +13,14 @@ jest.mock('~/hooks', () => ({
       key,
 }));
 
+/* The real hook returns a per-bucket constant ('index.html' for the
+ * sandpack-static buckets, 'content.md' for markdown/text/code). Keep it
+ * settable so the filename tests can exercise both. */
+const mockFileKey = { current: 'index.html' };
+
 jest.mock('~/hooks/Artifacts/useArtifactProps', () => ({
   __esModule: true,
-  default: () => ({ fileKey: 'index.html', files: {}, template: 'static', sharedProps: {} }),
+  default: () => ({ fileKey: mockFileKey.current, files: {}, template: 'static', sharedProps: {} }),
 }));
 
 jest.mock('~/Providers/EditorContext', () => ({
@@ -99,8 +104,11 @@ describe('DownloadArtifact', () => {
   let createObjectURL: jest.Mock;
   let revokeObjectURL: jest.Mock;
   let anchorClick: jest.SpyInstance;
+  let savedAs: string[];
 
   beforeEach(() => {
+    mockFileKey.current = 'index.html';
+    savedAs = [];
     mockFileDownload.mockReset();
     // The attachment helper resolves to `true` when a file was delivered.
     mockFileDownload.mockResolvedValue(true);
@@ -114,9 +122,11 @@ describe('DownloadArtifact', () => {
       configurable: true,
       value: revokeObjectURL,
     });
-    anchorClick = jest
-      .spyOn(HTMLAnchorElement.prototype, 'click')
-      .mockImplementation(() => undefined);
+    anchorClick = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+      this: HTMLAnchorElement,
+    ) {
+      savedAs.push(this.download);
+    });
   });
 
   afterEach(() => {
@@ -175,5 +185,40 @@ describe('DownloadArtifact', () => {
     });
     expect(mockFileDownload).toHaveBeenCalledTimes(1);
     expect(createObjectURL).not.toHaveBeenCalled();
+  });
+
+  /* Regression: the blob path handed `link.download` the sandpack file
+   * key, so every markdown artifact in every conversation saved as
+   * `content.md` and stacked up as `content (1).md`, `content (2).md`. */
+  describe('saved filename', () => {
+    const markdownArtifact = (overrides: Partial<Artifact>): Artifact => ({
+      id: 'md-1',
+      lastUpdateTime: 0,
+      type: TOOL_ARTIFACT_TYPES.MARKDOWN,
+      ...overrides,
+    });
+
+    const clickDownload = async (artifact: Artifact) => {
+      mockFileKey.current = 'content.md';
+      render(<DownloadArtifact artifact={artifact} />);
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button'));
+      });
+    };
+
+    it('saves a markdown artifact under its title, not the file key', async () => {
+      await clickDownload(markdownArtifact({ title: 'Quarterly Report', content: '# Q report' }));
+      expect(savedAs).toEqual(['Quarterly Report.md']);
+    });
+
+    it("saves under the document's heading when the artifact has no title", async () => {
+      await clickDownload(markdownArtifact({ content: '# Migration Plan\n\nSteps follow.' }));
+      expect(savedAs).toEqual(['Migration Plan.md']);
+    });
+
+    it('keeps the file key when nothing names the document', async () => {
+      await clickDownload(markdownArtifact({ content: 'no heading here' }));
+      expect(savedAs).toEqual(['content.md']);
+    });
   });
 });

--- a/client/src/utils/__tests__/artifacts.test.ts
+++ b/client/src/utils/__tests__/artifacts.test.ts
@@ -1,9 +1,13 @@
 import { FileSources } from 'librechat-data-provider';
 import type { ToolArtifactType } from '../artifacts';
+import type { Artifact } from '~/common';
 import {
   buildSandpackOptions,
   detectArtifactTypeFromFile,
   fileToArtifact,
+  firstMarkdownHeading,
+  getArtifactDownloadFilename,
+  GENERATED_ARTIFACT_TITLE,
   isCodeOnlyArtifact,
   isPreviewOnlyArtifact,
   languageForFilename,
@@ -973,4 +977,142 @@ describe('isCodeOnlyArtifact', () => {
       expect(isCodeOnlyArtifact(type)).toBe(false);
     },
   );
+});
+
+describe('firstMarkdownHeading', () => {
+  it('returns the first ATX heading', () => {
+    expect(firstMarkdownHeading('# Quarterly Report\n\nBody text.')).toBe('Quarterly Report');
+  });
+
+  it('accepts a deeper heading when no h1 comes first', () => {
+    expect(firstMarkdownHeading('Intro line\n\n## Section One\n')).toBe('Section One');
+  });
+
+  it('tolerates up to three leading spaces, CRLF line endings and closing hashes', () => {
+    expect(firstMarkdownHeading('   ## Budget 2026 ##\r\nbody')).toBe('Budget 2026');
+  });
+
+  it('strips emphasis and unwraps links', () => {
+    expect(firstMarkdownHeading('# The **Q3** [report](https://x.test)')).toBe('The Q3 report');
+  });
+
+  it('ignores a hash comment inside a fenced code block', () => {
+    const content = ['```bash', '# not a heading', '```', '', '# Real Heading'].join('\n');
+    expect(firstMarkdownHeading(content)).toBe('Real Heading');
+  });
+
+  it('ignores a tilde-fenced block and does not let a backtick run close it', () => {
+    const content = ['~~~', '# fenced', '```', '# still fenced', '~~~', '# Actual Title'].join(
+      '\n',
+    );
+    expect(firstMarkdownHeading(content)).toBe('Actual Title');
+  });
+
+  it('does not treat a setext underline as a heading', () => {
+    expect(firstMarkdownHeading('Some paragraph\n---\nmore text')).toBe('');
+  });
+
+  it('requires a space after the hashes', () => {
+    expect(firstMarkdownHeading('#hashtag not a heading')).toBe('');
+  });
+
+  it.each([[''], [undefined], ['no headings at all']])('returns empty for %s', (content) => {
+    expect(firstMarkdownHeading(content)).toBe('');
+  });
+});
+
+describe('getArtifactDownloadFilename', () => {
+  const artifact = (overrides: Partial<Artifact>): Artifact => ({
+    id: 'a1',
+    lastUpdateTime: 0,
+    type: TOOL_ARTIFACT_TYPES.MARKDOWN,
+    ...overrides,
+  });
+
+  it('uses the artifact title and appends the bucket extension', () => {
+    expect(getArtifactDownloadFilename(artifact({ title: 'Quarterly Report' }), 'content.md')).toBe(
+      'Quarterly Report.md',
+    );
+  });
+
+  it('falls back to the document heading when the title is the generic placeholder', () => {
+    const result = getArtifactDownloadFilename(
+      artifact({ title: GENERATED_ARTIFACT_TITLE, content: '# Migration Plan\n\ntext' }),
+      'content.md',
+    );
+    expect(result).toBe('Migration Plan.md');
+  });
+
+  it('falls back to the document heading when there is no title', () => {
+    expect(getArtifactDownloadFilename(artifact({ content: '# Design Notes' }), 'content.md')).toBe(
+      'Design Notes.md',
+    );
+  });
+
+  it('falls back to the sandpack file key when nothing names the document', () => {
+    expect(getArtifactDownloadFilename(artifact({ content: 'no heading' }), 'content.md')).toBe(
+      'content.md',
+    );
+  });
+
+  it('keeps an extension the title already carries', () => {
+    const result = getArtifactDownloadFilename(
+      artifact({ type: TOOL_ARTIFACT_TYPES.CODE, title: 'migrate_users.py' }),
+      'content.md',
+    );
+    expect(result).toBe('migrate_users.py');
+  });
+
+  it('does not mistake a version suffix for an extension', () => {
+    expect(getArtifactDownloadFilename(artifact({ title: 'Q4 Report v1.2' }), 'content.md')).toBe(
+      'Q4 Report v1.2.md',
+    );
+  });
+
+  it('does not read a heading out of source code', () => {
+    /* `#` opens a comment in shell and Python — the first one is a
+     * licence header far more often than a document title. */
+    const result = getArtifactDownloadFilename(
+      artifact({ type: TOOL_ARTIFACT_TYPES.CODE, content: '# Copyright 2026 Example Corp\n' }),
+      'content.md',
+    );
+    expect(result).toBe('content.md');
+  });
+
+  it('replaces path separators and characters Windows rejects', () => {
+    expect(getArtifactDownloadFilename(artifact({ title: 'Q3: profit/loss' }), 'content.md')).toBe(
+      'Q3- profit-loss.md',
+    );
+  });
+
+  it('does not produce a hidden file or a trailing dot', () => {
+    expect(getArtifactDownloadFilename(artifact({ title: '...draft...' }), 'content.md')).toBe(
+      'draft.md',
+    );
+  });
+
+  it('falls back when the title sanitizes away to nothing', () => {
+    expect(getArtifactDownloadFilename(artifact({ title: '///' }), 'content.md')).toBe(
+      'content.md',
+    );
+  });
+
+  it('caps a runaway heading', () => {
+    const long = 'A'.repeat(400);
+    const result = getArtifactDownloadFilename(artifact({ title: long }), 'content.md');
+    expect(result).toBe(`${'A'.repeat(100)}.md`);
+  });
+
+  it('appends no extension when the fallback has none', () => {
+    expect(getArtifactDownloadFilename(artifact({ title: 'Readme' }), 'Dockerfile')).toBe('Readme');
+  });
+
+  it('keeps the html bucket default for an untitled html artifact', () => {
+    expect(
+      getArtifactDownloadFilename(
+        artifact({ type: TOOL_ARTIFACT_TYPES.HTML, content: '<h1>hi</h1>' }),
+        'index.html',
+      ),
+    ).toBe('index.html');
+  });
 });

--- a/client/src/utils/artifacts.ts
+++ b/client/src/utils/artifacts.ts
@@ -312,6 +312,161 @@ const lookupOwn = <T>(record: Record<string, T>, key: string): T | undefined =>
   Object.prototype.hasOwnProperty.call(record, key) ? record[key] : undefined;
 
 /**
+ * Placeholder title `fileToArtifact` assigns when an attachment carries
+ * no filename. It names no document, so it must never become a download
+ * filename — the document's own heading (or the bucket default) is the
+ * better answer.
+ */
+export const GENERATED_ARTIFACT_TITLE = 'Generated artifact';
+
+/**
+ * Characters that are illegal in a filename on Windows, plus the path
+ * separators. `link.download` is advisory — each browser does its own
+ * stripping — so a title like `Q3: profit/loss` would otherwise land
+ * under a different name in every browser.
+ */
+const UNSAFE_FILENAME_CHARS = /[<>:"/\\|?*]/g;
+
+/** Control characters, matched through the Unicode `Cc` category so the
+ * pattern carries no literal control bytes of its own. */
+const CONTROL_CHARS = /\p{Cc}/gu;
+
+/**
+ * Cap the derived base name. Most filesystems reject a name over 255
+ * bytes, and a heading has no length limit of its own.
+ */
+const MAX_DOWNLOAD_BASENAME = 100;
+
+/**
+ * A trailing dotted segment counts as an extension only when it looks
+ * like one: short, alphanumeric, and carrying at least one letter. The
+ * letter rule is what keeps a version suffix out — `Q4 Report v1.2`
+ * must not be read as base `Q4 Report v1` plus extension `2`, or the
+ * markdown saves with no `.md` at all.
+ */
+const looksLikeExtension = (ext: string): boolean =>
+  /^[a-z0-9]{1,8}$/.test(ext) && /[a-z]/.test(ext);
+
+/**
+ * Unwrap links and drop emphasis markers so `# The **Q3** [report](x)`
+ * yields `The Q3 report` instead of carrying markdown syntax into the
+ * filename.
+ */
+const stripInlineMarkdown = (heading: string): string =>
+  heading
+    .replace(/\s+#+\s*$/, '')
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/[*_`~]/g, '')
+    .trim();
+
+/**
+ * First ATX heading (`# …`) of a markdown document, or `''`.
+ *
+ * Fenced blocks are skipped so a `# comment` on the first line of a
+ * shell snippet can't be mistaken for the document title. Setext
+ * headings (a line underlined with `===`) are deliberately not matched:
+ * `---` doubles as a thematic break AND as the YAML frontmatter fence,
+ * so matching that form would name documents after arbitrary body text.
+ */
+export function firstMarkdownHeading(content: string | undefined): string {
+  if (!content) {
+    return '';
+  }
+  let fence = '';
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.replace(/\r$/, '');
+    const fenceMatch = /^ {0,3}(`{3,}|~{3,})/.exec(line);
+    if (fenceMatch) {
+      const marker = fenceMatch[1][0];
+      if (!fence) {
+        fence = marker;
+      } else if (marker === fence) {
+        fence = '';
+      }
+      continue;
+    }
+    if (fence) {
+      continue;
+    }
+    const heading = /^ {0,3}#{1,6}\s+(.+?)\s*$/.exec(line);
+    if (heading) {
+      const stripped = stripInlineMarkdown(heading[1]);
+      if (stripped) {
+        return stripped;
+      }
+    }
+  }
+  return '';
+}
+
+/**
+ * Strip the characters a filename can't hold, collapse the whitespace a
+ * heading tends to carry, and cap the length. Returns `''` when nothing
+ * usable survives, so the caller falls back.
+ */
+const sanitizeDownloadBasename = (value: string): string =>
+  value
+    .replace(CONTROL_CHARS, '')
+    .replace(UNSAFE_FILENAME_CHARS, '-')
+    .replace(/\s+/g, ' ')
+    .replace(/-{2,}/g, '-')
+    .slice(0, MAX_DOWNLOAD_BASENAME)
+    /* No leading dot (that makes a hidden file) and no trailing dot or
+     * space (Windows silently drops both). */
+    .replace(/^[.\-\s]+/, '')
+    .replace(/[.\-\s]+$/, '');
+
+/**
+ * Markdown buckets whose CONTENT is prose, so its first heading names
+ * the document. Source code is excluded on purpose: `#` opens a comment
+ * in shell, Python, Ruby and YAML, and the first such comment is a
+ * licence header far more often than a title.
+ */
+const HEADING_NAMED_TYPES: ReadonlySet<string> = new Set([TOOL_ARTIFACT_TYPES.MARKDOWN, 'text/md']);
+
+/**
+ * The best name the artifact carries for itself, before sanitizing:
+ * its title, else the document's own first heading. `''` when it
+ * carries neither.
+ */
+const artifactNameCandidate = (artifact: Artifact): string => {
+  const title = artifact.title?.trim() ?? '';
+  if (title !== '' && title !== GENERATED_ARTIFACT_TITLE) {
+    return title;
+  }
+  if (HEADING_NAMED_TYPES.has(artifact.type ?? '')) {
+    return firstMarkdownHeading(artifact.content);
+  }
+  return '';
+};
+
+/**
+ * Filename for the artifacts panel download button.
+ *
+ * The blob path used to hand `link.download` the Sandpack file key
+ * verbatim, so every markdown, plain-text and source artifact in every
+ * conversation saved as `content.md`, and each new download landed as
+ * `content (1).md`. Prefer a name the user recognizes: the artifact
+ * title (which is the panel heading, and the original filename for a
+ * file-backed artifact), then the document's own first heading, and
+ * only then the bucket default.
+ */
+export function getArtifactDownloadFilename(artifact: Artifact, fallback: string): string {
+  const safe = sanitizeDownloadBasename(artifactNameCandidate(artifact));
+  if (!safe) {
+    return fallback;
+  }
+  /* Keep an extension the candidate already carries (`script.py` from a
+   * file-backed CODE artifact). Otherwise borrow the bucket default's
+   * (`content.md` → `.md`) so the file opens in the right application. */
+  if (looksLikeExtension(extensionFromBasename(safe))) {
+    return safe;
+  }
+  const fallbackExtension = extensionFromBasename(basenameOf(fallback));
+  return fallbackExtension ? `${safe}.${fallbackExtension}` : safe;
+}
+
+/**
  * Artifact types whose preview is server-rendered HTML — there's no
  * source for a "code" view because the underlying file is binary, and
  * showing the generated HTML blob in a code editor would just be
@@ -890,7 +1045,7 @@ export function fileToArtifact(
   return {
     id: toolArtifactKey(attachment),
     type,
-    title: attachment.filename ?? 'Generated artifact',
+    title: attachment.filename ?? GENERATED_ARTIFACT_TITLE,
     // Nullish coalesce — an empty string is a legitimate file (e.g. a
     // user wrote an empty `.md`) and should render as empty in the
     // panel rather than be replaced by the deferred-extraction


### PR DESCRIPTION
## Summary

Fixes #15826.

The artifacts panel download button saved **every** markdown, plain-text and source artifact as `content.md`. Download two documents from a conversation and you get `content.md` and `content (1).md` — neither name says which document it holds.

The cause is one value doing two jobs. `useArtifactProps` returns `fileKey`, a per-bucket constant that names the file **inside the Sandpack preview**, and `DownloadArtifact` passed it straight to `link.download`:

```ts
// client/src/hooks/Artifacts/useArtifactProps.ts
return ['content.md', getMarkdownFiles(artifact.content ?? '', isDarkMode, highContrast)];

// client/src/components/Artifacts/DownloadArtifact.tsx
link.download = fileName; // fileName === fileKey === 'content.md'
```

`fileKey` has to stay constant — it is also the key of the Sandpack `files` map that renders the preview. The saved filename does not, so this PR derives it separately.

## What changed

A new `getArtifactDownloadFilename(artifact, fallback)` in `client/src/utils/artifacts.ts` picks the first name that identifies the document:

1. **`artifact.title`** — the panel heading, and the original filename for a file-backed artifact.
2. **The document's own first markdown heading** — when the title is absent or is the generic `Generated artifact` placeholder.
3. **The bucket default** (`fileKey`) — unchanged behaviour when neither exists.

| Artifact | Before | After |
|---|---|---|
| Markdown titled *Quarterly Report* | `content.md` | `Quarterly Report.md` |
| Untitled markdown starting `# Migration Plan` | `content.md` | `Migration Plan.md` |
| Code artifact from `migrate_users.py` | `content.md` | `migrate_users.py` |
| Markdown with no title and no heading | `content.md` | `content.md` |

### Details worth reviewing

- **Sanitizing.** Path separators and the characters Windows rejects (`<>:"/\|?*`) become `-`; control characters are dropped; leading dots (hidden files), trailing dots and trailing spaces are trimmed; whitespace is collapsed; the base name is capped at 100 characters. If nothing usable survives, the helper returns the fallback.
- **Extensions.** A name that already carries one keeps it (`migrate_users.py`); otherwise the bucket default's extension is appended. `looksLikeExtension` requires a short alphanumeric run **containing a letter**, so `Q4 Report v1.2` is not read as base `Q4 Report v1` plus extension `2` and correctly saves as `Q4 Report v1.2.md`.
- **Headings come from markdown buckets only.** `#` opens a comment in shell, Python, Ruby and YAML, and the first such comment is a licence header far more often than a title, so source artifacts fall back rather than guess.
- **`firstMarkdownHeading` skips fenced blocks**, so a `# comment` inside a ```` ```bash ```` block cannot be mistaken for the title. Setext headings are deliberately not matched: `---` doubles as a thematic break and as the YAML frontmatter fence, so matching that form would name documents after arbitrary body text.
- **Both download paths now share one rule.** The office/original-file branch already preferred `artifact.title`; it now calls the same helper, so a `.docx` preview and a `.md` blob are named consistently.

This also improves the HTML/React/Mermaid buckets, which previously saved as `index.html` / `App.tsx` / `diagram.mmd` regardless of title.

## Testing

24 new unit tests in `client/src/utils/__tests__/artifacts.test.ts` and 3 new component tests in `client/src/components/Artifacts/__tests__/DownloadArtifact.test.tsx`, covering the priority order, the fallback, extension handling, the version-suffix trap, fenced-block heading extraction, the source-code exclusion, and each sanitizing rule.

```
PASS src/utils/__tests__/artifacts.test.ts                    (188 passed)
PASS src/components/Artifacts/__tests__/DownloadArtifact.test.tsx (8 passed)
PASS src/hooks/Artifacts/__tests__/useArtifactProps.test.ts
PASS src/hooks/Artifacts/__tests__/useArtifacts.test.ts
PASS src/components/Artifacts/Artifacts.test.tsx
PASS src/components/Artifacts/ArtifactTabs.test.tsx
```

ESLint is clean on all four changed files. No config, translation or API surface is touched, and the change is client-side only.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
