### PR TITLE
🥅 fix: Keep Tool Error Prefix Parsing In Bounds

### DIFF
--- a/client/src/components/Chat/Messages/Content/ToolOutput/OutputRenderer.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolOutput/OutputRenderer.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useCallback } from 'react';
 import copy from 'copy-to-clipboard';
 import { Button } from '@librechat/client';
+import { hasToolCallErrorPrefix, stripToolCallErrorPrefix } from 'librechat-data-provider';
 import CopyButton from '~/components/Messages/Content/CopyButton';
 import { useLocalize } from '~/hooks';
 import { cn } from '~/utils';
@@ -10,11 +11,10 @@ interface ContentBlock {
   text?: string;
 }
 
-const ERROR_PREFIX = /^Error:\s*(\[.*?\]\s*)*tool call failed:\s*/i;
 const ERROR_INNER = /^Error\s+\w+ing to endpoint\s*\(HTTP \d+\):\s*/i;
 
 function cleanError(text: string): string {
-  let cleaned = text.replace(ERROR_PREFIX, '').trim();
+  let cleaned = stripToolCallErrorPrefix(text).trim();
   cleaned = cleaned.replace(ERROR_INNER, '').trim();
   if (cleaned.endsWith('Please fix your mistakes.')) {
     cleaned = cleaned.slice(0, -'Please fix your mistakes.'.length).trim();
@@ -23,7 +23,7 @@ function cleanError(text: string): string {
 }
 
 export function isError(text: string): boolean {
-  return ERROR_PREFIX.test(text) || text.startsWith('Error processing tool');
+  return hasToolCallErrorPrefix(text) || text.startsWith('Error processing tool');
 }
 
 function isStructuredText(text: string): boolean {

--- a/client/src/components/Chat/Messages/Content/ToolOutput/__tests__/OutputRenderer.test.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolOutput/__tests__/OutputRenderer.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import OutputRenderer from '../OutputRenderer';
+import OutputRenderer, { isError } from '../OutputRenderer';
 
 jest.mock('copy-to-clipboard', () => jest.fn());
 
@@ -20,5 +20,9 @@ describe('OutputRenderer', () => {
     const copyPositioner = screen.getByTestId('copy-output').parentElement;
     expect(copyPositioner).toHaveClass('absolute', 'right-0', 'top-1/2', '-translate-y-1/2');
     expect(copyPositioner?.parentElement).toHaveClass('relative', 'pr-10');
+  });
+
+  it('does not treat text between bracketed prefixes as a tool-call error', () => {
+    expect(isError('Error: [agent] unexpected [search] tool call failed: unavailable')).toBe(false);
   });
 });

--- a/packages/api/src/agents/handlers.ts
+++ b/packages/api/src/agents/handlers.ts
@@ -2,7 +2,11 @@ import yaml from 'js-yaml';
 import { Types } from 'mongoose';
 import { GraphEvents, Constants, ToolEndHandler } from '@librechat/agents';
 import { logger, normalizeSkillFrontmatterKeys } from '@librechat/data-schemas';
-import { hasActivePiiFields, hasActivePiiPatterns } from 'librechat-data-provider';
+import {
+  hasActivePiiFields,
+  hasActivePiiPatterns,
+  hasToolCallErrorPrefix,
+} from 'librechat-data-provider';
 import type {
   LCTool,
   FileRefs,
@@ -5124,7 +5128,7 @@ function getFileAuthoringQueueKey(
  * failed background run renders as clean stdout.
  */
 function toBackgroundToolFailure(toolName: string, message: string): string {
-  if (/^Error:\s*(\[.*?\]\s*)*tool call failed:/i.test(message)) {
+  if (hasToolCallErrorPrefix(message)) {
     return message;
   }
   return `Error: [${toolName}] tool call failed: ${message}`;

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -8,6 +8,7 @@ import {
   ApprovalEvents,
   SteerEvents,
   parseTextParts,
+  hasToolCallErrorPrefix,
   reconcileContextUsageFromEvent,
 } from 'librechat-data-provider';
 import type {
@@ -126,7 +127,7 @@ function completedToolExecutionStatus(call: Agents.ToolCall): ToolExecutionStatu
   }
   const output = call.output;
   return typeof output === 'string' &&
-    (/^Error:\s*(\[.*?\]\s*)*tool call failed:/i.test(output) ||
+    (hasToolCallErrorPrefix(output) ||
       /^Error processing tool(?::|$)/i.test(output) ||
       /^Error:[\s\S]*\n Please fix your mistakes\.$/i.test(output))
     ? 'error'

--- a/packages/data-provider/src/errors.spec.ts
+++ b/packages/data-provider/src/errors.spec.ts
@@ -1,0 +1,30 @@
+import { hasToolCallErrorPrefix, stripToolCallErrorPrefix } from './errors';
+
+describe('tool call errors', () => {
+  test.each([
+    'Error: tool call failed: unavailable',
+    'Error: [search] tool call failed: unavailable',
+    'Error: [agent] [search] tool call failed: unavailable',
+  ])('recognizes %s', (message) => {
+    expect(hasToolCallErrorPrefix(message)).toBe(true);
+  });
+
+  test('does not scan across bracket boundaries', () => {
+    const ambiguous = 'Error: [agent] unexpected [search] tool call failed: unavailable';
+
+    expect(hasToolCallErrorPrefix(ambiguous)).toBe(false);
+    expect(stripToolCallErrorPrefix(ambiguous)).toBe(ambiguous);
+  });
+
+  test('rejects repeated bracket segments without the required suffix', () => {
+    const incomplete = `Error: ${'[tool] '.repeat(20)}unavailable`;
+
+    expect(hasToolCallErrorPrefix(incomplete)).toBe(false);
+  });
+
+  test('strips the complete prefix', () => {
+    expect(stripToolCallErrorPrefix('Error: [agent] [search] tool call failed: unavailable')).toBe(
+      'unavailable',
+    );
+  });
+});

--- a/packages/data-provider/src/errors.ts
+++ b/packages/data-provider/src/errors.ts
@@ -1,0 +1,9 @@
+const TOOL_CALL_ERROR_PREFIX = /^Error:\s*(?:\[[^\]]*\]\s*)*tool call failed:\s*/i;
+
+export function hasToolCallErrorPrefix(text: string): boolean {
+  return TOOL_CALL_ERROR_PREFIX.test(text);
+}
+
+export function stripToolCallErrorPrefix(text: string): string {
+  return text.replace(TOOL_CALL_ERROR_PREFIX, '');
+}

--- a/packages/data-provider/src/index.ts
+++ b/packages/data-provider/src/index.ts
@@ -9,6 +9,7 @@ export * from './file-config';
 export * from './resolve-llm-delivery-path';
 /* messages  */
 export * from './messages';
+export * from './errors';
 /* run steps */
 export * from './runSteps';
 /* artifacts  */


### PR DESCRIPTION
## Summary

A crafted tool output containing repeated bracketed prefixes could force exponential regex backtracking when a shared conversation rendered in a viewer's browser or when the server classified agent tool results. Tool-call error prefix parsing is now centralized and bounded by the first closing bracket, preserving valid error detection and cleanup while malformed inputs complete in linear time.

Addresses GHSA-hp5h-qr55-gwfq.

## How it works

The client renderer and both server consumers now share one parser instead of maintaining separate expressions:

```diff
-/^Error:\s*(\[.*?\]\s*)*tool call failed:/i
+hasToolCallErrorPrefix(output)
```

`hasToolCallErrorPrefix` and `stripToolCallErrorPrefix` use a non-capturing bracket segment whose body cannot consume `]`, eliminating ambiguous partitions across adjacent bracket pairs.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npm run build:data-provider`.
- Ran `npx jest src/errors.spec.ts --runInBand` in `packages/data-provider` (6 tests).
- Ran `npx jest src/components/Chat/Messages/Content/ToolOutput/__tests__/OutputRenderer.test.tsx --runInBand` in `client` (2 tests).
- Ran `npx jest src/stream/__tests__/terminalHostAction.spec.ts --runInBand` in `packages/api` (20 tests).
- Ran the focused background tool failure test in `packages/api` (1 test).
- Ran `npx tsc --noEmit` in `packages/data-provider` and `packages/api`.
- Ran `npm run typecheck` in `client`.
- Ran staged-file static checks (ESLint, Prettier, import sorting, package validation, and circular dependency checks).
- Verified a 400,008-byte adversarial-shaped non-match completes in approximately 2 ms.

### **Test Configuration**:

- Windows / PowerShell
- Node.js v24.16.0

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes