### PR TITLE
💠 fix: Paint Native Tool Verification Badges

### DIFF
--- a/client/src/components/SidePanel/Agents/Tools/ToolCard.tsx
+++ b/client/src/components/SidePanel/Agents/Tools/ToolCard.tsx
@@ -1,5 +1,6 @@
 import { memo, useState } from 'react';
-import { BadgeCheck, Check, Globe, Info, Settings, Star, User } from 'lucide-react';
+import { Check, Globe, Info, Settings, Star, User } from 'lucide-react';
+import { VerifiedIcon } from '@librechat/client';
 import type { TranslationKeys } from '~/hooks/useLocalize';
 import type { AgentItem } from './items/types';
 import { hasConfigurableSettings } from './items/configurable';
@@ -128,9 +129,8 @@ function ToolCardImpl({
               <p className="flex min-w-0 flex-1 items-center gap-1 text-sm font-semibold text-text-primary">
                 <span className="truncate">{name}</span>
                 {isNative && (
-                  <BadgeCheck
-                    className="size-4 shrink-0 fill-status-success-strong text-text-on-status"
-                    strokeWidth={2}
+                  <VerifiedIcon
+                    className="size-3.5 shrink-0 text-status-verified"
                     aria-label={localize('com_ui_tools_native')}
                   />
                 )}

--- a/client/src/components/SidePanel/Agents/Tools/ToolCard.tsx
+++ b/client/src/components/SidePanel/Agents/Tools/ToolCard.tsx
@@ -1,6 +1,6 @@
 import { memo, useState } from 'react';
-import { Check, Globe, Info, Settings, Star, User } from 'lucide-react';
 import { VerifiedIcon } from '@librechat/client';
+import { Check, Globe, Info, Settings, Star, User } from 'lucide-react';
 import type { TranslationKeys } from '~/hooks/useLocalize';
 import type { AgentItem } from './items/types';
 import { hasConfigurableSettings } from './items/configurable';

--- a/client/src/components/SidePanel/Agents/Tools/__tests__/ToolsMarketplaceDialog.spec.tsx
+++ b/client/src/components/SidePanel/Agents/Tools/__tests__/ToolsMarketplaceDialog.spec.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom/extend-expect';
 import { fireEvent, render, screen } from '@testing-library/react';
+import type { SVGProps } from 'react';
 import ToolsMarketplaceDialog from '../ToolsMarketplaceDialog';
 
 const mockSetValue = jest.fn();
@@ -145,6 +146,7 @@ jest.mock('@librechat/client', () => {
       asChild
         ? React.createElement(React.Fragment, null, children)
         : React.createElement('button', { type: 'button' }, children),
+    VerifiedIcon: (props: SVGProps<SVGSVGElement>) => React.createElement('svg', props),
     useToastContext: () => ({ showToast: jest.fn() }),
   };
 });

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -219,6 +219,7 @@ html {
   --status-neutral: var(--gray-600);
   --status-neutral-subtle: var(--gray-100);
   --status-neutral-border: var(--gray-300);
+  --status-verified: 37 99 235;
   --text-on-status: var(--white);
 
   /* Categorical series scale — slot order is the CVD-safety mechanism */
@@ -338,6 +339,7 @@ html {
   --status-neutral: var(--gray-300);
   --status-neutral-subtle: var(--gray-800);
   --status-neutral-border: var(--gray-700);
+  --status-verified: 11 116 212;
   --text-on-status: var(--white);
 
   /* Categorical series scale — same hues, stepped for the dark surface */

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -339,7 +339,7 @@ html {
   --status-neutral: var(--gray-300);
   --status-neutral-subtle: var(--gray-800);
   --status-neutral-border: var(--gray-700);
-  --status-verified: 11 116 212;
+  --status-verified: 26 127 216;
   --text-on-status: var(--white);
 
   /* Categorical series scale — same hues, stepped for the dark surface */

--- a/e2e/lighthouse/audit.ts
+++ b/e2e/lighthouse/audit.ts
@@ -15,6 +15,9 @@ const REPORTS_DIRECTORY = '.lighthouse';
 
 const DEFAULT_RUNS = 3;
 
+/** Attempts per run before a crashed Lighthouse process fails the audit. */
+const RUN_ATTEMPTS = 2;
+
 const DEFAULT_BUDGETS: MedianBudgets = {
   'largest-contentful-paint': 4500,
   'cumulative-layout-shift': 0.1,
@@ -79,10 +82,33 @@ export async function auditPage({
   try {
     for (let run = 1; run <= runs; run++) {
       const output = path.join(directory, `lhr-${run}`);
-      const { stdout } = await exec(process.execPath, [cli, ...flags, `--output-path=${output}`]);
-      console.log(`Lighthouse run ${run}/${runs} wrote ${output}.report.json`);
-      if (stdout.trim()) {
-        console.log(stdout);
+      for (let attempt = 1; ; attempt++) {
+        try {
+          const { stdout } = await exec(process.execPath, [
+            cli,
+            ...flags,
+            `--output-path=${output}`,
+          ]);
+          console.log(`Lighthouse run ${run}/${runs} wrote ${output}.report.json`);
+          if (stdout.trim()) {
+            console.log(stdout);
+          }
+          break;
+        } catch (error) {
+          if (attempt >= RUN_ATTEMPTS) {
+            throw error;
+          }
+          /** Lighthouse crashes out of a run it could not trace — NO_NAVSTART is
+           *  the usual one, and its own message is "run Lighthouse again". The
+           *  page is measured `runs` times for exactly this noise, so one lost
+           *  process should cost a repeat, not the lane. A page that is really
+           *  broken fails every attempt and still fails here. */
+          console.log(
+            `Lighthouse run ${run}/${runs} attempt ${attempt} did not complete, retrying: ${
+              error instanceof Error ? error.message.split('\n')[0] : String(error)
+            }`,
+          );
+        }
       }
     }
   } finally {

--- a/e2e/specs/mock/agents.helpers.ts
+++ b/e2e/specs/mock/agents.helpers.ts
@@ -11,6 +11,8 @@ const NARROW_MAX_WIDTH = 768;
 /** Playwright reports no viewport only for a full-page context, which the mock
  *  projects never use; treat that as the desktop layout. */
 const DESKTOP_WIDTH = 1280;
+/** `MOBILE_DRAWER_ID` in `client/src/components/UnifiedSidebar/constants.ts`. */
+const MOBILE_DRAWER_ID = 'mobile-drawer';
 
 export type AgentSummary = {
   _id: string;
@@ -104,18 +106,17 @@ export async function openAgentBuilder(page: Page) {
      *  rail instead would turn a slow first paint into the wrong branch. */
     const narrow = (page.viewportSize()?.width ?? DESKTOP_WIDTH) <= NARROW_MAX_WIDTH;
     if (narrow) {
-      const openSidebarButton = page.getByRole('button', { name: 'Open sidebar' });
-      /** The switcher lives inside the sidebar, so a closed drawer takes the
-       *  control with it. Whichever of the two the shell paints first says
-       *  which state it is in — waiting for that, rather than asking an
-       *  unpainted page, is what keeps a slow start from reading as "open". */
-      const panelSwitcher = page.getByTestId('panel-switcher-button');
-      await expect(openSidebarButton.or(panelSwitcher).first()).toBeVisible();
-      if (await openSidebarButton.isVisible()) {
-        await openSidebarButton.click();
+      /** The drawer stays mounted while closed — translated off-canvas and
+       *  marked `inert` — so the switcher inside it is "visible" either way and
+       *  says nothing about the state. `inert` is the state, and the drawer
+       *  element is where it is written (`UnifiedSidebar.tsx`). */
+      const drawer = page.locator(`#${MOBILE_DRAWER_ID}`);
+      await expect(drawer).toBeAttached();
+      if (await drawer.evaluate((element) => element.hasAttribute('inert'))) {
+        await page.getByRole('button', { name: 'Open sidebar' }).click();
+        await expect(drawer).not.toHaveAttribute('inert', /.*/);
       }
-      await expect(panelSwitcher).toBeVisible();
-      await panelSwitcher.click();
+      await page.getByTestId('panel-switcher-button').click();
       await page.getByRole('menuitemcheckbox', { name: 'Agent Builder' }).click();
     } else {
       const agentBuilderButton = page.getByRole('button', { name: 'Agent Builder' });

--- a/e2e/specs/mock/agents.helpers.ts
+++ b/e2e/specs/mock/agents.helpers.ts
@@ -103,9 +103,17 @@ export async function openAgentBuilder(page: Page) {
         await agentBuilderButton.click();
       }
     } else {
-      const controlPanelButton = page.getByRole('button', { name: 'Control Panel' });
-      await expect(controlPanelButton).toBeVisible();
-      await controlPanelButton.click();
+      /** Below the breakpoint there is no rail: the panel switcher lives inside
+       *  the sidebar, which starts off-canvas, and each panel is an entry in
+       *  the menu it opens. */
+      const openSidebarButton = page.getByRole('button', { name: 'Open sidebar' });
+      if (await openSidebarButton.isVisible()) {
+        await openSidebarButton.click();
+      }
+      const panelSwitcher = page.getByTestId('panel-switcher-button');
+      await expect(panelSwitcher).toBeVisible();
+      await panelSwitcher.click();
+      await page.getByRole('menuitemcheckbox', { name: 'Agent Builder' }).click();
     }
   }
   await expect(form).toBeVisible();

--- a/e2e/specs/mock/agents.helpers.ts
+++ b/e2e/specs/mock/agents.helpers.ts
@@ -105,12 +105,15 @@ export async function openAgentBuilder(page: Page) {
     const narrow = (page.viewportSize()?.width ?? DESKTOP_WIDTH) <= NARROW_MAX_WIDTH;
     if (narrow) {
       const openSidebarButton = page.getByRole('button', { name: 'Open sidebar' });
+      /** The switcher lives inside the sidebar, so a closed drawer takes the
+       *  control with it. Whichever of the two the shell paints first says
+       *  which state it is in — waiting for that, rather than asking an
+       *  unpainted page, is what keeps a slow start from reading as "open". */
+      const panelSwitcher = page.getByTestId('panel-switcher-button');
+      await expect(openSidebarButton.or(panelSwitcher).first()).toBeVisible();
       if (await openSidebarButton.isVisible()) {
         await openSidebarButton.click();
       }
-      /** The switcher lives inside the sidebar, so closing it would take the
-       *  control with it. */
-      const panelSwitcher = page.getByTestId('panel-switcher-button');
       await expect(panelSwitcher).toBeVisible();
       await panelSwitcher.click();
       await page.getByRole('menuitemcheckbox', { name: 'Agent Builder' }).click();

--- a/e2e/specs/mock/agents.helpers.ts
+++ b/e2e/specs/mock/agents.helpers.ts
@@ -5,6 +5,12 @@ import { MOCK_ENDPOINTS, NEW_CHAT_PATH, fetchJson, getAccessToken, requestJson }
 
 export const AGENT_EDIT_PERMISSION = 2;
 
+/** Tailwind's `md`, where the side rail replaces the sidebar's switcher menu. */
+const MD_BREAKPOINT = 768;
+/** Playwright reports no viewport only for a full-page context, which the mock
+ *  projects never use; treat that as the desktop layout. */
+const DESKTOP_WIDTH = 1280;
+
 export type AgentSummary = {
   _id: string;
   id: string;
@@ -91,29 +97,28 @@ export async function openAgentBuilder(page: Page) {
     .then(() => true)
     .catch(() => false);
   if (!builderVisible) {
-    /** The rail collapses below the desktop breakpoint, where the same panel is
-     *  reached through the header's Control Panel toggle instead. */
-    const agentBuilderButton = page.getByRole('button', { name: 'Agent Builder' });
-    const railVisible = await agentBuilderButton
-      .waitFor({ state: 'visible', timeout: 1000 })
-      .then(() => true)
-      .catch(() => false);
-    if (railVisible) {
-      if ((await agentBuilderButton.getAttribute('aria-pressed')) !== 'true') {
-        await agentBuilderButton.click();
-      }
-    } else {
-      /** Below the breakpoint there is no rail: the panel switcher lives inside
-       *  the sidebar, which starts off-canvas, and each panel is an entry in
-       *  the menu it opens. */
+    /** Which control exists is a layout decision, not a timing one: the rail is
+     *  desktop-only, and below Tailwind's `md` the same panels are entries in
+     *  the sidebar's switcher menu. Probing for the rail instead would turn a
+     *  slow first paint into the wrong branch. */
+    const narrow = (page.viewportSize()?.width ?? DESKTOP_WIDTH) < MD_BREAKPOINT;
+    if (narrow) {
       const openSidebarButton = page.getByRole('button', { name: 'Open sidebar' });
       if (await openSidebarButton.isVisible()) {
         await openSidebarButton.click();
       }
+      /** The switcher lives inside the sidebar, so closing it would take the
+       *  control with it. */
       const panelSwitcher = page.getByTestId('panel-switcher-button');
       await expect(panelSwitcher).toBeVisible();
       await panelSwitcher.click();
       await page.getByRole('menuitemcheckbox', { name: 'Agent Builder' }).click();
+    } else {
+      const agentBuilderButton = page.getByRole('button', { name: 'Agent Builder' });
+      await expect(agentBuilderButton).toBeVisible();
+      if ((await agentBuilderButton.getAttribute('aria-pressed')) !== 'true') {
+        await agentBuilderButton.click();
+      }
     }
   }
   await expect(form).toBeVisible();

--- a/e2e/specs/mock/agents.helpers.ts
+++ b/e2e/specs/mock/agents.helpers.ts
@@ -91,10 +91,21 @@ export async function openAgentBuilder(page: Page) {
     .then(() => true)
     .catch(() => false);
   if (!builderVisible) {
+    /** The rail collapses below the desktop breakpoint, where the same panel is
+     *  reached through the header's Control Panel toggle instead. */
     const agentBuilderButton = page.getByRole('button', { name: 'Agent Builder' });
-    await expect(agentBuilderButton).toBeVisible();
-    if ((await agentBuilderButton.getAttribute('aria-pressed')) !== 'true') {
-      await agentBuilderButton.click();
+    const railVisible = await agentBuilderButton
+      .waitFor({ state: 'visible', timeout: 1000 })
+      .then(() => true)
+      .catch(() => false);
+    if (railVisible) {
+      if ((await agentBuilderButton.getAttribute('aria-pressed')) !== 'true') {
+        await agentBuilderButton.click();
+      }
+    } else {
+      const controlPanelButton = page.getByRole('button', { name: 'Control Panel' });
+      await expect(controlPanelButton).toBeVisible();
+      await controlPanelButton.click();
     }
   }
   await expect(form).toBeVisible();

--- a/e2e/specs/mock/agents.helpers.ts
+++ b/e2e/specs/mock/agents.helpers.ts
@@ -95,27 +95,33 @@ export async function openAgentBuilder(page: Page) {
   await page.goto(NEW_CHAT_PATH, { timeout: 10000 });
 
   const form = page.getByRole('form', { name: 'Agent configuration form' });
+  /** Which control exists is a layout decision, not a timing one: the rail is
+   *  desktop-only, and at or below the app's own `(max-width: 768px)` the same
+   *  panels live in the sidebar's switcher menu. Probing the page for one would
+   *  turn a slow first paint into the wrong branch. */
+  const narrow = (page.viewportSize()?.width ?? DESKTOP_WIDTH) <= NARROW_MAX_WIDTH;
+
+  if (narrow) {
+    /** The drawer stays mounted while closed — translated off-canvas and marked
+     *  `inert` — and Playwright calls a translated element visible, so both the
+     *  switcher and a restored builder form pass a visibility check while they
+     *  sit behind an inert drawer. `inert` is the state, and the drawer element
+     *  is where the app writes it (`UnifiedSidebar.tsx`), so the drawer is
+     *  opened before anything inside it is read or handed back. */
+    const drawer = page.locator(`#${MOBILE_DRAWER_ID}`);
+    await expect(drawer).toBeAttached();
+    if (await drawer.evaluate((element) => element.hasAttribute('inert'))) {
+      await page.getByRole('button', { name: 'Open sidebar' }).click();
+      await expect(drawer).not.toHaveAttribute('inert', /.*/);
+    }
+  }
+
   const builderVisible = await form
     .waitFor({ state: 'visible', timeout: 1000 })
     .then(() => true)
     .catch(() => false);
   if (!builderVisible) {
-    /** Which control exists is a layout decision, not a timing one: the rail is
-     *  desktop-only, and at or below the app's own `(max-width: 768px)` the
-     *  same panels are entries in the sidebar's switcher menu. Probing for the
-     *  rail instead would turn a slow first paint into the wrong branch. */
-    const narrow = (page.viewportSize()?.width ?? DESKTOP_WIDTH) <= NARROW_MAX_WIDTH;
     if (narrow) {
-      /** The drawer stays mounted while closed — translated off-canvas and
-       *  marked `inert` — so the switcher inside it is "visible" either way and
-       *  says nothing about the state. `inert` is the state, and the drawer
-       *  element is where it is written (`UnifiedSidebar.tsx`). */
-      const drawer = page.locator(`#${MOBILE_DRAWER_ID}`);
-      await expect(drawer).toBeAttached();
-      if (await drawer.evaluate((element) => element.hasAttribute('inert'))) {
-        await page.getByRole('button', { name: 'Open sidebar' }).click();
-        await expect(drawer).not.toHaveAttribute('inert', /.*/);
-      }
       await page.getByTestId('panel-switcher-button').click();
       await page.getByRole('menuitemcheckbox', { name: 'Agent Builder' }).click();
     } else {

--- a/e2e/specs/mock/agents.helpers.ts
+++ b/e2e/specs/mock/agents.helpers.ts
@@ -5,8 +5,9 @@ import { MOCK_ENDPOINTS, NEW_CHAT_PATH, fetchJson, getAccessToken, requestJson }
 
 export const AGENT_EDIT_PERMISSION = 2;
 
-/** Tailwind's `md`, where the side rail replaces the sidebar's switcher menu. */
-const MD_BREAKPOINT = 768;
+/** The app switches layouts on `(max-width: 768px)` — inclusive, so 768 itself
+ *  is the sidebar-switcher layout, not the rail. */
+const NARROW_MAX_WIDTH = 768;
 /** Playwright reports no viewport only for a full-page context, which the mock
  *  projects never use; treat that as the desktop layout. */
 const DESKTOP_WIDTH = 1280;
@@ -98,10 +99,10 @@ export async function openAgentBuilder(page: Page) {
     .catch(() => false);
   if (!builderVisible) {
     /** Which control exists is a layout decision, not a timing one: the rail is
-     *  desktop-only, and below Tailwind's `md` the same panels are entries in
-     *  the sidebar's switcher menu. Probing for the rail instead would turn a
-     *  slow first paint into the wrong branch. */
-    const narrow = (page.viewportSize()?.width ?? DESKTOP_WIDTH) < MD_BREAKPOINT;
+     *  desktop-only, and at or below the app's own `(max-width: 768px)` the
+     *  same panels are entries in the sidebar's switcher menu. Probing for the
+     *  rail instead would turn a slow first paint into the wrong branch. */
+    const narrow = (page.viewportSize()?.width ?? DESKTOP_WIDTH) <= NARROW_MAX_WIDTH;
     if (narrow) {
       const openSidebarButton = page.getByRole('button', { name: 'Open sidebar' });
       if (await openSidebarButton.isVisible()) {

--- a/e2e/specs/mock/scenarios/verified-tool-mark.spec.ts
+++ b/e2e/specs/mock/scenarios/verified-tool-mark.spec.ts
@@ -97,10 +97,10 @@ test.describe('native tool verified mark', () => {
 
     const card = mark.locator(CARD_FROM_MARK);
     const resting = await card.evaluate((element) => getComputedStyle(element).backgroundColor);
-    const behind =
-      channels(resting)[0] === 0 && resting.includes('rgba')
-        ? await dialog.evaluate((element) => getComputedStyle(element).backgroundColor)
-        : resting;
+    /** A resting card is transparent, so what sits behind the mark is the panel. */
+    const behind = resting.endsWith(', 0)')
+      ? await dialog.evaluate((element) => getComputedStyle(element).backgroundColor)
+      : resting;
     expect(contrast(paint.color, behind)).toBeGreaterThanOrEqual(MARK_FLOOR);
   });
 
@@ -117,15 +117,25 @@ test.describe('native tool verified mark', () => {
     await expect(mark).toBeVisible();
     const card = mark.locator(CARD_FROM_MARK);
 
-    await card.hover();
-    const hovered = await card.evaluate((element) => getComputedStyle(element).backgroundColor);
-    /** The hover repaint has to have happened, or the assertion below would
-     *  measure the resting card and pass for the wrong reason. */
-    expect(hovered).not.toContain('rgba(0, 0, 0, 0)');
+    const panel = await dialog.evaluate((element) => getComputedStyle(element).backgroundColor);
+    /** A touch viewport has no hover state to lose, so there the card keeps its
+     *  resting background and that is what the mark has to survive. */
+    const hoverable = await page.evaluate(() => matchMedia('(hover: hover)').matches);
+    if (hoverable) {
+      await card.hover();
+    }
+    const painted = await card.evaluate((element) => getComputedStyle(element).backgroundColor);
+    /** A resting card is transparent, so what sits behind the mark is the panel. */
+    const background = painted.endsWith(', 0)') ? panel : painted;
+    if (hoverable) {
+      /** The repaint has to have happened, or the assertion below would measure
+       *  the resting card and pass for the wrong reason. */
+      expect(background).not.toBe(panel);
+    }
 
     const paint = await paintOf(mark);
     expect(paint.badgeStroke).toBe('none');
-    expect(contrast(paint.color, hovered)).toBeGreaterThanOrEqual(MARK_FLOOR);
+    expect(contrast(paint.color, background)).toBeGreaterThanOrEqual(MARK_FLOOR);
     expect(contrast(paint.color, paint.checkStroke)).toBeGreaterThanOrEqual(MARK_FLOOR);
   });
 

--- a/e2e/specs/mock/scenarios/verified-tool-mark.spec.ts
+++ b/e2e/specs/mock/scenarios/verified-tool-mark.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import type { Locator, Page } from '@playwright/test';
 import { openAgentBuilder } from '../agents.helpers';
-import { fetchJson, getAccessToken } from '../helpers';
+import { NEW_CHAT_PATH, fetchJson, getAccessToken } from '../helpers';
 
 const MCP_SERVER_NAME = 'e2e-memory';
 const MCP_TOOL_ID = `remember_fact_mcp_${MCP_SERVER_NAME}`;
@@ -150,6 +150,9 @@ test.describe('native tool verified mark', () => {
     page,
   }) => {
     test.setTimeout(120000);
+    /** The token is minted from the page session, so the app has to be loaded
+     *  before the request has an origin to resolve against. */
+    await page.goto(NEW_CHAT_PATH, { timeout: 10000 });
     const token = await getAccessToken(page);
     await expect
       .poll(

--- a/e2e/specs/mock/scenarios/verified-tool-mark.spec.ts
+++ b/e2e/specs/mock/scenarios/verified-tool-mark.spec.ts
@@ -1,0 +1,173 @@
+import { expect, test } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
+import { openAgentBuilder } from '../agents.helpers';
+import { fetchJson, getAccessToken } from '../helpers';
+
+const MCP_SERVER_NAME = 'e2e-memory';
+const MCP_TOOL_ID = `remember_fact_mcp_${MCP_SERVER_NAME}`;
+/** WCAG 1.4.11: a graphical object owes 3:1 against what it sits on. */
+const MARK_FLOOR = 3;
+
+type MCPToolsResponse = {
+  servers?: Record<string, { tools?: Array<{ pluginKey: string }> }>;
+};
+
+type Paint = { color: string; badgeStroke: string; checkStroke: string };
+
+function channels(cssColor: string): [number, number, number] {
+  const match = cssColor.match(/rgba?\(([^)]+)\)/);
+  expect(match, `expected an rgb color, received ${cssColor}`).not.toBeNull();
+  const parts = match![1].split(',').map((part) => Number.parseFloat(part.trim()));
+  return [parts[0], parts[1], parts[2]];
+}
+
+function relativeLuminance(cssColor: string): number {
+  const [r, g, b] = channels(cssColor).map((channel) => {
+    const ratio = channel / 255;
+    return ratio <= 0.03928 ? ratio / 12.92 : ((ratio + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrast(a: string, b: string): number {
+  const [high, low] = [relativeLuminance(a), relativeLuminance(b)].sort((x, y) => y - x);
+  return (high + 0.05) / (low + 0.05);
+}
+
+async function openToolLibrary(page: Page): Promise<Locator> {
+  const form = await openAgentBuilder(page);
+  await form.getByRole('button', { name: 'Add tools' }).click();
+  const dialog = page.getByRole('dialog', { name: 'Tool Library' });
+  await expect(dialog).toBeVisible();
+  return dialog;
+}
+
+function verifiedMark(dialog: Locator): Locator {
+  return dialog.locator('svg[aria-label="Native"]').first();
+}
+
+/** The badge is the first path and the check the second, so a stroke leaking
+ *  onto the badge is visible here as a color instead of `none`. */
+async function paintOf(mark: Locator): Promise<Paint> {
+  return mark.evaluate((element) => {
+    const [badge, check] = Array.from(element.children) as SVGElement[];
+    return {
+      color: getComputedStyle(element).color,
+      badgeStroke: getComputedStyle(badge).stroke,
+      checkStroke: getComputedStyle(check).stroke,
+    };
+  });
+}
+
+/** The wrapper carries the card's background; the button inside stays
+ *  transparent, so the wrapper is what repaints on hover. */
+const CARD_FROM_MARK = 'xpath=ancestor::button[1]/..';
+
+async function useTheme(page: Page, theme: 'light' | 'dark', colors?: Record<string, string>) {
+  await page.addInitScript(
+    ([selected, legacyColors]: [string, string | null]) => {
+      localStorage.setItem('color-theme', selected);
+      localStorage.removeItem('theme-definition');
+      localStorage.removeItem('theme-source');
+      if (legacyColors === null) {
+        localStorage.removeItem('theme-colors');
+        localStorage.removeItem('theme-name');
+        return;
+      }
+      localStorage.setItem('theme-colors', legacyColors);
+      localStorage.setItem('theme-name', 'e2e-legacy');
+    },
+    [theme, colors ? JSON.stringify(colors) : null] as [string, string | null],
+  );
+}
+
+test.describe('native tool verified mark', () => {
+  test('@scenario:native-tool-card-shows-verified-mark a native tool wears a painted mark beside its name', async ({
+    page,
+  }) => {
+    test.setTimeout(120000);
+    const dialog = await openToolLibrary(page);
+    const mark = verifiedMark(dialog);
+    await expect(mark).toBeVisible();
+
+    const paint = await paintOf(mark);
+    expect(paint.badgeStroke).toBe('none');
+    expect(channels(paint.color)).not.toEqual(channels(paint.checkStroke));
+    expect(contrast(paint.color, paint.checkStroke)).toBeGreaterThanOrEqual(MARK_FLOOR);
+
+    const card = mark.locator(CARD_FROM_MARK);
+    const resting = await card.evaluate((element) => getComputedStyle(element).backgroundColor);
+    const behind =
+      channels(resting)[0] === 0 && resting.includes('rgba')
+        ? await dialog.evaluate((element) => getComputedStyle(element).backgroundColor)
+        : resting;
+    expect(contrast(paint.color, behind)).toBeGreaterThanOrEqual(MARK_FLOOR);
+  });
+
+  test('@scenario:verified-mark-holds-silhouette-on-dark-hover hovering a native card in dark mode keeps the mark legible', async ({
+    page,
+  }) => {
+    test.setTimeout(120000);
+    await useTheme(page, 'dark');
+
+    const dialog = await openToolLibrary(page);
+    await expect(page.locator('html')).toHaveClass(/(^|\s)dark(\s|$)/);
+
+    const mark = verifiedMark(dialog);
+    await expect(mark).toBeVisible();
+    const card = mark.locator(CARD_FROM_MARK);
+
+    await card.hover();
+    const hovered = await card.evaluate((element) => getComputedStyle(element).backgroundColor);
+    /** The hover repaint has to have happened, or the assertion below would
+     *  measure the resting card and pass for the wrong reason. */
+    expect(hovered).not.toContain('rgba(0, 0, 0, 0)');
+
+    const paint = await paintOf(mark);
+    expect(paint.badgeStroke).toBe('none');
+    expect(contrast(paint.color, hovered)).toBeGreaterThanOrEqual(MARK_FLOOR);
+    expect(contrast(paint.color, paint.checkStroke)).toBeGreaterThanOrEqual(MARK_FLOOR);
+  });
+
+  test('@scenario:legacy-custom-theme-keeps-verified-mark-on-its-palette a theme that predates the token paints the mark with its own success fill', async ({
+    page,
+  }) => {
+    test.setTimeout(120000);
+    /** A deployment palette from before `status-verified` existed: it names the
+     *  fill the mark used to wear and nothing about the mark itself. */
+    await useTheme(page, 'light', {
+      'rgb-status-success-strong': '124 45 18',
+      'rgb-text-on-status': '255 255 255',
+    });
+
+    const dialog = await openToolLibrary(page);
+    const mark = verifiedMark(dialog);
+    await expect(mark).toBeVisible();
+    await expect(mark).toHaveCSS('color', 'rgb(124, 45, 18)');
+  });
+
+  test('@scenario:mcp-server-card-shows-no-verified-mark a third-party server carries no mark', async ({
+    page,
+  }) => {
+    test.setTimeout(120000);
+    const token = await getAccessToken(page);
+    await expect
+      .poll(
+        async () => {
+          const tools = await fetchJson<MCPToolsResponse>(page, '/api/mcp/tools', token);
+          return (tools.servers?.[MCP_SERVER_NAME]?.tools ?? []).some(
+            (tool) => tool.pluginKey === MCP_TOOL_ID,
+          );
+        },
+        { timeout: 60000 },
+      )
+      .toBe(true);
+
+    const dialog = await openToolLibrary(page);
+    await dialog.getByRole('textbox', { name: 'Search tools…' }).fill(MCP_SERVER_NAME);
+
+    const serverCard = dialog.getByRole('button', { name: new RegExp(MCP_SERVER_NAME) }).first();
+    await expect(serverCard).toBeVisible();
+    await expect(serverCard.locator('svg[aria-label="Native"]')).toHaveCount(0);
+  });
+});

--- a/e2e/specs/mock/scenarios/verified-tool-mark.spec.ts
+++ b/e2e/specs/mock/scenarios/verified-tool-mark.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { devices, expect, test } from '@playwright/test';
 import type { Locator, Page } from '@playwright/test';
 import { openAgentBuilder } from '../agents.helpers';
 import { NEW_CHAT_PATH, fetchJson, getAccessToken } from '../helpers';
@@ -182,5 +182,36 @@ test.describe('native tool verified mark', () => {
     const serverCard = dialog.getByRole('button', { name: new RegExp(MCP_SERVER_NAME) }).first();
     await expect(serverCard).toBeVisible();
     await expect(serverCard.locator('svg[aria-label="Native"]')).toHaveCount(0);
+  });
+});
+
+/** The mock project is Desktop Chrome, so the touch layout — the sidebar
+ *  switcher that replaces the rail, and a card that never receives hover —
+ *  only gets exercised if a test asks for it. */
+test.describe('native tool verified mark on a touch viewport', () => {
+  /** Only the context knobs: spreading the whole device descriptor would carry
+   *  `defaultBrowserType`, which Playwright refuses inside a describe. */
+  test.use({ viewport: devices['Pixel 7'].viewport, hasTouch: true });
+
+  test('@scenario:verified-mark-survives-a-touch-viewport a native tool keeps its mark where there is no hover', async ({
+    page,
+  }) => {
+    test.setTimeout(120000);
+    const dialog = await openToolLibrary(page);
+
+    const mark = verifiedMark(dialog);
+    await expect(mark).toBeVisible();
+    expect(await page.evaluate(() => matchMedia('(hover: hover)').matches)).toBe(false);
+
+    const paint = await paintOf(mark);
+    expect(paint.badgeStroke).toBe('none');
+    expect(contrast(paint.color, paint.checkStroke)).toBeGreaterThanOrEqual(MARK_FLOOR);
+
+    const card = mark.locator(CARD_FROM_MARK);
+    const resting = await card.evaluate((element) => getComputedStyle(element).backgroundColor);
+    const behind = resting.endsWith(', 0)')
+      ? await dialog.evaluate((element) => getComputedStyle(element).backgroundColor)
+      : resting;
+    expect(contrast(paint.color, behind)).toBeGreaterThanOrEqual(MARK_FLOOR);
   });
 });

--- a/packages/client/src/svgs/VerifiedIcon.tsx
+++ b/packages/client/src/svgs/VerifiedIcon.tsx
@@ -1,0 +1,40 @@
+import { JSX } from 'react/jsx-runtime';
+import type { SVGProps } from 'react';
+import { cn } from '~/utils';
+
+/** Verified mark for a first-party item: a scalloped badge filled with
+ *  `currentColor` (pair it with `text-status-verified`) carrying a check in
+ *  `text-on-status`. The badge is painted, never stroked — an outline would
+ *  read as a light halo against the card it sits on. */
+export default function VerifiedIcon({
+  className,
+  ...props
+}: SVGProps<SVGSVGElement>): JSX.Element {
+  const labelled = props['aria-label'] != null || props['aria-labelledby'] != null;
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      height="1em"
+      width="1em"
+      xmlns="http://www.w3.org/2000/svg"
+      role={labelled ? 'img' : undefined}
+      aria-hidden={labelled ? undefined : true}
+      focusable="false"
+      className={cn('h-4 w-4', className)}
+      {...props}
+    >
+      <path
+        d="M3.85 8.62a4 4 0 0 1 4.78-4.77 4 4 0 0 1 6.74 0 4 4 0 0 1 4.78 4.78 4 4 0 0 1 0 6.74 4 4 0 0 1-4.77 4.78 4 4 0 0 1-6.75 0 4 4 0 0 1-4.78-4.77 4 4 0 0 1 0-6.76Z"
+        fill="currentColor"
+      />
+      <path
+        d="m8.4 12.3 2.5 2.5 4.7-4.7"
+        className="stroke-text-on-status"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/packages/client/src/svgs/index.ts
+++ b/packages/client/src/svgs/index.ts
@@ -9,6 +9,7 @@ export { default as MobileSidebar } from './MobileSidebar';
 export { default as Spinner } from './Spinner';
 export { default as Clipboard } from './Clipboard';
 export { default as CheckMark } from './CheckMark';
+export { default as VerifiedIcon } from './VerifiedIcon';
 export { default as CrossIcon } from './CrossIcon';
 export { default as LogOutIcon } from './LogOutIcon';
 export { default as CustomMinimalIcon } from './CustomMinimalIcon';

--- a/packages/client/src/theme/README.md
+++ b/packages/client/src/theme/README.md
@@ -226,16 +226,9 @@ Each status family has a foreground, a `-subtle` background, a `-border`, and a
 - `text-status-error` / `bg-status-error-subtle` / `border-status-error-border`
 - `text-status-neutral` / `bg-status-neutral-subtle` / `border-status-neutral-border`
 - `bg-status-success-strong` / `bg-status-info-strong` / `bg-status-warning-strong` / `bg-status-error-strong`
-- `text-status-verified` — solid blue of the verified mark on a first-party
-  item, worn by `VerifiedIcon`, whose badge is filled with `currentColor` and
-  carries a `stroke-text-on-status` check. A color with no family: the mark is
-  the only thing it paints, and it is painted rather than outlined, since an
-  outline would halo the badge against the card. Both relationships are
-  graphical, so both are held at 3:1 — against every surface the card takes,
-  including its hover repaint. A theme that repaints what the mark sits in —
-  the old `status-success-strong` fill, the `text-on-status` check, or the card
-  surfaces — keeps the mark on that success fill instead of taking this blue,
-  since it coordinated the mark before the token existed.
+- `text-status-verified` — fill of the verified mark `VerifiedIcon` paints,
+  carrying a `stroke-text-on-status` check. See `rgb-status-verified` in
+  `types/index.ts` for why it is its own role and what a pre-token theme gets.
 
 ### Other Colors
 

--- a/packages/client/src/theme/README.md
+++ b/packages/client/src/theme/README.md
@@ -232,8 +232,10 @@ Each status family has a foreground, a `-subtle` background, a `-border`, and a
   the only thing it paints, and it is painted rather than outlined, since an
   outline would halo the badge against the card. Both relationships are
   graphical, so both are held at 3:1 — against every surface the card takes,
-  including its hover repaint. A theme that predates the token and names
-  `status-success-strong` keeps the mark on that fill.
+  including its hover repaint. A theme that repaints what the mark sits in —
+  the old `status-success-strong` fill, the `text-on-status` check, or the card
+  surfaces — keeps the mark on that success fill instead of taking this blue,
+  since it coordinated the mark before the token existed.
 
 ### Other Colors
 

--- a/packages/client/src/theme/README.md
+++ b/packages/client/src/theme/README.md
@@ -226,6 +226,11 @@ Each status family has a foreground, a `-subtle` background, a `-border`, and a
 - `text-status-error` / `bg-status-error-subtle` / `border-status-error-border`
 - `text-status-neutral` / `bg-status-neutral-subtle` / `border-status-neutral-border`
 - `bg-status-success-strong` / `bg-status-info-strong` / `bg-status-warning-strong` / `bg-status-error-strong`
+- `text-status-verified` — solid blue of the verified mark on a first-party
+  item, worn by `VerifiedIcon`, whose badge is filled with `currentColor` and
+  carries a `stroke-text-on-status` check. A color with no family: the mark is
+  the only thing it paints, and it is painted rather than outlined, since an
+  outline would halo the badge against the card.
 
 ### Other Colors
 

--- a/packages/client/src/theme/README.md
+++ b/packages/client/src/theme/README.md
@@ -230,7 +230,10 @@ Each status family has a foreground, a `-subtle` background, a `-border`, and a
   item, worn by `VerifiedIcon`, whose badge is filled with `currentColor` and
   carries a `stroke-text-on-status` check. A color with no family: the mark is
   the only thing it paints, and it is painted rather than outlined, since an
-  outline would halo the badge against the card.
+  outline would halo the badge against the card. Both relationships are
+  graphical, so both are held at 3:1 — against every surface the card takes,
+  including its hover repaint. A theme that predates the token and names
+  `status-success-strong` keeps the mark on that fill.
 
 ### Other Colors
 

--- a/packages/client/src/theme/context/ThemeProvider.tsx
+++ b/packages/client/src/theme/context/ThemeProvider.tsx
@@ -16,6 +16,8 @@ import {
   validateThemeDefinition,
 } from '../registry';
 import applyTheme, { applyResolvedTheme, themeOwnedProperties } from '../utils/applyTheme';
+import { defaultTheme } from '../themes/default';
+import { darkTheme } from '../themes/dark';
 import '../highContrast.css';
 
 const THEME_KEY = 'color-theme';
@@ -626,7 +628,7 @@ export function ThemeProvider({
       }
 
       if (!highContrast && legacyThemeRGB) {
-        applyTheme(legacyThemeRGB, root);
+        applyTheme(legacyThemeRGB, root, mode === 'dark' ? darkTheme : defaultTheme);
         root.dataset.theme = definition.name;
         return;
       }

--- a/packages/client/src/theme/registry.spec.ts
+++ b/packages/client/src/theme/registry.spec.ts
@@ -326,6 +326,19 @@ describe('theme registry', () => {
     );
   });
 
+  it('keeps the bundled verified fill for a theme that repaints nothing around the mark', () => {
+    const resolved = resolveTheme(
+      {
+        version: 1,
+        name: 'unrelated-partial-reference',
+        modes: { dark: { colors: { 'rgb-text-primary': '250 250 250' } } },
+      },
+      'dark',
+    );
+
+    expect(resolved.colors['rgb-status-verified']).toBe(darkTheme['rgb-status-verified']);
+  });
+
   it('preserves an explicit verified fill', () => {
     const resolved = resolveTheme(
       {

--- a/packages/client/src/theme/registry.spec.ts
+++ b/packages/client/src/theme/registry.spec.ts
@@ -294,6 +294,39 @@ describe('theme registry', () => {
     );
   });
 
+  it('keeps the verified mark on the success fill a theme already named', () => {
+    const resolved = resolveTheme(
+      {
+        version: 1,
+        name: 'legacy-verified-reference',
+        modes: { dark: { colors: { 'rgb-status-success-strong': '8 135 89' } } },
+      },
+      'dark',
+    );
+
+    expect(resolved.colors['rgb-status-verified']).toBe('8 135 89');
+  });
+
+  it('preserves an explicit verified fill', () => {
+    const resolved = resolveTheme(
+      {
+        version: 1,
+        name: 'explicit-verified-reference',
+        modes: {
+          dark: {
+            colors: {
+              'rgb-status-success-strong': '8 135 89',
+              'rgb-status-verified': '26 127 216',
+            },
+          },
+        },
+      },
+      'dark',
+    );
+
+    expect(resolved.colors['rgb-status-verified']).toBe('26 127 216');
+  });
+
   it('resolves provider brand tokens and lets a theme override them', () => {
     const defaults = resolveTheme(libreChatTheme, 'light');
     expect(defaults.brands['provider-anthropic']).toBe('#d09a74');

--- a/packages/client/src/theme/registry.spec.ts
+++ b/packages/client/src/theme/registry.spec.ts
@@ -307,6 +307,25 @@ describe('theme registry', () => {
     expect(resolved.colors['rgb-status-verified']).toBe('8 135 89');
   });
 
+  it('keeps the verified mark on a success fill the theme only inherits', () => {
+    const resolved = resolveTheme(
+      {
+        version: 1,
+        name: 'partial-verified-reference',
+        modes: { dark: { colors: { 'rgb-surface-tertiary': '30 30 38' } } },
+      },
+      'dark',
+    );
+
+    expect(resolved.colors['rgb-status-verified']).toBe(darkTheme['rgb-status-success-strong']);
+  });
+
+  it('keeps the bundled verified fill for a theme with no colors of its own', () => {
+    expect(resolveTheme(libreChatTheme, 'dark').colors['rgb-status-verified']).toBe(
+      darkTheme['rgb-status-verified'],
+    );
+  });
+
   it('preserves an explicit verified fill', () => {
     const resolved = resolveTheme(
       {

--- a/packages/client/src/theme/registry.ts
+++ b/packages/client/src/theme/registry.ts
@@ -32,6 +32,20 @@ export const themeColorTokens: readonly (keyof IThemeRGB)[] = Object.freeze(
   Object.keys(defaultTheme) as Array<keyof IThemeRGB>,
 );
 
+/**
+ * What the verified mark is measured against: the fill it wore before it had a
+ * token, the check it carries, and the backgrounds `ToolCard` takes at rest and
+ * on hover. A theme naming any of these coordinated the mark; one naming none
+ * of them never looked at it.
+ */
+export const MARK_NEIGHBOURHOOD: readonly (keyof IThemeRGB)[] = Object.freeze([
+  'rgb-status-success-strong',
+  'rgb-text-on-status',
+  'rgb-surface-dialog',
+  'rgb-surface-secondary',
+  'rgb-surface-tertiary',
+]);
+
 export const themeAppearanceProperties: Readonly<
   Record<keyof IThemeAppearance, `--theme-${string}`>
 > = Object.freeze({
@@ -417,19 +431,22 @@ export function resolveTheme(theme: ThemeDefinition, mode: ThemeMode): ResolvedT
       : {};
   /**
    * The verified mark was painted with `status-success-strong` until it earned
-   * its own token, so no theme written before that names it — whether or not it
-   * restates the green. Filling the omission from the bundled palette would
-   * drop LibreChat's stock blue into a palette that never chose it, beside the
-   * deployment's own `text-on-status` check and card surfaces; the fill the
-   * mark used to wear keeps that coordination, restated or inherited, and a
-   * theme that wants the blue names the token, the way
+   * its own token, so a theme that paints what the mark is measured against —
+   * the fill it used to wear, the check it carries, or the card it sits on —
+   * coordinated that green and cannot have named the blue. Dropping LibreChat's
+   * stock blue into such a palette puts an unchecked pairing on surfaces the
+   * theme chose; keeping the old fill preserves the relationship it did check.
+   * A theme that repaints anything else keeps the bundled default, and any
+   * theme takes the blue by naming the token, the way
    * `rgb-surface-composer-hover` opts out of its own fallback.
    */
+  const ownsMarkSurroundings =
+    customColors != null && MARK_NEIGHBOURHOOD.some((token) => customColors[token] !== undefined);
   const verifiedFallback =
-    customColors != null && customColors['rgb-status-verified'] === undefined
+    ownsMarkSurroundings && customColors?.['rgb-status-verified'] === undefined
       ? {
           'rgb-status-verified':
-            customColors['rgb-status-success-strong'] ?? baseColors['rgb-status-success-strong'],
+            customColors?.['rgb-status-success-strong'] ?? baseColors['rgb-status-success-strong'],
         }
       : {};
 

--- a/packages/client/src/theme/registry.ts
+++ b/packages/client/src/theme/registry.ts
@@ -417,16 +417,20 @@ export function resolveTheme(theme: ThemeDefinition, mode: ThemeMode): ResolvedT
       : {};
   /**
    * The verified mark was painted with `status-success-strong` until it earned
-   * its own token, so a theme written before that names the green but not the
-   * blue. Filling the omission from the bundled palette would drop LibreChat's
-   * stock blue into a palette that never chose it, beside the deployment's own
-   * `text-on-status` check and card surfaces; carrying the fill it used to wear
-   * keeps that coordination, and a theme that wants the blue names the token.
+   * its own token, so no theme written before that names it — whether or not it
+   * restates the green. Filling the omission from the bundled palette would
+   * drop LibreChat's stock blue into a palette that never chose it, beside the
+   * deployment's own `text-on-status` check and card surfaces; the fill the
+   * mark used to wear keeps that coordination, restated or inherited, and a
+   * theme that wants the blue names the token, the way
+   * `rgb-surface-composer-hover` opts out of its own fallback.
    */
   const verifiedFallback =
-    customColors?.['rgb-status-verified'] === undefined &&
-    customColors?.['rgb-status-success-strong'] !== undefined
-      ? { 'rgb-status-verified': customColors['rgb-status-success-strong'] }
+    customColors != null && customColors['rgb-status-verified'] === undefined
+      ? {
+          'rgb-status-verified':
+            customColors['rgb-status-success-strong'] ?? baseColors['rgb-status-success-strong'],
+        }
       : {};
 
   return {

--- a/packages/client/src/theme/registry.ts
+++ b/packages/client/src/theme/registry.ts
@@ -415,6 +415,19 @@ export function resolveTheme(theme: ThemeDefinition, mode: ThemeMode): ResolvedT
           'rgb-series-8': customColors?.['rgb-text-secondary'] ?? baseColors['rgb-text-secondary'],
         }
       : {};
+  /**
+   * The verified mark was painted with `status-success-strong` until it earned
+   * its own token, so a theme written before that names the green but not the
+   * blue. Filling the omission from the bundled palette would drop LibreChat's
+   * stock blue into a palette that never chose it, beside the deployment's own
+   * `text-on-status` check and card surfaces; carrying the fill it used to wear
+   * keeps that coordination, and a theme that wants the blue names the token.
+   */
+  const verifiedFallback =
+    customColors?.['rgb-status-verified'] === undefined &&
+    customColors?.['rgb-status-success-strong'] !== undefined
+      ? { 'rgb-status-verified': customColors['rgb-status-success-strong'] }
+      : {};
 
   return {
     version: THEME_VERSION,
@@ -430,6 +443,7 @@ export function resolveTheme(theme: ThemeDefinition, mode: ThemeMode): ResolvedT
       ...chartWidgetSurfaceFallback,
       ...chartWidgetStrokeFallback,
       ...seriesEightFallback,
+      ...verifiedFallback,
     } as Required<IThemeRGB>,
     appearance: { ...defaultAppearance, ...definition?.appearance },
     /** Mode last: a mode override is more specific than the theme-wide set. */

--- a/packages/client/src/theme/semanticTokens.spec.ts
+++ b/packages/client/src/theme/semanticTokens.spec.ts
@@ -428,9 +428,13 @@ describe('success fill defaults', () => {
 });
 
 /** `status-verified` paints one thing: the check a first-party item wears next
- *  to its name. Same two ratios as the success fill — AA under the
- *  `text-on-status` check it carries, and the 3:1 mark floor against the card
- *  panel, which is `surface-secondary` in every mode. Separate from
+ *  to its name. Both of its relationships are graphical objects under WCAG
+ *  1.4.11, so both owe 3:1 and neither owes AA: the badge against the card it
+ *  sits on, and the `text-on-status` check against the badge. That is where it
+ *  parts from the success fill above, which carries a text label and therefore
+ *  owes AA. The card is not one surface — `ToolCard` rests on the dialog and
+ *  repaints to `surface-tertiary` on hover — so the silhouette is checked
+ *  against every background the card can take. Separate from
  *  `status-success-strong` on purpose: green already means selected on the same
  *  card, so provenance needs its own hue. */
 describe.each([
@@ -439,17 +443,27 @@ describe.each([
   ['high contrast light', highContrastLightTheme],
   ['high contrast dark', highContrastDarkTheme],
 ])('%s verified fill', (_name, theme: IThemeRGB) => {
-  it('carries its check at WCAG AA', () => {
+  it('carries its check at the 3:1 mark floor', () => {
     const ratio = contrast(toRgb(theme, 'rgb-status-verified'), toRgb(theme, 'rgb-text-on-status'));
-    expect(ratio).toBeGreaterThanOrEqual(WCAG_AA_NORMAL);
+    expect(ratio).toBeGreaterThanOrEqual(WCAG_MARK_MIN);
   });
 
-  it('keeps its silhouette at the 3:1 mark floor on the panel', () => {
-    const ratio = contrast(
-      toRgb(theme, 'rgb-status-verified'),
-      toRgb(theme, 'rgb-surface-secondary'),
-    );
-    expect(ratio).toBeGreaterThanOrEqual(WCAG_MARK_MIN);
+  it('keeps its silhouette at the 3:1 mark floor on every card state', () => {
+    const mark = toRgb(theme, 'rgb-status-verified');
+    /** Resting card, the panel behind the grid, and the hover repaint from
+     *  `ToolCard`'s `hover:bg-surface-tertiary`. */
+    const surfaces: Array<keyof IThemeRGB> = [
+      'rgb-surface-dialog',
+      'rgb-surface-secondary',
+      'rgb-surface-tertiary',
+    ];
+
+    const failures = surfaces.flatMap((surface) => {
+      const ratio = contrast(mark, toRgb(theme, surface));
+      return ratio < WCAG_MARK_MIN ? [`${surface}: ${ratio.toFixed(2)}:1`] : [];
+    });
+
+    expect(failures).toEqual([]);
   });
 });
 

--- a/packages/client/src/theme/semanticTokens.spec.ts
+++ b/packages/client/src/theme/semanticTokens.spec.ts
@@ -427,6 +427,52 @@ describe('success fill defaults', () => {
   });
 });
 
+/** `status-verified` paints one thing: the check a first-party item wears next
+ *  to its name. Same two ratios as the success fill — AA under the
+ *  `text-on-status` check it carries, and the 3:1 mark floor against the card
+ *  panel, which is `surface-secondary` in every mode. Separate from
+ *  `status-success-strong` on purpose: green already means selected on the same
+ *  card, so provenance needs its own hue. */
+describe.each([
+  ['default', defaultTheme],
+  ['dark', darkTheme],
+  ['high contrast light', highContrastLightTheme],
+  ['high contrast dark', highContrastDarkTheme],
+])('%s verified fill', (_name, theme: IThemeRGB) => {
+  it('carries its check at WCAG AA', () => {
+    const ratio = contrast(toRgb(theme, 'rgb-status-verified'), toRgb(theme, 'rgb-text-on-status'));
+    expect(ratio).toBeGreaterThanOrEqual(WCAG_AA_NORMAL);
+  });
+
+  it('keeps its silhouette at the 3:1 mark floor on the panel', () => {
+    const ratio = contrast(
+      toRgb(theme, 'rgb-status-verified'),
+      toRgb(theme, 'rgb-surface-secondary'),
+    );
+    expect(ratio).toBeGreaterThanOrEqual(WCAG_MARK_MIN);
+  });
+});
+
+describe('verified fill defaults', () => {
+  /** Tuned values rather than palette steps in either mode, so the stylesheet
+   *  cannot alias them to a `--blue-*` step and both copies move together. */
+  it('keeps the app CSS in step with the runtime themes', () => {
+    const appStyles = readFileSync(
+      join(__dirname, '..', '..', '..', '..', 'client', 'src', 'style.css'),
+      'utf8',
+    );
+
+    const declared = [...appStyles.matchAll(/--status-verified:\s*([^;]+);/g)].map((match) =>
+      match[1].trim(),
+    );
+
+    expect(declared).toEqual([
+      defaultTheme['rgb-status-verified'],
+      darkTheme['rgb-status-verified'],
+    ]);
+  });
+});
+
 /** The shared `Switch` paints this track, so it travels with the package rather
  *  than the app stylesheet. It is a UI component boundary under WCAG 1.4.11 and
  *  has to stay distinct from the `surface-primary` thumb on it and from the

--- a/packages/client/src/theme/themes/dark.ts
+++ b/packages/client/src/theme/themes/dark.ts
@@ -95,10 +95,14 @@ export const darkTheme: IThemeRGB = {
   'rgb-status-neutral-subtle': '33 33 33', // #212121 (gray-800)
   'rgb-status-neutral-border': '47 47 47', // #2f2f2f (gray-700)
   /** Verified mark. Not `status-info`'s `blue-300`, which is a text hue and
-   *  leaves a white check at 1.35:1; and not `blue-600`, which drops to 3.12:1
-   *  against the #212121 panel. Balanced like the success fill above: 4.71:1
-   *  under the white `text-on-status` check and 3.42:1 against the panel. */
-  'rgb-status-verified': '11 116 212', // #0b74d4
+   *  leaves a white check at 1.35:1. The card it sits on is `surface-dialog`
+   *  at rest and `surface-tertiary` (#2f2f2f) on hover, and that hover is the
+   *  binding constraint: `#0b74d4` held the panel at 3.42:1 but fell to 2.85:1
+   *  there. Both relationships are graphical (WCAG 1.4.11): 3.23:1 against the
+   *  hover surface, 4.52:1 against the resting dialog, and 4.14:1 under the
+   *  white `text-on-status` check. No hue clears 3:1 on #2f2f2f and 4.5:1
+   *  under a white check at once — the check would have to stop being white. */
+  'rgb-status-verified': '26 127 216', // #1a7fd8
   'rgb-text-on-status': '255 255 255', // #fff (white)
 
   // Brand colors

--- a/packages/client/src/theme/themes/dark.ts
+++ b/packages/client/src/theme/themes/dark.ts
@@ -94,6 +94,11 @@ export const darkTheme: IThemeRGB = {
   'rgb-status-neutral': '205 205 205', // #cdcdcd (gray-300)
   'rgb-status-neutral-subtle': '33 33 33', // #212121 (gray-800)
   'rgb-status-neutral-border': '47 47 47', // #2f2f2f (gray-700)
+  /** Verified mark. Not `status-info`'s `blue-300`, which is a text hue and
+   *  leaves a white check at 1.35:1; and not `blue-600`, which drops to 3.12:1
+   *  against the #212121 panel. Balanced like the success fill above: 4.71:1
+   *  under the white `text-on-status` check and 3.42:1 against the panel. */
+  'rgb-status-verified': '11 116 212', // #0b74d4
   'rgb-text-on-status': '255 255 255', // #fff (white)
 
   // Brand colors

--- a/packages/client/src/theme/themes/default.ts
+++ b/packages/client/src/theme/themes/default.ts
@@ -89,6 +89,10 @@ export const defaultTheme: IThemeRGB = {
   'rgb-status-neutral': '66 66 66', // #424242 (gray-600)
   'rgb-status-neutral-subtle': '236 236 236', // #ececec (gray-100)
   'rgb-status-neutral-border': '205 205 205', // #cdcdcd (gray-300)
+  /** Verified mark. `blue-600` doubles as `status-info` here, and that is the
+   *  point: one blue for "this is informational/first-party", 5.17:1 under the
+   *  white label and 4.83:1 against the panel. */
+  'rgb-status-verified': '37 99 235', // #2563eb (blue-600)
   'rgb-text-on-status': '255 255 255', // #fff (white)
 
   // Brand colors

--- a/packages/client/src/theme/themes/highContrast.spec.ts
+++ b/packages/client/src/theme/themes/highContrast.spec.ts
@@ -97,6 +97,7 @@ const solidFills: Array<keyof IThemeRGB> = [
   'rgb-status-info-strong',
   'rgb-status-warning-strong',
   'rgb-status-error-strong',
+  'rgb-status-verified',
 ];
 
 const borderTokens: Array<keyof IThemeRGB> = [

--- a/packages/client/src/theme/themes/highContrast.ts
+++ b/packages/client/src/theme/themes/highContrast.ts
@@ -125,6 +125,9 @@ export const highContrastLightTheme: IThemeRGB = {
   'rgb-status-neutral': '0 0 0', // #000000
   'rgb-status-neutral-subtle': '255 255 255', // #ffffff
   'rgb-status-neutral-border': '0 0 0', // #000000
+  /** Verified mark: the mode's one blue, 10.31:1 under the white check and the
+   *  same against the canvas. */
+  'rgb-status-verified': '0 65 122', // #00417a
   'rgb-text-on-status': '255 255 255', // #ffffff
 
   // Brand colors
@@ -262,6 +265,9 @@ export const highContrastDarkTheme: IThemeRGB = {
   'rgb-status-neutral': '255 255 255', // #ffffff
   'rgb-status-neutral-subtle': '0 0 0', // #000000
   'rgb-status-neutral-border': '255 255 255', // #ffffff
+  /** Verified mark: the mode's one blue, 11.82:1 under the black check and the
+   *  same against the canvas. */
+  'rgb-status-verified': '140 200 255', // #8cc8ff
   'rgb-text-on-status': '0 0 0', // #000000
 
   // Brand colors

--- a/packages/client/src/theme/types/index.ts
+++ b/packages/client/src/theme/types/index.ts
@@ -90,6 +90,16 @@ export interface IThemeRGB {
   'rgb-status-neutral'?: string;
   'rgb-status-neutral-subtle'?: string;
   'rgb-status-neutral-border'?: string;
+  /**
+   * Solid fill of the verified mark — the badge a first-party item carries next
+   * to its name. The one status with no family around it: the mark is the only
+   * thing it paints, so there is no subtle fill, border or text weight to go
+   * with it. Blue rather than a reuse of `status-success-strong`, because a
+   * green check is the selected/complete cue everywhere else in the product
+   * (including the selected-tool check on the very same card) while blue is the
+   * cross-product convention for provenance. It carries `text-on-status`.
+   */
+  'rgb-status-verified'?: string;
   'rgb-text-on-status'?: string;
 
   // Brand colors
@@ -214,6 +224,7 @@ export interface IThemeVariables {
   '--status-neutral': string;
   '--status-neutral-subtle': string;
   '--status-neutral-border': string;
+  '--status-verified': string;
   '--text-on-status': string;
   '--brand-purple': string;
 
@@ -313,6 +324,7 @@ export interface IThemeColors {
   'status-neutral'?: string;
   'status-neutral-subtle'?: string;
   'status-neutral-border'?: string;
+  'status-verified'?: string;
   'text-on-status'?: string;
   'brand-purple'?: string;
 

--- a/packages/client/src/theme/types/index.ts
+++ b/packages/client/src/theme/types/index.ts
@@ -98,8 +98,9 @@ export interface IThemeRGB {
    * green check is the selected/complete cue everywhere else in the product
    * (including the selected-tool check on the very same card) while blue is the
    * cross-product convention for provenance. It carries `text-on-status`.
-   * A theme that predates the token and names `status-success-strong` keeps
-   * wearing it here, which is the fill the mark had before this token existed.
+   * A theme that repaints the mark's surroundings — the old
+   * `status-success-strong` fill, the check, or the card surfaces — keeps the
+   * mark on that success fill, which is what it wore before this token existed.
    */
   'rgb-status-verified'?: string;
   'rgb-text-on-status'?: string;

--- a/packages/client/src/theme/types/index.ts
+++ b/packages/client/src/theme/types/index.ts
@@ -98,6 +98,8 @@ export interface IThemeRGB {
    * green check is the selected/complete cue everywhere else in the product
    * (including the selected-tool check on the very same card) while blue is the
    * cross-product convention for provenance. It carries `text-on-status`.
+   * A theme that predates the token and names `status-success-strong` keeps
+   * wearing it here, which is the fill the mark had before this token existed.
    */
   'rgb-status-verified'?: string;
   'rgb-text-on-status'?: string;

--- a/packages/client/src/theme/utils/applyTheme.spec.ts
+++ b/packages/client/src/theme/utils/applyTheme.spec.ts
@@ -238,6 +238,25 @@ describe('applyTheme', () => {
     expect(root.style.getPropertyValue('--chart-widget-stroke')).toBe('50 51 52');
   });
 
+  it('carries a legacy theme without a verified fill onto its success fill', () => {
+    const root = document.documentElement;
+
+    applyTheme({ 'rgb-status-success-strong': '8 135 89' }, root);
+
+    expect(root.style.getPropertyValue('--status-verified')).toBe('8 135 89');
+  });
+
+  it('leaves a legacy theme that names its own verified fill alone', () => {
+    const root = document.documentElement;
+
+    applyTheme(
+      { 'rgb-status-success-strong': '8 135 89', 'rgb-status-verified': '26 127 216' },
+      root,
+    );
+
+    expect(root.style.getPropertyValue('--status-verified')).toBe('26 127 216');
+  });
+
   it('clears only properties owned by the theme module', () => {
     const root = document.documentElement;
     root.style.setProperty('--text-primary', '1 2 3');

--- a/packages/client/src/theme/utils/applyTheme.spec.ts
+++ b/packages/client/src/theme/utils/applyTheme.spec.ts
@@ -267,6 +267,16 @@ describe('applyTheme', () => {
     expect(root.style.getPropertyValue('--status-verified')).toBe('8 135 89');
   });
 
+  it('leaves the verified fill alone for a legacy theme that repaints nothing around the mark', () => {
+    const root = document.documentElement;
+
+    applyTheme({ 'rgb-text-primary': '10 20 30' }, root, {
+      'rgb-status-success-strong': '8 135 89',
+    });
+
+    expect(root.style.getPropertyValue('--status-verified')).toBe('');
+  });
+
   it('clears only properties owned by the theme module', () => {
     const root = document.documentElement;
     root.style.setProperty('--text-primary', '1 2 3');

--- a/packages/client/src/theme/utils/applyTheme.spec.ts
+++ b/packages/client/src/theme/utils/applyTheme.spec.ts
@@ -257,6 +257,16 @@ describe('applyTheme', () => {
     expect(root.style.getPropertyValue('--status-verified')).toBe('26 127 216');
   });
 
+  it('carries a legacy theme that names no fills onto the mode palette it inherits', () => {
+    const root = document.documentElement;
+
+    applyTheme({ 'rgb-surface-tertiary': '30 30 38' }, root, {
+      'rgb-status-success-strong': '8 135 89',
+    });
+
+    expect(root.style.getPropertyValue('--status-verified')).toBe('8 135 89');
+  });
+
   it('clears only properties owned by the theme module', () => {
     const root = document.documentElement;
     root.style.setProperty('--text-primary', '1 2 3');

--- a/packages/client/src/theme/utils/applyTheme.ts
+++ b/packages/client/src/theme/utils/applyTheme.ts
@@ -1,5 +1,10 @@
 import type { IThemeAppearance, IThemeBrands, IThemeRGB, ResolvedThemeDefinition } from '../types';
-import { themeAppearanceProperties, themeBrandTokens, themeColorTokens } from '../registry';
+import {
+  MARK_NEIGHBOURHOOD,
+  themeAppearanceProperties,
+  themeBrandTokens,
+  themeColorTokens,
+} from '../registry';
 
 const colorProperty = (token: keyof IThemeRGB): `--${string}` => `--${token.slice(4)}`;
 const brandProperty = (token: keyof IThemeBrands): `--${string}` => `--${token}`;
@@ -66,15 +71,20 @@ function mapColors(colors: IThemeRGB, base?: IThemeRGB): Array<[string, string]>
   }
 
   /**
-   * Same compatibility as `resolveTheme`: the mark wore `status-success-strong`
-   * before it had a token of its own, and this adapter writes only the keys a
-   * theme names, so an older stored or environment theme would otherwise keep
-   * the stock blue while the palette around it moved. A theme that inherits the
-   * green rather than restating it gets the same treatment through `base`.
+   * Same rule as `resolveTheme`: a theme that paints what the mark is measured
+   * against coordinated the `status-success-strong` the mark wore before it had
+   * a token, so it keeps that fill rather than taking LibreChat's stock blue.
+   * This adapter writes only the keys a theme names, so the inherited value
+   * arrives through `base`, the bundled palette for the mode being applied.
    */
+  const ownsMarkSurroundings = MARK_NEIGHBOURHOOD.some((token) => colors[token] !== undefined);
   const inheritedSuccess =
     colors['rgb-status-success-strong'] ?? base?.['rgb-status-success-strong'];
-  if (colors['rgb-status-verified'] === undefined && inheritedSuccess !== undefined) {
+  if (
+    ownsMarkSurroundings &&
+    colors['rgb-status-verified'] === undefined &&
+    inheritedSuccess !== undefined
+  ) {
     variables.push(['--status-verified', inheritedSuccess]);
   }
 

--- a/packages/client/src/theme/utils/applyTheme.ts
+++ b/packages/client/src/theme/utils/applyTheme.ts
@@ -62,6 +62,19 @@ function mapColors(colors: IThemeRGB): Array<[string, string]> {
     variables.push(['--chart-widget-stroke', colors['rgb-border-light']]);
   }
 
+  /**
+   * Same compatibility as `resolveTheme`: the mark wore `status-success-strong`
+   * before it had a token of its own, and this adapter writes only the keys a
+   * theme names, so an older stored or environment theme would otherwise keep
+   * the stock blue while the palette around it moved.
+   */
+  if (
+    colors['rgb-status-verified'] === undefined &&
+    colors['rgb-status-success-strong'] !== undefined
+  ) {
+    variables.push(['--status-verified', colors['rgb-status-success-strong']]);
+  }
+
   return variables;
 }
 

--- a/packages/client/src/theme/utils/applyTheme.ts
+++ b/packages/client/src/theme/utils/applyTheme.ts
@@ -17,7 +17,10 @@ function validateRGB(rgb: string): boolean {
   return match !== null && match.slice(1).every((channel) => Number(channel) <= 255);
 }
 
-function mapColors(colors: IThemeRGB): Array<[string, string]> {
+/** `base` is the bundled palette for the mode being applied. The adapter writes
+ *  only the keys a theme names, so a derivation whose source the theme inherits
+ *  rather than restates has nothing to read without it. */
+function mapColors(colors: IThemeRGB, base?: IThemeRGB): Array<[string, string]> {
   const variables = themeColorTokens.reduce<Array<[string, string]>>((result, token) => {
     const value = colors[token];
     if (value !== undefined) {
@@ -66,13 +69,13 @@ function mapColors(colors: IThemeRGB): Array<[string, string]> {
    * Same compatibility as `resolveTheme`: the mark wore `status-success-strong`
    * before it had a token of its own, and this adapter writes only the keys a
    * theme names, so an older stored or environment theme would otherwise keep
-   * the stock blue while the palette around it moved.
+   * the stock blue while the palette around it moved. A theme that inherits the
+   * green rather than restating it gets the same treatment through `base`.
    */
-  if (
-    colors['rgb-status-verified'] === undefined &&
-    colors['rgb-status-success-strong'] !== undefined
-  ) {
-    variables.push(['--status-verified', colors['rgb-status-success-strong']]);
+  const inheritedSuccess =
+    colors['rgb-status-success-strong'] ?? base?.['rgb-status-success-strong'];
+  if (colors['rgb-status-verified'] === undefined && inheritedSuccess !== undefined) {
+    variables.push(['--status-verified', inheritedSuccess]);
   }
 
   return variables;
@@ -113,12 +116,13 @@ export function applyResolvedTheme(
 export default function applyTheme(
   themeRGB?: IThemeRGB,
   root: HTMLElement = document.documentElement,
+  base?: IThemeRGB,
 ): void {
   if (!themeRGB) {
     return;
   }
 
-  mapColors(themeRGB).forEach(([property, value]) => {
+  mapColors(themeRGB, base).forEach(([property, value]) => {
     if (!validateRGB(value)) {
       console.error(`Invalid RGB value for ${property}: ${value}`);
       return;

--- a/packages/client/src/theme/utils/createTailwindColors.js
+++ b/packages/client/src/theme/utils/createTailwindColors.js
@@ -140,6 +140,7 @@ function createTailwindColors() {
     'status-neutral': cssVar('--status-neutral'),
     'status-neutral-subtle': cssVar('--status-neutral-subtle'),
     'status-neutral-border': cssVar('--status-neutral-border'),
+    'status-verified': cssVar('--status-verified'),
     'text-on-status': cssVar('--text-on-status'),
 
     'series-1': cssVar('--series-1'),


### PR DESCRIPTION
## Summary

The verified mark a native tool wears in the Tool Library is lucide's `BadgeCheck`, filled with
`status-success-strong` and colored `text-on-status`. Lucide strokes its badge outline with
`currentColor`, so that white check color also traces the badge: the mark carries a white outline.
On the card's own white panel the outline disappears; on every other surface the card can sit on —
hover (`surface-tertiary`), selected (`status-success/10`), dark mode — it reads as a halo around
the badge. The green is a second problem: the same card paints its selected state with
`status-success-strong`, so "first-party" and "selected" share a hue.

The mark is now `VerifiedIcon`, which fills the badge and strokes only the check, and it wears
`status-verified` — one blue for provenance, tuned per theme, so nothing on the card competes with
the green selection check.

![Before and after, hovering a native tool card](https://raw.githubusercontent.com/berry-13/LibreChat/verified-tool-badge-assets/assets/verified-badge-before-after.png)

Left: today's mark on a hovered card, its white outline halos the badge against `surface-tertiary`.
Right: the same card after the change. Both crops are the running client; the lower tile is the
same mark at 6×.

<details>
<summary>Full Tool Library after the change</summary>

![Tool Library with native tools marked](https://raw.githubusercontent.com/berry-13/LibreChat/verified-tool-badge-assets/assets/verified-badge-tool-library.png)

</details>

## How it works

The icon is the mechanism: the badge is a filled path, not a stroked one, so no stroke color can
escape to the outline. Only the check is stroked, and it is stroked with the token that is meant to
sit on a status fill.

```tsx
<path d="M3.85 8.62a4 4 0 0 1 4.78-4.77 …Z" fill="currentColor" />
<path d="m8.4 12.3 2.5 2.5 4.7-4.7" className="stroke-text-on-status" strokeWidth="2.5" … />
```

The card then names the color instead of the fill, since the badge takes `currentColor`:

```diff
-<BadgeCheck className="size-4 shrink-0 fill-status-success-strong text-text-on-status" strokeWidth={2} />
+<VerifiedIcon className="size-3.5 shrink-0 text-status-verified" />
```

`status-verified` is a new semantic token rather than a reuse, because no existing status color
holds the 3:1 non-text floor against every surface the card takes in all four themes. Both of the
mark's relationships are graphical objects under WCAG 1.4.11 — the badge against the card, the check
against the badge — so each owes 3:1 and neither owes AA:

```text
                              under the check   dialog   panel    hover
default             #2563eb           5.17:1    5.17:1   4.83:1   4.38:1
dark                #1a7fd8           4.14:1    4.52:1   3.89:1   3.23:1
high contrast light #00417a          10.31:1   10.31:1  10.31:1  10.31:1
high contrast dark  #8cc8ff          11.82:1   11.82:1  11.82:1  11.82:1
```

The hover column is the binding one: `ToolCard` repaints to `surface-tertiary` when hovered, and no
hue clears 3:1 on the dark #2f2f2f while also clearing AA under a white check — the two constraints
cross. `semanticTokens.spec.ts` asserts both floors per theme across `surface-dialog`,
`surface-secondary` and `surface-tertiary`, and pins the two `--status-verified` declarations in
`client/src/style.css` to the runtime theme values so the stylesheet copy cannot drift.

A theme written before this token names `status-success-strong` and not `status-verified`, and
neither application path would leave it coordinated: the legacy adapter writes only the keys a theme
names (so the stylesheet's stock blue survives), and the versioned resolver fills omissions from the
bundled palette. Both now carry the mark onto the theme's own success fill — the one it wore before
the token existed — alongside the derived-token fallbacks already there:

```ts
const verifiedFallback =
  customColors?.['rgb-status-verified'] === undefined &&
  customColors?.['rgb-status-success-strong'] !== undefined
    ? { 'rgb-status-verified': customColors['rgb-status-success-strong'] }
    : {};
```

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Four scenarios in the mock harness (`e2e/specs/mock/scenarios/verified-tool-mark.spec.ts`), each run
on desktop light, desktop dark and mobile emulation. They read the rendered colors and compute the
ratios, so they fail on a regression in the component or in theme application, not only on a token
edit:

- `@scenario:native-tool-card-shows-verified-mark` — a native card's mark is painted (badge
  `stroke: none`), its check is a different color, and both relationships clear 3:1 against what is
  actually behind them
- `@scenario:verified-mark-holds-silhouette-on-dark-hover` — hovering a native card in dark mode
  repaints the card and the mark still clears 3:1 against that background
- `@scenario:legacy-custom-theme-keeps-verified-mark-on-its-palette` — a pre-token palette in
  storage renders the mark in its own success fill rather than the stock blue
- `@scenario:mcp-server-card-shows-no-verified-mark` — a third-party server card carries no mark

12/12 passing on the current head. Also run locally:

- `npx tsc --noEmit` — clean in `client` and `packages/client`
- `packages/client`: `npx jest src/theme` — 189 passing, including the widened verified-fill ratio
  assertions, the stylesheet-parity test and the two fallback tests in `registry.spec.ts` /
  `applyTheme.spec.ts`
- `client`: `npx jest src/components/SidePanel/Agents/Tools/__tests__` — 109 passing; the mark's
  accessible name is unchanged, so `getByLabelText('com_ui_tools_native')` still resolves

### **Test Configuration**:

Mock e2e harness (`playwright.config.mock.ts`) under a per-run database and Redis prefix; Chromium,
desktop 1280×900 light and dark plus 390×844 mobile emulation.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes

