### PR TITLE
🛅 fix: Preserve Agent Management Upload IDs

### DIFF
--- a/e2e/playwright.config.mock.ts
+++ b/e2e/playwright.config.mock.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from '@playwright/test';
 import fs from 'fs';
 import path from 'path';
 import { getLocalE2EEnv, getE2EBaseURL } from './setup/env';
+import { managementAuth } from './setup/agent-management';
 
 const rootPath = path.resolve(__dirname, '..');
 const replicaCount = Number(process.env.E2E_REPLICAS || '1');
@@ -177,6 +178,10 @@ function writeRuntimeMockConfig() {
     process.env.E2E_MODEL_SPECS_ENFORCE === 'true'
       ? template.replace('\n  enforce: false\n', '\n  enforce: true\n')
       : template;
+  config = config.replace(
+    '  agents:\n',
+    `  agents:\n    managementApi: ${JSON.stringify({ auth: managementAuth })}\n`,
+  );
   const dynamicMcpConfig = enableDynamicMcp
     ? {
         allowedDomain: '- http://127.0.0.1:8766',

--- a/e2e/setup/agent-management.ts
+++ b/e2e/setup/agent-management.ts
@@ -1,0 +1,58 @@
+import jwt from 'jsonwebtoken';
+import { createServer } from 'http';
+import { generateKeyPairSync, randomUUID } from 'crypto';
+
+export const managementUserId = '00000000000000000000a901';
+export const managementTenantId = 'e2e-agent-management';
+const port = Number(process.env.E2E_MANAGEMENT_OIDC_PORT ?? '8792');
+const issuer = `http://127.0.0.1:${port}`;
+const audience = 'e2e-agent-management';
+const clientId = 'e2e-management-client';
+
+export const managementAuth = {
+  oidc: { enabled: true, issuer, audience },
+  clients: [{ clientId, userId: managementUserId, tenantId: managementTenantId }],
+};
+
+/** Only the identity provider is a fixture; LibreChat verifies the token over HTTP. */
+export async function startManagementOidc() {
+  const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const jwk = {
+    ...publicKey.export({ format: 'jwk' }),
+    kid: randomUUID(),
+    alg: 'RS256',
+    use: 'sig',
+  };
+  const server = createServer((req, res) => {
+    res.setHeader('Content-Type', 'application/json');
+    if (req.url === '/.well-known/openid-configuration') {
+      res.end(JSON.stringify({ issuer, jwks_uri: `${issuer}/jwks` }));
+      return;
+    }
+    if (req.url === '/jwks') {
+      res.end(JSON.stringify({ keys: [jwk] }));
+      return;
+    }
+    res.writeHead(404).end();
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', resolve);
+  });
+  const token = jwt.sign({ client_id: clientId }, privateKey, {
+    algorithm: 'RS256',
+    keyid: jwk.kid,
+    issuer,
+    audience,
+    subject: clientId,
+    expiresIn: '1h',
+  });
+  return {
+    token,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+        server.closeAllConnections();
+      }),
+  };
+}

--- a/e2e/specs/mock/agent-management-files.spec.ts
+++ b/e2e/specs/mock/agent-management-files.spec.ts
@@ -51,8 +51,25 @@ test.describe('agent management file lifecycle', () => {
   });
 
   test.afterAll(async () => {
-    await mongoose.disconnect();
-    await oidc?.close();
+    try {
+      // Unlinking intentionally retains files; teardown owns the fixture tenant's data.
+      await withMongo(async (db) => {
+        for (const { name } of await db.listCollections({}, { nameOnly: true }).toArray()) {
+          if (name.startsWith('system.')) {
+            continue;
+          }
+          await db.collection(name).deleteMany({ tenantId: managementTenantId });
+        }
+      });
+      await fs.promises.rm(path.resolve('uploads', managementUserId), {
+        recursive: true,
+        force: true,
+      });
+      await fs.promises.rm(stagingPath, { recursive: true, force: true });
+    } finally {
+      await mongoose.disconnect();
+      await oidc?.close();
+    }
   });
 
   for (const purpose of ['context', 'file_search', 'execute_code']) {

--- a/e2e/specs/mock/agent-management-files.spec.ts
+++ b/e2e/specs/mock/agent-management-files.spec.ts
@@ -1,0 +1,175 @@
+import fs from 'fs';
+import path from 'path';
+import mongoose from 'mongoose';
+import { expect, test } from '@playwright/test';
+import { createModels, createMethods, tenantStorage } from '@librechat/data-schemas';
+import type { CodeProvisionRecord, RagEmbedRecord } from './helpers';
+import {
+  managementUserId,
+  managementTenantId,
+  startManagementOidc,
+} from '../../setup/agent-management';
+import { applyRuntimeEnv } from '../../setup/runtimeEnv';
+import { CODE_API_BASE, RAG_API_BASE } from './helpers';
+import { withMongo } from './db';
+
+const agentsPath = '/api/agents/v1/agents';
+const content = 'Agent management upload regression: violet.\n';
+const stagingPath = path.resolve('uploads', 'temp', managementUserId);
+
+test.describe('agent management file lifecycle', () => {
+  test.describe.configure({ mode: 'default' });
+  let oidc: Awaited<ReturnType<typeof startManagementOidc>>;
+  let headers: { Authorization: string };
+
+  test.beforeAll(async () => {
+    oidc = await startManagementOidc();
+    headers = { Authorization: `Bearer ${oidc.token}` };
+    applyRuntimeEnv();
+    await mongoose.connect(process.env.MONGO_URI!);
+    createModels(mongoose);
+    const methods = createMethods(mongoose);
+    await tenantStorage.run({ tenantId: managementTenantId }, async () => {
+      await methods.initializeRoles();
+      await methods.seedDefaultRoles();
+      await methods.seedSystemGrants();
+      await mongoose.models.User.updateOne(
+        { _id: managementUserId },
+        {
+          $set: {
+            name: 'Agent Management E2E',
+            email: 'agent-management@example.test',
+            emailVerified: true,
+            provider: 'local',
+            role: 'ADMIN',
+            tenantId: managementTenantId,
+          },
+        },
+        { upsert: true },
+      );
+    });
+  });
+
+  test.afterAll(async () => {
+    await mongoose.disconnect();
+    await oidc?.close();
+  });
+
+  for (const purpose of ['context', 'file_search', 'execute_code']) {
+    test(`uploads, persists, lists and unlinks ${purpose} files`, async ({ request }) => {
+      const created = await request.post(agentsPath, {
+        headers,
+        data: { name: `Upload ${purpose}`, provider: 'Mock Provider A', model: 'mock-model-a' },
+      });
+      expect(created.status(), await created.text()).toBe(201);
+      const { id: agentId } = await created.json();
+      const filesPath = `${agentsPath}/${agentId}/files`;
+      try {
+        const filename = `${purpose}.txt`;
+        const uploaded = await request.post(filesPath, {
+          headers,
+          multipart: {
+            purpose,
+            file: { name: filename, mimeType: 'text/plain', buffer: Buffer.from(content) },
+          },
+        });
+        expect(uploaded.status(), await uploaded.text()).toBe(200);
+        const file = await uploaded.json();
+        expect(file).toMatchObject({
+          filename,
+          bytes: Buffer.byteLength(content),
+          purposes: [purpose],
+        });
+        expect(file.id).toMatch(/^[a-f\d-]{36}$/i);
+
+        await withMongo(async (db) => {
+          const stored = await db.collection('files').findOne({
+            file_id: file.id,
+            tenantId: managementTenantId,
+            user: new mongoose.Types.ObjectId(managementUserId),
+          });
+          expect(stored).not.toBeNull();
+          if (purpose === 'context') {
+            expect(stored?.text).toBe(content);
+          } else if (purpose === 'file_search') {
+            expect(stored?.embedded).toBe(true);
+          } else {
+            expect(stored?.metadata?.codeEnvRef?.file_id).toBeTruthy();
+          }
+        });
+
+        if (purpose !== 'context') {
+          const url =
+            purpose === 'file_search'
+              ? `${RAG_API_BASE}/__debug/embedded`
+              : `${CODE_API_BASE}/__debug/uploads`;
+          const provisioned = await request.get(url);
+          expect(provisioned.status()).toBe(200);
+          const records = await provisioned.json();
+          if (purpose === 'file_search') {
+            expect(
+              records.embedded.map((record: RagEmbedRecord & { bytes: number }) => ({
+                file_id: record.file_id,
+                entity_id: record.entity_id,
+                bytes: record.bytes,
+              })),
+            ).toContainEqual({
+              file_id: file.id,
+              entity_id: agentId,
+              bytes: Buffer.byteLength(content),
+            });
+          } else {
+            expect(
+              records.uploads.map((record: CodeProvisionRecord & { bytes: number }) => ({
+                filename: record.filename,
+                id: record.id,
+                bytes: record.bytes,
+              })),
+            ).toContainEqual({ filename, id: agentId, bytes: Buffer.byteLength(content) });
+          }
+        }
+
+        const listed = await request.get(filesPath, { headers });
+        expect(listed.status()).toBe(200);
+        expect((await listed.json()).data).toEqual([expect.objectContaining({ id: file.id })]);
+        const unlinked = await request.delete(`${filesPath}/${file.id}`, { headers });
+        expect(unlinked.status(), await unlinked.text()).toBe(200);
+        expect(await unlinked.json()).toEqual({ id: file.id, deleted: true });
+        expect((await (await request.get(filesPath, { headers })).json()).data).toEqual([]);
+        await withMongo(async (db) => {
+          expect(await db.collection('files').countDocuments({ file_id: file.id })).toBe(1);
+        });
+        expect(fs.existsSync(stagingPath) ? fs.readdirSync(stagingPath) : []).toEqual([]);
+      } finally {
+        const deleted = await request.delete(`${agentsPath}/${agentId}`, { headers });
+        expect(deleted.status(), await deleted.text()).toBe(200);
+      }
+    });
+  }
+
+  test('rejects invalid uploads and cleans staged files', async ({ request }) => {
+    const created = await request.post(agentsPath, {
+      headers,
+      data: { name: 'Rejected uploads', provider: 'Mock Provider A', model: 'mock-model-a' },
+    });
+    expect(created.status(), await created.text()).toBe(201);
+    const { id: agentId } = await created.json();
+    const filesPath = `${agentsPath}/${agentId}/files`;
+    try {
+      for (const [purpose, buffer] of [
+        ['unsupported', Buffer.from(content)],
+        ['context', Buffer.alloc(0)],
+      ] as const) {
+        const uploaded = await request.post(filesPath, {
+          headers,
+          multipart: { purpose, file: { name: 'invalid.txt', mimeType: 'text/plain', buffer } },
+        });
+        expect(uploaded.status(), await uploaded.text()).toBe(400);
+        expect((await (await request.get(filesPath, { headers })).json()).data).toEqual([]);
+        expect(fs.existsSync(stagingPath) ? fs.readdirSync(stagingPath) : []).toEqual([]);
+      }
+    } finally {
+      expect((await request.delete(`${agentsPath}/${agentId}`, { headers })).status()).toBe(200);
+    }
+  });
+});

--- a/packages/api/src/agents/files.spec.ts
+++ b/packages/api/src/agents/files.spec.ts
@@ -45,7 +45,12 @@ const agent = {
 };
 
 function makeRequest(params: Record<string, string>): Request {
-  return { user, params, headers: {} } as unknown as Request;
+  return {
+    user,
+    params,
+    headers: {},
+    file_id: '91a0f989-24cc-4161-a924-9de85c496633',
+  } as unknown as Request;
 }
 
 function makeResponse(): Response {
@@ -237,6 +242,7 @@ describe('Agent Management file handlers', () => {
 
       expect(deps.processUpload).toHaveBeenCalledWith(request, response);
       expect(request.body).toEqual({
+        file_id: '91a0f989-24cc-4161-a924-9de85c496633',
         endpoint: 'Moonshot',
         endpointType: 'custom',
         agent_id: 'agent-one',

--- a/packages/api/src/agents/files.ts
+++ b/packages/api/src/agents/files.ts
@@ -467,7 +467,7 @@ export function createAgentManagementFileHandlers(deps: AgentManagementFileDeps)
     }
   }
 
-  async function upload(req: Request, res: Response): Promise<Response> {
+  async function upload(req: Request & { file_id?: string }, res: Response): Promise<Response> {
     try {
       const purpose = req.body?.purpose as string | undefined;
       if (!req.file || !UPLOAD_PURPOSES.includes(purpose as AgentUploadPurpose)) {
@@ -501,6 +501,7 @@ export function createAgentManagementFileHandlers(deps: AgentManagementFileDeps)
           }
 
           req.body = {
+            file_id: req.file_id,
             endpoint: authorized.uploadConfig.endpoint,
             endpointType: authorized.uploadConfig.endpointType,
             agent_id: req.params.id,


### PR DESCRIPTION
## Summary

File uploads through the Agent Management API introduced in #15666 return HTTP 500 because its adapter drops the server-generated file ID required by the shared upload handler. Preserve that ID so uploads succeed for `context`, `file_search`, and `execute_code`.

Add HTTP E2E coverage through the running application, including persistence, listing, unlinking, and rejected-upload cleanup.

## How it works

Multipart middleware generates `req.file_id`. The adapter now includes it when constructing the request body consumed by the shared upload handler:

```diff
 req.body = {
+  file_id: req.file_id,
   endpoint: authorized.uploadConfig.endpoint,
   endpointType: authorized.uploadConfig.endpointType,
   agent_id: req.params.id,
   tool_resource: purpose,
 };
```

The existing server-generated ID is reused; clients do not supply it.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Four HTTP E2E tests pass: upload lifecycles for all three purposes, plus invalid-upload rejection and cleanup.
- Independently verify stored file records in MongoDB and provisioning requests received by the external-service fixtures.
- Confirm unlinking removes the agent association while preserving the underlying file.
- Regression verification: removing only the fix causes all three upload lifecycle tests to fail with HTTP 500.
- Two consecutive runs against the same existing disposable MongoDB pass; teardown removes fixture records and upload storage while preserving unrelated tenant data.
- All 26 agent file-handler unit tests pass.
- Typechecks, scoped import checks, ESLint, Prettier, and Lighthouse pass.

### **Test Configuration**:

The existing Playwright mock profile runs LibreChat with disposable MongoDB. Local OIDC, RAG, and code-service fixtures replace external services; application authentication, routing, upload handling, and persistence execute normally.

After the usual E2E setup and workspace builds:

```sh
E2E_USE_MEMORY_MONGO=true npx playwright test \
  --config=e2e/playwright.config.mock.ts \
  agent-management-files.spec.ts
```

The tests are also discovered by the normal mock E2E suite.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
