### PR TITLE
🏷️ fix: Model-Agnostic Hint for Short Skill Descriptions

### DIFF
--- a/packages/data-schemas/src/methods/skill.ts
+++ b/packages/data-schemas/src/methods/skill.ts
@@ -29,7 +29,7 @@ import logger from '~/config/winston';
 /**
  * A single validation issue emitted by a skill validator. Most issues are
  * errors and block the mutation; some are warnings (e.g. "description is
- * awfully short, Claude may undertrigger the skill") that surface inline
+ * awfully short, the agent may undertrigger the skill") that surface inline
  * coaching without rejecting the request.
  */
 export type ValidationIssue = {
@@ -163,7 +163,7 @@ export function validateSkillDescription(description: unknown): ValidationIssue[
       code: 'TOO_SHORT',
       severity: 'warning',
       message:
-        'Short descriptions may cause Claude to miss triggering opportunities — aim for a concrete "when to use this skill" sentence.',
+        'Short descriptions may cause the agent to miss triggering opportunities — aim for a concrete "when to use this skill" sentence.',
     });
   }
   return issues;


### PR DESCRIPTION
## Summary

Importing or creating a skill with a short description shows the inline warning "Short descriptions may cause Claude to miss triggering opportunities …", which names Claude although the skill is used with whatever model the agent runs on. The warning now says "the agent", and the doc comment on `ValidationIssue` that quotes it is aligned. No validation logic, code, or severity changes; `validateSkillDescription` still emits the same `TOO_SHORT` warning.

Fixes #15831

## How it works

```diff
-        'Short descriptions may cause Claude to miss triggering opportunities — aim for a concrete "when to use this skill" sentence.',
+        'Short descriptions may cause the agent to miss triggering opportunities — aim for a concrete "when to use this skill" sentence.',
```

`packages/data-schemas/src/methods/skill.spec.ts` (119 tests) passes; prettier and eslint are clean on the file.
