### PR TITLE
📴 fix: Stop Hidden Code Spinners

### DIFF
--- a/client/src/components/Chat/Input/QuoteButton.tsx
+++ b/client/src/components/Chat/Input/QuoteButton.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef, useState, useEffect, useCallback, useLayoutEffect } from 'react';
+import { memo, useRef, useEffect, useCallback, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { TextQuote } from 'lucide-react';
 import { useSetRecoilState } from 'recoil';
@@ -244,7 +244,7 @@ const resolveTop = (anchor: Anchor, height: number, preferBelow: boolean): numbe
  */
 function QuoteButton({ conversationId }: { conversationId: string }) {
   const localize = useLocalize();
-  const [selection, setSelection] = useState<SelectionState | null>(null);
+  const selectionRef = useRef<SelectionState | null>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const rangeRef = useRef<Range | null>(null);
   const clippersRef = useRef<HTMLElement[]>([]);
@@ -254,6 +254,32 @@ function QuoteButton({ conversationId }: { conversationId: string }) {
   /** Set by the listener effect so the press handlers can dismiss the popup. */
   const hideRef = useRef<() => void>(() => undefined);
   const setQuotes = useSetRecoilState(store.pendingQuotesByConvoId(conversationId));
+
+  /** Selection and scroll events must not enter React's commit/selection-restoration
+   *  path. Keep the portal mounted and update only its transient presentation. */
+  const presentSelection = useCallback((next: SelectionState | null) => {
+    selectionRef.current = next;
+    const button = buttonRef.current;
+    if (!button) {
+      return;
+    }
+    if (!next) {
+      button.style.display = 'none';
+      return;
+    }
+    const touch = String(next.viaTouch);
+    if (button.dataset.touch !== touch) {
+      button.dataset.touch = touch;
+    }
+    if (button.style.display === 'none') {
+      button.style.display = 'inline-flex';
+    }
+    const { width, height } = button.getBoundingClientRect();
+    const maxLeft = Math.max(EDGE_MARGIN, window.innerWidth - width - EDGE_MARGIN);
+    const left = Math.min(Math.max(anchorCenterX(next.anchor) - width / 2, EDGE_MARGIN), maxLeft);
+    button.style.top = `${resolveTop(next.anchor, height, next.viaTouch)}px`;
+    button.style.left = `${left}px`;
+  }, []);
 
   useEffect(() => {
     let settleTimer: ReturnType<typeof setTimeout> | undefined;
@@ -279,7 +305,7 @@ function QuoteButton({ conversationId }: { conversationId: string }) {
       }
       rangeRef.current = null;
       clippersRef.current = [];
-      setSelection(null);
+      presentSelection(null);
     };
 
     const hide = () => {
@@ -299,18 +325,18 @@ function QuoteButton({ conversationId }: { conversationId: string }) {
         hide();
         return;
       }
-      rangeRef.current = reading.range;
+      /** Native handle drags can mutate the Selection's Range in place. */
+      rangeRef.current = reading.range.cloneRange();
       clippersRef.current = reading.clippers;
-      /** Reuse the previous state object when nothing moved so a redundant
-       *  settle pass costs no render. */
-      setSelection((prev) =>
-        prev &&
-        prev.text === reading.text &&
-        prev.viaTouch === touch &&
-        sameAnchor(prev.anchor, reading.anchor)
-          ? prev
-          : { text: reading.text, anchor: reading.anchor, viaTouch: touch },
-      );
+      const previous = selectionRef.current;
+      if (
+        !previous ||
+        previous.text !== reading.text ||
+        previous.viaTouch !== touch ||
+        !sameAnchor(previous.anchor, reading.anchor)
+      ) {
+        presentSelection({ text: reading.text, anchor: reading.anchor, viaTouch: touch });
+      }
     };
 
     const handlePointerDown = (event: PointerEvent) => {
@@ -382,9 +408,10 @@ function QuoteButton({ conversationId }: { conversationId: string }) {
         hide();
         return;
       }
-      setSelection((prev) =>
-        prev && !sameAnchor(prev.anchor, anchor) ? { ...prev, anchor } : prev,
-      );
+      const previous = selectionRef.current;
+      if (previous && !sameAnchor(previous.anchor, anchor)) {
+        presentSelection({ ...previous, anchor });
+      }
     };
 
     const scheduleReanchor = () => {
@@ -422,29 +449,17 @@ function QuoteButton({ conversationId }: { conversationId: string }) {
       document.removeEventListener('scroll', scheduleReanchor, true);
       window.removeEventListener('resize', scheduleReanchor);
     };
-  }, []);
+  }, [presentSelection]);
 
-  /** Clamp using the button's real size so it never lands off-screen. Apply the
-   *  measured layout directly before paint: feeding it back through state adds
-   *  a synchronous render to every selection update and can exhaust React's
-   *  nested-update limit while the browser is still changing the selection. */
+  /** A parent render (for example a locale change) can change the button size. */
   useLayoutEffect(() => {
-    const button = buttonRef.current;
-    if (!selection || !button) {
-      return;
-    }
-    const { width, height } = button.getBoundingClientRect();
-    const maxLeft = Math.max(EDGE_MARGIN, window.innerWidth - width - EDGE_MARGIN);
-    const left = Math.min(
-      Math.max(anchorCenterX(selection.anchor) - width / 2, EDGE_MARGIN),
-      maxLeft,
-    );
-    const top = resolveTop(selection.anchor, height, selection.viaTouch);
+    presentSelection(selectionRef.current);
+  });
 
-    button.style.top = `${top}px`;
-    button.style.left = `${left}px`;
-    button.style.visibility = 'visible';
-  }, [selection]);
+  useLayoutEffect(() => {
+    pressedTextRef.current = null;
+    hideRef.current();
+  }, [conversationId]);
 
   const commitQuote = useCallback(
     (text: string) => {
@@ -454,18 +469,19 @@ function QuoteButton({ conversationId }: { conversationId: string }) {
       rangeRef.current = null;
       clippersRef.current = [];
       pressedTextRef.current = null;
-      setSelection(null);
+      presentSelection(null);
       window.getSelection()?.removeAllRanges();
       document.getElementById(mainTextareaId)?.focus();
     },
-    [setQuotes],
+    [setQuotes, presentSelection],
   );
 
   const addQuote = useCallback(() => {
+    const selection = selectionRef.current;
     if (selection) {
       commitQuote(selection.text);
     }
-  }, [selection, commitQuote]);
+  }, [commitQuote]);
 
   /**
    * End a touch press that did not commit. While a press is in flight the
@@ -482,16 +498,12 @@ function QuoteButton({ conversationId }: { conversationId: string }) {
     }
   }, []);
 
-  if (!selection) {
-    return null;
-  }
-
   return createPortal(
     <button
       ref={buttonRef}
       type="button"
       /** A tap is also the gesture that dismisses a selection, so `click` can
-       *  never be relied on here: the button is already unmounted by the time it
+       *  never be relied on here: the button can be hidden by the time it
        *  would fire. The excerpt is captured on the press and committed on the
        *  release instead, which keeps a button's normal escape hatches — drag
        *  off the button, or have the gesture stolen by a scroll, and nothing is
@@ -501,7 +513,7 @@ function QuoteButton({ conversationId }: { conversationId: string }) {
           return;
         }
         event.preventDefault();
-        pressedTextRef.current = selection.text;
+        pressedTextRef.current = selectionRef.current?.text ?? null;
         try {
           event.currentTarget.setPointerCapture(event.pointerId);
         } catch {
@@ -539,13 +551,12 @@ function QuoteButton({ conversationId }: { conversationId: string }) {
       style={{
         top: 0,
         left: 0,
-        /** Hidden until measured so it never flashes at an unclamped position. */
-        visibility: 'hidden',
+        display: 'none',
       }}
       className={cn(
         'fixed z-50 inline-flex items-center gap-1.5 rounded-full border border-border-light bg-surface-secondary text-sm font-medium text-text-primary shadow-lg transition-colors hover:bg-surface-tertiary',
         /** Comfortable tap target when the selection came from a finger. */
-        selection.viaTouch ? 'min-h-11 px-4 py-2.5' : 'px-3 py-1.5',
+        'px-3 py-1.5 data-[touch=true]:min-h-11 data-[touch=true]:px-4 data-[touch=true]:py-2.5',
       )}
     >
       <TextQuote className="h-4 w-4" aria-hidden="true" />

--- a/client/src/components/Chat/Input/__tests__/QuoteButton.test.tsx
+++ b/client/src/components/Chat/Input/__tests__/QuoteButton.test.tsx
@@ -1,12 +1,14 @@
 import React, { Profiler } from 'react';
-import { RecoilRoot } from 'recoil';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { RecoilRoot, useRecoilValue } from 'recoil';
+import { act, render, screen, fireEvent } from '@testing-library/react';
 
 jest.mock('~/hooks', () => ({
   useLocalize: () => (key: string) => key,
 }));
 
 import QuoteButton from '../QuoteButton';
+import store from '~/store';
+import { mainTextareaId } from '~/common';
 
 const CONVO_ID = 'convo-1';
 const SELECTED_TEXT = 'Selected assistant text';
@@ -34,13 +36,25 @@ const rect = ({
     toJSON: () => ({}),
   }) as DOMRect;
 
+function Quotes() {
+  const quotes = useRecoilValue(store.pendingQuotesByConvoId(CONVO_ID));
+  return <output data-testid="quotes">{JSON.stringify(quotes)}</output>;
+}
+
+function pointer(target: Document | HTMLElement, type: string) {
+  const event = new MouseEvent(type, { bubbles: true, clientX: 50, clientY: 15 });
+  Object.defineProperty(event, 'pointerType', { value: 'touch' });
+  fireEvent(target, event);
+}
+
 describe('QuoteButton', () => {
   afterEach(() => {
     window.getSelection()?.removeAllRanges();
   });
 
-  it('positions a new selection without scheduling a layout-state render', () => {
-    const rangeRect = rect({ top: 100, bottom: 120, left: 200, right: 260 });
+  it('shows, moves, and dismisses selections without React commits, then commits a touch quote', () => {
+    jest.useFakeTimers();
+    let rangeRect = rect({ top: 100, bottom: 120, left: 200, right: 260 });
     const buttonRect = rect({ top: 0, bottom: 30, left: 0, right: 100 });
     const originalRangeRect = Range.prototype.getBoundingClientRect;
     const elementRect = jest
@@ -60,6 +74,8 @@ describe('QuoteButton', () => {
       render(
         <RecoilRoot>
           <div className="message-render">{SELECTED_TEXT}</div>
+          <textarea id={mainTextareaId} />
+          <Quotes />
           <Profiler id="quote-button" onRender={onRender}>
             <QuoteButton conversationId={CONVO_ID} />
           </Profiler>
@@ -82,10 +98,47 @@ describe('QuoteButton', () => {
       expect(screen.getByTestId('add-to-chat-button')).toHaveStyle({
         top: '62px',
         left: '180px',
-        visibility: 'visible',
       });
-      expect(onRender).toHaveBeenCalledTimes(1);
+      const button = screen.getByTestId('add-to-chat-button');
+      expect(button).toBeVisible();
+      expect(onRender).not.toHaveBeenCalled();
+
+      rangeRect = rect({ top: 200, bottom: 220, left: 200, right: 260 });
+      fireEvent.scroll(document);
+      act(() => jest.advanceTimersByTime(20));
+      expect(button).toHaveStyle({ top: '162px' });
+      expect(onRender).not.toHaveBeenCalled();
+
+      window.getSelection()?.removeAllRanges();
+      fireEvent(document, new Event('selectionchange'));
+      expect(button).not.toBeVisible();
+      expect(onRender).not.toHaveBeenCalled();
+
+      pointer(document, 'pointerdown');
+      window.getSelection()?.addRange(range);
+      fireEvent(document, new Event('selectionchange'));
+      act(() => jest.advanceTimersByTime(300));
+      expect(button).toBeVisible();
+      expect(button).toHaveAttribute('data-touch', 'true');
+      expect(button).toHaveStyle({ top: '228px' });
+
+      range.setEnd(textNode, 8);
+      fireEvent(document, new Event('selectionchange'));
+      expect(button).not.toBeVisible();
+      act(() => jest.advanceTimersByTime(300));
+      expect(button).toBeVisible();
+      expect(onRender).not.toHaveBeenCalled();
+
+      pointer(button, 'pointerdown');
+      window.getSelection()?.removeAllRanges();
+      fireEvent(document, new Event('selectionchange'));
+      expect(button).toBeVisible();
+      pointer(button, 'pointerup');
+      expect(button).not.toBeVisible();
+      expect(screen.getByTestId('quotes')).toHaveTextContent('["Selected"]');
+      expect(screen.getByRole('textbox')).toHaveFocus();
     } finally {
+      jest.useRealTimers();
       elementRect.mockRestore();
       if (originalRangeRect) {
         Object.defineProperty(Range.prototype, 'getBoundingClientRect', {
@@ -96,5 +149,97 @@ describe('QuoteButton', () => {
         delete (Range.prototype as Partial<Range>).getBoundingClientRect;
       }
     }
+  });
+});
+
+describe('QuoteButton lifecycle', () => {
+  const originalRangeRect = Range.prototype.getBoundingClientRect;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    Object.defineProperty(Range.prototype, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => rect({ top: 100, bottom: 120, left: 200, right: 260 }),
+    });
+  });
+
+  afterEach(() => {
+    window.getSelection()?.removeAllRanges();
+    jest.useRealTimers();
+    if (originalRangeRect) {
+      Object.defineProperty(Range.prototype, 'getBoundingClientRect', {
+        configurable: true,
+        value: originalRangeRect,
+      });
+    } else {
+      delete (Range.prototype as Partial<Range>).getBoundingClientRect;
+    }
+  });
+
+  function setup() {
+    const content = (conversationId: string) => (
+      <RecoilRoot>
+        <div className="message-render">{SELECTED_TEXT}</div>
+        <textarea id={mainTextareaId} />
+        <Quotes />
+        <QuoteButton conversationId={conversationId} />
+      </RecoilRoot>
+    );
+    const view = render(content(CONVO_ID));
+    const range = document.createRange();
+    range.selectNodeContents(screen.getByText(SELECTED_TEXT));
+    window.getSelection()?.removeAllRanges();
+    window.getSelection()?.addRange(range);
+    return {
+      ...view,
+      button: screen.getByTestId('add-to-chat-button'),
+      navigate: () => view.rerender(content('convo-2')),
+    };
+  }
+
+  it('supports keyboard selection and activation', () => {
+    const { button } = setup();
+    fireEvent.keyDown(document, { key: 'Shift' });
+    fireEvent.keyUp(document, { key: 'Shift' });
+    expect(button).toBeVisible();
+    expect(button).toHaveAttribute('data-touch', 'false');
+    fireEvent.click(button, { detail: 0 });
+    expect(screen.getByTestId('quotes')).toHaveTextContent(JSON.stringify([SELECTED_TEXT]));
+    expect(screen.getByRole('textbox')).toHaveFocus();
+    expect(button).not.toBeVisible();
+  });
+
+  it('dismisses a canceled touch press without adding a quote', () => {
+    const { button } = setup();
+    fireEvent.mouseUp(document);
+    pointer(button, 'pointerdown');
+    window.getSelection()?.removeAllRanges();
+    fireEvent(document, new Event('selectionchange'));
+    pointer(button, 'pointercancel');
+    expect(button).not.toBeVisible();
+    expect(screen.getByTestId('quotes')).toHaveTextContent('[]');
+  });
+
+  it('clears visible and pending selections when the conversation changes', () => {
+    const { button, navigate } = setup();
+    fireEvent.mouseUp(document);
+    expect(button).toBeVisible();
+    fireEvent(document, new Event('selectionchange'));
+    navigate();
+    expect(button).not.toBeVisible();
+    act(() => jest.advanceTimersByTime(500));
+    expect(button).not.toBeVisible();
+    expect(screen.getByTestId('quotes')).toHaveTextContent('[]');
+  });
+
+  it('cancels pending selection work and removes the portal on unmount', () => {
+    const { unmount } = setup();
+    fireEvent(document, new Event('selectionchange'));
+    const readSelection = jest.spyOn(window, 'getSelection');
+    unmount();
+    readSelection.mockClear();
+    act(() => jest.advanceTimersByTime(500));
+    expect(readSelection).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('add-to-chat-button')).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/Messages/Content/RunCode.tsx
+++ b/client/src/components/Messages/Content/RunCode.tsx
@@ -143,7 +143,7 @@ const RunCode: React.FC<CodeBarProps & { iconOnly?: boolean }> = React.memo(
               isLoading ? 'opacity-100' : 'opacity-0',
             )}
           >
-            <Spinner className="animate-spin" size={18} />
+            {isLoading && <Spinner size={18} />}
           </span>
         </span>
         {!iconOnly && (

--- a/client/src/components/Messages/Content/__tests__/RunCode.test.tsx
+++ b/client/src/components/Messages/Content/__tests__/RunCode.test.tsx
@@ -18,6 +18,9 @@ jest.mock('~/Providers', () => jest.requireActual('~/Providers/MessageContext'))
 jest.mock('~/data-provider', () => jest.requireActual('~/data-provider/Tools/mutations'));
 
 describe('RunCode animation lifecycle', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
   it.each(['success', 'error'] as const)(
     'only animates during execution, including %s and retry',
     async (outcome) => {
@@ -51,7 +54,10 @@ describe('RunCode animation lifecycle', () => {
       );
       const button = screen.getByRole('button', { name: 'com_ui_run_code' });
       expect(container.querySelector('.spinner')).not.toBeInTheDocument();
-      fireEvent.click(button);
+      await act(async () => {
+        fireEvent.click(button);
+        await jest.advanceTimersByTimeAsync(0);
+      });
       await waitFor(() => expect(callTool).toHaveBeenCalledTimes(1));
       await waitFor(() => expect(button).toBeDisabled());
       expect(container.querySelector('.spinner')).toBeInTheDocument();
@@ -62,9 +68,12 @@ describe('RunCode animation lifecycle', () => {
       await waitFor(() => expect(button).toBeEnabled());
       expect(container.querySelector('.spinner')).not.toBeInTheDocument();
       await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 1100));
+        jest.advanceTimersByTime(1100);
       });
-      fireEvent.click(button);
+      await act(async () => {
+        fireEvent.click(button);
+        await jest.advanceTimersByTimeAsync(0);
+      });
       await waitFor(() => expect(callTool).toHaveBeenCalledTimes(2));
       await waitFor(() => expect(button).toBeDisabled());
       expect(container.querySelector('.spinner')).toBeInTheDocument();

--- a/client/src/components/Messages/Content/__tests__/RunCode.test.tsx
+++ b/client/src/components/Messages/Content/__tests__/RunCode.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { RecoilRoot } from 'recoil';
+import { ToastProvider } from '@librechat/client';
+import { dataService } from 'librechat-data-provider';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { ToolCallResponse } from 'librechat-data-provider';
+import { MessageContext } from '~/Providers/MessageContext';
+import RunCode from '../RunCode';
+
+jest.mock('librechat-data-provider', () => {
+  const actual = jest.requireActual('librechat-data-provider');
+  return { ...actual, dataService: { ...actual.dataService, callTool: jest.fn() } };
+});
+
+jest.mock('~/hooks', () => ({ useLocalize: () => (key: string) => key }));
+jest.mock('~/Providers', () => jest.requireActual('~/Providers/MessageContext'));
+jest.mock('~/data-provider', () => jest.requireActual('~/data-provider/Tools/mutations'));
+
+describe('RunCode animation lifecycle', () => {
+  it.each(['success', 'error'] as const)(
+    'only animates during execution, including %s and retry',
+    async (outcome) => {
+      let settle: (value: ToolCallResponse) => void = () => undefined;
+      let reject: (reason: Error) => void = () => undefined;
+      const callTool = jest.mocked(dataService.callTool).mockImplementation(
+        () =>
+          new Promise<ToolCallResponse>((resolve, fail) => {
+            settle = resolve;
+            reject = fail;
+          }),
+      );
+      const queryClient = new QueryClient({
+        defaultOptions: { mutations: { retry: false } },
+        logger: { log: console.log, warn: console.warn, error: () => undefined },
+      });
+      const code = document.createElement('code');
+      code.textContent = 'print(1)';
+      const { container, unmount } = render(
+        <QueryClientProvider client={queryClient}>
+          <RecoilRoot>
+            <ToastProvider>
+              <MessageContext.Provider
+                value={{ messageId: 'message', conversationId: 'conversation', isExpanded: false }}
+              >
+                <RunCode lang="python" codeRef={{ current: code }} blockIndex={0} />
+              </MessageContext.Provider>
+            </ToastProvider>
+          </RecoilRoot>
+        </QueryClientProvider>,
+      );
+      const button = screen.getByRole('button', { name: 'com_ui_run_code' });
+      expect(container.querySelector('.spinner')).not.toBeInTheDocument();
+      fireEvent.click(button);
+      await waitFor(() => expect(callTool).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(button).toBeDisabled());
+      expect(container.querySelector('.spinner')).toBeInTheDocument();
+      await act(async () => {
+        if (outcome === 'success') settle({ result: '1', attachments: [] });
+        else reject(new Error('Execution failed'));
+      });
+      await waitFor(() => expect(button).toBeEnabled());
+      expect(container.querySelector('.spinner')).not.toBeInTheDocument();
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1100));
+      });
+      fireEvent.click(button);
+      await waitFor(() => expect(callTool).toHaveBeenCalledTimes(2));
+      await waitFor(() => expect(button).toBeDisabled());
+      expect(container.querySelector('.spinner')).toBeInTheDocument();
+      await act(async () => settle({ result: '1', attachments: [] }));
+      await waitFor(() => expect(button).toBeEnabled());
+      expect(container.querySelector('.spinner')).not.toBeInTheDocument();
+      unmount();
+      queryClient.clear();
+    },
+  );
+});

--- a/client/src/hooks/Input/useTextarea.spec.tsx
+++ b/client/src/hooks/Input/useTextarea.spec.tsx
@@ -281,7 +281,7 @@ describe('useTextarea long-paste fallback', () => {
 
   it('does not restore the paste when the attachment is accepted', async () => {
     mockRouteFiles.mockResolvedValueOnce(true);
-    const { result } = renderTextareaHook();
+    const { result, textArea } = renderTextareaHook();
     const event = createPasteEvent();
 
     act(() =>
@@ -296,7 +296,7 @@ describe('useTextarea long-paste fallback', () => {
       }),
     );
     expect(mockInsertTextAtCursor).not.toHaveBeenCalled();
-    expect(mockForceResize).not.toHaveBeenCalled();
+    expect(textArea.value).toBe('');
   });
 
   it('replaces selected draft text when the attachment is accepted', async () => {

--- a/e2e/benchmarks-mobile-chat/README.md
+++ b/e2e/benchmarks-mobile-chat/README.md
@@ -41,3 +41,32 @@ REACT_SCAN_PATH=/tmp/librechat-react-scan/package/dist/auto.global.js \
 
 JSON snapshots are attached to the Playwright results under
 `e2e/benchmarks/.test-results/mobile-chat`.
+
+## Deterministic regression guards
+
+The normal mock E2E suite includes `idle-animations.spec.ts`. It renders six settled
+messages, including three code blocks, in desktop and narrow layouts and asserts
+that the transcript has **no running infinite animations**. The check uses the
+browser's animation API, so it catches opacity-hidden spinners and other perpetual
+CSS animations. It explicitly enables motion, waits for every code control to
+mount, permits finite entrance transitions, and reports the offending animation
+and element when it fails. It needs neither a large transcript nor a CPU/time
+threshold to catch work that would multiply across a long chat.
+
+After preparing the production client, run it with:
+
+```bash
+npx playwright test --config=e2e/playwright.config.mock.ts idle-animations.spec.ts
+```
+
+The component tests cover the complementary invariants: `RunCode.test.tsx`
+checks that the spinner exists only during execution, including success, failure,
+and retry, with fake timers and controlled HTTP completion. `QuoteButton.test.tsx`
+uses a React Profiler to assert zero commits for selection and positioning events.
+
+Keep the browser timing measurements above as diagnostic evidence rather than a
+single-run merge gate. When a benchmark identifies a regression, add a focused
+invariant test at the cause—such as no idle animations, no unrelated renders, or
+bounded request counts—where possible. Timing and memory totals vary with the
+runner, garbage collection, and browser version; these structural checks do not
+require those numbers to stay below an arbitrary threshold.

--- a/e2e/specs/mock/idle-animations.spec.ts
+++ b/e2e/specs/mock/idle-animations.spec.ts
@@ -1,0 +1,89 @@
+import { randomUUID } from 'node:crypto';
+import { expect, test } from '@playwright/test';
+import {
+  seedConversations,
+  seedMessages,
+  deleteConversations,
+  deleteMessagesByConversation,
+} from './db';
+import { getE2EUser } from '../../setup/user';
+
+/** Exercise real animation CSS even on hosts whose OS prefers reduced motion. */
+test.use({ reducedMotion: 'no-preference' });
+
+for (const viewport of [
+  { width: 1280, height: 720 },
+  { width: 390, height: 664 },
+]) {
+  test(`settled code messages have no continuously running animations (${viewport.width}px)`, async ({
+    page,
+  }) => {
+    await page.setViewportSize(viewport);
+    const conversationId = randomUUID();
+    const userEmail = getE2EUser().email;
+    const messages = [];
+    let parentMessageId = '00000000-0000-0000-0000-000000000000';
+    for (let index = 0; index < 6; index++) {
+      const messageId = `${conversationId}-${index}`;
+      const isCreatedByUser = index % 2 === 0;
+      messages.push({
+        messageId,
+        parentMessageId,
+        isCreatedByUser,
+        sender: isCreatedByUser ? 'User' : 'Assistant',
+        text: isCreatedByUser
+          ? `Show example ${index}`
+          : `Settled example ${index}\n\n\`\`\`python\nprint(${index})\n\`\`\``,
+      });
+      parentMessageId = messageId;
+    }
+
+    try {
+      await seedConversations(userEmail, [
+        { conversationId, title: 'Idle animations', updatedAt: new Date() },
+      ]);
+      await seedMessages(userEmail, conversationId, messages);
+      await page.goto(`/c/${conversationId}`);
+      const rows = page.locator('.message-render');
+      await expect(rows).toHaveCount(messages.length);
+      for (let index = 1; index < messages.length; index += 2) {
+        await expect(
+          rows.nth(index).getByRole('button', { name: 'Run Code', exact: true }).first(),
+        ).toBeAttached();
+      }
+
+      /** Finite entrance transitions are allowed; opacity-hidden infinite loops are not. */
+      await expect
+        .poll(
+          () =>
+            rows.evaluateAll((elements) =>
+              elements.flatMap((element) =>
+                element
+                  .getAnimations({ subtree: true })
+                  .filter(
+                    (animation) =>
+                      animation.playState === 'running' &&
+                      animation.effect?.getTiming().iterations === Infinity,
+                  )
+                  .map((animation) => ({
+                    animation:
+                      animation instanceof CSSAnimation ? animation.animationName : animation.id,
+                    target: (animation.effect as KeyframeEffect | null)?.target?.outerHTML.slice(
+                      0,
+                      250,
+                    ),
+                  })),
+              ),
+            ),
+          {
+            message:
+              'Idle transcript must not continuously animate, including invisible descendants',
+          },
+        )
+        .toEqual([]);
+    } finally {
+      await deleteMessagesByConversation([conversationId]);
+      await deleteConversations([conversationId]);
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Long chats containing code blocks continuously animate invisible “Run code” loading spinners, even when no code is running. The opacity-only hiding introduced in #14697 leaves the spinners active: a 300-message test transcript had 60 running animations while idle. Mount the spinner only during execution, preserving loading, success, failure, and retry behavior.

The quote popup also updates its transient position and selection directly, without scheduling React commits. Real-browser instrumentation confirms that the original popup updates do **not** rerender the transcript; that change alone did not materially improve overall performance in the tested long chat.

## How it works

```diff
-<Spinner className="animate-spin" size={18} />
+{isLoading && <Spinner size={18} />}
```

The popup stays mounted but hidden when unused. Selection and scroll events update only its presentation; activation still appends the quote normally. A cloned range detects native selection changes, and conversation changes clear pending popup work.

## Browser evidence

Production builds of the actual app, deterministic 300-message transcript with prose/lists/tables/code, Chromium with iPhone 13 viewport and 6× CPU throttling during interactions. Main-thread task time from Chromium's Performance domain; raw runs have no React instrumentation.

| Scenario | Original | Final | Reduction |
|---|---:|---:|---:|
| Idle, ~3 seconds | 2,174 ms | 169 ms | 92% |
| 30 text selections | 2,168 ms | 590 ms | 73% |
| 30 settled selection extensions | 8,044 ms | 888 ms | 89% |
| 30 scroll adjustments | 2,417 ms | 534 ms | 78% |

Isolation controls: disabling the quote popup left the high workload intact. Pausing only the invisible spinners in the original build reduced idle work to 165 ms and selection work to 658 ms. The code fix eliminates those animations without browser-side intervention. Separate react-scan runs showed 30 popup renders for 30 selections before the change, zero afterward, and zero transcript renders in either version.

These are controlled local measurements, not a physical iPhone crash reproduction or a statistically repeated hardware benchmark. Both original and final builds also completed the 1,000-message comparison without crashes. At that size, original idle/selection/extension/scroll phases recorded 60/28/20/6 long tasks; the final build recorded zero in all four phases. The reported mobile crash remains unverified.

## Validation

- All 43 focused tests pass across useTextarea, QuoteButton, and RunCode, including paste fallback, execution success/failure/retry, and selection lifecycle behavior.
- Verify accepted paste leaves the composer empty without forbidding unrelated placeholder resizing. Injecting a 100 ms upload delay reproduces the previous CI assertion failure; the corrected assertion passes with the same delay.
- Both regression tests fail against the original code and pass with the fixes.
- Client `npx tsc --noEmit` passes after building isolated workspace dependencies.
- ESLint on changed files, formatting, and `git diff --check` pass.
- Production client builds and real-browser comparisons pass.



## Regression prevention

The regular mock E2E suite now seeds six settled messages with three code blocks and checks the real browser animation API for zero running infinite animations inside the transcript. It covers desktop and narrow layouts, explicitly enables motion, waits for every code control, permits finite entrance transitions, and reports offending animation names/elements. There are no elapsed-time or CPU thresholds.

The guard failed against the original production build in both layouts and passed six repeated executions against the fixed build. The unit execution lifecycle test uses fake timers and controlled HTTP completion instead of waiting on the wall clock. Seven focused unit tests, client typechecking, and lint pass. The mobile benchmark README documents structural guards versus diagnostic timing measurements.

