### PR TITLE
🏰 fix: Read OpenID Flight State From Mongo Primary

### DIFF
--- a/packages/data-schemas/src/methods/openidRefreshFlight.spec.ts
+++ b/packages/data-schemas/src/methods/openidRefreshFlight.spec.ts
@@ -71,6 +71,26 @@ describe('OpenIDRefreshFlight Methods', () => {
     expect(second.flight?.status).toBe('pending');
   });
 
+  it('reads an existing flight from the primary when resolving an acquisition conflict', async () => {
+    const readSpy = jest.spyOn(mongoose.Query.prototype, 'read');
+    await methods.acquireOpenIDRefreshFlight({
+      key: 'flight-key',
+      ownerId: 'owner-1',
+      lockExpiresAt: new Date(Date.now() + 30000),
+      expiresAt: new Date(Date.now() + 60000),
+    });
+
+    await methods.acquireOpenIDRefreshFlight({
+      key: 'flight-key',
+      ownerId: 'owner-2',
+      lockExpiresAt: new Date(Date.now() + 30000),
+      expiresAt: new Date(Date.now() + 60000),
+    });
+
+    expect(readSpy).toHaveBeenCalledWith('primary');
+    readSpy.mockRestore();
+  });
+
   it('reclaims an expired pending lock', async () => {
     await methods.acquireOpenIDRefreshFlight({
       key: 'flight-key',
@@ -211,6 +231,15 @@ describe('OpenIDRefreshFlight Methods', () => {
     );
 
     await expect(methods.findOpenIDRefreshFlight({ key: 'flight-key' })).resolves.toBeNull();
+  });
+
+  it('reads publication state from the primary', async () => {
+    const readSpy = jest.spyOn(mongoose.Query.prototype, 'read');
+
+    await methods.findOpenIDRefreshFlight({ key: 'flight-key' });
+
+    expect(readSpy).toHaveBeenCalledWith('primary');
+    readSpy.mockRestore();
   });
 
   it('persists a logout revocation fence that an active owner cannot publish through', async () => {

--- a/packages/data-schemas/src/methods/openidRefreshFlight.ts
+++ b/packages/data-schemas/src/methods/openidRefreshFlight.ts
@@ -130,7 +130,9 @@ export function createOpenIDRefreshFlightMethods(mongoose: typeof import('mongoo
       const existing = await OpenIDRefreshFlight.findOne({
         key: data.key,
         expiresAt: { $gt: now },
-      }).lean<IOpenIDRefreshFlight>();
+      })
+        .read('primary')
+        .lean<IOpenIDRefreshFlight>();
 
       return { acquired: false, flight: existing };
     } catch (error) {
@@ -243,7 +245,9 @@ export function createOpenIDRefreshFlightMethods(mongoose: typeof import('mongoo
       return await OpenIDRefreshFlight.findOne({
         key: query.key,
         expiresAt: { $gt: new Date() },
-      }).lean<IOpenIDRefreshFlight>();
+      })
+        .read('primary')
+        .lean<IOpenIDRefreshFlight>();
     } catch (error) {
       logger.debug('[findOpenIDRefreshFlight] Error finding flight:', error);
       throw error;


### PR DESCRIPTION
## Summary

I fixed OpenID logins that could reject a successfully completed refresh-flight publication when `OPENID_REUSE_TOKENS=true` and MongoDB used a non-primary read preference. After the completion write, the ownership check could read the older `pending` state from a secondary and throw `OPENID_REFRESH_OWNERSHIP_LOST`; flight coordination now reads authoritative state from the primary. Fixes #15799.

- Pin the acquisition-conflict lookup to the MongoDB primary so a follower observes the flight that caused the unique-key conflict.
- Pin publication, ownership, logout-fence, and follower polling reads to the primary through the shared `findOpenIDRefreshFlight` method.
- Add Mongo-backed regressions that assert both coordination lookup paths override the connection's read preference.

## How it works

```text
sendOpenIDAuthResponse
  completeOpenIDRefreshFlight       # atomic write on primary
  assertOpenIDRefreshFlightAvailable
    findOpenIDRefreshFlight         # authoritative read on primary
  setOpenIDAuthTokens
```

This keeps Mongo-specific consistency policy inside `packages/data-schemas`; the OpenID service continues to consume plain flight records.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `packages/data-schemas`: `jest src/methods/openidRefreshFlight.spec.ts --runInBand` — 15 tests passed.
- `packages/api`: `jest src/auth/openid/flight.spec.ts src/auth/openid/recovery.spec.ts --runInBand` — 9 tests passed.
- `packages/data-schemas`: `npx tsc --noEmit` — passed after rebuilding the current `data-provider` workspace.
- `npm run static-checks -- --against origin/dev` — passed ESLint, Prettier, import sorting, and circular-dependency checks.
- `npm run lighthouse` — package builds passed, but the frontend build could not start Lighthouse because the reused local dependency tree has an older `lucide-react` without the `HatGlasses` export required by current `dev`; CI should run this with the lockfile-matched dependency tree.

### **Test Configuration**:

- Node.js 24.16.0
- MongoDB Memory Server 11.0.1
- macOS

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
