### PR TITLE
🔐 fix: Stop an MCP Credential Refresh From Fencing Its Own Connection

### DIFF
--- a/api/server/services/Config/__tests__/getCachedTools.spec.js
+++ b/api/server/services/Config/__tests__/getCachedTools.spec.js
@@ -431,10 +431,25 @@ describe('MCP tool cache', () => {
     );
   });
 
+  it('reports the rotated generation so its caller can tell its own fence from a foreign one', async () => {
+    mockCache.set.mockResolvedValue(true);
+    mockCache.delete.mockResolvedValue(true);
+
+    const published = await invalidateCachedTools({ userId: 'user1', serverName: 'github' });
+
+    expect(published).toEqual(expect.any(String));
+    expect(mockCache.set).toHaveBeenNthCalledWith(
+      2,
+      ToolCacheKeys.MCP_SERVER_GENERATION('user1', 'github'),
+      published,
+      expect.any(Number),
+    );
+  });
+
   it('invalidates only the static global key for broad config changes', async () => {
     mockCache.delete.mockResolvedValue(true);
 
-    await invalidateCachedTools({ invalidateGlobal: true });
+    await expect(invalidateCachedTools({ invalidateGlobal: true })).resolves.toBeUndefined();
 
     expect(mockCache.delete).toHaveBeenCalledTimes(1);
     expect(mockCache.delete).toHaveBeenCalledWith(ToolCacheKeys.GLOBAL);

--- a/packages/api/src/mcp/UserConnectionManager.ts
+++ b/packages/api/src/mcp/UserConnectionManager.ts
@@ -796,6 +796,27 @@ export abstract class UserConnectionManager {
         ephemeralConnection,
       };
 
+      /**
+       * A credential refresh performed while this connection is being built rotates the very
+       * generation captured above, so the build would otherwise fence itself: the connection
+       * holding the newest credentials publishes under a generation its own refresh retired.
+       * Recording what it published lets the fence keep pointing at foreign rotations only.
+       */
+      let selfPublishedGeneration: string | undefined;
+      const trackPublishedGeneration: t.UserConnectionContext['onOAuthCredentialsChanging'] =
+        onOAuthCredentialsChanging == null
+          ? undefined
+          : async (scope) => {
+              const publish = await onOAuthCredentialsChanging(scope);
+              return async () => {
+                const published = await publish();
+                if (published) {
+                  selfPublishedGeneration = published;
+                }
+                return published;
+              };
+            };
+
       const useOAuth = usesDirectOpenIDBearerRecovery(config)
         ? false
         : requiresOAuthMachinery(runtimeConfig);
@@ -826,7 +847,7 @@ export abstract class UserConnectionManager {
           requestBody: requestBody,
           connectionTimeout: connectionTimeout,
           onOAuthCredentialsChanged,
-          onOAuthCredentialsChanging,
+          onOAuthCredentialsChanging: trackPublishedGeneration,
         };
       } else {
         connectionOptions = {
@@ -844,8 +865,12 @@ export abstract class UserConnectionManager {
 
       this.assertCreationNotCancelled(creationGuard, userId, serverName);
 
-      if (publicationGeneration) {
-        this.toolPublicationGenerations.set(connection, publicationGeneration);
+      const effectiveGeneration = ephemeralConnection
+        ? undefined
+        : (selfPublishedGeneration ?? publicationGeneration);
+
+      if (effectiveGeneration) {
+        this.toolPublicationGenerations.set(connection, effectiveGeneration);
       }
       if (configGeneration) {
         this.toolConfigGenerations.set(connection, configGeneration);
@@ -857,7 +882,7 @@ export abstract class UserConnectionManager {
           userId,
           serverName,
           serverConfig: config,
-          ...(publicationGeneration && { publicationGeneration }),
+          ...(effectiveGeneration && { publicationGeneration: effectiveGeneration }),
           ...(publicationRevision && { publicationRevision }),
         });
       });

--- a/packages/api/src/mcp/__tests__/MCPManager.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPManager.test.ts
@@ -4350,6 +4350,32 @@ describe('MCPManager', () => {
         dispose: jest.fn().mockResolvedValue(undefined),
       }) as unknown as MCPConnection;
 
+    /** An OAuth server whose connection build refreshes credentials, fencing the catalog mid-build. */
+    const refreshingOAuthServer = () => {
+      const connection = newUserConnection();
+      const serverConfig: t.ParsedServerConfig = {
+        type: 'streamable-http',
+        url: 'https://oauth-mcp.example.com/mcp',
+        source: 'yaml',
+        startup: false,
+        requiresOAuth: true,
+      };
+      mockAppConnections({ has: jest.fn().mockResolvedValue(false) });
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue(serverConfig);
+      (MCPConnectionFactory.create as jest.Mock).mockImplementation(
+        async (_basic: t.BasicConnectionOptions, options: t.OAuthConnectionOptions) => {
+          const publish = await options.onOAuthCredentialsChanging?.({ userId, serverName });
+          await publish?.();
+          return connection;
+        },
+      );
+      return {
+        connection,
+        serverConfig,
+        flowManager: mockFlowManager as unknown as t.UserMCPConnectionOptions['flowManager'],
+      };
+    };
+
     it('should pass useOAuth for servers with configured oauth and no requiresOAuth value', async () => {
       mockAppConnections({
         has: jest.fn().mockResolvedValue(false),
@@ -5465,6 +5491,70 @@ describe('MCPManager', () => {
         );
 
         expect(connection.removeAllListeners).toHaveBeenCalledWith('toolsChanged');
+        expect(connection.dispose).toHaveBeenCalled();
+        expect(manager.getUserConnections(userId)?.has(serverName) ?? false).toBe(false);
+      } finally {
+        generationSpy.mockRestore();
+        renewalSpy.mockRestore();
+      }
+    });
+
+    it('leases a new connection under the generation its own credential refresh published', async () => {
+      const generationSpy = jest
+        .spyOn(toolsChanged, 'getMCPToolsChangedGeneration')
+        .mockResolvedValue('generation-a');
+      const renewalSpy = jest
+        .spyOn(toolsChanged, 'renewMCPToolsChangedGeneration')
+        .mockResolvedValue(true);
+      const { serverConfig, flowManager } = refreshingOAuthServer();
+
+      try {
+        const manager = await MCPManager.createInstance(newMCPServersConfig());
+        await manager.getUserConnection({
+          serverName,
+          user: mockUser,
+          flowManager,
+          serverConfig,
+          onOAuthCredentialsChanging: async () => async () => 'generation-b',
+        });
+
+        expect(renewalSpy).toHaveBeenCalledWith({
+          userId,
+          serverName,
+          publicationGeneration: 'generation-b',
+        });
+      } finally {
+        generationSpy.mockRestore();
+        renewalSpy.mockRestore();
+      }
+    });
+
+    it('still fences a new connection when a rotation follows its own credential refresh', async () => {
+      const generationSpy = jest
+        .spyOn(toolsChanged, 'getMCPToolsChangedGeneration')
+        .mockResolvedValue('generation-a');
+      const renewalSpy = jest
+        .spyOn(toolsChanged, 'renewMCPToolsChangedGeneration')
+        .mockResolvedValue(false);
+      const { serverConfig, flowManager, connection } = refreshingOAuthServer();
+
+      try {
+        const manager = await MCPManager.createInstance(newMCPServersConfig());
+        await expect(
+          manager.getUserConnection({
+            serverName,
+            user: mockUser,
+            flowManager,
+            serverConfig,
+            onOAuthCredentialsChanging: async () => async () => 'generation-b',
+          }),
+        ).rejects.toThrow('Publication lease is no longer current');
+
+        expect(renewalSpy).toHaveBeenCalledWith({
+          userId,
+          serverName,
+          publicationGeneration: 'generation-b',
+        });
         expect(connection.dispose).toHaveBeenCalled();
         expect(manager.getUserConnections(userId)?.has(serverName) ?? false).toBe(false);
       } finally {

--- a/packages/api/src/mcp/authorization.ts
+++ b/packages/api/src/mcp/authorization.ts
@@ -134,11 +134,14 @@ export interface PersistMCPAuthorizationTransactionDeps<TTokens>
   inactiveServerError: () => Error;
 }
 
-/** Writes a durable intent now and returns the exact publication that clears only that intent. */
+/**
+ * Writes a durable intent now and returns the exact publication that clears only that intent.
+ * The publication reports the generation it wrote so its own caller can adopt it.
+ */
 export async function prepareMCPAuthorizationMutation(
   scope: MCPRecoveryGenerationScope,
   deps: MCPAuthorizationPublicationDeps,
-): Promise<() => Promise<void>> {
+): Promise<() => Promise<string | undefined>> {
   const publicationRetryVersion = await deps.persistPublicationRetry?.(scope);
   return () =>
     publishMCPAuthorizationMutation(scope, {

--- a/packages/api/src/mcp/catalog/recovery.ts
+++ b/packages/api/src/mcp/catalog/recovery.ts
@@ -75,7 +75,7 @@ export async function publishMCPAuthorizationMutation(
     retryDelaysMs?: readonly number[];
     attemptTimeoutMs?: number;
   },
-): Promise<void> {
+): Promise<string | undefined> {
   /** Persist retry intent before touching the shared cache. A credential writer can keep this
    * inside its rollback boundary, so a cache outage never leaves a committed mutation with no
    * durable path to fence other replicas. */
@@ -89,8 +89,9 @@ export async function publishMCPAuthorizationMutation(
       const attemptTimeoutMs =
         deps.attemptTimeoutMs ?? DEFAULT_RECOVERY_POLICY.authorizationFenceTimeoutMs;
       let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      let published: unknown;
       try {
-        await Promise.race([
+        published = await Promise.race([
           deps.invalidateRecoveryGeneration(scope),
           new Promise<never>((_, reject) => {
             timeoutId = setTimeout(
@@ -114,7 +115,7 @@ export async function publishMCPAuthorizationMutation(
         );
       }
       deps.clearLocalRecovery?.(scope.userId, scope.serverName);
-      return;
+      return typeof published === 'string' && published.length > 0 ? published : undefined;
     } catch (error) {
       lastError = error;
       logger.warn(

--- a/packages/api/src/mcp/catalog/store.ts
+++ b/packages/api/src/mcp/catalog/store.ts
@@ -239,7 +239,7 @@ export interface MCPCatalogStore {
     userId?: string;
     serverName?: string;
     invalidateGlobal?: boolean;
-  }) => Promise<void>;
+  }) => Promise<string | undefined>;
 }
 
 function isTools(value: unknown): value is LCAvailableTools {
@@ -851,41 +851,46 @@ export function createMCPCatalogStore(deps: CatalogStoreDeps): MCPCatalogStore {
     return Number(written) === 1;
   }
 
+  /** Returns the generation this invalidation published for a user and server, so a caller that
+   *  fenced its own credential mutation can tell that rotation apart from a foreign one. */
   async function invalidateCachedTools(
     options: {
       userId?: string;
       serverName?: string;
       invalidateGlobal?: boolean;
     } = {},
-  ): Promise<void> {
+  ): Promise<string | undefined> {
     const cache = await getReadyCache();
     if (options.invalidateGlobal) {
       await runWithGlobalCacheLock(() => deleteGlobalWithinLock(cache));
     }
     const { userId, serverName } = options;
-    if (userId && serverName) {
-      await withUserQueue(userId, serverName, async () => {
-        if (
-          (await cache.set(
-            ToolCacheKeys.MCP_SERVER_LEGACY_FENCE(userId, serverName),
-            true,
-            generationTtl,
-          )) === false
-        ) {
-          throw new Error('Tool cache rejected the legacy migration fence');
-        }
-        if (
-          (await cache.set(
-            ToolCacheKeys.MCP_SERVER_GENERATION(userId, serverName),
-            randomUUID(),
-            generationTtl,
-          )) === false
-        ) {
-          throw new Error('Tool publication generation cache rejected invalidation');
-        }
-        await cache.delete(ToolCacheKeys.MCP_SERVER(userId, serverName));
-      });
+    if (!userId || !serverName) {
+      return undefined;
     }
+    return withUserQueue(userId, serverName, async () => {
+      const generation = randomUUID();
+      if (
+        (await cache.set(
+          ToolCacheKeys.MCP_SERVER_LEGACY_FENCE(userId, serverName),
+          true,
+          generationTtl,
+        )) === false
+      ) {
+        throw new Error('Tool cache rejected the legacy migration fence');
+      }
+      if (
+        (await cache.set(
+          ToolCacheKeys.MCP_SERVER_GENERATION(userId, serverName),
+          generation,
+          generationTtl,
+        )) === false
+      ) {
+        throw new Error('Tool publication generation cache rejected invalidation');
+      }
+      await cache.delete(ToolCacheKeys.MCP_SERVER(userId, serverName));
+      return generation;
+    });
   }
 
   return {

--- a/packages/api/src/mcp/oauth/OAuthReconnectionManager.ts
+++ b/packages/api/src/mcp/oauth/OAuthReconnectionManager.ts
@@ -1,6 +1,6 @@
 import { logger } from '@librechat/data-schemas';
 import type { TokenMethods, IUser } from '@librechat/data-schemas';
-import type { ParsedServerConfig } from '~/mcp/types';
+import type { ParsedServerConfig, UserConnectionContext } from '~/mcp/types';
 import type { MCPOAuthTokens } from './types';
 import { MCPServersRegistry } from '~/mcp/registry/MCPServersRegistry';
 import { OAuthReconnectionTracker } from './OAuthReconnectionTracker';
@@ -23,10 +23,7 @@ export class OAuthReconnectionManager {
     serverName: string;
   }) => Promise<void>;
 
-  private readonly onOAuthCredentialsChanging?: (scope: {
-    userId: string;
-    serverName: string;
-  }) => Promise<() => Promise<void>>;
+  private readonly onOAuthCredentialsChanging?: UserConnectionContext['onOAuthCredentialsChanging'];
 
   private readonly reconnectionsTracker: OAuthReconnectionTracker;
 
@@ -42,10 +39,7 @@ export class OAuthReconnectionManager {
     tokenMethods: TokenMethods,
     reconnections?: OAuthReconnectionTracker,
     onOAuthCredentialsChanged?: (scope: { userId: string; serverName: string }) => Promise<void>,
-    onOAuthCredentialsChanging?: (scope: {
-      userId: string;
-      serverName: string;
-    }) => Promise<() => Promise<void>>,
+    onOAuthCredentialsChanging?: UserConnectionContext['onOAuthCredentialsChanging'],
   ): Promise<OAuthReconnectionManager> {
     if (OAuthReconnectionManager.instance != null) {
       throw new Error('OAuthReconnectionManager already initialized');
@@ -68,10 +62,7 @@ export class OAuthReconnectionManager {
     tokenMethods: TokenMethods,
     reconnections?: OAuthReconnectionTracker,
     onOAuthCredentialsChanged?: (scope: { userId: string; serverName: string }) => Promise<void>,
-    onOAuthCredentialsChanging?: (scope: {
-      userId: string;
-      serverName: string;
-    }) => Promise<() => Promise<void>>,
+    onOAuthCredentialsChanging?: UserConnectionContext['onOAuthCredentialsChanging'],
   ) {
     this.flowManager = flowManager;
     this.tokenMethods = tokenMethods;

--- a/packages/api/src/mcp/types/index.ts
+++ b/packages/api/src/mcp/types/index.ts
@@ -263,11 +263,15 @@ export interface UserConnectionContext {
   deadlineMs?: number;
   /** Advances application authorization state after OAuth token persistence succeeds. */
   onOAuthCredentialsChanged?: (scope: { userId: string; serverName: string }) => Promise<void>;
-  /** Persists authorization-fence intent before OAuth token rows change and returns its publisher. */
+  /**
+   * Persists authorization-fence intent before OAuth token rows change and returns its publisher.
+   * The publisher reports the generation it wrote, so a caller that fenced its own credential
+   * change can adopt that generation instead of the one it captured beforehand.
+   */
   onOAuthCredentialsChanging?: (scope: {
     userId: string;
     serverName: string;
-  }) => Promise<() => Promise<void>>;
+  }) => Promise<() => Promise<string | undefined>>;
 }
 
 export interface RequestScopedMCPConnectionStore {


### PR DESCRIPTION
## Summary

A tool call against an OAuth MCP server fails with `Publication lease is no longer current` when the access token expires at the moment the connection has to be rebuilt. The connection is disposed immediately after it is established, the tool call errors, and the agent's next attempt succeeds — so each occurrence costs one wasted tool call and a stack trace that looks like a cross-replica conflict but is not one.

`createUserConnectionInternal` captures the tool-cache publication generation *before* it resolves credentials, so a rotation published by another replica fences whatever this connection later writes to the shared catalog. During the same build, `MCPConnectionFactory` performs a silent token refresh and publishes an authorization fence of its own, which rotates that same generation. The build then fails the lease check against the rotation it just caused: the connection holding the newest credentials is the one declared stale.

`invalidateCachedTools` now reports the generation it wrote, the authorization publication carries it back to its caller, and a connection build adopts the generation its own refresh published. A rotation from anywhere else still moves the stored generation past that value, so the fence keeps failing the builds it was meant to fail.

Observed sequence before the change, one second end to end:

```text
Establishing new connection                 # captures generation A
Refresh request to <token endpoint>         # access token had expired
Successfully refreshed and stored OAuth tokens
Connection successfully established
[MCP Cache] Ignored stale tool publication  # catalog write rejected, generation is now B
Publication lease is no longer current      # renew(A) fails, connection disposed
<tool> tool call failed: Publication lease is no longer current
```

## How it works

The generation travels back up the same path the fence went down:

```text
createUserConnectionInternal
  getMCPToolsChangedGeneration                                  # captures A
  MCPConnectionFactory.create
    prepareOAuthRefreshSuccess
      publishPreparedMutation
        publishMCPAuthorizationMutation
          invalidateRecoveryGeneration -> invalidateCachedTools  # writes B
  toolPublicationGenerations.set(connection, B)                  # was A
  updateUserLastActivity -> renewIfCurrent(B)                    # was renewIfCurrent(A) -> false
```

The manager wraps the `onOAuthCredentialsChanging` it was handed, so the factory keeps calling one opaque publisher and needs no new argument:

```diff
-      if (publicationGeneration) {
-        this.toolPublicationGenerations.set(connection, publicationGeneration);
+      const effectiveGeneration = ephemeralConnection
+        ? undefined
+        : (selfPublishedGeneration ?? publicationGeneration);
+
+      if (effectiveGeneration) {
+        this.toolPublicationGenerations.set(connection, effectiveGeneration);
       }
```

Adoption is deliberately narrow. It applies only to the generation this build published for its own user and server; an ephemeral connection publishes nothing and keeps `undefined`, and a value written by any other writer never reaches `selfPublishedGeneration`, so `renewIfCurrent` still returns `false` and the connection is still torn down.

`OAuthReconnectionManager` declared the publisher's shape inline in three places; those now reference `UserConnectionContext['onOAuthCredentialsChanging']` instead of restating a widened signature three more times.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Two tests in `MCPManager.test.ts` drive a connection build whose factory invokes `onOAuthCredentialsChanging` and publishes a new generation mid-build. Both fail on `dev` with `generation-a` where `generation-b` is expected:

- the build leases under the generation its own refresh published;
- a rotation that lands after its own publication still fences the build, proving adoption did not disable the check.

`getCachedTools.spec.js` covers `invalidateCachedTools` reporting the generation it rotated to, and reporting nothing for a global-only invalidation.

### **Test Configuration**:

- `packages/api`: `npx tsc --noEmit` clean; `npx jest src/mcp` — 1987 passed. The 4 suites that fail without infrastructure pass against a real Redis (`USE_REDIS=true`, single node): `npx jest --testPathPatterns="src/mcp/.*\.cache_integration\.spec\.ts$"` — 82 passed.
- `api`: `npx jest server/services/Config/__tests__/ server/controllers/__tests__/mcp.servers.spec.js server/controllers/__tests__/UserController.mcpOAuth.spec.js server/services/initializeOAuthReconnectManager.spec.js` — 83 passed.
- Not run locally: the Redis **cluster** leg of the cache-integration workflow (no 3-node cluster available); CI covers it. `src/mcp/registry/__tests__/MCPReinitRecovery.integration.test.ts` fails on `dev` as well — it mocks `@librechat/data-schemas` down to `logger`, so `scopedCacheKey` is undefined — and is untouched here.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
