### PR TITLE
🧵 fix: Preserve Per-Message Inspection Budgets Through Provider Preparation

### DIFF
--- a/packages/api/src/agents/hitl/inspection.spec.ts
+++ b/packages/api/src/agents/hitl/inspection.spec.ts
@@ -55,6 +55,30 @@ function buildInput(trustLiveFileContent?: boolean) {
 }
 
 describe('resume file inspection trust boundary', () => {
+  it('resumes a long persisted branch with one batched owner-file lookup', async () => {
+    const input = buildInput();
+    const history = Array.from({ length: 58 }, (_, index) => ({
+      messageId: `history-${index}`,
+      parentMessageId: index === 0 ? String(Constants.NO_PARENT) : `history-${index - 1}`,
+      conversationId: 'conversation-1',
+      isCreatedByUser: true,
+      content: Array.from({ length: 80 }, () => ({ type: 'text', text: 'safe history' })),
+      files: index === 57 ? [{ file_id: 'owned-file' }] : [],
+    }));
+    input.getMessages.mockResolvedValue(history);
+    input.getFiles.mockResolvedValue([{ file_id: 'owned-file', text: 'safe extraction' }]);
+    const result = await getResumeContentInspection({
+      ...input,
+      targetMessageId: 'history-57',
+      supplementalMessages: [],
+      fileReferenceInputs: history,
+    });
+    expect(result.storedMessages).toHaveLength(58);
+    expect(result.originalStoredMessages).toEqual(history);
+    expect(result.hydratedFiles).toEqual([{ file_id: 'owned-file', text: 'safe extraction' }]);
+    expect(input.getFiles).toHaveBeenCalledTimes(1);
+  });
+
   it('does not accept request/job file metadata as extraction coverage', async () => {
     await expect(getResumeContentInspection(buildInput())).rejects.toMatchObject({
       code: 'content_filter_uninspectable',

--- a/packages/api/src/agents/hitl/inspection.ts
+++ b/packages/api/src/agents/hitl/inspection.ts
@@ -13,7 +13,7 @@ import type { LocatorTraversalReporter } from '../../protection/diagnostics';
 import type { ExternalChatMessage } from '~/protection/adapters/messages';
 import {
   hasActiveFilePolicy,
-  resolveCanonicalFileReferences,
+  resolveCanonicalFileReferenceUnits,
   type GetCanonicalFilesForInspection,
   type CanonicalFileInspectionFile,
 } from '~/protection/files';
@@ -370,16 +370,16 @@ async function getResumeFileInspection(
     };
   }
 
-  const originalInput = {
-    storedMessages,
-    submittedMessages: input.submittedMessages,
-    fileReferenceInputs: input.fileReferenceInputs ?? [],
-  };
-  const fileInspection = await resolveCanonicalFileReferences({
+  const units = [
+    ...storedMessages.map((storedMessage) => ({ storedMessage })),
+    ...input.submittedMessages.map((submittedMessage) => ({ submittedMessage })),
+    ...(input.fileReferenceInputs ?? []).map((fileReferenceInput) => ({ fileReferenceInput })),
+  ];
+  const fileInspection = await resolveCanonicalFileReferenceUnits({
     messageCount: storedMessages.length + input.submittedMessages.length,
     onTraversalFailure: input.onTraversalFailure,
     filters,
-    input: originalInput,
+    input: units,
     user: input.user,
     ...(input.trustLiveFileContent === true && {
       trustedLiveFiles: input.liveFiles,
@@ -387,8 +387,12 @@ async function getResumeFileInspection(
     getFiles: input.getFiles,
   });
   return {
-    storedMessages: fileInspection.sanitizedInput.storedMessages,
-    submittedMessages: fileInspection.sanitizedInput.submittedMessages,
+    storedMessages: fileInspection.sanitizedInput.flatMap((unit) =>
+      'storedMessage' in unit ? [unit.storedMessage] : [],
+    ),
+    submittedMessages: fileInspection.sanitizedInput.flatMap((unit) =>
+      'submittedMessage' in unit ? [unit.submittedMessage] : [],
+    ),
     originalStoredMessages: storedMessages,
     hydratedFiles: fileInspection.hydratedFiles,
     hydratedFilters: fileInspection.hydratedFilters,

--- a/packages/api/src/assistants/protection.spec.ts
+++ b/packages/api/src/assistants/protection.spec.ts
@@ -78,6 +78,48 @@ describe('Assistants model-bound content preflight', () => {
     getFiles = jest.fn().mockResolvedValue([]);
   });
 
+  it('inspects long remote thread history with one owner-file lookup', async () => {
+    const { openai } = createOpenAI({
+      assistant: {},
+      firstPage: {
+        data: Array.from({ length: 58 }, (_, index) => ({
+          id: `history-${index}`,
+          role: 'user',
+          content: Array.from({ length: 80 }, () => ({
+            type: 'text',
+            text: { value: 'safe history' },
+          })),
+          file_ids: index === 57 ? ['owned-file'] : [],
+        })),
+        has_more: false,
+      },
+    });
+    getFiles.mockResolvedValue([{ file_id: 'owned-file', text: 'safe extraction' }]);
+    await expect(
+      preflightAssistantRunContent({
+        config: {
+          messageFilter: {
+            pii: {
+              starterPatterns: [],
+              customPatterns: [{ id: 'private', label: 'private value', regex: 'PRIVATE-LEGACY' }],
+            },
+          },
+          filters: {
+            files: {
+              pii: { fields: ['extracted_text'], starterPatterns: [], uninspectable: 'block' },
+            },
+          },
+        },
+        openai,
+        user: { id: 'owner' },
+        assistantId: 'assistant',
+        threadId: 'thread',
+        getFiles,
+      }),
+    ).resolves.toEqual({});
+    expect(getFiles).toHaveBeenCalledTimes(1);
+  });
+
   it('does not perform remote reads when no applicable policy is configured', async () => {
     const { openai, retrieve, list } = createOpenAI({});
 

--- a/packages/api/src/assistants/protection.ts
+++ b/packages/api/src/assistants/protection.ts
@@ -11,7 +11,11 @@ import type {
 } from '../protection/adapters/submissions';
 import type { ExternalChatMessage } from '../protection/adapters/messages';
 import type { LocatorTraversalReporter } from '../protection/diagnostics';
-import { hasActiveFilePolicy, resolveCanonicalFileReferences } from '../protection/files';
+import {
+  hasActiveFilePolicy,
+  resolveCanonicalFileReferences,
+  resolveCanonicalFileReferenceUnits,
+} from '../protection/files';
 import { ContentTraversalLimitError } from '../protection/adapters/nested';
 import { assertModelBoundContent } from '../middleware/modelBoundContent';
 
@@ -134,23 +138,6 @@ function normalizeUserMessage(
     content: message.content,
     file_ids: message.file_ids,
     attachments: message.attachments,
-  };
-}
-
-function toLegacySubmittedMessage(message: AssistantThreadMessage): ExternalChatMessage {
-  return {
-    role: 'user',
-    name: message.name,
-    content: message.content?.map((part) => {
-      if (part == null) {
-        return part;
-      }
-      const text = part.text;
-      return {
-        ...part,
-        text: typeof text === 'string' ? text : text?.value,
-      };
-    }),
   };
 }
 
@@ -342,15 +329,22 @@ export async function preflightAssistantRunContent({
   };
   let resolvedFiles: CanonicalFileInspectionFile[] = [];
   if (hasActiveFilePolicy(filters)) {
-    const fileInspection = await resolveCanonicalFileReferences({
+    const units = [
+      { assistant: content.assistant, storedMessages: [] as typeof storedMessages },
+      ...storedMessages.map((message) => ({ assistant: undefined, storedMessages: [message] })),
+    ];
+    const fileInspection = await resolveCanonicalFileReferenceUnits({
       messageCount: storedMessages.length,
       onTraversalFailure,
       filters,
-      input: content,
+      input: units,
       user,
       getFiles,
     });
-    content = fileInspection.sanitizedInput;
+    content = {
+      assistant: fileInspection.sanitizedInput[0]?.assistant,
+      storedMessages: fileInspection.sanitizedInput.flatMap((unit) => unit.storedMessages),
+    };
     resolvedFiles = fileInspection.hydratedFiles;
   }
 
@@ -358,9 +352,6 @@ export async function preflightAssistantRunContent({
     onTraversalFailure,
     filters,
     legacyPii,
-    submittedMessages: hasActivePiiPatterns(legacyPii)
-      ? content.storedMessages.map(toLegacySubmittedMessage)
-      : undefined,
     assistants: content.assistant == null ? undefined : [content.assistant],
     storedMessages: content.storedMessages,
     resolvedFiles,

--- a/packages/api/src/imports.ts
+++ b/packages/api/src/imports.ts
@@ -25,7 +25,7 @@ import {
 import {
   getBlockedOpaqueFileField,
   hasActiveFilePolicy,
-  resolveCanonicalFileReferences,
+  resolveCanonicalFileReferenceUnits,
   UninspectableFileError,
 } from './protection/files';
 import { assertModelBoundContent as assertModelBoundContentAtBoundary } from './middleware/modelBoundContent';
@@ -132,7 +132,7 @@ async function inspectConversationImportContent(
   let storedMessages = snapshot.messages;
   let resolvedFiles: CanonicalFileInspectionFile[] = [];
   if (hasActiveFilePolicy(activeFilters)) {
-    const fileInspection = await resolveCanonicalFileReferences({
+    const fileInspection = await resolveCanonicalFileReferenceUnits({
       messageCount: snapshot.messages.length,
       onTraversalFailure: context.onTraversalFailure,
       filters: activeFilters,

--- a/packages/api/src/middleware/modelBoundContent.spec.ts
+++ b/packages/api/src/middleware/modelBoundContent.spec.ts
@@ -5636,7 +5636,7 @@ describe('assertModelBoundProviderContent', () => {
     ).toThrow('Submitted content contains a private value');
   });
 
-  it('shares aggregate nested extraction work across callback batches', () => {
+  it('inspects individually bounded nested messages across callback batches', () => {
     const callbackFilters: FiltersConfig = {
       messages: {
         pii: {
@@ -5682,7 +5682,7 @@ describe('assertModelBoundProviderContent', () => {
 
     expect(() =>
       callback.handleChatModelStart(undefined, [createBatch(0), createBatch(1), createBatch(2)]),
-    ).toThrow('Submitted content could not be completely inspected before processing.');
+    ).not.toThrow();
   });
 
   it('keeps the model callback usable after caller-owned state is released', () => {

--- a/packages/api/src/middleware/modelBoundContent.ts
+++ b/packages/api/src/middleware/modelBoundContent.ts
@@ -168,6 +168,7 @@ function getProviderPartSnapshotTraversalScopes(
 interface ProviderProjectionWorkBudget {
   remaining: number;
   overflowed: boolean;
+  parent?: ProviderProjectionWorkBudget;
 }
 
 interface ProviderProjectionWorkBudgets {
@@ -178,6 +179,35 @@ interface ProviderProjectionWorkBudgets {
   readonly provenance: ProviderProjectionWorkBudget;
   readonly storedState: ProviderProjectionWorkBudget;
   readonly nestedTraversal: VisitNestedStringsBudget;
+}
+
+/**
+ * JSON structure is bounded per message. Dynamic proxy arrays retain the
+ * shared work ceiling; their reads can execute arbitrary code. Either budget
+ * latches failures into the enclosing projection, including subsequent batches.
+ */
+function createMessageWorkBudget(
+  parent: ProviderProjectionWorkBudget,
+  candidate: unknown,
+  remaining = MAX_PROVIDER_PROJECTION_WORK,
+): ProviderProjectionWorkBudget {
+  if (isProxy(candidate)) {
+    return parent;
+  }
+  let overflowed = false;
+  return {
+    remaining,
+    parent,
+    get overflowed() {
+      return overflowed;
+    },
+    set overflowed(value: boolean) {
+      overflowed ||= value;
+      if (value && this.parent != null) {
+        this.parent.overflowed = true;
+      }
+    },
+  };
 }
 
 function captureProviderArrayLength(candidate: readonly unknown[]): number {
@@ -347,9 +377,10 @@ export function collectModelBoundHistoricalFileIdState(
         continue;
       }
       const contentCount = captureProviderArrayLength(contentCandidate);
+      const contentBudget = createMessageWorkBudget(budget, contentCandidate);
       let contentIndex = 0;
       for (; contentIndex < contentCount; contentIndex++) {
-        if (!consumeProviderProjectionWork(budget, 1)) {
+        if (!consumeProviderProjectionWork(contentBudget, 1)) {
           break;
         }
         const part = contentCandidate[contentIndex];
@@ -1049,7 +1080,7 @@ function normalizeProviderSourceMessageId(candidate: unknown): string | undefine
 
 function getProviderMessageProvenanceState(
   message: ModelBoundProviderMessage,
-  budget: ProviderProjectionWorkBudget,
+  parentBudget: ProviderProjectionWorkBudget,
 ): ModelBoundProviderProvenanceState {
   const candidate: unknown = message.additional_kwargs?.provenance;
   if (candidate == null) {
@@ -1064,6 +1095,11 @@ function getProviderMessageProvenanceState(
   if (version !== 1 || !Array.isArray(candidateParts)) {
     return { invalid: true };
   }
+  const budget = createMessageWorkBudget(
+    parentBudget,
+    candidateParts,
+    MAX_PROVIDER_PROVENANCE_PARSE_WORK,
+  );
   let candidatePartCount: number;
   try {
     candidatePartCount = captureProviderArrayLength(candidateParts);
@@ -1135,7 +1171,12 @@ function getProviderMessageProvenanceState(
       if (totalIndexRefs > MAX_PROVIDER_PROVENANCE_INDEX_REFS) {
         return { invalid: true };
       }
-      if (!consumeProviderProjectionWork(budget, candidateIndexCount)) {
+      if (
+        !consumeProviderProjectionWork(
+          isProxy(candidateSourceContentPartIndices) ? parentBudget : budget,
+          candidateIndexCount,
+        )
+      ) {
         return { invalid: true };
       }
       sourceContentPartIndices = new Set<number>();
@@ -1191,12 +1232,17 @@ function getProviderMessageProvenanceState(
 
 function getLegacyProviderLineage(
   message: ModelBoundProviderMessage,
-  budget: ProviderProjectionWorkBudget,
+  parentBudget: ProviderProjectionWorkBudget,
 ): LegacyProviderLineage {
   const sourceIds = new Set<string>();
   let invalid = false;
   let hasPluralLineage = false;
   const pluralCandidate: unknown = message.additional_kwargs?.sourceMessageIds;
+  const budget = createMessageWorkBudget(
+    parentBudget,
+    pluralCandidate,
+    MAX_PROVIDER_PROVENANCE_PARSE_WORK,
+  );
   if (pluralCandidate != null) {
     if (!Array.isArray(pluralCandidate)) {
       invalid = true;
@@ -1480,9 +1526,10 @@ function appendStoredMessageFileIds(
       return;
     }
     const contentCount = captureProviderArrayLength(contentCandidate);
+    const contentBudget = createMessageWorkBudget(budget, contentCandidate);
     let index = 0;
     for (; index < contentCount; index++) {
-      if (!consumeProviderProjectionWork(budget, 1)) {
+      if (!consumeProviderProjectionWork(contentBudget, 1)) {
         break;
       }
       const part = contentCandidate[index];
@@ -1549,6 +1596,7 @@ function snapshotModelBoundPartArray(
   try {
     if (isProxy(candidate)) {
       markProviderProjectionWorkOverflow(context.budget);
+      return snapshot;
     }
     const length = captureProviderArrayLength(candidate);
     let index = 0;
@@ -1873,9 +1921,11 @@ function snapshotProviderMessageEnvelope(
 
 function snapshotProviderMessageContent(
   message: ModelBoundProviderMessage,
-  budget: ProviderProjectionWorkBudget,
-  partSnapshotBudget: ProviderProjectionWorkBudget,
+  parentBudget: ProviderProjectionWorkBudget,
+  parentPartSnapshotBudget: ProviderProjectionWorkBudget,
 ): unknown {
+  const budget = createMessageWorkBudget(parentBudget, message.content);
+  const partSnapshotBudget = createMessageWorkBudget(parentPartSnapshotBudget, message.content);
   try {
     const messageContent = message.content;
     const messageText = messageContent == null ? message.text : undefined;
@@ -1970,7 +2020,7 @@ function projectProviderMessage(
 
 function projectStoredMessageForProvider(
   message: StoredModelBoundMessage,
-  budget: ProviderProjectionWorkBudget,
+  parentBudget: ProviderProjectionWorkBudget,
   partSnapshotBudget: ProviderProjectionWorkBudget,
   selectedContentPartIndices?: ReadonlySet<number>,
   attribution?: Extract<ProviderExactAttribution, 'user' | 'tool'>,
@@ -1979,6 +2029,7 @@ function projectStoredMessageForProvider(
   submittedPathsSnapshot?: readonly string[],
   submittedFieldPathsSnapshot?: readonly UserSubmittedMessageFieldPath[],
 ): StoredModelBoundMessage {
+  const budget = createMessageWorkBudget(parentBudget, message.content);
   const messageContentCandidate = message.content;
   const storedText = message.text;
   const rawFieldPathCandidate = message.userSubmittedMessageFieldPaths;
@@ -2178,6 +2229,7 @@ interface StoredProviderContributionState {
 }
 
 interface CachedStoredProviderState {
+  readonly provenanceBudget: ProviderProjectionWorkBudget;
   readonly messageSnapshot: StoredModelBoundMessage;
   readonly contentLength?: number;
   readonly contentParts: Map<number, unknown>;
@@ -2256,9 +2308,10 @@ function getStoredSubmittedPathState(
     return cachedState.explicitSubmittedPathState;
   }
   if (cachedState.wholeSubmittedPathState == null) {
+    const semanticBudget = createMessageWorkBudget(budget, cachedState.messageSnapshot.content);
     const semanticState = getUserSubmittedPathState(cachedState.messageSnapshot, {
       includeExplicitPaths: false,
-      budget,
+      budget: semanticBudget,
       capturedContent: cachedState.messageSnapshot.content,
       hasCapturedContent: true,
       capturedContentLength: cachedState.contentLength,
@@ -2340,8 +2393,9 @@ function getStoredProviderContributionState(
   let hasSelectedMaterial = selectedContentPartIndices == null;
   let hasSelectedSemanticPath = false;
   if (!hasSelectedMaterial && cachedState.contentLength != null) {
+    const selectionBudget = createMessageWorkBudget(budget, cachedState.messageSnapshot.content);
     for (const index of selectedContentPartIndices ?? []) {
-      if (!consumeProviderProjectionWork(budget, 1)) {
+      if (!consumeProviderProjectionWork(selectionBudget, 1)) {
         break;
       }
       const part = readCachedStoredContentPart(cachedState, index, budget);
@@ -2403,8 +2457,9 @@ function getSelectedRawStoredMessageFileIds(
       if (cachedState.contentLength != null) {
         const contentLength = cachedState.contentLength;
         const contentCount = Math.min(contentLength, MAX_PROVIDER_PROJECTION_WORK);
+        const contentBudget = createMessageWorkBudget(budget, cachedState.messageSnapshot.content);
         for (let index = 0; index < contentCount; index++) {
-          if (!consumeProviderProjectionWork(budget, 1)) {
+          if (!consumeProviderProjectionWork(contentBudget, 1)) {
             break;
           }
           const part = readCachedStoredContentPart(cachedState, index, budget);
@@ -2433,8 +2488,9 @@ function getSelectedRawStoredMessageFileIds(
     if (cachedState.contentLength == null) {
       return fileIds;
     }
+    const selectionBudget = createMessageWorkBudget(budget, cachedState.messageSnapshot.content);
     for (const index of selectedContentPartIndices) {
-      if (!consumeProviderProjectionWork(budget, 1)) {
+      if (!consumeProviderProjectionWork(selectionBudget, 1)) {
         break;
       }
       const part = readCachedStoredContentPart(cachedState, index, budget);
@@ -2523,13 +2579,24 @@ interface ModelBoundProviderContentIndex {
 function getCachedStoredProviderState(
   index: ModelBoundProviderContentIndex,
   message: StoredModelBoundMessage,
-  budget: ProviderProjectionWorkBudget,
-  partSnapshotBudget: ProviderProjectionWorkBudget,
+  parentBudget: ProviderProjectionWorkBudget,
+  parentPartSnapshotBudget: ProviderProjectionWorkBudget,
 ): CachedStoredProviderState {
   const cached = index.storedStateByMessage.get(message);
   if (cached != null) {
+    /** Cached snapshots outlive a model invocation; attach failures to the current budgets. */
+    cached.provenanceBudget.parent = parentBudget;
+    if (cached.provenanceBudget.overflowed) {
+      markProviderProjectionWorkOverflow(parentBudget);
+    }
+    cached.partSnapshotBudget.parent = parentPartSnapshotBudget;
+    if (cached.partSnapshotBudget.overflowed) {
+      markProviderProjectionWorkOverflow(parentPartSnapshotBudget);
+    }
     return cached;
   }
+  const budget = createMessageWorkBudget(parentBudget, undefined, MAX_PROVIDER_STORED_STATE_WORK);
+  const partSnapshotBudget = createMessageWorkBudget(parentPartSnapshotBudget, undefined);
   let messageSnapshot: StoredModelBoundMessage = {};
   try {
     messageSnapshot = {
@@ -2566,8 +2633,13 @@ function getCachedStoredProviderState(
     contentLength = -1;
   }
   const contentParts = new Map<number, unknown>();
+  const pathBudget =
+    isProxy(messageSnapshot.userSubmittedPaths) ||
+    isProxy(messageSnapshot.userSubmittedMessageFieldPaths)
+      ? parentBudget
+      : budget;
   const provenanceOptions = {
-    budget,
+    budget: pathBudget,
     capturedContent: messageSnapshot.content,
     hasCapturedContent: true,
     capturedContentLength: contentLength,
@@ -2582,10 +2654,11 @@ function getCachedStoredProviderState(
     messageSnapshot,
     provenanceOptions,
   );
-  if (explicitSubmittedPathState.overflowed) {
+  if (explicitSubmittedPathState.overflowed || pathBudget.overflowed) {
     markProviderProjectionWorkOverflow(budget);
   }
   const state: CachedStoredProviderState = {
+    provenanceBudget: budget,
     messageSnapshot,
     contentLength,
     contentParts,
@@ -2751,7 +2824,7 @@ function projectModelBoundProviderContent(
       projectStoredMessageForProvider(
         cachedState.messageSnapshot,
         projectionBudget,
-        partSnapshotBudget,
+        cachedState.partSnapshotBudget,
         undefined,
         undefined,
         cachedState.contentParts,
@@ -2848,7 +2921,7 @@ function projectModelBoundProviderContent(
               projectStoredMessageForProvider(
                 cachedState.messageSnapshot,
                 projectionBudget,
-                partSnapshotBudget,
+                cachedState.partSnapshotBudget,
                 contribution.selectedContentPartIndices,
                 exactAttribution,
                 cachedState.contentParts,
@@ -3552,6 +3625,18 @@ function inspectModelBoundContent(
     traversalErrors.push(error);
   };
   for (const message of input.storedMessages ?? []) {
+    /** Structural limits belong to the message; assembled-text allocations remain request-wide. */
+    const messageTraversalBudget: VisitNestedStringsBudget = {
+      visitedNodes: 0,
+      maxNodes: MAX_MODEL_BOUND_NESTED_TRAVERSAL_WORK,
+      get materializedCharacters() {
+        return storedMessageTraversalBudget.materializedCharacters;
+      },
+      set materializedCharacters(value: number | undefined) {
+        storedMessageTraversalBudget.materializedCharacters = value;
+      },
+      maxMaterializedCharacters: storedMessageTraversalBudget.maxMaterializedCharacters,
+    };
     const submittedPathState = getUserSubmittedPathState(message);
     const submittedMessageFieldState = getUserSubmittedMessageFieldPathState(message);
     const semanticUserSubmittedPaths = submittedMessageFieldState.entries.map(
@@ -3573,7 +3658,7 @@ function inspectModelBoundContent(
     let messageFragments: readonly TextContentFragment[];
     let traversalError: ContentTraversalLimitError | null = null;
     try {
-      messageFragments = extractStoredMessageContent(message, storedMessageTraversalBudget);
+      messageFragments = extractStoredMessageContent(message, messageTraversalBudget);
     } catch (error) {
       if (!isContentTraversalLimitError(error)) {
         throw error;
@@ -3599,7 +3684,7 @@ function inspectModelBoundContent(
         const exactMessageInspection = extractExactUserSubmittedMessageFragments(
           message,
           submittedMessageFieldState.entries,
-          storedMessageTraversalBudget,
+          messageTraversalBudget,
         );
         exactMessageFragments = exactMessageInspection.fragments;
         exactMessageTraversalError = exactMessageInspection.traversalError;
@@ -3692,7 +3777,7 @@ function inspectModelBoundContent(
           ) {
             const userSubmittedAssembledContext = createUserSubmittedAssembledContext(
               assembledText,
-              storedMessageTraversalBudget,
+              messageTraversalBudget,
             );
             if (userSubmittedAssembledContext.fragment != null) {
               inspectFragment(userSubmittedAssembledContext.fragment);

--- a/packages/api/src/middleware/modelBoundHistory.spec.ts
+++ b/packages/api/src/middleware/modelBoundHistory.spec.ts
@@ -1,0 +1,211 @@
+import { ContentTypes } from 'librechat-data-provider';
+import { formatAgentMessages } from '@librechat/agents';
+import type { FiltersConfig } from 'librechat-data-provider';
+import type { TPayload } from '@librechat/agents';
+import type { ModelBoundProviderMessage } from './modelBoundContent';
+import {
+  assertModelBoundContent,
+  collectModelBoundHistoricalFileIdState,
+  createModelBoundChatModelCallback,
+  projectModelBoundSourceFiles,
+} from './modelBoundContent';
+import { resolveCanonicalFileReferenceUnits } from '../protection/files';
+import { assertConversationImportContentAllowed } from '../imports';
+
+const filters: FiltersConfig = {
+  messages: {
+    pii: {
+      fields: ['text', 'content_part', 'assembled_context'],
+      starterPatterns: [],
+      customPatterns: [{ id: 'private', label: 'private value', regex: 'PRIVATE-HISTORY' }],
+    },
+  },
+  files: {
+    pii: {
+      fields: ['extracted_text'],
+      starterPatterns: [],
+      customPatterns: [{ id: 'private', label: 'private value', regex: 'PRIVATE-FILE' }],
+      uninspectable: 'block',
+    },
+  },
+};
+
+/** Dustin's PR #15841 bundle: 58 user turns, 80 text parts each, optionally interleaved. */
+function createHistory(interleaved: boolean) {
+  return Array.from({ length: 58 }, (_, turn) => {
+    const user = {
+      messageId: `history-user-${turn}`,
+      role: 'user' as const,
+      isCreatedByUser: true,
+      isUserSubmitted: true,
+      text: `Historical user step ${turn}`,
+      files: [] as { file_id: string }[],
+      content: Array.from({ length: 80 }, (_, part) => ({
+        type: ContentTypes.TEXT,
+        text: `safe preview material ${turn}-${part}`,
+      })),
+    };
+    return interleaved
+      ? [
+          user,
+          {
+            messageId: `history-assistant-${turn}`,
+            role: 'assistant' as const,
+            isCreatedByUser: false,
+            // The import boundary marks assistant rows as user-submitted too.
+            isUserSubmitted: true,
+            text: `Acknowledged historical step ${turn}`,
+            files: [] as { file_id: string }[],
+            content: [{ type: ContentTypes.TEXT, text: `Acknowledged historical step ${turn}` }],
+          },
+        ]
+      : [user];
+  }).flat();
+}
+
+it.each([
+  { interleaved: false, agents: false },
+  { interleaved: true, agents: false },
+  { interleaved: false, agents: true },
+  { interleaved: true, agents: true },
+])('continues the imported attachment history: %j', async ({ interleaved, agents }) => {
+  const history = createHistory(interleaved);
+  const canonicalFile = { file_id: 'owned', text: 'CUSTOMER_HISTORY_ATTACHMENT_OK' };
+  const getFiles = jest.fn(async () => [canonicalFile]);
+  const context = { user: { id: 'owner', tenantId: 'tenant' }, getFiles };
+  await assertConversationImportContentAllowed(
+    filters,
+    { conversations: [], messages: history },
+    context,
+  );
+
+  const attachedTurn = {
+    ...history[0],
+    messageId: 'attachment-turn',
+    content: [{ type: ContentTypes.TEXT, text: 'Store this attachment. Reply only FILE_STORED.' }],
+    files: [{ file_id: 'owned' }],
+  };
+  history.push(attachedTurn);
+
+  for (const reload of [false, true]) {
+    const storedMessages = reload
+      ? (JSON.parse(JSON.stringify(history)) as typeof history)
+      : history;
+    getFiles.mockClear();
+    const hydration = await resolveCanonicalFileReferenceUnits({
+      ...context,
+      filters,
+      input: storedMessages,
+    });
+    expect(getFiles).toHaveBeenCalledTimes(1);
+    expect(getFiles).toHaveBeenCalledWith(
+      { file_id: { $in: ['owned'] }, user: 'owner', tenantId: 'tenant' },
+      {},
+      {},
+    );
+    assertModelBoundContent({ filters, storedMessages, resolvedFiles: hydration.hydratedFiles });
+    const historicalFileState = collectModelBoundHistoricalFileIdState(storedMessages);
+    expect(historicalFileState).toEqual({ fileIds: ['owned'], overflowed: false });
+    const projection = projectModelBoundSourceFiles({
+      sourceMessages: storedMessages,
+      messageFilesBySourceMessageId: Object.fromEntries(
+        storedMessages.map((m) => [m.messageId, m.files]),
+      ),
+      replayHistoricalFiles: true,
+      historicalFiles: hydration.hydratedFiles,
+      initiallyOverflowed: historicalFileState.overflowed,
+    });
+    expect(projection.overflowed).toBe(false);
+    const payload: TPayload = storedMessages;
+    const providerMessages = agents
+      ? (formatAgentMessages(payload).messages as ModelBoundProviderMessage[])
+      : storedMessages.map((message) => ({
+          id: message.messageId,
+          role: message.role,
+          content: message.content,
+        }));
+    const callbackInput = {
+      filters,
+      storedMessages,
+      resolvedFiles: projection.resolvedFiles,
+      fileIdsBySourceMessageId: projection.fileIdsBySourceMessageId,
+      sourceFileProjectionOverflowed: projection.overflowed,
+    };
+    const callback = createModelBoundChatModelCallback(callbackInput);
+    expect(() => callback.handleChatModelStart(undefined, [providerMessages])).not.toThrow();
+    expect(() => callback.handleChatModelStart(undefined, [providerMessages])).not.toThrow();
+
+    expect(() =>
+      assertModelBoundContent({
+        ...callbackInput,
+        resolvedFiles: [{ ...canonicalFile, text: 'PRIVATE-FILE' }],
+      }),
+    ).toThrow('Submitted content contains a private value');
+
+    const lateContent = { role: 'user', content: [{ type: 'text', text: 'PRIVATE-HISTORY' }] };
+    expect(() =>
+      callback.handleChatModelStart(undefined, [[...providerMessages, lateContent]]),
+    ).toThrow('Submitted content contains a private value');
+  }
+});
+
+it('keeps a cached source snapshot failure fatal on later callback invocations', () => {
+  const storedMessages = [
+    {
+      messageId: 'source',
+      role: 'user',
+      isCreatedByUser: true,
+      content: [
+        { type: 'text', text: 'safe' },
+        {
+          type: 'text',
+          get text(): string {
+            throw new Error('uninspectable source part');
+          },
+        },
+      ],
+    },
+  ];
+  const callback = createModelBoundChatModelCallback({ filters, storedMessages });
+  const batch = (part: number) => [
+    [
+      {
+        role: 'user',
+        content: 'safe provider text',
+        additional_kwargs: {
+          provenance: {
+            version: 1 as const,
+            parts: [
+              {
+                attribution: 'user' as const,
+                sourceMessageId: 'source',
+                sourceContentPartIndices: [part],
+              },
+            ],
+          },
+        },
+      },
+    ],
+  ];
+  expect(() => callback.handleChatModelStart(undefined, batch(0))).not.toThrow();
+  expect(() => callback.handleChatModelStart(undefined, batch(1))).toThrow(
+    'Submitted content could not be completely inspected before processing.',
+  );
+  expect(() => callback.handleChatModelStart(undefined, batch(1))).toThrow(
+    'Submitted content could not be completely inspected before processing.',
+  );
+});
+
+it('keeps persisted user-submitted path bookkeeping per message', () => {
+  const storedMessages = createHistory(true).map((message) => ({
+    ...message,
+    userSubmittedPaths: message.content.map((_part, index) => `/content/${index}/text`),
+  }));
+  const callback = createModelBoundChatModelCallback({ filters, storedMessages });
+  const providerMessages = storedMessages.map((message) => ({
+    id: message.messageId,
+    role: message.role,
+    content: message.content,
+  }));
+  expect(() => callback.handleChatModelStart(undefined, [providerMessages])).not.toThrow();
+});

--- a/packages/api/src/protection/files.spec.ts
+++ b/packages/api/src/protection/files.spec.ts
@@ -15,6 +15,7 @@ import {
   hasActiveFilePolicy,
   omitResolvedCanonicalFileLocators,
   resolveCanonicalFileReferences,
+  resolveCanonicalFileReferenceUnits,
   UPLOAD_EXTRACTED_TEXT_PLANS,
   UninspectableFileError,
 } from './files';
@@ -2015,5 +2016,60 @@ describe('file content inspection policy', () => {
     });
 
     expect(getBlockedOpaqueFileField(filters, inspection.sanitizedInput)).toBe('extracted_text');
+  });
+});
+
+describe('canonical file inspection units', () => {
+  const filters: FiltersConfig = {
+    files: {
+      pii: {
+        fields: ['extracted_text'],
+        starterPatterns: [],
+        uninspectable: 'block',
+      },
+    },
+  };
+
+  it('retains a single oversized-unit rejection before owner lookup', async () => {
+    const getFiles = jest.fn(async () => [{ file_id: 'owned', text: 'safe' }]);
+    await expect(
+      resolveCanonicalFileReferenceUnits({
+        filters,
+        user: { id: 'owner' },
+        getFiles,
+        input: [
+          {
+            files: [{ file_id: 'owned' }],
+            content: Array.from({ length: 4200 }, () => ({ text: 'safe' })),
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({ code: 'content_filter_uninspectable' });
+    expect(getFiles).not.toHaveBeenCalled();
+  });
+
+  it('does not dispatch array map or iterators while sanitizing units', async () => {
+    const units = [{ file_id: 'owned' }, { file_id: 'missing' }];
+    const map = jest.fn(() => []);
+    const iterator = jest.fn(() => {
+      throw new Error('iterator must not execute');
+    });
+    Object.defineProperty(units, 'map', { value: map });
+    Object.defineProperty(units, Symbol.iterator, { value: iterator });
+    const input = {
+      filters,
+      input: units,
+      user: { id: 'owner' },
+      getFiles: jest.fn(async () => [{ file_id: 'owned', text: 'safe' }]),
+    };
+    await expect(resolveCanonicalFileReferenceUnits(input)).rejects.toMatchObject({
+      code: 'content_filter_uninspectable',
+    });
+    units.pop();
+    await expect(resolveCanonicalFileReferenceUnits(input)).resolves.toMatchObject({
+      sanitizedInput: [{}],
+    });
+    expect(map).not.toHaveBeenCalled();
+    expect(iterator).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/protection/files.ts
+++ b/packages/api/src/protection/files.ts
@@ -1190,6 +1190,56 @@ export function allowHydratedFileReferences(
 export async function resolveCanonicalFileReferences<T>(
   input: CanonicalFileReferenceInspectionInput<T>,
 ): Promise<CanonicalFileReferenceInspection<T>> {
+  return resolveCanonicalReferences(
+    input,
+    () => getCanonicalFileReferenceIds(input.input),
+    (files) => omitResolvedCanonicalFileLocators(input.input, files, input),
+  );
+}
+
+/** Shares one owner-scoped lookup across independently bounded inspection units. */
+export async function resolveCanonicalFileReferenceUnits<T>(
+  input: CanonicalFileReferenceInspectionInput<readonly T[]>,
+): Promise<CanonicalFileReferenceInspection<readonly T[]>> {
+  const messages = input.input;
+  const context = { ...input, messageCount: 0 };
+  let messageCount = 0;
+  return resolveCanonicalReferences(
+    context,
+    () => {
+      messageCount = captureOpaqueArrayLength(messages);
+      context.messageCount = input.messageCount ?? messageCount;
+      const fileIds = new Set<string>();
+      let incomplete = false;
+      let fileRelevantIncomplete = false;
+      for (let index = 0; index < messageCount; index++) {
+        const references = getCanonicalFileReferenceIds(messages[index]);
+        incomplete ||= references.incomplete;
+        fileRelevantIncomplete ||= references.fileRelevantIncomplete;
+        for (const fileId of references.fileIds) {
+          if (fileIds.size >= MAX_OPAQUE_NODES && !fileIds.has(fileId)) {
+            throw new ContentTraversalLimitError();
+          }
+          fileIds.add(fileId);
+        }
+      }
+      return { fileIds, incomplete, fileRelevantIncomplete };
+    },
+    (files) => {
+      const sanitized: T[] = [];
+      for (let index = 0; index < messageCount; index++) {
+        sanitized.push(omitResolvedCanonicalFileLocators(messages[index], files, context));
+      }
+      return sanitized;
+    },
+  );
+}
+
+async function resolveCanonicalReferences<T>(
+  input: CanonicalFileReferenceInspectionInput<T>,
+  collectReferences: () => CanonicalReferenceTraversal,
+  sanitize: (files: ReadonlyMap<string, CanonicalFileInspectionFile>) => T,
+): Promise<CanonicalFileReferenceInspection<T>> {
   const filters = input.filters;
   if (!hasActiveFilePolicy(filters)) {
     return {
@@ -1201,7 +1251,7 @@ export async function resolveCanonicalFileReferences<T>(
 
   const trustedLiveFiles = snapshotCanonicalFiles(input.trustedLiveFiles);
 
-  const references = getCanonicalFileReferenceIds(input.input);
+  const references = collectReferences();
   if (references.incomplete) {
     const blockedField = getRequiredOpaqueFileField(filters);
     if (blockedField != null) {
@@ -1276,10 +1326,7 @@ export async function resolveCanonicalFileReferences<T>(
   let sanitizedInput = input.input;
   if (currentById.size > 0) {
     try {
-      sanitizedInput = omitResolvedCanonicalFileLocators(input.input, currentById, {
-        messageCount: input.messageCount,
-        onTraversalFailure: input.onTraversalFailure,
-      });
+      sanitizedInput = sanitize(currentById);
     } catch (error) {
       if (!(error instanceof ContentTraversalLimitError)) {
         throw error;


### PR DESCRIPTION
## Summary

I fixed long conversations that still fail before inference after #15841. A history containing 58 individually valid user messages with 80 text parts each exhausted shared budgets during historical file discovery, provider projection, provenance processing, and nested extraction. Each message now retains its own structural inspection allowance through those boundaries.

- Scope provider content, canonical projections, provenance, and nested snapshots to individual messages without increasing any traversal constants.
- Hydrate import/copy, Assistants, and resumed-agent history through independently bounded units with one owner/tenant-scoped file lookup.
- Inspect stored Assistants content directly under legacy policy, removing duplicate aggregate submission inspection.
- Preserve request-wide message/file cardinality and text-materialization limits, bounded proxy reads, fail-closed locator handling, and cached-snapshot rejection across callback invocations.

## How it works

```text
Import / Assistants / agent resume
  resolveCanonicalFileReferenceUnits
    discover references per unit → one owner-scoped lookup → sanitize per unit
Chat / historical replay
  collectModelBoundHistoricalFileIdState
  provider projection and provenance (per-message budgets)
  nested content inspection (per-message nodes, shared text-materialization budget)
```

The regression covers both consecutive and interleaved history, the real agent formatter, attachment hydration, persisted reload, repeated callbacks, late sensitive content, and canonical file content. A separate case verifies that a cached incomplete source cannot become acceptable on a later callback.

The change increases the maximum synchronous work relative to the broken aggregate-node budget. Existing cardinality and per-message limits keep work finite, but the synthetic benchmark does not establish acceptable latency at their Cartesian-product maximum. A new aggregate history-node threshold would recreate thread lockout; reducing repeated traversal or scheduling inspection cooperatively remains separate performance work.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Pass 639 tests across 20 focused `packages/api` suites for model-bound content/history, protection, imports, Assistants, HITL inspection/protection, and content-filter middleware.
- Run both exact synthetic JSON files from Dustin's reproduction bundle through the local import/hydration/provider-callback harness.
- Run `npm run build:api` and staged `npm run static-checks`.
- Run `npx tsc --noEmit` in `packages/api`: local dependency declarations produce the same 253 diagnostic lines on unchanged base and this branch, after normalizing positions. The CI TypeScript check passes.
- Attempt `npm run lighthouse`: the local prerequisite build stops because `tsdown` cannot resolve from the data-provider workspace. The CI Lighthouse check passes.

- Benchmark the local provider-inspection callback: median 30 ms for 58 user turns and 61 ms for 116 (80 text parts per turn, interleaved assistant messages); repeated callbacks take 28 ms and 56 ms. These synthetic CPU measurements exclude database and model latency.

### Test Configuration

No traversal limits or configuration defaults changed. Regression policies enable message text/content-part/assembled-context inspection and fail-closed extracted-file-text inspection. The local harness does not call a live model or validate the staging UI.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
